### PR TITLE
Plan 3 — Codex and ACP (Cursor/Gemini) agent adapters

### DIFF
--- a/apps/desktop/src/renderer/src/panes/session/Composer.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/Composer.tsx
@@ -1,4 +1,4 @@
-import { AGENT_MODELS, EFFORT_LEVELS, PERMISSION_MODES, type Project, type Session, type SessionStatus } from "@realm/contracts";
+import { AGENT_MODELS, AGENT_SUPPORTS_PERMISSION_MODES, EFFORT_LEVELS, PERMISSION_MODES, type Project, type Session, type SessionStatus } from "@realm/contracts";
 import { Icon } from "@realm/ui";
 import { useLayoutEffect, useRef, useState, type KeyboardEvent } from "react";
 import type { SessionOptions } from "../../state/store";
@@ -14,6 +14,9 @@ export function Composer({ session, status, project, onSend, onStop, onOptions }
   const ta = useRef<HTMLTextAreaElement>(null);
   const running = status === "running" || status === "waiting_permission";
   const models = AGENT_MODELS[session.agentKind] as ReadonlyArray<{ id: string; label: string }>;
+  // Hidden exactly like the model picker is when the agent has no models: an option Realm cannot transmit
+  // is worse than no option at all.
+  const canSetPermissionMode = AGENT_SUPPORTS_PERMISSION_MODES[session.agentKind];
   const cwdName = session.cwd.replace(/\/+$/, "").split("/").pop() || session.cwd;
 
   useLayoutEffect(() => {
@@ -43,9 +46,11 @@ export function Composer({ session, status, project, onSend, onStop, onOptions }
             {!session.effort && <option value="">Default effort</option>}
             {EFFORT_LEVELS.map((l) => <option key={l} value={l}>{l}</option>)}
           </select>
-          <select aria-label="Permission mode" className="composer-select" value={session.permissionMode} onChange={(e) => onOptions({ permissionMode: e.target.value })}>
-            {PERMISSION_MODES.map((m) => <option key={m.id} value={m.id}>{m.label}</option>)}
-          </select>
+          {canSetPermissionMode && (
+            <select aria-label="Permission mode" className="composer-select" value={session.permissionMode} onChange={(e) => onOptions({ permissionMode: e.target.value })}>
+              {PERMISSION_MODES.map((m) => <option key={m.id} value={m.id}>{m.label}</option>)}
+            </select>
+          )}
           <span className="composer-chip" title={session.cwd}><Icon name="folder" size={12} />{project ? `${project.name} · ` : ""}{cwdName}</span>
         </div>
         <div className="composer-actions">

--- a/apps/desktop/src/renderer/src/panes/session/NewSessionSheet.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/NewSessionSheet.tsx
@@ -1,4 +1,4 @@
-import { AGENT_META, AGENT_MODELS, AGENT_LOGIN_HINTS, PERMISSION_MODES, type AgentKind } from "@realm/contracts";
+import { AGENT_META, AGENT_MODELS, AGENT_LOGIN_HINTS, AGENT_SUPPORTS_PERMISSION_MODES, PERMISSION_MODES, type AgentKind } from "@realm/contracts";
 import { Icon } from "@realm/ui";
 import { useEffect, useState } from "react";
 import { useApp } from "../../state/store";
@@ -30,6 +30,9 @@ export function NewSessionSheet() {
   useEffect(() => { if (!agent) { const first = probe.find((p) => p.available); if (first) setAgent(first.kind); } }, [probe, agent]);
 
   const models = agent ? (AGENT_MODELS[agent] as ReadonlyArray<{ id: string; label: string }>) : [];
+  // Hidden exactly like the model picker is when the agent has no models: an option Realm cannot transmit
+  // is worse than no option at all.
+  const canSetPermissionMode = !agent || AGENT_SUPPORTS_PERMISSION_MODES[agent];
   const chosen = probe.find((p) => p.kind === agent);
   const canCreate = !!agent && !!chosen?.available;
   const submit = () => {
@@ -70,11 +73,13 @@ export function NewSessionSheet() {
             </select>
           </label>
         )}
-        <label className="field"><span>Permissions</span>
-          <select aria-label="Permission mode" value={permissionMode} onChange={(e) => setPermissionMode(e.target.value)}>
-            {PERMISSION_MODES.map((m) => <option key={m.id} value={m.id}>{m.label}</option>)}
-          </select>
-        </label>
+        {canSetPermissionMode && (
+          <label className="field"><span>Permissions</span>
+            <select aria-label="Permission mode" value={permissionMode} onChange={(e) => setPermissionMode(e.target.value)}>
+              {PERMISSION_MODES.map((m) => <option key={m.id} value={m.id}>{m.label}</option>)}
+            </select>
+          </label>
+        )}
         <div className="form-actions">
           <button type="button" className="btn" onClick={closeSheet}>Cancel</button>
           <button type="submit" className="btn primary" disabled={!canCreate}>Create</button>

--- a/apps/desktop/src/renderer/src/panes/session/NewSessionSheet.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/NewSessionSheet.tsx
@@ -1,4 +1,4 @@
-import { AGENT_META, AGENT_MODELS, PERMISSION_MODES, type AgentKind } from "@realm/contracts";
+import { AGENT_META, AGENT_MODELS, AGENT_LOGIN_HINTS, PERMISSION_MODES, type AgentKind } from "@realm/contracts";
 import { Icon } from "@realm/ui";
 import { useEffect, useState } from "react";
 import { useApp } from "../../state/store";
@@ -44,7 +44,6 @@ export function NewSessionSheet() {
           <div className="agent-list" role="radiogroup" aria-label="Agent">
             {probing && probe.length === 0 && <div className="muted">Checking installed agents…</div>}
             {probeError && <div className="agent-error" role="alert">Couldn't check agents: {probeError}</div>}
-            {probe.some((p) => p.kind === "claude") && <div className="agent-hint-text muted">Claude uses your <code>claude</code> login — run <code>claude auth login</code> if sessions fail to authenticate.</div>}
             {!probing && !probeError && probe.length === 0 && <div className="muted">No agents available.</div>}
             {probe.map((p) => (
               <button type="button" key={p.kind} role="radio" aria-checked={agent === p.kind} className="agent-choice" data-selected={agent === p.kind || undefined}
@@ -55,6 +54,7 @@ export function NewSessionSheet() {
               </button>
             ))}
           </div>
+          {agent && <div className="agent-hint-text muted">{AGENT_LOGIN_HINTS[agent]}</div>}
         </div>
         <label className="field"><span>Working directory</span>
           <select aria-label="Working directory" value={projectId} onChange={(e) => setProjectId(e.target.value)}>

--- a/apps/desktop/src/renderer/src/panes/session/session-pane.test.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/session-pane.test.tsx
@@ -154,4 +154,22 @@ describe("NewSessionSheet", () => {
     expect(store.getState().sheet).toBeNull();
     expect(store.getState().items.some((i) => i.kind === "session" && i.refId === s.id)).toBe(true);
   });
+
+  it("shows a login hint for the selected agent only, and it switches when the selection changes", async () => {
+    const api = fakeApi();
+    api.probeAgents = async () => [
+      { kind: "fake", available: true, version: "fake", loggedIn: true, reason: null },
+      { kind: "claude", available: true, version: "1.0", loggedIn: true, reason: null },
+    ];
+    const store = createAppStore(api); await store.getState().boot();
+    store.getState().openSheet({ kind: "new-session" });
+    render(<StoreContext.Provider value={store}><NewSessionSheet /></StoreContext.Provider>);
+    await waitFor(() => expect(screen.getByRole("radio", { name: /Fake agent/ })).toHaveAttribute("aria-checked", "true"));
+    expect(screen.getByText(/Scripted offline agent used for development\./)).toBeInTheDocument();
+    expect(screen.queryByText(/claude auth login/)).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("radio", { name: /Claude/ }));
+    await waitFor(() => expect(screen.getByRole("radio", { name: /Claude/ })).toHaveAttribute("aria-checked", "true"));
+    expect(screen.getByText(/claude auth login/)).toBeInTheDocument();
+    expect(screen.queryByText(/Scripted offline agent used for development\./)).not.toBeInTheDocument();
+  });
 });

--- a/apps/desktop/src/renderer/src/panes/session/session-pane.test.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/session-pane.test.tsx
@@ -24,6 +24,14 @@ async function mount(status: "idle" | "running" | "waiting_permission" = "waitin
   return { api, store, ...r };
 }
 
+/** Mounts the pane for a session of a given agent kind — the composer's option set is per-kind. */
+async function mountKind(agentKind: "codex" | "acp:cursor") {
+  const api = fakeApi({ sessions: [session("se1", "s1", { status: "idle", agentKind })] });
+  const store = createAppStore(api); await store.getState().boot();
+  store.setState({ sessionStatus: { se1: "idle" }, transcripts: { se1: { lastSeq: 0, t: reduceAll([]) } } });
+  return render(<StoreContext.Provider value={store}><SessionPane item={item("i9", "s1", { kind: "session", refId: "se1", title: "s" })} visible /></StoreContext.Provider>);
+}
+
 describe("SessionPane", () => {
   it("renders transcript blocks, shows permission card, and sends composer text", async () => {
     const { api } = await mount();
@@ -105,6 +113,16 @@ describe("SessionPane", () => {
     expect(screen.getByRole("alert")).toHaveTextContent("OAuth session expired");
     expect(screen.getByText("/a/b.ts")).toBeInTheDocument();
   });
+
+  it("offers the composer permission picker only for agents whose permission model Realm controls", async () => {
+    const codex = await mountKind("codex");
+    expect(screen.getByRole("combobox", { name: "Permission mode" })).toBeInTheDocument();
+    codex.unmount();
+    // AcpAdapter never transmits Realm's mode ids, so the picker would silently do nothing for an ACP agent.
+    await mountKind("acp:cursor");
+    expect(screen.queryByRole("combobox", { name: "Permission mode" })).toBeNull();
+    expect(screen.getByRole("combobox", { name: "Effort" })).toBeInTheDocument(); // the rest of the bar is untouched
+  });
 });
 
 describe("markdown + summaries", () => {
@@ -171,5 +189,21 @@ describe("NewSessionSheet", () => {
     await waitFor(() => expect(screen.getByRole("radio", { name: /Claude/ })).toHaveAttribute("aria-checked", "true"));
     expect(screen.getByText(/claude auth login/)).toBeInTheDocument();
     expect(screen.queryByText(/Scripted offline agent used for development\./)).not.toBeInTheDocument();
+  });
+  it("hides the Permissions field for an ACP agent and keeps it for Codex", async () => {
+    const api = fakeApi();
+    api.probeAgents = async () => [
+      { kind: "codex", available: true, version: "1.0", loggedIn: true, reason: null },
+      { kind: "acp:cursor", available: true, version: "1.0", loggedIn: true, reason: null },
+    ];
+    const store = createAppStore(api); await store.getState().boot();
+    store.getState().openSheet({ kind: "new-session" });
+    render(<StoreContext.Provider value={store}><NewSessionSheet /></StoreContext.Provider>);
+    await waitFor(() => expect(screen.getByRole("radio", { name: /Codex/ })).toHaveAttribute("aria-checked", "true"));
+    expect(screen.getByRole("combobox", { name: "Permission mode" })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("radio", { name: /Cursor/ }));
+    // Offering Plan for an agent that never receives it is the dangerous kind of inconsistency.
+    await waitFor(() => expect(screen.queryByRole("combobox", { name: "Permission mode" })).toBeNull());
+    expect(screen.getByRole("combobox", { name: "Working directory" })).toBeInTheDocument();
   });
 });

--- a/apps/server/scripts/live-agent-check.ts
+++ b/apps/server/scripts/live-agent-check.ts
@@ -1,0 +1,124 @@
+/**
+ * Live end-to-end check of the Realm agent stack against the REAL agent CLIs.
+ *
+ * Boots the actual server (`createApp` + `defaultAdapters`), creates a session per agent kind,
+ * sends a real prompt, and asserts the normalized SessionEvent stream that SessionService persisted.
+ * This exercises everything the unit tests stub out: process spawn, the real wire protocols, the
+ * registry wiring (including whether each ACP kind got its own binary), and resume.
+ *
+ *   pnpm --filter @realm/server exec tsx scripts/live-agent-check.ts [kinds] [prompt]
+ *   pnpm --filter @realm/server exec tsx scripts/live-agent-check.ts codex,acp:cursor
+ *
+ * Exits non-zero if any check fails. Requires the relevant CLIs to be installed and logged in.
+ */
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { AgentKind, SessionEvent } from "@realm/contracts";
+import { createApp, defaultAdapters } from "../src/app";
+import { ProfilesStore } from "../src/store/profiles";
+import { SpacesStore } from "../src/store/spaces";
+
+const KINDS = (process.argv[2] ?? "codex,acp:cursor").split(",").filter(Boolean) as AgentKind[];
+const PROMPT = process.argv[3] ?? "Reply with exactly: REALM OK";
+const TURN_TIMEOUT_MS = 120_000;
+const RESUME_TIMEOUT_MS = 60_000;
+
+let failures = 0;
+const ok = (label: string, cond: boolean, detail = "") => {
+  console.log(`  ${cond ? "PASS" : "FAIL"}  ${label}${detail ? ` — ${detail}` : ""}`);
+  if (!cond) failures += 1;
+};
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+/** Poll the persisted event log until the turn settles (idle after text, or a terminal status). */
+async function drain(read: () => SessionEvent[], timeoutMs: number): Promise<SessionEvent[]> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const evs = read();
+    const lastStatus = evs.filter((e) => e.type === "status").at(-1)?.payload.status;
+    const settled = lastStatus === "idle" && evs.some((e) => e.type === "assistant_text");
+    if (settled || lastStatus === "error" || lastStatus === "ended") return evs;
+    await sleep(200);
+  }
+  return read();
+}
+
+async function main() {
+  const home = mkdtempSync(join(tmpdir(), "realm-live-"));
+  const work = mkdtempSync(join(tmpdir(), "realm-work-"));
+  writeFileSync(join(work, "NOTES.txt"), "realm live check\n");
+
+  const app = await createApp({ home, port: 0, adapters: defaultAdapters() });
+  console.log(`server up on :${app.port}\n`);
+
+  const probes = await app.sessions.probeAll();
+  console.log("probes:");
+  for (const p of probes) {
+    console.log(`  ${p.kind.padEnd(12)} available=${String(p.available).padEnd(5)} version=${(p.version ?? "-").padEnd(24)} loggedIn=${p.loggedIn} ${p.reason ?? ""}`);
+  }
+
+  const profile = new ProfilesStore(app.db).create({ name: "Live", icon: "home", color: "#7c6cff" });
+  const space = new SpacesStore(app.db, home).create({ profileId: profile.id, name: "Live", icon: "home" });
+
+  for (const kind of KINDS) {
+    console.log(`\n=== ${kind} ===`);
+    const probe = probes.find((p) => p.kind === kind);
+    if (!probe?.available) { ok("agent available", false, probe?.reason ?? "not registered"); continue; }
+
+    const { session } = app.sessions.create({
+      spaceId: space.id, agentKind: kind, projectId: null,
+      model: null, effort: null, permissionMode: "bypassPermissions",
+    });
+    // Run in a scratch dir rather than the space folder so file tools have something harmless to touch.
+    app.db.prepare("UPDATE sessions SET cwd = ? WHERE id = ?").run(work, session.id);
+
+    const read = () => app.sessions.events(session.id, 0, 1000).map((s) => s.event);
+
+    const t0 = Date.now();
+    await app.sessions.send(session.id, { text: PROMPT, attachments: [] });
+    const sendMs = Date.now() - t0;
+    const evs = await drain(read, TURN_TIMEOUT_MS);
+
+    const text = evs.filter((e) => e.type === "assistant_text").map((e) => (e.payload as { text: string }).text).join("");
+    const errs = evs.filter((e) => e.type === "error").map((e) => (e.payload as { message: string }).message);
+    const init = evs.find((e) => e.type === "init");
+    const providerId = init ? (init.payload as { providerSessionId: string }).providerSessionId : null;
+    const userMsgs = evs.filter((e) => e.type === "user_message").length;
+
+    ok("send() returns on acceptance, not turn completion", sendMs < 20_000, `${sendMs}ms`);
+    ok("init emitted with a providerSessionId", !!providerId, providerId ?? "none");
+    ok("assistant text received", text.trim().length > 0, JSON.stringify(text.slice(0, 60)));
+    ok("exactly one user_message (SessionService owns it)", userMsgs === 1, String(userMsgs));
+    ok("no error events", errs.length === 0, errs.join(" | ").slice(0, 240));
+    ok("session row ends idle", app.sessions.get(session.id).status === "idle", app.sessions.get(session.id).status);
+    console.log(`  events: ${evs.map((e) => e.type).join(" ")}`);
+
+    // Resume: drop the live handle the way a restart would, then send again.
+    await app.sessions.closeAll();
+    (app.sessions as unknown as { closing: boolean }).closing = false;
+    app.sessions.markStaleOnBoot();
+
+    const before = read().length;
+    await app.sessions.send(session.id, { text: "Reply with exactly: RESUMED", attachments: [] });
+    await drain(read, RESUME_TIMEOUT_MS);
+    const after = read().slice(before);
+    const init2 = after.find((e) => e.type === "init");
+    const resumedId = init2 ? (init2.payload as { providerSessionId: string }).providerSessionId : null;
+    const text2 = after.filter((e) => e.type === "assistant_text").map((e) => (e.payload as { text: string }).text).join("");
+
+    ok("resume reuses the provider session id", !!resumedId && resumedId === providerId, `${resumedId} vs ${providerId}`);
+    ok("resumed turn produced text", text2.trim().length > 0, JSON.stringify(text2.slice(0, 60)));
+    ok("no duplicated history on resume", after.filter((e) => e.type === "user_message").length === 1,
+      String(after.filter((e) => e.type === "user_message").length));
+  }
+
+  await app.close();
+  rmSync(home, { recursive: true, force: true });
+  rmSync(work, { recursive: true, force: true });
+  console.log(`\n${failures === 0 ? "ALL CHECKS PASSED" : `${failures} CHECK(S) FAILED`}`);
+  process.exit(failures === 0 ? 0 : 1);
+}
+
+main().catch((e) => { console.error("driver crashed:", e); process.exit(2); });

--- a/apps/server/scripts/live-agent-check.ts
+++ b/apps/server/scripts/live-agent-check.ts
@@ -21,8 +21,15 @@ import { SpacesStore } from "../src/store/spaces";
 
 const KINDS = (process.argv[2] ?? "codex,acp:cursor").split(",").filter(Boolean) as AgentKind[];
 const PROMPT = process.argv[3] ?? "Reply with exactly: REALM OK";
+/**
+ * Per-turn budget, applied to the resume leg too.
+ *
+ * It has to be this generous: `cursor-agent acp` sits silent for a fixed ~60s after `session/prompt` before it
+ * streams a single chunk (reproducible with a bare JSON-RPC client, so it is the CLI, not Realm). The resume leg
+ * used to get half this, which put the deadline within a few hundred milliseconds of when the answer actually
+ * arrives — the turn was still in flight when the check gave up on it.
+ */
 const TURN_TIMEOUT_MS = 120_000;
-const RESUME_TIMEOUT_MS = 60_000;
 
 let failures = 0;
 const ok = (label: string, cond: boolean, detail = "") => {
@@ -32,17 +39,23 @@ const ok = (label: string, cond: boolean, detail = "") => {
 
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
-/** Poll the persisted event log until the turn settles (idle after text, or a terminal status). */
-async function drain(read: () => SessionEvent[], timeoutMs: number): Promise<SessionEvent[]> {
+/**
+ * Poll the persisted event log until the turn that begins at index `from` settles, and return that turn's slice.
+ *
+ * Scoped to `from` rather than to the whole log on purpose: `read()` hands back the session's entire history, and
+ * on the resume leg that history already ends in the previous turn's `assistant_text` followed by `idle`. A
+ * whole-history condition is therefore satisfiable before the new turn has produced anything at all.
+ */
+async function drain(read: () => SessionEvent[], from: number, timeoutMs: number): Promise<SessionEvent[]> {
   const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    const evs = read();
+  for (;;) {
+    const evs = read().slice(from);
     const lastStatus = evs.filter((e) => e.type === "status").at(-1)?.payload.status;
     const settled = lastStatus === "idle" && evs.some((e) => e.type === "assistant_text");
     if (settled || lastStatus === "error" || lastStatus === "ended") return evs;
+    if (Date.now() >= deadline) return evs;
     await sleep(200);
   }
-  return read();
 }
 
 async function main() {
@@ -76,10 +89,11 @@ async function main() {
 
     const read = () => app.sessions.events(session.id, 0, 1000).map((s) => s.event);
 
+    const from = read().length;
     const t0 = Date.now();
     await app.sessions.send(session.id, { text: PROMPT, attachments: [] });
     const sendMs = Date.now() - t0;
-    const evs = await drain(read, TURN_TIMEOUT_MS);
+    const evs = await drain(read, from, TURN_TIMEOUT_MS);
 
     const text = evs.filter((e) => e.type === "assistant_text").map((e) => (e.payload as { text: string }).text).join("");
     const errs = evs.filter((e) => e.type === "error").map((e) => (e.payload as { message: string }).message);
@@ -102,8 +116,7 @@ async function main() {
 
     const before = read().length;
     await app.sessions.send(session.id, { text: "Reply with exactly: RESUMED", attachments: [] });
-    await drain(read, RESUME_TIMEOUT_MS);
-    const after = read().slice(before);
+    const after = await drain(read, before, TURN_TIMEOUT_MS);
     const init2 = after.find((e) => e.type === "init");
     const resumedId = init2 ? (init2.payload as { providerSessionId: string }).providerSessionId : null;
     const text2 = after.filter((e) => e.type === "assistant_text").map((e) => (e.payload as { text: string }).text).join("");

--- a/apps/server/src/app.test.ts
+++ b/apps/server/src/app.test.ts
@@ -14,4 +14,10 @@ describe("defaultAdapters", () => {
     expect(defaultAdapters().fake).toBeDefined();
     delete process.env.REALM_ENABLE_FAKE_AGENT;
   });
+
+  it("registers both ACP agents with their own launch commands", () => {
+    const reg = defaultAdapters();
+    expect(reg["acp:cursor"]?.kind).toBe("acp:cursor");
+    expect(reg["acp:gemini"]?.kind).toBe("acp:gemini");
+  });
 });

--- a/apps/server/src/app.test.ts
+++ b/apps/server/src/app.test.ts
@@ -8,11 +8,17 @@ describe("defaultAdapters", () => {
     expect(reg.codex?.kind).toBe("codex");
   });
   it("only registers the fake agent behind the env flag", () => {
-    delete process.env.REALM_ENABLE_FAKE_AGENT;
-    expect(defaultAdapters().fake).toBeUndefined();
-    process.env.REALM_ENABLE_FAKE_AGENT = "1";
-    expect(defaultAdapters().fake).toBeDefined();
-    delete process.env.REALM_ENABLE_FAKE_AGENT;
+    const before = process.env.REALM_ENABLE_FAKE_AGENT;
+    try {
+      delete process.env.REALM_ENABLE_FAKE_AGENT;
+      expect(defaultAdapters().fake).toBeUndefined();
+      process.env.REALM_ENABLE_FAKE_AGENT = "1";
+      expect(defaultAdapters().fake).toBeDefined();
+    } finally {
+      // A failed assertion would otherwise leave the flag set for every later test in this process.
+      if (before === undefined) delete process.env.REALM_ENABLE_FAKE_AGENT;
+      else process.env.REALM_ENABLE_FAKE_AGENT = before;
+    }
   });
 
   it("registers both ACP agents with their own launch commands", () => {

--- a/apps/server/src/app.test.ts
+++ b/apps/server/src/app.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from "vitest";
+import { defaultAdapters } from "./app";
+
+describe("defaultAdapters", () => {
+  it("registers claude and codex by default", () => {
+    const reg = defaultAdapters();
+    expect(Object.keys(reg).sort()).toContain("codex");
+    expect(reg.codex?.kind).toBe("codex");
+  });
+  it("only registers the fake agent behind the env flag", () => {
+    delete process.env.REALM_ENABLE_FAKE_AGENT;
+    expect(defaultAdapters().fake).toBeUndefined();
+    process.env.REALM_ENABLE_FAKE_AGENT = "1";
+    expect(defaultAdapters().fake).toBeDefined();
+    delete process.env.REALM_ENABLE_FAKE_AGENT;
+  });
+});

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -9,16 +9,16 @@ import { TerminalsStore } from "./store/terminals";
 import { TerminalService } from "./terminals/service";
 import { SessionsStore, SessionEventsStore } from "./store/sessions";
 import { SessionService } from "./sessions/service";
-import { ClaudeAdapter, FakeAdapter, type AdapterRegistry } from "@realm/adapters";
+import { ClaudeAdapter, CodexAdapter, FakeAdapter, type AdapterRegistry } from "@realm/adapters";
 import { RpcServer } from "./rpc/server";
 import { registerMethods } from "./rpc/methods";
 
 export type App = { port: number; db: Db; terminals: TerminalService; sessions: SessionService; close(): Promise<void> };
 export const SERVER_VERSION = "0.0.1";
 
-/** Claude always; the scripted fake only when REALM_ENABLE_FAKE_AGENT=1 (offline dev). */
+/** Claude and Codex always; the scripted fake only when REALM_ENABLE_FAKE_AGENT=1 (offline dev). */
 export function defaultAdapters(): AdapterRegistry {
-  const reg: AdapterRegistry = { claude: new ClaudeAdapter() };
+  const reg: AdapterRegistry = { claude: new ClaudeAdapter(), codex: new CodexAdapter() };
   if (process.env.REALM_ENABLE_FAKE_AGENT === "1") reg.fake = new FakeAdapter({ script: [], delayMs: 15 });
   return reg;
 }

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -9,16 +9,37 @@ import { TerminalsStore } from "./store/terminals";
 import { TerminalService } from "./terminals/service";
 import { SessionsStore, SessionEventsStore } from "./store/sessions";
 import { SessionService } from "./sessions/service";
-import { ClaudeAdapter, CodexAdapter, FakeAdapter, type AdapterRegistry } from "@realm/adapters";
+import { ClaudeAdapter, CodexAdapter, AcpAdapter, FakeAdapter, type AdapterRegistry } from "@realm/adapters";
 import { RpcServer } from "./rpc/server";
 import { registerMethods } from "./rpc/methods";
 
 export type App = { port: number; db: Db; terminals: TerminalService; sessions: SessionService; close(): Promise<void> };
 export const SERVER_VERSION = "0.0.1";
 
-/** Claude and Codex always; the scripted fake only when REALM_ENABLE_FAKE_AGENT=1 (offline dev). */
+/**
+ * Claude, Codex and both ACP agents are always registered; availability is reported by `agents.probe` so the
+ * New Session sheet can disable the ones that are not installed or not signed in. The scripted fake is only
+ * registered when REALM_ENABLE_FAKE_AGENT=1 (offline dev).
+ */
 export function defaultAdapters(): AdapterRegistry {
-  const reg: AdapterRegistry = { claude: new ClaudeAdapter(), codex: new CodexAdapter() };
+  const reg: AdapterRegistry = {
+    claude: new ClaudeAdapter(),
+    codex: new CodexAdapter(),
+    "acp:cursor": new AcpAdapter({
+      kind: "acp:cursor",
+      bin: process.env.REALM_CURSOR_BIN ?? "cursor-agent",
+      args: ["acp"],
+      label: "Cursor",
+      loginHint: "Run `cursor-agent login`.",
+    }),
+    "acp:gemini": new AcpAdapter({
+      kind: "acp:gemini",
+      bin: process.env.REALM_GEMINI_BIN ?? "gemini",
+      args: ["--acp"],
+      label: "Gemini",
+      loginHint: "Gemini's free personal tier was discontinued — configure a Gemini API key or Vertex AI credentials.",
+    }),
+  };
   if (process.env.REALM_ENABLE_FAKE_AGENT === "1") reg.fake = new FakeAdapter({ script: [], delayMs: 15 });
   return reg;
 }

--- a/docs/superpowers/plans/2026-08-22-plan-03-codex-acp-adapters.md
+++ b/docs/superpowers/plans/2026-08-22-plan-03-codex-acp-adapters.md
@@ -87,18 +87,20 @@ process.stdin.on("data", (c) => {
     const msg = JSON.parse(line);
     if (msg.method === "ping") process.stdout.write(JSON.stringify({ id: msg.id, result: { pong: msg.params?.n ?? 0 } }) + "\\n");
     if (msg.method === "boom") process.stdout.write(JSON.stringify({ id: msg.id, error: { code: -32600, message: "nope", data: { action: "relogin" } } }) + "\\n");
-    if (msg.method === "provoke") {
-      // server -> client request using id 0, which collides with our own client id space
-      process.stdout.write(JSON.stringify({ method: "askYou", id: 0, params: { q: "ok?" } }) + "\\n");
+    if (msg.method === "slowPing") {
+      // Fire a server -> client request that REUSES this same request's id while it is still pending,
+      // then deliver the real response ~150ms later. A dispatcher that resolves by id-lookup instead of
+      // frame shape would settle the client's promise from the collision, not the real response.
+      process.stdout.write(JSON.stringify({ method: "askYou", id: msg.id, params: { q: "ok?" } }) + "\\n");
+      setTimeout(() => process.stdout.write(JSON.stringify({ id: msg.id, result: { pong: msg.params?.n ?? 0 } }) + "\\n"), 150);
     }
     if (msg.method === "notifyMe") process.stdout.write(JSON.stringify({ method: "tick", params: { at: 1 }, emittedAtMs: 7 }) + "\\n");
-    if (msg.id === 0 && msg.result) process.stdout.write(JSON.stringify({ method: "answered", params: msg.result }) + "\\n");
     if (msg.method === "loud") process.stderr.write("noise-1\\nnoise-2\\n");
   }
 });
 `;
 
-const make = (over: Partial<Parameters<typeof StdioJsonRpc.prototype.constructor>[0]> = {}) => {
+const make = (over: Partial<ConstructorParameters<typeof StdioJsonRpc>[0]> = {}) => {
   const notifications: { method: string; params: unknown }[] = [];
   const serverRequests: { id: number | string; method: string; params: unknown }[] = [];
   const stderr: string[] = [];
@@ -132,29 +134,31 @@ describe("StdioJsonRpc", () => {
   });
 
   it("dispatches a server request whose id collides with a live client id", async () => {
-    const { rpc, serverRequests, notifications } = make();
-    // Burn client id 1..N so ids overlap, and keep a request in flight.
-    const inFlight = rpc.request("ping", { n: 1 });
-    await rpc.request("provoke");
+    const { rpc, serverRequests } = make();
+    // The child immediately fires a server request reusing this SAME id while the request is still
+    // pending, then delays the real response ~150ms. This is a genuine race, not a coincidence of
+    // disjoint id spaces: id-first dispatch would find the pending entry and settle the promise wrong.
+    const inFlight = rpc.request("slowPing", { n: 1 });
     await vi.waitFor(() => expect(serverRequests).toHaveLength(1));
-    expect(serverRequests[0]).toMatchObject({ id: 0, method: "askYou" });
-    // The in-flight client request must NOT have been resolved by the server request.
+    expect(serverRequests[0]).toMatchObject({ method: "askYou" });
+    const liveId = serverRequests[0]!.id;
+    // The colliding server request must not have touched the pending client request: it should still
+    // resolve, ~150ms later, from the real deferred response and not from the collision.
     await expect(inFlight).resolves.toEqual({ pong: 1 });
-    rpc.respond(0, { ok: true });
-    await vi.waitFor(() => expect(notifications.map((n) => n.method)).toContain("answered"));
+    rpc.respond(liveId, { ok: true });
     await rpc.dispose();
   });
 
   it("delivers notifications (which have no id)", async () => {
     const { rpc, notifications } = make();
-    await rpc.request("notifyMe");
+    rpc.notify("notifyMe");
     await vi.waitFor(() => expect(notifications).toContainEqual({ method: "tick", params: { at: 1 } }));
     await rpc.dispose();
   });
 
   it("keeps a bounded stderr tail and forwards lines", async () => {
     const { rpc, stderr } = make();
-    await rpc.request("loud");
+    rpc.notify("loud");
     await vi.waitFor(() => expect(stderr).toEqual(["noise-1", "noise-2"]));
     expect(rpc.stderrTail).toEqual(["noise-1", "noise-2"]);
     await rpc.dispose();

--- a/docs/superpowers/plans/2026-08-22-plan-03-codex-acp-adapters.md
+++ b/docs/superpowers/plans/2026-08-22-plan-03-codex-acp-adapters.md
@@ -506,6 +506,29 @@ describe("createCodexMapper", () => {
     expect(out[1]).toMatchObject({ type: "status", payload: { status: "idle" } });
   });
 
+  it("labels a force-closed item with the turn status when the turn wasn't interrupted", () => {
+    // Pins the non-interrupted branch of the force-close wording: it should never read as if the
+    // turn itself succeeded/failed with that word as its result — it should say what actually happened
+    // (the item never got its own item/completed).
+    const m = createCodexMapper();
+    m.map("turn/started", { turn: { id: "t1" } });
+    m.map("item/started", { item: { type: "commandExecution", id: "c10", command: "sleep 60", cwd: "/tmp" } });
+    const out = m.map("turn/completed", { turn: { id: "t1", status: "completed", items: [] } });
+    expect(out[0]).toMatchObject({ type: "tool_result", payload: { toolUseId: "c10", isError: true, content: "turn ended without a result (completed)" } });
+  });
+
+  it("emits only status on a normal completion — no leftover tool_result once item/completed already closed the item", () => {
+    // Regression guard for the openTools bookkeeping: if item/completed stopped deleting the id from
+    // openTools, turn/completed would force-close it a second time and every tool call in every turn
+    // would get a spurious extra error tool_result.
+    const m = createCodexMapper();
+    m.map("turn/started", { turn: { id: "t1" } });
+    m.map("item/started", { item: { type: "commandExecution", id: "c11", command: "echo hi", cwd: "/tmp" } });
+    m.map("item/completed", { item: { type: "commandExecution", id: "c11", status: "completed", aggregatedOutput: "hi\n", exitCode: 0 } });
+    const out = m.map("turn/completed", { turn: { id: "t1", status: "completed", items: [] } });
+    expect(types(out)).toEqual(["status"]);
+  });
+
   it("reports a failed turn as an error before going idle", () => {
     const m = createCodexMapper();
     m.map("turn/started", { turn: { id: "t1" } });
@@ -533,6 +556,51 @@ describe("createCodexMapper", () => {
     const m = createCodexMapper();
     const out = m.map("error", { error: { message: "rate limited" }, willRetry: true });
     expect(out[0]).toMatchObject({ type: "error", payload: { message: "rate limited (retrying)" } });
+  });
+
+  it("maps mcpToolCall to tool_call then tool_result, using server.tool as the name", () => {
+    const m = createCodexMapper();
+    const start = m.map("item/started", { item: { type: "mcpToolCall", id: "mcp1", server: "figma", tool: "get_file", arguments: { fileId: "abc" } } });
+    expect(start[0]).toMatchObject({ type: "tool_call", payload: { toolUseId: "mcp1", name: "figma.get_file", input: { fileId: "abc" }, parentToolUseId: null } });
+    const done = m.map("item/completed", { item: { type: "mcpToolCall", id: "mcp1", status: "completed", result: "ok" } });
+    expect(done[0]).toMatchObject({ type: "tool_result", payload: { toolUseId: "mcp1", content: "ok", isError: false } });
+  });
+
+  it("surfaces the mcpToolCall error field as the result content when the call fails", () => {
+    const m = createCodexMapper();
+    m.map("item/started", { item: { type: "mcpToolCall", id: "mcp2", server: "notion", tool: "search", arguments: {} } });
+    const done = m.map("item/completed", { item: { type: "mcpToolCall", id: "mcp2", status: "failed", error: "401 unauthorized" } });
+    expect(done[0]).toMatchObject({ type: "tool_result", payload: { toolUseId: "mcp2", content: "401 unauthorized", isError: true } });
+  });
+
+  it("appends the exit code to a nonzero-exit command's output", () => {
+    const m = createCodexMapper();
+    m.map("item/started", { item: { type: "commandExecution", id: "c3", command: "false", cwd: "/tmp" } });
+    const done = m.map("item/completed", { item: { type: "commandExecution", id: "c3", status: "failed", aggregatedOutput: "boom", exitCode: 1 } });
+    expect((done[0] as { payload: { content: string } }).payload.content).toBe("boom\n[exit 1]");
+  });
+
+  it("closeOpenTools force-closes items awaiting item/completed and clears them", () => {
+    const m = createCodexMapper();
+    m.map("item/started", { item: { type: "commandExecution", id: "c4", command: "sleep 5", cwd: "/tmp" } });
+    m.map("item/started", { item: { type: "fileChange", id: "p2", status: "inProgress", changes: [] } });
+    const closed = m.closeOpenTools("process exited");
+    expect(closed).toHaveLength(2);
+    expect(closed).toContainEqual({ type: "tool_result", ts: expect.any(Number), payload: { toolUseId: "c4", content: "process exited", isError: true } });
+    expect(closed).toContainEqual({ type: "tool_result", ts: expect.any(Number), payload: { toolUseId: "p2", content: "process exited", isError: true } });
+    // calling it again finds nothing left open
+    expect(m.closeOpenTools("again")).toEqual([]);
+  });
+
+  it("returns no event for item/commandExecution/outputDelta (streamed stdout, coalesced by item/completed)", () => {
+    const m = createCodexMapper();
+    m.map("item/started", { item: { type: "commandExecution", id: "c12", command: "echo hi", cwd: "/tmp" } });
+    expect(m.map("item/commandExecution/outputDelta", { itemId: "c12", delta: "hi\n" })).toEqual([]);
+  });
+
+  it("maps a systemError thread status to the error status", () => {
+    const m = createCodexMapper();
+    expect(m.map("thread/status/changed", { status: { type: "systemError" } })[0]).toMatchObject({ type: "status", payload: { status: "error" } });
   });
 
   it("drops advisory and firehose notifications", () => {
@@ -610,8 +678,8 @@ function toolOutputFor(item: Bag): string {
  * - Advisory notifications return `[]` — the adapter logs them instead of putting them in the transcript.
  */
 export function createCodexMapper() {
-  /** itemId -> tool name, for items still awaiting item/completed. */
-  const openTools = new Map<string, string>();
+  /** itemIds of tool items still awaiting item/completed. */
+  const openTools = new Set<string>();
   let numTurns = 0;
 
   return {
@@ -624,7 +692,7 @@ export function createCodexMapper() {
           const item = obj(p.item);
           const id = str(item.id);
           const name = toolNameFor(item);
-          if (name) { openTools.set(id, name); out.push(sessionEvent("tool_call", { toolUseId: id, name, input: toolInputFor(item), parentToolUseId: null })); }
+          if (name) { openTools.add(id); out.push(sessionEvent("tool_call", { toolUseId: id, name, input: toolInputFor(item), parentToolUseId: null })); }
           return out; // userMessage / agentMessage / reasoning starts carry no Realm event
         }
 
@@ -661,7 +729,8 @@ export function createCodexMapper() {
         case "turn/completed": {
           const turn = obj(p.turn);
           const status = str(turn.status);
-          for (const [id] of openTools) out.push(sessionEvent("tool_result", { toolUseId: id, content: status === "interrupted" ? "interrupted" : status, isError: true }));
+          // An item still open here never got its own item/completed (an interrupt skips it entirely).
+          for (const id of openTools) out.push(sessionEvent("tool_result", { toolUseId: id, content: status === "interrupted" ? "interrupted" : `turn ended without a result (${status})`, isError: true }));
           openTools.clear();
           if (status === "failed") out.push(sessionEvent("error", { message: str(obj(turn.error).message) || "turn failed" }));
           out.push(sessionEvent("status", { status: "idle" }));
@@ -693,7 +762,7 @@ export function createCodexMapper() {
 
     /** Close anything still open — used when the process dies mid-turn. */
     closeOpenTools(reason: string): SessionEvent[] {
-      const out = [...openTools.keys()].map((id) => sessionEvent("tool_result", { toolUseId: id, content: reason, isError: true }));
+      const out = [...openTools].map((id) => sessionEvent("tool_result", { toolUseId: id, content: reason, isError: true }));
       openTools.clear();
       return out;
     },
@@ -704,7 +773,7 @@ export function createCodexMapper() {
 - [ ] **Step 4: Run the test to verify it passes**
 
 Run: `pnpm vitest run packages/adapters/src/codex/map-codex.test.ts`
-Expected: PASS — 12 tests.
+Expected: PASS — 20 tests.
 
 - [ ] **Step 5: Commit**
 

--- a/docs/superpowers/plans/2026-08-22-plan-03-codex-acp-adapters.md
+++ b/docs/superpowers/plans/2026-08-22-plan-03-codex-acp-adapters.md
@@ -96,6 +96,16 @@ process.stdin.on("data", (c) => {
     }
     if (msg.method === "notifyMe") process.stdout.write(JSON.stringify({ method: "tick", params: { at: 1 }, emittedAtMs: 7 }) + "\\n");
     if (msg.method === "loud") process.stderr.write("noise-1\\nnoise-2\\n");
+    if (msg.method === "spam") {
+      // 60 lines, one write each, to exercise the 50-line stderrTail cap's shift() branch.
+      for (let n = 1; n <= 60; n++) process.stderr.write("line-" + n + "\\n");
+    }
+    if (msg.method === "big") {
+      // A single large write is split across multiple stdout 'data' chunks by the OS pipe buffer
+      // (well under 500KB on any platform), exercising the outBuf reassembly loop for real.
+      const s = "x".repeat(500000);
+      process.stdout.write(JSON.stringify({ id: msg.id, result: { s: s } }) + "\\n");
+    }
   }
 });
 `;
@@ -125,11 +135,7 @@ describe("StdioJsonRpc", () => {
 
   it("rejects with a JsonRpcCallError carrying code and data", async () => {
     const { rpc } = make();
-    await expect(rpc.request("boom")).rejects.toBeInstanceOf(JsonRpcCallError);
-    await rpc.request("boom").catch((e: JsonRpcCallError) => {
-      expect(e.code).toBe(-32600);
-      expect(e.data).toEqual({ action: "relogin" });
-    });
+    await expect(rpc.request("boom")).rejects.toMatchObject({ code: -32600, data: { action: "relogin" } });
     await rpc.dispose();
   });
 
@@ -164,10 +170,36 @@ describe("StdioJsonRpc", () => {
     await rpc.dispose();
   });
 
+  it("caps the stderr tail at 50 lines, dropping the oldest", async () => {
+    const { rpc, stderr } = make();
+    rpc.notify("spam");
+    await vi.waitFor(() => expect(stderr).toHaveLength(60));
+    expect(rpc.stderrTail).toHaveLength(50);
+    expect(rpc.stderrTail[0]).toBe("line-11");
+    expect(rpc.stderrTail[49]).toBe("line-60");
+    await rpc.dispose();
+  });
+
+  it("reassembles a JSON-RPC frame split across multiple stdout chunks", async () => {
+    const { rpc } = make();
+    const result = await rpc.request<{ s: string }>("big");
+    expect(result.s).toHaveLength(500_000);
+    expect(result.s).toBe("x".repeat(500_000));
+    await rpc.dispose();
+  });
+
+  it("dispose() reports onExit exactly once with disposed: true", async () => {
+    const { rpc, onExit } = make();
+    await rpc.dispose();
+    expect(onExit).toHaveBeenCalledTimes(1);
+    expect(onExit).toHaveBeenCalledWith(expect.objectContaining({ disposed: true, reason: "disposed" }));
+  });
+
   it("rejects in-flight requests and reports exit when the child dies", async () => {
     const { rpc, onExit } = make({ args: ["-e", "process.exit(3)"] });
     await expect(rpc.request("ping")).rejects.toThrow(/exited/);
     await vi.waitFor(() => expect(onExit).toHaveBeenCalled());
+    expect(onExit).toHaveBeenCalledWith(expect.objectContaining({ disposed: false }));
     await rpc.dispose();
   });
 
@@ -175,6 +207,7 @@ describe("StdioJsonRpc", () => {
     const { rpc, onExit } = make({ command: "/definitely/not/a/binary", args: [] });
     await expect(rpc.request("ping")).rejects.toThrow();
     await vi.waitFor(() => expect(onExit).toHaveBeenCalled());
+    expect(onExit).toHaveBeenCalledWith(expect.objectContaining({ disposed: false }));
     await rpc.dispose();
   });
 });
@@ -205,6 +238,7 @@ export class JsonRpcCallError extends Error {
 }
 
 const STDERR_TAIL_LINES = 50;
+const DISPOSE_KILL_TIMEOUT_MS = 2000;
 
 export type StdioJsonRpcOptions = {
   command: string;
@@ -215,7 +249,9 @@ export type StdioJsonRpcOptions = {
   /** MUST be answered with respond()/respondError() — an unanswered server request stalls the agent's turn forever. */
   onServerRequest: (r: JsonRpcServerRequest) => void;
   onStderr?: (line: string) => void;
-  onExit: (info: { code: number | null; signal: NodeJS.Signals | null; reason: string }) => void;
+  /** `disposed` is the reliable signal for "we caused this shutdown" vs "the child actually died" —
+   *  branch on it, not on parsing `reason`, which is a free-form string for logs only. */
+  onExit: (info: { code: number | null; signal: NodeJS.Signals | null; reason: string; disposed: boolean }) => void;
 };
 
 /**
@@ -234,7 +270,8 @@ export class StdioJsonRpc {
   private outBuf = "";
   private errBuf = "";
   private dead: Error | null = null;
-  readonly stderrTail: string[] = [];
+  private childExited = false;
+  private _stderrTail: string[] = [];
 
   constructor(private o: StdioJsonRpcOptions, deps: { spawn?: typeof nodeSpawn } = {}) {
     const spawnFn = deps.spawn ?? nodeSpawn;
@@ -243,11 +280,24 @@ export class StdioJsonRpc {
     this.child.stderr?.setEncoding("utf8");
     this.child.stdout?.on("data", (c: string) => this.onStdout(c));
     this.child.stderr?.on("data", (c: string) => this.onStderrChunk(c));
-    this.child.on("error", (e: Error) => this.die(`failed to start ${o.command}: ${e.message}`, null, null));
-    this.child.on("exit", (code, signal) => this.die(`${o.command} exited (code ${code ?? "null"}, signal ${signal ?? "null"})`, code, signal));
+    // Stream 'error' (EPIPE, ERR_STREAM_WRITE_AFTER_END, ...) is otherwise unhandled and crashes the whole
+    // process with an uncaughtException. It isn't fatal to the RPC session by itself — 'exit' is what ends
+    // that — so just surface it as a diagnostic.
+    this.child.stdin?.on("error", (e: Error) => this.o.onStderr?.(`stdin error: ${e.message}`));
+    this.child.stdout?.on("error", (e: Error) => this.o.onStderr?.(`stdout error: ${e.message}`));
+    this.child.stderr?.on("error", (e: Error) => this.o.onStderr?.(`stderr error: ${e.message}`));
+    this.child.on("error", (e: Error) => {
+      this.childExited = true; // never actually started; nothing left to reap
+      this.die(`failed to start ${o.command}: ${e.message}`, null, null, false);
+    });
+    this.child.on("exit", (code, signal) => {
+      this.childExited = true;
+      this.die(`${o.command} exited (code ${code ?? "null"}, signal ${signal ?? "null"})`, code, signal, false);
+    });
   }
 
   get alive(): boolean { return this.dead === null; }
+  get stderrTail(): readonly string[] { return [...this._stderrTail]; }
 
   request<T = unknown>(method: string, params?: unknown): Promise<T> {
     if (this.dead) return Promise.reject(this.dead);
@@ -273,15 +323,32 @@ export class StdioJsonRpc {
     this.write({ jsonrpc: "2.0", id, error: { code, message } });
   }
 
+  /**
+   * Sends EOF — most CLI agents exit cleanly on stdin close — then waits briefly for the real process to
+   * go away, escalating to SIGKILL if it hasn't. The child is not spawned detached, so a hard crash of
+   * this process still orphans it; this only covers the graceful path.
+   */
   async dispose(): Promise<void> {
-    if (!this.dead) this.die("disposed", null, null);
+    if (!this.dead) this.die("disposed", null, null, true);
     this.child.stdin?.end();
-    if (this.child.exitCode === null && this.child.signalCode === null) this.child.kill("SIGTERM");
+    await this.reap();
+  }
+
+  private reap(): Promise<void> {
+    if (this.childExited) return Promise.resolve();
+    return new Promise<void>((resolve) => {
+      const finish = () => { clearTimeout(killTimer); resolve(); };
+      this.child.once("exit", finish);
+      this.child.once("error", finish); // spawn never actually started; nothing more to wait for
+      const killTimer = setTimeout(() => this.child.kill("SIGKILL"), DISPOSE_KILL_TIMEOUT_MS);
+    });
   }
 
   private write(msg: unknown): void {
+    // Guards synchronous throws only (e.g. writing after the stream is already destroyed); async write
+    // failures surface via the stdin 'error' listener registered in the constructor instead.
     try { this.child.stdin?.write(JSON.stringify(msg) + "\n"); }
-    catch { /* the exit handler already rejected everything in flight */ }
+    catch { /* swallow: the 'error'/'exit' handlers already reject everything in flight */ }
   }
 
   private onStdout(chunk: string): void {
@@ -305,7 +372,7 @@ export class StdioJsonRpc {
     if (hasId && typeof msg.method === "string") { this.o.onServerRequest({ id, method: msg.method, params: msg.params }); return; }
     if (hasId && ("result" in msg || "error" in msg)) {
       const p = this.pending.get(id);
-      if (!p) return; // a response we never asked for; ignore rather than guess
+      if (!p) { this.o.onStderr?.(`response for unknown request id ${String(id)}: ${line.slice(0, 200)}`); return; }
       this.pending.delete(id);
       if ("error" in msg) {
         const e = (msg.error ?? {}) as { code?: number; message?: string; data?: unknown };
@@ -325,17 +392,17 @@ export class StdioJsonRpc {
       this.errBuf = this.errBuf.slice(i + 1);
       if (!line.trim()) continue;
       this.o.onStderr?.(line);
-      this.stderrTail.push(line);
-      if (this.stderrTail.length > STDERR_TAIL_LINES) this.stderrTail.shift();
+      this._stderrTail.push(line);
+      if (this._stderrTail.length > STDERR_TAIL_LINES) this._stderrTail.shift();
     }
   }
 
-  private die(reason: string, code: number | null, signal: NodeJS.Signals | null): void {
+  private die(reason: string, code: number | null, signal: NodeJS.Signals | null, disposed: boolean): void {
     if (this.dead) return;
     this.dead = new Error(reason);
     for (const [, p] of this.pending) p.reject(this.dead);
     this.pending.clear();
-    this.o.onExit({ code, signal, reason });
+    this.o.onExit({ code, signal, reason, disposed });
   }
 }
 ```
@@ -343,7 +410,7 @@ export class StdioJsonRpc {
 - [ ] **Step 4: Run the test to verify it passes**
 
 Run: `pnpm vitest run packages/adapters/src/jsonrpc/stdio.test.ts`
-Expected: PASS — 7 tests.
+Expected: PASS — 10 tests.
 
 - [ ] **Step 5: Commit**
 

--- a/docs/superpowers/plans/2026-08-22-plan-03-codex-acp-adapters.md
+++ b/docs/superpowers/plans/2026-08-22-plan-03-codex-acp-adapters.md
@@ -8,6 +8,12 @@
 
 **Tech Stack:** No new runtime dependencies. Raw ndjson JSON-RPC rather than `@zed-industries/agent-client-protocol`, because (a) Codex has no SDK at all so the transport must exist regardless, (b) both protocols' shipped types were verified to *lag the live wire* (Codex's `availableDecisions`, Cursor's `sessionCapabilities`), so permissive hand-written types are the correct posture, and (c) the ACP SDK is ESM-only with a Web-Streams argument order that silently hangs when reversed.
 
+> **Status: SHIPPED.** All 12 tasks are implemented and merged. Several tasks deviated from the code blocks
+> below during implementation and review — most notably Task 4's routing rule (the plan's `buffer.has` branch was
+> a bug that made the `-32601` reject path unreachable), Task 4's `onGone(reason, disposed)` signature, and Task
+> 5's/Task 9's refcount and shutdown shapes. **Where this plan and the source disagree, the source is
+> authoritative.** See the follow-up list at the end of this document.
+
 **Protocol references — read these before starting.** They are captured from live processes and are the source of truth for every shape in this plan:
 - `docs/dev/codex-app-server-protocol.md`
 - `docs/dev/acp-protocol.md`
@@ -2720,3 +2726,49 @@ Commit anything the verification turned up, then use `superpowers:finishing-a-de
 - ACP `plan`, `available_commands_update`, and `current_mode_update` are parsed and dropped.
 - ACP sessions emit no `usage`, so the Codex/Claude token display will be blank for them.
 - Gemini is registered but cannot open a session on this machine until an API key or Vertex credentials are configured.
+
+
+---
+
+## Plan 3 follow-ups (recorded, not done)
+
+From the final pre-merge review. None block the merge; all are real.
+
+**Correctness / UX**
+- **Map Realm's permission modes onto ACP's `modes.availableModes`** returned by `session/new`, and apply one at
+  session start. Today `AcpAdapter` ignores `opts.permissionMode` entirely, so the Permissions picker is hidden
+  for `acp:*` kinds (`AGENT_SUPPORTS_PERMISSION_MODES`) rather than wrong. Cursor exposes `agent`/`plan`/`ask`.
+- **Surface ACP's `models` in the model picker.** `session/new` returns ~35 entries for Cursor, including
+  `claude-opus-5`. `AGENT_MODELS["acp:*"]` is `[]`, so these sessions run on the agent's default. Model ids
+  encode options in brackets and must be treated as opaque.
+- **Extend `toolSummary`/`toolIcon`** (`panes/session/tool-summary.ts`) to Codex (`exec_command`, `apply_patch`)
+  and ACP tool titles. They currently fall through to the generic Claude heuristics.
+- **Decide whether Codex's `costUsd: 0` should render blank** rather than `$0.000` — Codex reports no cost, and
+  `$0.000` reads as "free" rather than "unknown". ACP emits no `usage` at all, which is the better behaviour.
+
+**Robustness**
+- **Close the post-detach buffering hole in `CodexConnection`**: `threads.size === 0` is used as the proxy for
+  "startup race", but a detached last thread also leaves size 0, so a late approval for a dead thread is queued
+  rather than refused. Track detached ids or a `hasEverAttached` flag.
+- **Replace peer JSON-RPC ids with `newId()` for `permission_request.requestId`** in both new adapters. Peer ids
+  restart at 0 per process, so persisted ids repeat across restarts. Claude uses `newId()`; no live bug today
+  because the dangling-permission queries are order-based, but it is a latent hazard.
+- **Codex's residual orphan window**: if `dispose()` times out while `CodexConnection.open` is still pending, the
+  child survives until the boot timeout (≤30s). Bounded and leak-free, but closing it fully needs a cancellation
+  path in `open()`.
+- **SIGKILL escalation** in `apps/desktop/src/main/index.ts` — the server is currently sent a bare SIGTERM on quit.
+- **Per-session `env` and the shared Codex process**: the shared `codex app-server` binds `cwd`/`env` from
+  whichever session spawned it. Moot today (`SessionService` never passes `env`) but wrong the moment it does.
+
+**Hygiene**
+- Add `scripts/` to `apps/server/tsconfig.json` so `live-agent-check.ts` is typechecked, and declare `tsx` as a
+  dependency of `@realm/server` (it is currently only a devDependency of `@realm/adapters`).
+- `AGENT_LOGIN_HINTS` renders literal markdown backticks as text; the line it replaced used real `<code>`
+  elements. It also duplicates the copy in each `AcpAgentSpec.loginHint` — two sources that will drift.
+- Dead/asymmetric exports: `AcpCall.kind` is written but never read; `titleOf`/`onUnroutedReply` are test-only
+  hooks on production types; `createCodexMapper` is exported from `index.ts` but `createAcpMapper` is not.
+
+**Known external constraint, not ours to fix**
+- `cursor-agent acp` sits silent for a **fixed ~60s** after `session/prompt` before streaming its first chunk
+  (six samples, 59.97–60.66s, reproducible with a bare JSON-RPC client and unaffected by declared capabilities;
+  `cursor-agent -p` answers in ~2s). Every Cursor turn in Realm will feel a minute slow until Cursor changes this.

--- a/docs/superpowers/plans/2026-08-22-plan-03-codex-acp-adapters.md
+++ b/docs/superpowers/plans/2026-08-22-plan-03-codex-acp-adapters.md
@@ -881,277 +881,207 @@ git commit -m "feat(adapters): codex CLI probe"
 
 ### Task 4: `CodexConnection` — one shared `app-server`, fanned out by `threadId`
 
+**Status: shipped.** The code below is the implementation as merged; `packages/adapters/src/codex/` is authoritative if the two ever drift.
+
 A single `codex app-server` process multiplexes any number of threads, and every notification and approval request is tagged with `threadId` (verified live with two concurrent threads). Realm therefore runs **one** process for all Codex sessions rather than one per session.
 
-Two subtleties this task must handle:
+Subtleties this task handles:
 
-- **The attach race.** Notifications for a thread can arrive before `thread/start` returns and we know its id. The connection buffers frames for unknown thread ids (bounded) and flushes them on `attach`.
-- **Unknown server requests must still be answered.** Codex can send approval kinds we don't implement (`item/permissions/requestApproval`, `item/tool/requestUserInput`). Dropping one stalls the turn permanently, so anything unrouted gets a `-32601` reply.
+- **The attach race.** Notifications for a thread can arrive before `thread/start` returns and we know its id. The connection buffers notifications for unknown thread ids (bounded) and flushes them, in order, on `attach`.
+- **Every server request gets an answer, on every path.** Codex can send approval kinds we don't implement (`item/permissions/requestApproval`, `item/tool/requestUserInput`). Dropping one stalls the turn permanently. So a request is answered — by the thread's listener, or by the connection with a JSON-RPC error — when it is unroutable, when the buffer is full, when its thread detaches with it still queued, and when the listener throws while handling it.
+- **Listener callbacks are never trusted.** They run inside the stdout `data` handler; an escaping throw is an `uncaughtException`, which in Electron main is a whole-app crash caused by one misbehaving session. Every `onNotification` / `onServerRequest` / `onGone` call is wrapped.
 
 **Files:**
 - Create: `packages/adapters/src/codex/connection.ts`
 - Create: `packages/adapters/src/codex/fixtures/fake-codex-server.mjs`
 - Create: `packages/adapters/src/codex/connection.test.ts`
 
-- [ ] **Step 1: Write the fake server fixture**
+- [x] **Step 1: Write the fake server fixture**
 
-Create `packages/adapters/src/codex/fixtures/fake-codex-server.mjs`. This speaks enough of the real protocol to drive the adapter tests, using the exact frame shapes captured in `docs/dev/codex-app-server-protocol.md`:
+`packages/adapters/src/codex/fixtures/fake-codex-server.mjs` — a single coherent script, all state declared up front, speaking the frame shapes captured in `docs/dev/codex-app-server-protocol.md`. Task 5 builds its adapter tests on this file, so fidelity to the captured protocol matters more than brevity.
 
-```js
-// Minimal `codex app-server` stand-in for adapter tests. Newline-delimited JSON-RPC.
-// Responses deliberately omit `jsonrpc`, and server->client requests start at id 0, exactly like the real server.
-let buf = "";
-let threadSeq = 0;
-let turnSeq = 0;
-let serverReqId = 0;
-const send = (o) => process.stdout.write(JSON.stringify(o) + "\n");
-const notify = (method, params) => send({ method, params, emittedAtMs: 1 });
+- Newline-delimited JSON. **Responses omit `jsonrpc`** and **server→client request ids start at 0**, mirroring the real server, so tests exercise the two-id-space handling for real.
+- Client **responses** (`result`/`error`, no `method`) route to the pending-approval logic, checked *before* the request dispatcher since the id spaces overlap. An error response counts as "not accepted", so a refused approval still unblocks the turn.
+- `initialize` → `{ id, result: { userAgent, codexHome } }`; `initialized` → ignored.
+- `thread/start` → `th_N`, `{ thread: { id, status:{type:"idle"}, cwd, turns: [] }, model, cwd }`. `params.model === "explode"` instead returns `{ code: -32600, message: "failed to load configuration", data: { action: "relogin", statusCode: 401 } }` (drives Task 5's revoked-login test). `thread/resume` is the same but reuses `params.threadId`.
+- `turn/start` → `tu_N`, `{ turn: { id, status: "inProgress", items: [] } }`, then streams asynchronously.
+- **Every turn opens with the sequence the real server was captured emitting** (protocol reference §2.4): `thread/status/changed{active}` → `turn/started` → `item/started(userMessage)`, carrying the real input text. What follows keys off that text:
+  - contains `APPROVE`: `item/started`(commandExecution), then a server→client `item/commandExecution/requestApproval` with `availableDecisions: ["accept","cancel"]`, and waits. On the client's answer: `serverRequest/resolved`, `item/completed` (`completed`/`hi\n`/`exitCode 0` on `accept`, else `failed`/`exitCode 1`), `thread/status/changed{idle}`, `turn/completed{completed}`.
+  - contains `HANG`: stops after the opening and never completes the turn. It must still emit the opening — a Task 5 adapter that mishandles `turn/started` would otherwise pass its interrupt tests against a sequence the real server never produces.
+  - otherwise: `item/started`(agentMessage), two `item/agentMessage/delta` (`"hel"`, `"lo"`), `item/completed`(agentMessage, `"hello"`), `thread/tokenUsage/updated` (`total.inputTokens 10`, `outputTokens 2`), `thread/status/changed{idle}`, `turn/completed{completed}`. **Exactly 10 notifications**, which the buffer tests count on.
+- `turn/interrupt` → `{}`, then `thread/status/changed{idle}` and `turn/completed` with `status:"interrupted"`, `items: []`.
+- Every notification carries `threadId` (and `turnId` where turn-scoped) — that is exactly what the connection routes on.
+- Any other request with an id → `-32600`. `process.stdin` `end` → exit, so `dispose()` doesn't wait out its 2s SIGKILL timer on every test.
+- Two test-only hooks: the `$test/exit` request kills the process (so tests can tell an unexpected death from an intentional dispose), and `FAKE_CODEX_MUTE_INITIALIZE=1` makes `initialize` go unanswered (drives the `open()` timeout test).
 
-process.stdin.setEncoding("utf8");
-process.stdin.on("data", (c) => {
-  buf += c;
-  let i;
-  while ((i = buf.indexOf("\n")) >= 0) {
-    const line = buf.slice(0, i); buf = buf.slice(i + 1);
-    if (line.trim()) handle(JSON.parse(line));
-  }
-});
+- [x] **Step 2: Write the failing test**
 
-function handle(msg) {
-  const { id, method, params } = msg;
-  if (method === "initialize") return send({ id, result: { userAgent: "fake/0.0.1", codexHome: "/tmp/codex-home" } });
-  if (method === "initialized") return;
-  if (method === "thread/start" || method === "thread/resume") {
-    const threadId = method === "thread/resume" ? params.threadId : `th_${++threadSeq}`;
-    if (params.model === "explode") return send({ id, error: { code: -32600, message: "failed to load configuration", data: { action: "relogin", statusCode: 401 } } });
-    return send({ id, result: { thread: { id: threadId, status: { type: "idle" }, cwd: params.cwd, turns: [] }, model: params.model ?? "gpt-fake", cwd: params.cwd } });
-  }
-  if (method === "turn/start") {
-    const threadId = params.threadId;
-    const turnId = `tu_${++turnSeq}`;
-    send({ id, result: { turn: { id: turnId, status: "inProgress", items: [] } } });
-    const text = params.input.map((b) => b.text ?? "").join("");
-    queueMicrotask(() => runTurn(threadId, turnId, text));
-    return;
-  }
-  if (method === "turn/interrupt") {
-    send({ id, result: {} });
-    notify("thread/status/changed", { threadId: params.threadId, status: { type: "idle" } });
-    notify("turn/completed", { threadId: params.threadId, turn: { id: params.turnId, status: "interrupted", items: [] } });
-    return;
-  }
-  if (id !== undefined && id !== null) send({ id, error: { code: -32600, message: `unknown method ${method}` } });
-}
+`packages/adapters/src/codex/connection.test.ts` — 17 tests. Each pins one invariant; all are mutation-verified (see Step 6).
 
-function runTurn(threadId, turnId, text) {
-  const base = { threadId, turnId };
-  notify("thread/status/changed", { threadId, status: { type: "active", activeFlags: [] } });
-  notify("turn/started", { threadId, turn: { id: turnId, status: "inProgress" } });
-  notify("item/started", { ...base, item: { type: "userMessage", id: "u1", content: [{ type: "text", text }] } });
+| Test | Invariant it pins |
+| --- | --- |
+| initializes and starts a thread | the handshake works end to end |
+| rejects instead of hanging when the server never answers `initialize` | a spawned-but-mute child fails session creation loudly instead of hanging forever |
+| routes notifications to the attached thread listener only | fan-out by `threadId`; no cross-talk between sessions |
+| delivers an approval to its attached thread and answers nothing itself | **the production approval path** — the listener receives it, its `accept` reaches the child (asserted via `exitCode: 0`), and the connection does *not* also refuse the same id |
+| buffers frames that arrive before attach and flushes them in order | the attach race, and that flush order survives (the mapper needs deltas before `item/completed`) |
+| buffers a server request that arrives before any thread has attached | the buffer branch of the routing rule |
+| answers unroutable server requests with `-32601` so turns never stall | the reject branch — asserted **end to end**, by watching the orphan thread receive `serverRequest/resolved → item/completed → turn/completed`, not just by the `onUnroutedReply` spy |
+| stops buffering at the per-thread cap, and still answers requests it cannot queue | bounded buffer; overflow refuses rather than drops |
+| stops delivering to a detached listener and drops its buffer | both halves of `detach` |
+| answers buffered server requests when their thread detaches | a queued approval is refused, not abandoned, while the child is still alive |
+| survives a listener that throws on a notification | the throw is logged, later frames still land, the connection stays alive |
+| answers `-32603` when a listener throws on a server request | a session-level bug cannot wedge its own turn |
+| keeps fanning out when a listener throws on gone | one broken teardown cannot strand sibling sessions |
+| does not replay an already-flushed buffer to a later listener | `attach` clears the queue before flushing |
+| tells every attached thread when the process dies, flagging an intentional dispose | `onGone(reason, disposed: true)` |
+| reports an unexpected death as not disposed | `onGone(reason, disposed: false)`, including for listeners attaching afterwards |
+| tells a listener that attaches after the process is already gone | no listener silently wired to a dead connection |
 
-  if (text.includes("APPROVE")) {
-    const itemId = "call_1";
-    notify("item/started", { ...base, item: { type: "commandExecution", id: itemId, command: "/bin/zsh -lc 'echo hi'", cwd: "/tmp", status: "inProgress" } });
-    const reqId = serverReqId++;
-    send({ method: "item/commandExecution/requestApproval", id: reqId, params: { ...base, itemId, command: "/bin/zsh -lc 'echo hi'", cwd: "/tmp", availableDecisions: ["accept", "cancel"] } });
-    return; // the rest of the turn waits for our answer (see onApproval)
-  }
-  if (text.includes("HANG")) return; // never completes, for interrupt tests
+Determinism note: tests wait on `c.bufferedCount(threadId)` reaching a known frame count via `vi.waitFor`, never on a bare `setTimeout`. A wall-clock settle would let a frame route *live* instead of through the buffer, silently testing the wrong path.
 
-  notify("item/started", { ...base, item: { type: "agentMessage", id: "msg_1", text: "" } });
-  notify("item/agentMessage/delta", { ...base, itemId: "msg_1", delta: "hel" });
-  notify("item/agentMessage/delta", { ...base, itemId: "msg_1", delta: "lo" });
-  notify("item/completed", { ...base, item: { type: "agentMessage", id: "msg_1", text: "hello" } });
-  notify("thread/tokenUsage/updated", { ...base, tokenUsage: { total: { totalTokens: 12, inputTokens: 10, outputTokens: 2 }, last: {}, modelContextWindow: 1000 } });
-  notify("thread/status/changed", { threadId, status: { type: "idle" } });
-  notify("turn/completed", { threadId, turn: { id: turnId, status: "completed", items: [] } });
-}
-
-// Answering an approval finishes the command and the turn.
-const origHandle = handle;
-process.on("exit", () => {});
-let pendingApproval = null;
-const _send = send;
-// Intercept client responses to our server requests.
-const originalDispatch = handle;
-function onClientResponse(msg) {
-  if (msg.result && msg.result.decision !== undefined) {
-    notify("serverRequest/resolved", { threadId: pendingApproval?.threadId, requestId: msg.id });
-    if (!pendingApproval) return;
-    const { threadId, turnId } = pendingApproval;
-    const base = { threadId, turnId };
-    const accepted = msg.result.decision === "accept";
-    notify("item/completed", { ...base, item: { type: "commandExecution", id: "call_1", status: accepted ? "completed" : "failed", aggregatedOutput: accepted ? "hi\n" : "", exitCode: accepted ? 0 : 1 } });
-    notify("thread/status/changed", { threadId, status: { type: "idle" } });
-    notify("turn/completed", { threadId, turn: { id: turnId, status: "completed", items: [] } });
-    pendingApproval = null;
-  }
-}
-```
-
-Note: the trailing block above is illustrative of intent but duplicates state. **Write the fixture as a single coherent script** — declare `pendingApproval` at the top with the other `let` declarations, set it inside `runTurn` when it sends the approval request, and route client responses from `handle()` like this, replacing the final block:
-
-```js
-function handle(msg) {
-  const { id, method, params, result } = msg;
-  if (result !== undefined && method === undefined) return onClientResponse(msg);
-  // …the method branches above…
-}
-```
-
-- [ ] **Step 2: Write the failing test**
-
-Create `packages/adapters/src/codex/connection.test.ts`:
-
-```ts
-import { describe, it, expect, vi } from "vitest";
-import { fileURLToPath } from "node:url";
-import { CodexConnection } from "./connection";
-
-const FAKE = fileURLToPath(new URL("./fixtures/fake-codex-server.mjs", import.meta.url));
-const open = () => CodexConnection.open({ bin: process.execPath, args: [FAKE], cwd: process.cwd() });
-
-describe("CodexConnection", () => {
-  it("initializes and starts a thread", async () => {
-    const c = await open();
-    const r = await c.request<{ thread: { id: string } }>("thread/start", { cwd: "/tmp" });
-    expect(r.thread.id).toMatch(/^th_/);
-    await c.dispose();
-  });
-
-  it("routes notifications to the attached thread listener only", async () => {
-    const c = await open();
-    const a = await c.request<{ thread: { id: string } }>("thread/start", { cwd: "/tmp" });
-    const b = await c.request<{ thread: { id: string } }>("thread/start", { cwd: "/tmp" });
-    const seenA: string[] = []; const seenB: string[] = [];
-    c.attach(a.thread.id, { onNotification: (m) => seenA.push(m), onServerRequest: () => {}, onGone: () => {} });
-    c.attach(b.thread.id, { onNotification: (m) => seenB.push(m), onServerRequest: () => {}, onGone: () => {} });
-    await c.request("turn/start", { threadId: a.thread.id, input: [{ type: "text", text: "hi", text_elements: [] }] });
-    await vi.waitFor(() => expect(seenA).toContain("turn/completed"));
-    expect(seenB).toEqual([]);
-    await c.dispose();
-  });
-
-  it("buffers frames that arrive before attach and flushes them", async () => {
-    const c = await open();
-    const t = await c.request<{ thread: { id: string } }>("thread/start", { cwd: "/tmp" });
-    await c.request("turn/start", { threadId: t.thread.id, input: [{ type: "text", text: "hi", text_elements: [] }] });
-    await new Promise((r) => setTimeout(r, 50)); // let the whole turn stream out unattached
-    const seen: string[] = [];
-    c.attach(t.thread.id, { onNotification: (m) => seen.push(m), onServerRequest: () => {}, onGone: () => {} });
-    await vi.waitFor(() => expect(seen).toContain("turn/completed"));
-    await c.dispose();
-  });
-
-  it("answers unroutable server requests with -32601 so turns never stall", async () => {
-    const c = await open();
-    const replies: unknown[] = [];
-    c.onUnroutedReply = (id, code) => replies.push({ id, code });
-    // A decoy thread is attached, so the buffering path (which only applies before ANY thread attaches) is off
-    // and an approval for a second, unattached thread must be rejected rather than queued.
-    const decoy = await c.request<{ thread: { id: string } }>("thread/start", { cwd: "/tmp" });
-    c.attach(decoy.thread.id, { onNotification: () => {}, onServerRequest: () => {}, onGone: () => {} });
-    const orphan = await c.request<{ thread: { id: string } }>("thread/start", { cwd: "/tmp" });
-    await c.request("turn/start", { threadId: orphan.thread.id, input: [{ type: "text", text: "APPROVE", text_elements: [] }] });
-    await vi.waitFor(() => expect(replies).toHaveLength(1));
-    expect(replies[0]).toMatchObject({ code: -32601 });
-    await c.dispose();
-  });
-
-  it("tells every attached thread when the process dies", async () => {
-    const c = await open();
-    const t = await c.request<{ thread: { id: string } }>("thread/start", { cwd: "/tmp" });
-    const gone: string[] = [];
-    c.attach(t.thread.id, { onNotification: () => {}, onServerRequest: () => {}, onGone: (r) => gone.push(r) });
-    await c.dispose();
-    await vi.waitFor(() => expect(gone).toHaveLength(1));
-  });
-});
-```
-
-- [ ] **Step 3: Run the test to verify it fails**
+- [x] **Step 3: Run the test to verify it fails**
 
 Run: `pnpm vitest run packages/adapters/src/codex/connection.test.ts`
 Expected: FAIL — `Failed to resolve import "./connection"`.
 
-- [ ] **Step 4: Write the implementation**
+- [x] **Step 4: Write the implementation**
 
-Create `packages/adapters/src/codex/connection.ts`:
+`packages/adapters/src/codex/connection.ts`:
 
 ```ts
 import { StdioJsonRpc, type JsonRpcId } from "../jsonrpc/stdio";
 
 export type ThreadListener = {
   onNotification: (method: string, params: unknown) => void;
-  /** MUST answer via connection.respond()/respondError(). */
+  /** MUST answer via connection.respond()/respondError(). If this throws, the connection answers -32603 for you. */
   onServerRequest: (id: JsonRpcId, method: string, params: unknown) => void;
-  onGone: (reason: string) => void;
+  /** `disposed` is true when Realm shut the process down on purpose — only `disposed: false` is an error. */
+  onGone: (reason: string, disposed: boolean) => void;
+};
+
+export type CodexConnectionOptions = {
+  bin: string;
+  args?: string[];
+  cwd: string;
+  env?: Record<string, string>;
+  onLog?: (line: string) => void;
+  /** Overridable for tests. A spawned-but-mute `codex app-server` must not hang session creation forever. */
+  initializeTimeoutMs?: number;
 };
 
 type Buffered = { kind: "note"; method: string; params: unknown } | { kind: "req"; id: JsonRpcId; method: string; params: unknown };
 
 const MAX_BUFFERED_PER_THREAD = 200;
+const INITIALIZE_TIMEOUT_MS = 10_000;
 
 const threadIdOf = (params: unknown): string | null => {
   const t = (params as { threadId?: unknown } | null)?.threadId;
   return typeof t === "string" ? t : null;
 };
 
+const reason = (e: unknown): string => (e instanceof Error ? e.message : String(e));
+
+function withTimeout<T>(p: Promise<T>, ms: number, message: string): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(message)), ms);
+    p.then(resolve, reject).finally(() => clearTimeout(timer));
+  });
+}
+
 /**
  * One `codex app-server` process, shared by every Codex session and fanned out by `threadId`.
  *
- * Frames whose thread has no listener yet are buffered (bounded) and flushed on `attach`, because notifications can
- * beat the `thread/start` response that tells us the id. Server requests for unknown threads are answered -32601
- * rather than dropped: an unanswered request stalls that turn forever.
+ * Notifications for a thread with no listener yet are buffered (bounded) and flushed on `attach`, because
+ * they can beat the `thread/start` response that tells us the id.
+ *
+ * Server requests are only buffered while NO thread is attached at all — that is the one window where an
+ * unknown thread id really means "the startup race, our `thread/start` has not returned yet". Once any
+ * thread is attached, a request for an unknown thread is a genuine orphan and is answered -32601 rather
+ * than queued: an unanswered server request stalls that turn forever, whereas a rejected one fails it
+ * cleanly. Do not widen this to "always buffer".
+ *
+ * That invariant holds through every exit: a listener that throws, a thread that detaches with an approval
+ * still queued, and a full buffer all answer the request rather than dropping it. One session's bug must
+ * never wedge a turn or take down its neighbours, so listener callbacks are never trusted to not throw.
  */
 export class CodexConnection {
-  private threads = new Map<string, ThreadListener>();
-  private buffer = new Map<string, Buffered[]>();
-  private constructor(private rpc: StdioJsonRpc, private onLog?: (line: string) => void) {}
+  private readonly threads = new Map<string, ThreadListener>();
+  private readonly buffer = new Map<string, Buffered[]>();
+  private readonly rpc: StdioJsonRpc;
+  private readonly onLog?: (line: string) => void;
+  private gone: { reason: string; disposed: boolean } | null = null;
 
-  /** Visible for tests: called when a server request cannot be routed to any thread. */
+  /** Visible for tests: fires whenever the connection itself answers a server request instead of a listener. */
   onUnroutedReply?: (id: JsonRpcId, code: number) => void;
 
-  static async open(opts: { bin: string; args?: string[]; cwd: string; env?: Record<string, string>; onLog?: (line: string) => void }): Promise<CodexConnection> {
-    let self: CodexConnection;
-    const rpc = new StdioJsonRpc({
+  private constructor(opts: CodexConnectionOptions) {
+    this.onLog = opts.onLog;
+    // `this` is fully initialized here (field initializers run first) and StdioJsonRpc never invokes a
+    // callback synchronously from its constructor, but binding through `this` rather than a `let` declared
+    // after the call keeps that from mattering.
+    this.rpc = new StdioJsonRpc({
       command: opts.bin,
       args: opts.args ?? ["app-server"],
       cwd: opts.cwd,
       env: opts.env,
-      onNotification: (n) => self.routeNotification(n.method, n.params),
-      onServerRequest: (r) => self.routeServerRequest(r.id, r.method, r.params),
-      onStderr: (l) => opts.onLog?.(l),
-      onExit: ({ reason }) => self.fanOutGone(reason),
+      onNotification: (n) => this.routeNotification(n.method, n.params),
+      onServerRequest: (r) => this.routeServerRequest(r.id, r.method, r.params),
+      onStderr: (l) => this.onLog?.(l),
+      onExit: ({ reason: why, disposed }) => this.fanOutGone(why, disposed),
     });
-    self = new CodexConnection(rpc, opts.onLog);
-    await rpc.request("initialize", {
-      clientInfo: { name: "realm", title: "Realm", version: "0.0.1" },
-      capabilities: { experimentalApi: true, requestAttestation: false },
-    });
-    rpc.notify("initialized");
-    return self;
+  }
+
+  static async open(opts: CodexConnectionOptions): Promise<CodexConnection> {
+    const conn = new CodexConnection(opts);
+    const ms = opts.initializeTimeoutMs ?? INITIALIZE_TIMEOUT_MS;
+    try {
+      // A child that spawns but never answers would otherwise leave this promise pending forever, hanging
+      // session creation with nothing to show the user.
+      await withTimeout(
+        conn.rpc.request("initialize", {
+          clientInfo: { name: "realm", title: "Realm", version: "0.0.1" },
+          capabilities: { experimentalApi: true, requestAttestation: false },
+        }),
+        ms,
+        `${opts.bin} did not answer initialize within ${ms}ms`,
+      );
+    } catch (e) {
+      await conn.dispose(); // never leave a half-spawned child behind
+      throw e;
+    }
+    conn.rpc.notify("initialized");
+    return conn;
   }
 
   get threadCount(): number { return this.threads.size; }
   get alive(): boolean { return this.rpc.alive; }
-  get stderrTail(): string[] { return this.rpc.stderrTail; }
+  get stderrTail(): readonly string[] { return this.rpc.stderrTail; }
+
+  /** Visible for tests: frames queued for a thread that has not attached yet. */
+  bufferedCount(threadId: string): number { return this.buffer.get(threadId)?.length ?? 0; }
 
   request<T = unknown>(method: string, params?: unknown): Promise<T> { return this.rpc.request<T>(method, params); }
   respond(id: JsonRpcId, result: unknown): void { this.rpc.respond(id, result); }
   respondError(id: JsonRpcId, code: number, message: string): void { this.rpc.respondError(id, code, message); }
 
   attach(threadId: string, listener: ThreadListener): void {
+    if (this.gone) { this.deliverGone(listener, this.gone.reason, this.gone.disposed); return; }
     this.threads.set(threadId, listener);
     const queued = this.buffer.get(threadId);
-    this.buffer.delete(threadId);
+    this.buffer.delete(threadId); // before the flush, so re-entrant pushes are not replayed or lost
     for (const f of queued ?? []) {
-      if (f.kind === "note") listener.onNotification(f.method, f.params);
-      else listener.onServerRequest(f.id, f.method, f.params);
+      if (f.kind === "note") this.deliverNotification(listener, f.method, f.params);
+      else this.deliverServerRequest(listener, f.id, f.method, f.params);
     }
   }
 
-  detach(threadId: string): void { this.threads.delete(threadId); this.buffer.delete(threadId); }
+  detach(threadId: string): void {
+    this.threads.delete(threadId);
+    // Anything still queued for this thread will never be delivered, and the child is still alive waiting
+    // on it — so answer the requests before dropping them.
+    this.drainBuffer(threadId, "thread detached");
+  }
 
   async dispose(): Promise<void> { await this.rpc.dispose(); }
 
@@ -1159,48 +1089,94 @@ export class CodexConnection {
     const threadId = threadIdOf(params);
     if (!threadId) { this.onLog?.(`[codex] ${method}`); return; } // global advisory: rate limits, config warnings
     const l = this.threads.get(threadId);
-    if (l) { l.onNotification(method, params); return; }
+    if (l) { this.deliverNotification(l, method, params); return; }
     this.push(threadId, { kind: "note", method, params });
   }
 
   private routeServerRequest(id: JsonRpcId, method: string, params: unknown): void {
     const threadId = threadIdOf(params);
     const l = threadId ? this.threads.get(threadId) : undefined;
-    if (l) { l.onServerRequest(id, method, params); return; }
-    if (threadId && this.buffer.has(threadId)) { this.push(threadId, { kind: "req", id, method, params }); return; }
+    if (l) { this.deliverServerRequest(l, id, method, params); return; }
     if (threadId && this.threads.size === 0) { this.push(threadId, { kind: "req", id, method, params }); return; }
     this.onLog?.(`[codex] unroutable server request ${method} (thread ${threadId ?? "none"})`);
-    this.rpc.respondError(id, -32601, "no client for this thread");
-    this.onUnroutedReply?.(id, -32601);
+    this.refuse(id, -32601, "no client for this thread");
+  }
+
+  /** A listener throwing is a bug in one session; it must not escape into the stdout handler and crash the app. */
+  private deliverNotification(l: ThreadListener, method: string, params: unknown): void {
+    try { l.onNotification(method, params); }
+    catch (e) { this.onLog?.(`[codex] listener threw on ${method}: ${reason(e)}`); }
+  }
+
+  private deliverServerRequest(l: ThreadListener, id: JsonRpcId, method: string, params: unknown): void {
+    try { l.onServerRequest(id, method, params); }
+    catch (e) {
+      // If the listener already answered before throwing, the child ignores this second frame; a duplicate
+      // reply is strictly better than a turn wedged forever on a half-handled request.
+      this.onLog?.(`[codex] listener threw on ${method}: ${reason(e)}`);
+      this.refuse(id, -32603, "client failed to handle this request");
+    }
+  }
+
+  private deliverGone(l: ThreadListener, why: string, disposed: boolean): void {
+    try { l.onGone(why, disposed); }
+    catch (e) { this.onLog?.(`[codex] listener threw on gone: ${reason(e)}`); }
+  }
+
+  private refuse(id: JsonRpcId, code: number, message: string): void {
+    this.rpc.respondError(id, code, message);
+    this.onUnroutedReply?.(id, code);
   }
 
   private push(threadId: string, f: Buffered): void {
     const q = this.buffer.get(threadId) ?? [];
     if (q.length >= MAX_BUFFERED_PER_THREAD) {
-      if (f.kind === "req") { this.rpc.respondError(f.id, -32601, "buffer overflow"); this.onUnroutedReply?.(f.id, -32601); }
+      if (f.kind === "req") this.refuse(f.id, -32601, "buffer overflow");
       return;
     }
     q.push(f);
     this.buffer.set(threadId, q);
   }
 
-  private fanOutGone(reason: string): void {
+  private drainBuffer(threadId: string, why: string): void {
+    const q = this.buffer.get(threadId);
+    this.buffer.delete(threadId);
+    for (const f of q ?? []) if (f.kind === "req") this.refuse(f.id, -32601, why);
+  }
+
+  private fanOutGone(why: string, disposed: boolean): void {
+    this.gone = { reason: why, disposed };
     const listeners = [...this.threads.values()];
+    // Cleared before the fan-out so a listener that calls detach() (or re-enters routing) from onGone sees
+    // an already-empty connection instead of resurrecting state. Map.delete on a missing key is a no-op.
     this.threads.clear();
+    // Not drained: the peer is gone, so there is nothing left to answer (respondError is a no-op once dead).
     this.buffer.clear();
-    for (const l of listeners) l.onGone(reason);
+    for (const l of listeners) this.deliverGone(l, why, disposed);
   }
 }
 ```
 
 **Why the routing rule has two branches.** Before *any* thread attaches, an inbound frame is almost certainly the startup race (the `thread/start` response has not returned yet), so it is buffered. Once at least one thread is attached, a frame for an unknown thread is a genuine orphan and is rejected with `-32601` immediately. Never weaken this to "always buffer" — an approval that is never answered stalls that turn forever, which is the failure mode this task exists to prevent.
 
-- [ ] **Step 5: Run the test to verify it passes**
+> **Correction to an earlier draft of this plan.** That draft had a third branch ahead of the size check, `if (threadId && this.buffer.has(threadId)) push(...)`, meant to preserve ordering. It makes the reject branch unreachable: `routeNotification` buffers unconditionally, and the approval turn emits `item/started` *before* the approval request, so `buffer.has(threadId)` is always true by the time the request arrives — every orphaned approval would be queued forever, which is exactly the stall this task exists to prevent. Verified: re-adding it fails the orphan test. Ordering loses to never-stall; the branch is gone.
+
+Three further corrections to that draft, all shipped above:
+
+- **`onGone` carries `disposed`.** The draft passed only `reason`, so a normal app shutdown was indistinguishable from a mid-turn crash. Task 5 turns `onGone` into a user-visible error event, so quitting Realm would have sprayed "codex app-server exited" across every open Codex session. Only `disposed: false` is an error.
+- **`open()` no longer uses a `let self` closed over before assignment.** It was safe in fact — `StdioJsonRpc` never fires a callback synchronously from its constructor — but it is a correctness argument about another module's internals that a future edit could silently break. The spawn moved into the constructor body and callbacks bind through `this`.
+- **`open()` disposes the child on a failed *or silent* handshake.** A rejected `initialize` used to orphan the process; an unanswered one used to hang forever, since `StdioJsonRpc.request` has no timeout of its own.
+
+- [x] **Step 5: Run the test to verify it passes**
 
 Run: `pnpm vitest run packages/adapters/src/codex/connection.test.ts`
-Expected: PASS — 5 tests.
+Expected: PASS — 17 tests.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Mutation-verify, then commit**
+
+Both earlier tasks on this branch were reviewed by mutation testing and in both the *tests*, not the code, were the weak point. 22 mutants, all killed: the two-branch routing rule in both directions; live approval delivery in both directions (never deliver / deliver *and* also refuse); `refuse` notifying the spy but never answering the child; `buffer.delete` in `attach`; reversed flush order; the cap and its overflow-refuse; both halves of `detach`, including abandoning queued requests; each of the three listener try/catch blocks; the `initialize` timeout; `threadIdOf`; and both `disposed` polarities.
+
+Watch for two shapes of weak test in particular: asserting a refusal only against `onUnroutedReply` (a test-only spy — the mutant that keeps the spy and deletes the real `respondError` survives), and leaving the live delivery path uncovered while the unroutable path is heavily tested.
 
 ```bash
 git add packages/adapters/src/codex/connection.ts packages/adapters/src/codex/connection.test.ts packages/adapters/src/codex/fixtures
@@ -1469,7 +1445,15 @@ export class CodexAdapter implements AgentAdapter {
           suggestions: available,
         }));
       },
-      onGone: (reason) => fail(reason),
+      // `disposed: true` means Realm shut the process down on purpose (app quit, last session released) —
+      // end the stream quietly. Only a real death is an error the user needs to see.
+      onGone: (reason, wasDisposed) => {
+        if (!wasDisposed && !disposed) { fail(reason); return; }
+        if (events.isClosed) return;
+        for (const e of mapper.closeOpenTools("session ended")) events.push(e);
+        events.push(sessionEvent("status", { status: "ended" }));
+        events.close();
+      },
     };
 
     const boot = (async () => {

--- a/packages/adapters/src/acp/acp-adapter.test.ts
+++ b/packages/adapters/src/acp/acp-adapter.test.ts
@@ -624,6 +624,59 @@ describe("AcpAdapter", () => {
     expect(errors(evs)).toEqual([]); // the stream is closed; nothing can be pushed onto it any more
   });
 
+  it("bounds initialize so a child that spawns and answers nothing cannot hang the session", async () => {
+    // No timeout here and boot stays pending forever: dispose() -> App.close() never returns and the desktop
+    // main process SIGTERMs the server out from under its agent children.
+    const dir = await mkdtemp(join(tmpdir(), "realm-acp-"));
+    const marker = join(dir, "child-exited");
+    const adapter = newAdapter({ bootTimeoutMs: 200, env: { FAKE_ACP_MUTE_INITIALIZE: "1", FAKE_ACP_EXIT_MARKER: marker } });
+    const handle = adapter.start(startOpts());
+    const { evs, done } = drain(handle);
+    // send() and setOptions() await boot too, so a bounded boot is what stops them hanging the WebSocket
+    // call as well — neither has a timeout of its own.
+    await expect(handle.send({ text: "hi", attachments: [] })).resolves.toBeUndefined();
+    await expect(handle.setOptions({ model: "x" })).resolves.toBeUndefined();
+    await done;
+    expect(errors(evs)[0]).toMatch(/initialize within 200ms/);
+    expect(statuses(evs)).toEqual(["error", "ended"]);
+    expect(existsSync(marker)).toBe(true); // and the child it already spawned is gone with it
+    await handle.dispose();
+  });
+
+  it("bounds session/new the same way", async () => {
+    const adapter = newAdapter({ bootTimeoutMs: 200, env: { FAKE_ACP_MUTE_SESSION_NEW: "1" } });
+    const { evs, done } = drain(adapter.start(startOpts()));
+    await done;
+    expect(errors(evs)[0]).toMatch(/session\/new within 200ms/);
+    expect(statuses(evs)).toEqual(["error", "ended"]);
+  });
+
+  it("falls back to a new session when session/load never answers", async () => {
+    const logs: string[] = [];
+    const adapter = newAdapter({ bootTimeoutMs: 200, env: { FAKE_ACP_MUTE_SESSION_LOAD: "1" } });
+    const handle = adapter.start(startOpts({ resume: "sess_prev", onLog: (l) => logs.push(l) }));
+    const { evs } = drain(handle);
+    await vi.waitFor(() => expect(types(evs)).toContain("init"), { timeout: 10_000, interval: 25 });
+    expect(of(evs, "init")[0]!.payload.providerSessionId).toBe("sess_0");
+    expect(logs.join("\n")).toMatch(/session\/load within 200ms/);
+    await handle.dispose();
+  });
+
+  it("completes dispose even when the boot itself never settles", async () => {
+    // The boot timeout is deliberately far longer than DISPOSE_TIMEOUT_MS here, so the only thing that can
+    // resolve this dispose is the race in dispose() itself.
+    const dir = await mkdtemp(join(tmpdir(), "realm-acp-"));
+    const marker = join(dir, "child-exited");
+    const adapter = newAdapter({ bootTimeoutMs: 60_000, env: { FAKE_ACP_MUTE_SESSION_NEW: "1", FAKE_ACP_EXIT_MARKER: marker } });
+    const handle = adapter.start(startOpts());
+    const { done } = drain(handle);
+    const t0 = Date.now();
+    await handle.dispose();
+    expect(Date.now() - t0).toBeLessThan(10_000);
+    await done;
+    expect(existsSync(marker)).toBe(true);
+  });
+
   it("serves fs callbacks during a replay but cancels permission requests raised by it", async () => {
     const dir = await mkdtemp(join(tmpdir(), "realm-acp-"));
     const path = join(dir, "REPLAY.txt");

--- a/packages/adapters/src/acp/acp-adapter.test.ts
+++ b/packages/adapters/src/acp/acp-adapter.test.ts
@@ -1,10 +1,12 @@
 import { describe, it, expect, vi } from "vitest";
 import { fileURLToPath } from "node:url";
-import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { mkdtemp, readFile, realpath, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { SessionEvent, SessionEventOf, SessionEventType } from "@realm/contracts";
-import { AcpAdapter, pickAcpOption, type AcpAgentSpec } from "./acp-adapter";
+import { AcpAdapter, acpBootFailureMessage, pickAcpOption, sliceLines, type AcpAgentSpec } from "./acp-adapter";
+import { JsonRpcCallError } from "../jsonrpc/stdio";
 import type { AgentHandle, StartOptions } from "../types";
 
 const FAKE = fileURLToPath(new URL("./fixtures/fake-acp-agent.mjs", import.meta.url));
@@ -87,6 +89,73 @@ describe("pickAcpOption", () => {
   });
 });
 
+describe("sliceLines", () => {
+  const FOUR = "one\ntwo\nthree\nfour\n";
+
+  it("returns the whole file when the agent asked for no window", () => {
+    expect(sliceLines(FOUR, undefined, undefined)).toBe(FOUR);
+    expect(sliceLines(FOUR, null, null)).toBe(FOUR);
+  });
+
+  it("treats line as 1-based and limit as a line count", () => {
+    expect(sliceLines(FOUR, 2, 2)).toBe("two\nthree");
+    expect(sliceLines(FOUR, 1, 1)).toBe("one");
+  });
+
+  it("honours line on its own", () => {
+    expect(sliceLines(FOUR, 3, undefined)).toBe("three\nfour\n");
+    expect(sliceLines(FOUR, 1, null)).toBe(FOUR);
+  });
+
+  it("honours limit on its own", () => {
+    expect(sliceLines(FOUR, undefined, 2)).toBe("one\ntwo");
+    expect(sliceLines(FOUR, null, 1)).toBe("one");
+  });
+
+  it("clamps a line before the start of the file", () => {
+    expect(sliceLines(FOUR, 0, 1)).toBe("one");
+    expect(sliceLines(FOUR, -5, 1)).toBe("one");
+  });
+});
+
+describe("acpBootFailureMessage", () => {
+  const SPEC = { label: "Cursor", loginHint: "Run `cursor-agent login`." };
+  const AUTH = [{ id: "cursor_login", name: "Cursor Login" }];
+
+  it("leaves a non-protocol failure alone", () => {
+    // A missing binary or a dead pipe is not a login problem; appending the hint would misdirect the user.
+    const msg = acpBootFailureMessage(new Error("spawn cursor-agent ENOENT"), SPEC, AUTH);
+    expect(msg).toBe("spawn cursor-agent ENOENT");
+  });
+
+  it("names the agent, the auth methods and the hint on -32000", () => {
+    const msg = acpBootFailureMessage(new JsonRpcCallError(-32000, "API key is missing.", undefined), SPEC, AUTH);
+    expect(msg).toContain("Cursor");
+    expect(msg).toContain("sign in");
+    expect(msg).toContain("API key is missing.");
+    expect(msg).toContain("Cursor Login");
+    expect(msg).toContain("Run `cursor-agent login`.");
+  });
+
+  it("echoes Cursor's -32603 data verbatim and still appends the hint", () => {
+    const e = new JsonRpcCallError(-32603, "Internal error", { message: "Failed to initialize session services", details: "[unauthenticated] Error" });
+    const msg = acpBootFailureMessage(e, SPEC, AUTH);
+    expect(msg).toContain("Internal error");
+    expect(msg).toContain("Failed to initialize session services");
+    expect(msg).toContain("[unauthenticated] Error");
+    expect(msg).toContain("Run `cursor-agent login`.");
+    expect(msg).not.toContain("sign in"); // -32603 is generic: do not claim to know it is an auth problem
+  });
+
+  it("falls back to auth method ids and copes with no auth methods at all", () => {
+    const e = new JsonRpcCallError(-32000, "nope", undefined);
+    expect(acpBootFailureMessage(e, SPEC, [{ id: "vertex-ai" }])).toContain("vertex-ai");
+    const bare = acpBootFailureMessage(e, SPEC, []);
+    expect(bare).not.toContain("Sign-in methods");
+    expect(bare).toContain("Run `cursor-agent login`.");
+  });
+});
+
 describe("AcpAdapter", () => {
   it("reports the kind it was constructed with", () => {
     expect(newAdapter().kind).toBe("acp:cursor");
@@ -99,6 +168,35 @@ describe("AcpAdapter", () => {
     expect(good.version).toMatch(/^v?\d/);
     const bad = await newAdapter({ kind: "acp:gemini", bin: "/nonexistent/acp-bin" }).probe();
     expect(bad).toMatchObject({ kind: "acp:gemini", available: false, version: null });
+  });
+
+  it("spawns the child in the session's cwd and lets session env override the spec's", async () => {
+    const dir = await realpath(await mkdtemp(join(tmpdir(), "realm-acp-")));
+    const png = join(dir, "shot.png");
+    await writeFile(png, Buffer.from([1, 2, 3, 4]));
+    // The spec's env is a default for the agent; a session's own env is the more specific value and wins.
+    const { handle, evs } = await booted({ cwd: dir, env: { FAKE_ACP_NOIMAGE: "" } }, { env: { FAKE_ACP_NOIMAGE: "1" } });
+    await handle.send({ text: "ECHO", attachments: [{ path: png, mime: "image/png" }] });
+    await vi.waitFor(() => expect(texts(evs)).toHaveLength(1));
+    expect((JSON.parse(texts(evs)[0]!) as Record<string, unknown>[])[1]).toMatchObject({ type: "image" });
+    await turn(handle, evs, "REVEAL");
+    expect((JSON.parse(texts(evs)[1]!) as { cwd: string }).cwd).toBe(dir);
+    await handle.dispose();
+  });
+
+  it("fails the session when the agent answers session/new without a session id", async () => {
+    const { evs, done } = await booted({}, { env: { FAKE_ACP_NOSESSIONID: "1" } });
+    await done;
+    expect(errors(evs)[0]).toContain("Cursor did not return a session id");
+    expect(statuses(evs)).toEqual(["error", "ended"]);
+  });
+
+  it("survives a malformed authMethods on the failure path", async () => {
+    const { evs, done } = await booted({}, { env: { FAKE_ACP_AUTHFAIL: "1", FAKE_ACP_BADAUTH: "1" } });
+    await done;
+    expect(errors(evs)[0]).toContain("Run `cursor-agent login`.");
+    expect(errors(evs)[0]).not.toContain("Sign-in methods");
+    expect(statuses(evs)).toEqual(["error", "ended"]);
   });
 
   it("emits init then a full streaming turn, and never a user_message", async () => {
@@ -118,6 +216,24 @@ describe("AcpAdapter", () => {
     expect(types(evs)).not.toContain("user_message");
     expect(errors(evs)).toEqual([]);
     await handle.dispose();
+  });
+
+  it("accepts a send that arrives before the boot has finished", async () => {
+    const handle = newAdapter().start(startOpts());
+    const { evs } = drain(handle);
+    await handle.send({ text: "hi", attachments: [] }); // no wait for init
+    await vi.waitFor(() => expect(texts(evs)).toEqual(["Hello"]));
+    expect(types(evs).indexOf("init")).toBeLessThan(types(evs).indexOf("assistant_text"));
+    await handle.dispose();
+  });
+
+  it("reports a child that dies during the handshake once, then ends", async () => {
+    const handle = newAdapter({ args: ["-e", "process.exit(3)"] }).start(startOpts());
+    const { evs, done } = drain(handle);
+    await done;
+    expect(errors(evs)).toHaveLength(1);
+    expect(errors(evs)[0]).toMatch(/exited/);
+    expect(statuses(evs)).toEqual(["error", "ended"]);
   });
 
   it("returns from send() without waiting for the turn to finish", async () => {
@@ -148,6 +264,7 @@ describe("AcpAdapter", () => {
     // The request's toolCall is a sparse patch carrying only toolCallId, so both the name and the input come
     // from the tool_call the mapper already recorded.
     expect(req.toolName).toBe("Run step 0");
+    expect(req.title).toBe("Run step 0");
     expect(req.input).toEqual({ command: "echo 0" });
     expect(req.suggestions).toHaveLength(3);
     expect(req.suggestions[0]).toMatchObject({ optionId: "allow-once", kind: "allow_once" });
@@ -292,8 +409,10 @@ describe("AcpAdapter", () => {
     expect(texts(evs)[0]).toBe("read:one\ntwo\nthree\nfour\n");
     await turn(handle, evs, `READFILE ${path} 2 2`);
     expect(texts(evs)[1]).toBe("read:two\nthree");
+    await turn(handle, evs, `READFILE ${path} 3`); // a line with no limit runs to the end of the file
+    expect(texts(evs)[2]).toBe("read:three\nfour\n");
     await turn(handle, evs, `READFILE ${join(dir, "missing.txt")}`);
-    expect(texts(evs)[2]).toContain("read failed:");
+    expect(texts(evs)[3]).toContain("read failed:");
     await handle.dispose();
   });
 
@@ -433,12 +552,56 @@ describe("AcpAdapter", () => {
     expect(statuses(evs)).toEqual(["idle", "ended"]);
   });
 
+  it("takes the child process down with the session", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "realm-acp-"));
+    const marker = join(dir, "child-exited");
+    const { handle } = await booted({}, { env: { FAKE_ACP_EXIT_MARKER: marker } });
+    expect(existsSync(marker)).toBe(false);
+    await handle.dispose();
+    // dispose() does not resolve until the child is actually gone, so this needs no polling.
+    expect(existsSync(marker)).toBe(true);
+  });
+
+  it("flushes a half-streamed message when the session is disposed", async () => {
+    const { handle, evs, done } = await booted();
+    await handle.send({ text: "OPENTEXT", attachments: [] });
+    await vi.waitFor(() => expect(of(evs, "assistant_delta")).toHaveLength(1));
+    await handle.dispose();
+    await done;
+    // assistant_delta is ephemeral: without the flush the partial answer never reaches the transcript at all.
+    expect(texts(evs)).toEqual(["partial"]);
+  });
+
+  it("answers a permission still open at dispose instead of leaving it dangling", async () => {
+    const { handle, evs, done } = await booted();
+    await handle.send({ text: "PERMIT", attachments: [] });
+    await vi.waitFor(() => expect(of(evs, "permission_request")).toHaveLength(1));
+    const { requestId } = of(evs, "permission_request")[0]!.payload;
+    await handle.dispose();
+    await done;
+    // A request with no response leaves a card the UI renders as still waiting, forever.
+    expect(of(evs, "permission_response").map((e) => e.payload)).toEqual([{ requestId, decision: "deny" }]);
+  });
+
+  it("closes a tool call that is still open when the session is disposed", async () => {
+    const { handle, evs, done } = await booted();
+    await handle.send({ text: "OPENTOOL", attachments: [] });
+    await vi.waitFor(() => expect(of(evs, "tool_call")).toHaveLength(1));
+    await handle.dispose();
+    await done;
+    expect(of(evs, "tool_result")[0]!.payload).toEqual({ toolUseId: of(evs, "tool_call")[0]!.payload.toolUseId, content: "session closed", isError: true });
+    expect(types(evs)).not.toContain("error"); // a dispose is not a failure, open card or not
+    expect(statuses(evs).at(-1)).toBe("ended");
+  });
+
   it("closes an open tool call and reports an error when the child dies unexpectedly", async () => {
     const { handle, evs, done } = await booted();
     await handle.send({ text: "DIE", attachments: [] });
     await done;
     expect(errors(evs)[0]).toMatch(/exited/);
-    expect(of(evs, "tool_result")[0]!.payload).toMatchObject({ isError: true });
+    // The card is closed with why the child died, not with the generic dispose reason.
+    expect(of(evs, "tool_result")[0]!.payload.content).toMatch(/exited/);
+    expect(of(evs, "tool_result")[0]!.payload.isError).toBe(true);
     expect(statuses(evs)).toEqual(["idle", "running", "error", "ended"]);
     await handle.dispose();
   });

--- a/packages/adapters/src/acp/acp-adapter.test.ts
+++ b/packages/adapters/src/acp/acp-adapter.test.ts
@@ -1,11 +1,11 @@
 import { describe, it, expect, vi } from "vitest";
 import { fileURLToPath } from "node:url";
 import { existsSync } from "node:fs";
-import { mkdtemp, readFile, realpath, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, realpath, symlink, truncate, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { SessionEvent, SessionEventOf, SessionEventType } from "@realm/contracts";
-import { AcpAdapter, acpBootFailureMessage, pickAcpOption, sliceLines, type AcpAgentSpec } from "./acp-adapter";
+import { AcpAdapter, acpBootFailureMessage, MAX_FS_READ_BYTES, pickAcpOption, sliceLines, type AcpAgentSpec } from "./acp-adapter";
 import { JsonRpcCallError } from "../jsonrpc/stdio";
 import type { AgentHandle, StartOptions } from "../types";
 
@@ -404,7 +404,7 @@ describe("AcpAdapter", () => {
     const dir = await mkdtemp(join(tmpdir(), "realm-acp-"));
     const path = join(dir, "NOTES.txt");
     await writeFile(path, "one\ntwo\nthree\nfour\n");
-    const { handle, evs } = await booted();
+    const { handle, evs } = await booted({ cwd: dir });
     await turn(handle, evs, `READFILE ${path}`);
     expect(texts(evs)[0]).toBe("read:one\ntwo\nthree\nfour\n");
     await turn(handle, evs, `READFILE ${path} 2 2`);
@@ -418,11 +418,93 @@ describe("AcpAdapter", () => {
 
   it("serves fs/write_text_file", async () => {
     const dir = await mkdtemp(join(tmpdir(), "realm-acp-"));
-    const path = join(dir, "OUT.txt");
-    const { handle, evs } = await booted();
+    const path = join(dir, "OUT.txt"); // does not exist yet: the target is resolved through its parent
+    const { handle, evs } = await booted({ cwd: dir });
     await turn(handle, evs, `WRITEFILE ${path} written by the agent`);
     expect(texts(evs)[0]).toBe("write:ok");
     expect(await readFile(path, "utf8")).toBe("written by the agent");
+    await handle.dispose();
+  });
+
+  it("refuses to read a path that escapes the session's working directory", async () => {
+    // Absolute paths are all an agent needs to ask for ~/.ssh/id_rsa or ~/.aws/credentials, and none of this
+    // reaches a permission card. Declaring fs:false would not take the capability away — but confining our own
+    // handlers costs a well-behaved agent nothing, it just falls back to its own I/O.
+    const dir = await realpath(await mkdtemp(join(tmpdir(), "realm-acp-")));
+    const work = join(dir, "work");
+    await mkdir(work);
+    const outside = join(dir, "SECRET.txt");
+    await writeFile(outside, "credentials");
+    const logs: string[] = [];
+    const { handle, evs } = await booted({ cwd: work, onLog: (l) => logs.push(l) });
+    await turn(handle, evs, `READFILE ${outside}`);
+    expect(texts(evs)[0]).toContain("read failed:");
+    expect(texts(evs)[0]).toContain("outside");
+    await turn(handle, evs, `READFILE ../../../etc/passwd`); // relative traversal, resolved against cwd
+    expect(texts(evs)[1]).toContain("outside");
+    expect(logs.join("\n")).toContain("outside");
+    await handle.dispose();
+  });
+
+  it("refuses to write outside the working directory and leaves the target untouched", async () => {
+    const dir = await realpath(await mkdtemp(join(tmpdir(), "realm-acp-")));
+    const work = join(dir, "work");
+    await mkdir(work);
+    const outside = join(dir, "ZSHRC");
+    await writeFile(outside, "original");
+    const { handle, evs } = await booted({ cwd: work });
+    await turn(handle, evs, `WRITEFILE ${outside} clobbered`);
+    expect(texts(evs)[0]).toContain("write failed:");
+    expect(await readFile(outside, "utf8")).toBe("original");
+    // …and a brand new file outside cwd is not created either.
+    await turn(handle, evs, `WRITEFILE ${join(dir, "NEW.txt")} hello`);
+    expect(texts(evs)[1]).toContain("write failed:");
+    expect(existsSync(join(dir, "NEW.txt"))).toBe(false);
+    await handle.dispose();
+  });
+
+  it("refuses a symlink inside the working directory that points outside it", async () => {
+    const dir = await realpath(await mkdtemp(join(tmpdir(), "realm-acp-")));
+    const work = join(dir, "work");
+    await mkdir(work);
+    const outside = join(dir, "SECRET.txt");
+    await writeFile(outside, "credentials");
+    // Resolving the link is the whole point: a containment check on the literal path would wave this through.
+    await symlink(outside, join(work, "innocent.txt"));
+    const { handle, evs } = await booted({ cwd: work });
+    await turn(handle, evs, `READFILE ${join(work, "innocent.txt")}`);
+    expect(texts(evs)[0]).toContain("outside");
+    expect(texts(evs)[0]).not.toContain("credentials");
+    await turn(handle, evs, `WRITEFILE ${join(work, "innocent.txt")} clobbered`);
+    expect(texts(evs)[1]).toContain("write failed:");
+    expect(await readFile(outside, "utf8")).toBe("credentials");
+    await handle.dispose();
+  });
+
+  it("refuses a sibling directory whose name merely starts with the working directory's", async () => {
+    // /…/work-evil is not inside /…/work, however much a naive prefix test would like it to be.
+    const dir = await realpath(await mkdtemp(join(tmpdir(), "realm-acp-")));
+    const work = join(dir, "work");
+    await mkdir(work);
+    await mkdir(join(dir, "work-evil"));
+    const sibling = join(dir, "work-evil", "SECRET.txt");
+    await writeFile(sibling, "credentials");
+    const { handle, evs } = await booted({ cwd: work });
+    await turn(handle, evs, `READFILE ${sibling}`);
+    expect(texts(evs)[0]).toContain("outside");
+    expect(texts(evs)[0]).not.toContain("credentials");
+    await handle.dispose();
+  });
+
+  it("refuses to read a file past the size cap", async () => {
+    const dir = await realpath(await mkdtemp(join(tmpdir(), "realm-acp-")));
+    const huge = join(dir, "HUGE.bin");
+    await writeFile(huge, "");
+    await truncate(huge, MAX_FS_READ_BYTES + 1); // sparse: no real bytes written
+    const { handle, evs } = await booted({ cwd: dir });
+    await turn(handle, evs, `READFILE ${huge}`);
+    expect(texts(evs)[0]).toContain("read failed:");
+    expect(texts(evs)[0]).toMatch(/too large|bytes/);
     await handle.dispose();
   });
 
@@ -682,7 +764,7 @@ describe("AcpAdapter", () => {
     const path = join(dir, "REPLAY.txt");
     await writeFile(path, "replayed content");
     const { handle, evs } = await booted(
-      { resume: "sess_prev" },
+      { resume: "sess_prev", cwd: dir },
       { env: { FAKE_ACP_LOAD_ASKS: "1", FAKE_ACP_LOAD_ASKS_PATH: path } },
     );
     await turn(handle, evs, "REVEAL");

--- a/packages/adapters/src/acp/acp-adapter.test.ts
+++ b/packages/adapters/src/acp/acp-adapter.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, afterEach, vi } from "vitest";
 import { fileURLToPath } from "node:url";
 import { existsSync } from "node:fs";
 import { mkdir, mkdtemp, readFile, realpath, symlink, truncate, writeFile } from "node:fs/promises";
@@ -9,6 +9,13 @@ import { AcpAdapter, acpBootFailureMessage, MAX_FS_READ_BYTES, pickAcpOption, sl
 import { JsonRpcCallError } from "../jsonrpc/stdio";
 import type { AgentHandle, StartOptions } from "../types";
 
+/**
+ * Every assertion in this file is gated on a real child process: node cold start, module load and at least one
+ * round trip. vitest's 1000 ms default is routinely too tight for that on a loaded two-core CI runner, and a
+ * longer bound costs nothing when the assertion passes.
+ */
+const waitFor = <T>(fn: () => T | Promise<T>) => vi.waitFor(fn, { timeout: 10_000, interval: 25 });
+
 const FAKE = fileURLToPath(new URL("./fixtures/fake-acp-agent.mjs", import.meta.url));
 const spec = (o: Partial<AcpAgentSpec> = {}): AcpAgentSpec => ({
   kind: "acp:cursor", bin: process.execPath, args: [FAKE],
@@ -17,12 +24,18 @@ const spec = (o: Partial<AcpAgentSpec> = {}): AcpAgentSpec => ({
 const newAdapter = (o: Partial<AcpAgentSpec> = {}) => new AcpAdapter(spec(o));
 const startOpts = (o: Partial<StartOptions> = {}): StartOptions => ({ cwd: process.cwd(), mcpServers: [], ...o });
 
-/** Drains the handle's event stream into an array the assertions poll with `vi.waitFor`. */
+/** Drains the handle's event stream into an array the assertions poll with `waitFor`. */
 function drain(h: AgentHandle) {
+  live.push(h);
   const evs: SessionEvent[] = [];
   const done = (async () => { for await (const e of h.events) evs.push(e); })();
   return { evs, done };
 }
+
+/** Every handle a test drained. A failing assertion skips the test's own dispose(); this stops that leaking a
+ *  child process into the rest of the run. */
+const live: AgentHandle[] = [];
+afterEach(async () => { for (const h of live.splice(0)) await h.dispose().catch(() => {}); });
 const types = (evs: SessionEvent[]) => evs.map((e) => e.type);
 const statuses = (evs: SessionEvent[]) => evs.filter((e) => e.type === "status").map((e) => e.payload.status);
 const of = <T extends SessionEventType>(evs: SessionEvent[], t: T) => evs.filter((e) => e.type === t) as SessionEventOf<T>[];
@@ -34,18 +47,15 @@ async function booted(o: Partial<StartOptions> = {}, s: Partial<AcpAgentSpec> = 
   const adapter = newAdapter(s);
   const handle = adapter.start(startOpts(o));
   const { evs, done } = drain(handle);
-  await vi.waitFor(() => expect(types(evs).some((t) => t === "init" || t === "error")).toBe(true));
+  await waitFor(() => expect(types(evs).some((t) => t === "init" || t === "error")).toBe(true));
   return { adapter, handle, evs, done };
 }
-
-/** Lets the queue hand everything already pushed to the drain loop, which delivers asynchronously. */
-const settled = () => new Promise((r) => setTimeout(r, 0));
 
 /** Runs one turn and waits for it to settle back to idle. */
 async function turn(handle: AgentHandle, evs: SessionEvent[], text: string) {
   const before = statuses(evs).length;
   await handle.send({ text, attachments: [] });
-  await vi.waitFor(() => expect(statuses(evs).slice(before).at(-1)).toBe("idle"));
+  await waitFor(() => expect(statuses(evs).slice(before).at(-1)).toBe("idle"));
 }
 
 const ALLOW_ONLY = [
@@ -177,7 +187,7 @@ describe("AcpAdapter", () => {
     // The spec's env is a default for the agent; a session's own env is the more specific value and wins.
     const { handle, evs } = await booted({ cwd: dir, env: { FAKE_ACP_NOIMAGE: "" } }, { env: { FAKE_ACP_NOIMAGE: "1" } });
     await handle.send({ text: "ECHO", attachments: [{ path: png, mime: "image/png" }] });
-    await vi.waitFor(() => expect(texts(evs)).toHaveLength(1));
+    await waitFor(() => expect(texts(evs)).toHaveLength(1));
     expect((JSON.parse(texts(evs)[0]!) as Record<string, unknown>[])[1]).toMatchObject({ type: "image" });
     await turn(handle, evs, "REVEAL");
     expect((JSON.parse(texts(evs)[1]!) as { cwd: string }).cwd).toBe(dir);
@@ -222,7 +232,7 @@ describe("AcpAdapter", () => {
     const handle = newAdapter().start(startOpts());
     const { evs } = drain(handle);
     await handle.send({ text: "hi", attachments: [] }); // no wait for init
-    await vi.waitFor(() => expect(texts(evs)).toEqual(["Hello"]));
+    await waitFor(() => expect(texts(evs)).toEqual(["Hello"]));
     expect(types(evs).indexOf("init")).toBeLessThan(types(evs).indexOf("assistant_text"));
     await handle.dispose();
   });
@@ -244,9 +254,9 @@ describe("AcpAdapter", () => {
     // session/prompt stays pending for the whole turn. SessionService.send() awaits this, and the RPC method
     // awaits that, so awaiting the prompt would hang the WebSocket call for the length of the turn.
     expect(elapsed).toBeLessThan(1000);
-    await vi.waitFor(() => expect(statuses(evs)).toEqual(["idle", "running"]));
+    await waitFor(() => expect(statuses(evs)).toEqual(["idle", "running"]));
     await handle.interrupt();
-    await vi.waitFor(() => expect(statuses(evs).at(-1)).toBe("idle"));
+    await waitFor(() => expect(statuses(evs).at(-1)).toBe("idle"));
     // The connection survives cancellation: the agent flushed "bye" before resolving, and the next turn works.
     expect(texts(evs)).toEqual(["bye"]);
     expect(errors(evs)).toEqual([]);
@@ -258,7 +268,7 @@ describe("AcpAdapter", () => {
   it("bridges a permission request, allows it, and surfaces the tool result", async () => {
     const { handle, evs } = await booted();
     await handle.send({ text: "PERMIT", attachments: [] });
-    await vi.waitFor(() => expect(of(evs, "permission_request")).toHaveLength(1));
+    await waitFor(() => expect(of(evs, "permission_request")).toHaveLength(1));
     const req = of(evs, "permission_request")[0]!.payload;
     expect(statuses(evs)).toEqual(["idle", "running", "waiting_permission"]);
     // The request's toolCall is a sparse patch carrying only toolCallId, so both the name and the input come
@@ -270,7 +280,7 @@ describe("AcpAdapter", () => {
     expect(req.suggestions[0]).toMatchObject({ optionId: "allow-once", kind: "allow_once" });
 
     handle.respondPermission(req.requestId, "allow");
-    await vi.waitFor(() => expect(statuses(evs).at(-1)).toBe("idle"));
+    await waitFor(() => expect(statuses(evs).at(-1)).toBe("idle"));
     expect(of(evs, "permission_response")[0]!.payload).toEqual({ requestId: req.requestId, decision: "allow" });
     expect(of(evs, "tool_result")[0]!.payload).toMatchObject({ content: "outcome:allow-once", isError: false });
     expect(statuses(evs)).toEqual(["idle", "running", "waiting_permission", "running", "idle"]);
@@ -280,9 +290,9 @@ describe("AcpAdapter", () => {
   it("echoes the reject option a deny maps to", async () => {
     const { handle, evs } = await booted();
     await handle.send({ text: "PERMIT", attachments: [] });
-    await vi.waitFor(() => expect(of(evs, "permission_request")).toHaveLength(1));
+    await waitFor(() => expect(of(evs, "permission_request")).toHaveLength(1));
     handle.respondPermission(of(evs, "permission_request")[0]!.payload.requestId, "deny");
-    await vi.waitFor(() => expect(of(evs, "tool_result")).toHaveLength(1));
+    await waitFor(() => expect(of(evs, "tool_result")).toHaveLength(1));
     expect(of(evs, "tool_result")[0]!.payload).toMatchObject({ content: "outcome:reject-once", isError: true });
     await handle.dispose();
   });
@@ -290,9 +300,9 @@ describe("AcpAdapter", () => {
   it("answers cancelled — never an allow — when the agent offers no reject option", async () => {
     const { handle, evs } = await booted({}, { env: { FAKE_ACP_ALLOWONLY: "1" } });
     await handle.send({ text: "PERMIT", attachments: [] });
-    await vi.waitFor(() => expect(of(evs, "permission_request")).toHaveLength(1));
+    await waitFor(() => expect(of(evs, "permission_request")).toHaveLength(1));
     handle.respondPermission(of(evs, "permission_request")[0]!.payload.requestId, "deny");
-    await vi.waitFor(() => expect(of(evs, "tool_result")).toHaveLength(1));
+    await waitFor(() => expect(of(evs, "tool_result")).toHaveLength(1));
     expect(of(evs, "tool_result")[0]!.payload.content).toBe("outcome:cancelled");
     await handle.dispose();
   });
@@ -300,16 +310,18 @@ describe("AcpAdapter", () => {
   it("raises waiting_permission once while two requests are open", async () => {
     const { handle, evs } = await booted();
     await handle.send({ text: "PERMIT2", attachments: [] });
-    await vi.waitFor(() => expect(of(evs, "permission_request")).toHaveLength(2));
+    await waitFor(() => expect(of(evs, "permission_request")).toHaveLength(2));
     expect(statuses(evs).filter((s) => s === "waiting_permission")).toHaveLength(1);
     const [a, b] = of(evs, "permission_request").map((e) => e.payload.requestId);
     handle.respondPermission(a!, "allow");
-    await settled();
+    // A positive signal rather than one macrotask: the agent completes that call as soon as it is answered,
+    // so its tool_result is proof the answer was delivered and acted on.
+    await waitFor(() => expect(of(evs, "tool_result")).toHaveLength(1));
     // One answer does not end the wait — the other request is still open.
     expect(statuses(evs).at(-1)).toBe("waiting_permission");
     handle.respondPermission(b!, "allow_always");
-    await vi.waitFor(() => expect(statuses(evs).filter((s) => s === "running")).toHaveLength(2));
-    await vi.waitFor(() => expect(statuses(evs).at(-1)).toBe("idle"));
+    await waitFor(() => expect(statuses(evs).filter((s) => s === "running")).toHaveLength(2));
+    await waitFor(() => expect(statuses(evs).at(-1)).toBe("idle"));
     expect(statuses(evs)).toEqual(["idle", "running", "waiting_permission", "running", "idle"]);
     expect(of(evs, "tool_result").map((e) => e.payload.content).sort()).toEqual(["outcome:allow-always", "outcome:allow-once"]);
     await handle.dispose();
@@ -318,12 +330,12 @@ describe("AcpAdapter", () => {
   it("cancels every open permission on interrupt without killing the connection", async () => {
     const { handle, evs } = await booted();
     await handle.send({ text: "PERMIT", attachments: [] });
-    await vi.waitFor(() => expect(of(evs, "permission_request")).toHaveLength(1));
+    await waitFor(() => expect(of(evs, "permission_request")).toHaveLength(1));
     await handle.interrupt();
-    await vi.waitFor(() => expect(of(evs, "tool_result")).toHaveLength(1));
+    await waitFor(() => expect(of(evs, "tool_result")).toHaveLength(1));
     expect(of(evs, "tool_result")[0]!.payload.content).toBe("outcome:cancelled");
     expect(of(evs, "permission_response")).toHaveLength(1);
-    await vi.waitFor(() => expect(statuses(evs).at(-1)).toBe("idle"));
+    await waitFor(() => expect(statuses(evs).at(-1)).toBe("idle"));
     expect(types(evs)).not.toContain("error");
     await handle.dispose();
   });
@@ -554,7 +566,7 @@ describe("AcpAdapter", () => {
     await writeFile(png, Buffer.from([1, 2, 3, 4]));
     const { handle, evs } = await booted();
     await handle.send({ text: "ECHO", attachments: [{ path: png, mime: "image/png" }] });
-    await vi.waitFor(() => expect(texts(evs)).toHaveLength(1));
+    await waitFor(() => expect(texts(evs)).toHaveLength(1));
     const prompt = JSON.parse(texts(evs)[0]!) as Record<string, unknown>[];
     expect(prompt[0]).toEqual({ type: "text", text: "ECHO" });
     expect(prompt[1]).toEqual({ type: "image", data: Buffer.from([1, 2, 3, 4]).toString("base64"), mimeType: "image/png" });
@@ -571,7 +583,7 @@ describe("AcpAdapter", () => {
     expect(prompt).toHaveLength(1);
     const linked = await booted({}, { env: { FAKE_ACP_NOIMAGE: "1" } });
     await linked.handle.send({ text: "ECHO", attachments: [{ path: png, mime: "image/png" }] });
-    await vi.waitFor(() => expect(texts(linked.evs)).toHaveLength(1));
+    await waitFor(() => expect(texts(linked.evs)).toHaveLength(1));
     expect((JSON.parse(texts(linked.evs)[0]!) as Record<string, unknown>[])[1])
       .toEqual({ type: "resource_link", uri: `file://${png}`, name: "shot.png", mimeType: "image/png" });
     await handle.dispose();
@@ -582,7 +594,7 @@ describe("AcpAdapter", () => {
     const { handle, evs } = await booted();
     // Cursor reports embeddedContext:false, so a `resource` block would be rejected outright.
     await handle.send({ text: "ECHO", attachments: [{ path: "/tmp/notes.txt", mime: "text/plain" }] });
-    await vi.waitFor(() => expect(texts(evs)).toHaveLength(1));
+    await waitFor(() => expect(texts(evs)).toHaveLength(1));
     const prompt = JSON.parse(texts(evs)[0]!) as Record<string, unknown>[];
     expect(prompt[1]).toEqual({ type: "resource_link", uri: "file:///tmp/notes.txt", name: "notes.txt", mimeType: "text/plain" });
     await handle.dispose();
@@ -604,7 +616,7 @@ describe("AcpAdapter", () => {
   it("reports a failed prompt and settles back to idle", async () => {
     const { handle, evs } = await booted();
     await handle.send({ text: "FAIL", attachments: [] });
-    await vi.waitFor(() => expect(statuses(evs).at(-1)).toBe("idle"));
+    await waitFor(() => expect(statuses(evs).at(-1)).toBe("idle"));
     expect(errors(evs)[0]).toContain("prompt exploded");
     await handle.dispose();
   });
@@ -647,7 +659,7 @@ describe("AcpAdapter", () => {
   it("flushes a half-streamed message when the session is disposed", async () => {
     const { handle, evs, done } = await booted();
     await handle.send({ text: "OPENTEXT", attachments: [] });
-    await vi.waitFor(() => expect(of(evs, "assistant_delta")).toHaveLength(1));
+    await waitFor(() => expect(of(evs, "assistant_delta")).toHaveLength(1));
     await handle.dispose();
     await done;
     // assistant_delta is ephemeral: without the flush the partial answer never reaches the transcript at all.
@@ -657,7 +669,7 @@ describe("AcpAdapter", () => {
   it("answers a permission still open at dispose instead of leaving it dangling", async () => {
     const { handle, evs, done } = await booted();
     await handle.send({ text: "PERMIT", attachments: [] });
-    await vi.waitFor(() => expect(of(evs, "permission_request")).toHaveLength(1));
+    await waitFor(() => expect(of(evs, "permission_request")).toHaveLength(1));
     const { requestId } = of(evs, "permission_request")[0]!.payload;
     await handle.dispose();
     await done;
@@ -679,7 +691,7 @@ describe("AcpAdapter", () => {
   it("closes a tool call that is still open when the session is disposed", async () => {
     const { handle, evs, done } = await booted();
     await handle.send({ text: "OPENTOOL", attachments: [] });
-    await vi.waitFor(() => expect(of(evs, "tool_call")).toHaveLength(1));
+    await waitFor(() => expect(of(evs, "tool_call")).toHaveLength(1));
     await handle.dispose();
     await done;
     expect(of(evs, "tool_result")[0]!.payload).toEqual({ toolUseId: of(evs, "tool_call")[0]!.payload.toolUseId, content: "session closed", isError: true });
@@ -738,7 +750,7 @@ describe("AcpAdapter", () => {
     const adapter = newAdapter({ bootTimeoutMs: 200, env: { FAKE_ACP_MUTE_SESSION_LOAD: "1" } });
     const handle = adapter.start(startOpts({ resume: "sess_prev", onLog: (l) => logs.push(l) }));
     const { evs } = drain(handle);
-    await vi.waitFor(() => expect(types(evs)).toContain("init"), { timeout: 10_000, interval: 25 });
+    await waitFor(() => expect(types(evs)).toContain("init"));
     expect(of(evs, "init")[0]!.payload.providerSessionId).toBe("sess_0");
     expect(logs.join("\n")).toMatch(/session\/load within 200ms/);
     await handle.dispose();

--- a/packages/adapters/src/acp/acp-adapter.test.ts
+++ b/packages/adapters/src/acp/acp-adapter.test.ts
@@ -1,0 +1,471 @@
+import { describe, it, expect, vi } from "vitest";
+import { fileURLToPath } from "node:url";
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { SessionEvent, SessionEventOf, SessionEventType } from "@realm/contracts";
+import { AcpAdapter, pickAcpOption, type AcpAgentSpec } from "./acp-adapter";
+import type { AgentHandle, StartOptions } from "../types";
+
+const FAKE = fileURLToPath(new URL("./fixtures/fake-acp-agent.mjs", import.meta.url));
+const spec = (o: Partial<AcpAgentSpec> = {}): AcpAgentSpec => ({
+  kind: "acp:cursor", bin: process.execPath, args: [FAKE],
+  label: "Cursor", loginHint: "Run `cursor-agent login`.", ...o,
+});
+const newAdapter = (o: Partial<AcpAgentSpec> = {}) => new AcpAdapter(spec(o));
+const startOpts = (o: Partial<StartOptions> = {}): StartOptions => ({ cwd: process.cwd(), mcpServers: [], ...o });
+
+/** Drains the handle's event stream into an array the assertions poll with `vi.waitFor`. */
+function drain(h: AgentHandle) {
+  const evs: SessionEvent[] = [];
+  const done = (async () => { for await (const e of h.events) evs.push(e); })();
+  return { evs, done };
+}
+const types = (evs: SessionEvent[]) => evs.map((e) => e.type);
+const statuses = (evs: SessionEvent[]) => evs.filter((e) => e.type === "status").map((e) => e.payload.status);
+const of = <T extends SessionEventType>(evs: SessionEvent[], t: T) => evs.filter((e) => e.type === t) as SessionEventOf<T>[];
+const texts = (evs: SessionEvent[]) => of(evs, "assistant_text").map((e) => e.payload.text);
+const errors = (evs: SessionEvent[]) => of(evs, "error").map((e) => e.payload.message);
+
+/** Boots a session and waits for the first terminal event of boot: `init` or `error`. */
+async function booted(o: Partial<StartOptions> = {}, s: Partial<AcpAgentSpec> = {}) {
+  const adapter = newAdapter(s);
+  const handle = adapter.start(startOpts(o));
+  const { evs, done } = drain(handle);
+  await vi.waitFor(() => expect(types(evs).some((t) => t === "init" || t === "error")).toBe(true));
+  return { adapter, handle, evs, done };
+}
+
+/** Lets the queue hand everything already pushed to the drain loop, which delivers asynchronously. */
+const settled = () => new Promise((r) => setTimeout(r, 0));
+
+/** Runs one turn and waits for it to settle back to idle. */
+async function turn(handle: AgentHandle, evs: SessionEvent[], text: string) {
+  const before = statuses(evs).length;
+  await handle.send({ text, attachments: [] });
+  await vi.waitFor(() => expect(statuses(evs).slice(before).at(-1)).toBe("idle"));
+}
+
+const ALLOW_ONLY = [
+  { optionId: "a1", name: "Allow once", kind: "allow_once" },
+  { optionId: "a2", name: "Always allow", kind: "allow_always" },
+];
+const FULL = [...ALLOW_ONLY, { optionId: "r1", name: "Reject", kind: "reject_once" }, { optionId: "r2", name: "Always reject", kind: "reject_always" }];
+
+describe("pickAcpOption", () => {
+  it("prefers allow_once for allow and falls back to allow_always", () => {
+    expect(pickAcpOption("allow", FULL)).toBe("a1");
+    expect(pickAcpOption("allow", [FULL[1]!, FULL[2]!])).toBe("a2");
+  });
+
+  it("prefers allow_always for allow_always and falls back to allow_once", () => {
+    expect(pickAcpOption("allow_always", FULL)).toBe("a2");
+    expect(pickAcpOption("allow_always", [FULL[0]!, FULL[2]!])).toBe("a1");
+  });
+
+  it("prefers reject_once for deny and falls back to reject_always", () => {
+    expect(pickAcpOption("deny", FULL)).toBe("r1");
+    expect(pickAcpOption("deny", [FULL[0]!, FULL[3]!])).toBe("r2");
+  });
+
+  it("returns null rather than degrading a deny into an allow", () => {
+    // The caller answers {outcome:"cancelled"} on null. Falling back to options[0] here would silently
+    // execute the very tool call the user just rejected.
+    expect(pickAcpOption("deny", ALLOW_ONLY)).toBeNull();
+    expect(pickAcpOption("deny", [])).toBeNull();
+  });
+
+  it("returns null when no option matches an allow either", () => {
+    expect(pickAcpOption("allow", [FULL[2]!])).toBeNull();
+    expect(pickAcpOption("allow_always", [FULL[3]!])).toBeNull();
+    expect(pickAcpOption("allow", [])).toBeNull();
+  });
+
+  it("ignores malformed options instead of picking them", () => {
+    expect(pickAcpOption("allow", [null, 7, { name: "no kind" }, { optionId: "x", kind: "allow_once" }])).toBe("x");
+    expect(pickAcpOption("allow", [{ kind: "allow_once" }])).toBeNull(); // no optionId to echo back
+  });
+});
+
+describe("AcpAdapter", () => {
+  it("reports the kind it was constructed with", () => {
+    expect(newAdapter().kind).toBe("acp:cursor");
+    expect(newAdapter({ kind: "acp:gemini" }).kind).toBe("acp:gemini");
+  });
+
+  it("probes the configured binary and tags the result with its kind", async () => {
+    const good = await newAdapter().probe(); // process.execPath --version
+    expect(good).toMatchObject({ kind: "acp:cursor", available: true, loggedIn: null });
+    expect(good.version).toMatch(/^v?\d/);
+    const bad = await newAdapter({ kind: "acp:gemini", bin: "/nonexistent/acp-bin" }).probe();
+    expect(bad).toMatchObject({ kind: "acp:gemini", available: false, version: null });
+  });
+
+  it("emits init then a full streaming turn, and never a user_message", async () => {
+    const { handle, evs } = await booted();
+    const init = of(evs, "init")[0]!;
+    expect(init.payload.providerSessionId).toBe("sess_0");
+    expect(init.payload.model).toBe("fake-model-1");
+    expect(init.payload.cwd).toBe(process.cwd());
+    expect(statuses(evs)).toEqual(["idle"]);
+
+    await turn(handle, evs, "hi");
+    expect(of(evs, "assistant_delta").map((e) => e.payload.delta)).toEqual(["Hel", "lo"]);
+    expect(texts(evs)).toEqual(["Hello"]);
+    expect(of(evs, "thinking").map((e) => e.payload.text)).toEqual(["pondering"]);
+    expect(statuses(evs)).toEqual(["idle", "running", "idle"]);
+    // SessionService emits user_message itself; a second one from the adapter would double every message.
+    expect(types(evs)).not.toContain("user_message");
+    expect(errors(evs)).toEqual([]);
+    await handle.dispose();
+  });
+
+  it("returns from send() without waiting for the turn to finish", async () => {
+    const { handle, evs } = await booted();
+    const t0 = Date.now();
+    await handle.send({ text: "HANG", attachments: [] });
+    const elapsed = Date.now() - t0;
+    // session/prompt stays pending for the whole turn. SessionService.send() awaits this, and the RPC method
+    // awaits that, so awaiting the prompt would hang the WebSocket call for the length of the turn.
+    expect(elapsed).toBeLessThan(1000);
+    await vi.waitFor(() => expect(statuses(evs)).toEqual(["idle", "running"]));
+    await handle.interrupt();
+    await vi.waitFor(() => expect(statuses(evs).at(-1)).toBe("idle"));
+    // The connection survives cancellation: the agent flushed "bye" before resolving, and the next turn works.
+    expect(texts(evs)).toEqual(["bye"]);
+    expect(errors(evs)).toEqual([]);
+    await turn(handle, evs, "again");
+    expect(texts(evs)).toEqual(["bye", "Hello"]);
+    await handle.dispose();
+  });
+
+  it("bridges a permission request, allows it, and surfaces the tool result", async () => {
+    const { handle, evs } = await booted();
+    await handle.send({ text: "PERMIT", attachments: [] });
+    await vi.waitFor(() => expect(of(evs, "permission_request")).toHaveLength(1));
+    const req = of(evs, "permission_request")[0]!.payload;
+    expect(statuses(evs)).toEqual(["idle", "running", "waiting_permission"]);
+    // The request's toolCall is a sparse patch carrying only toolCallId, so both the name and the input come
+    // from the tool_call the mapper already recorded.
+    expect(req.toolName).toBe("Run step 0");
+    expect(req.input).toEqual({ command: "echo 0" });
+    expect(req.suggestions).toHaveLength(3);
+    expect(req.suggestions[0]).toMatchObject({ optionId: "allow-once", kind: "allow_once" });
+
+    handle.respondPermission(req.requestId, "allow");
+    await vi.waitFor(() => expect(statuses(evs).at(-1)).toBe("idle"));
+    expect(of(evs, "permission_response")[0]!.payload).toEqual({ requestId: req.requestId, decision: "allow" });
+    expect(of(evs, "tool_result")[0]!.payload).toMatchObject({ content: "outcome:allow-once", isError: false });
+    expect(statuses(evs)).toEqual(["idle", "running", "waiting_permission", "running", "idle"]);
+    await handle.dispose();
+  });
+
+  it("echoes the reject option a deny maps to", async () => {
+    const { handle, evs } = await booted();
+    await handle.send({ text: "PERMIT", attachments: [] });
+    await vi.waitFor(() => expect(of(evs, "permission_request")).toHaveLength(1));
+    handle.respondPermission(of(evs, "permission_request")[0]!.payload.requestId, "deny");
+    await vi.waitFor(() => expect(of(evs, "tool_result")).toHaveLength(1));
+    expect(of(evs, "tool_result")[0]!.payload).toMatchObject({ content: "outcome:reject-once", isError: true });
+    await handle.dispose();
+  });
+
+  it("answers cancelled — never an allow — when the agent offers no reject option", async () => {
+    const { handle, evs } = await booted({}, { env: { FAKE_ACP_ALLOWONLY: "1" } });
+    await handle.send({ text: "PERMIT", attachments: [] });
+    await vi.waitFor(() => expect(of(evs, "permission_request")).toHaveLength(1));
+    handle.respondPermission(of(evs, "permission_request")[0]!.payload.requestId, "deny");
+    await vi.waitFor(() => expect(of(evs, "tool_result")).toHaveLength(1));
+    expect(of(evs, "tool_result")[0]!.payload.content).toBe("outcome:cancelled");
+    await handle.dispose();
+  });
+
+  it("raises waiting_permission once while two requests are open", async () => {
+    const { handle, evs } = await booted();
+    await handle.send({ text: "PERMIT2", attachments: [] });
+    await vi.waitFor(() => expect(of(evs, "permission_request")).toHaveLength(2));
+    expect(statuses(evs).filter((s) => s === "waiting_permission")).toHaveLength(1);
+    const [a, b] = of(evs, "permission_request").map((e) => e.payload.requestId);
+    handle.respondPermission(a!, "allow");
+    await settled();
+    // One answer does not end the wait — the other request is still open.
+    expect(statuses(evs).at(-1)).toBe("waiting_permission");
+    handle.respondPermission(b!, "allow_always");
+    await vi.waitFor(() => expect(statuses(evs).filter((s) => s === "running")).toHaveLength(2));
+    await vi.waitFor(() => expect(statuses(evs).at(-1)).toBe("idle"));
+    expect(statuses(evs)).toEqual(["idle", "running", "waiting_permission", "running", "idle"]);
+    expect(of(evs, "tool_result").map((e) => e.payload.content).sort()).toEqual(["outcome:allow-always", "outcome:allow-once"]);
+    await handle.dispose();
+  });
+
+  it("cancels every open permission on interrupt without killing the connection", async () => {
+    const { handle, evs } = await booted();
+    await handle.send({ text: "PERMIT", attachments: [] });
+    await vi.waitFor(() => expect(of(evs, "permission_request")).toHaveLength(1));
+    await handle.interrupt();
+    await vi.waitFor(() => expect(of(evs, "tool_result")).toHaveLength(1));
+    expect(of(evs, "tool_result")[0]!.payload.content).toBe("outcome:cancelled");
+    expect(of(evs, "permission_response")).toHaveLength(1);
+    await vi.waitFor(() => expect(statuses(evs).at(-1)).toBe("idle"));
+    expect(types(evs)).not.toContain("error");
+    await handle.dispose();
+  });
+
+  it("drops the session/load replay instead of appending it to the transcript", async () => {
+    const { handle, evs } = await booted({ resume: "sess_prev" });
+    expect(of(evs, "init")[0]!.payload.providerSessionId).toBe("sess_prev");
+    // Realm already persisted this conversation; re-emitting the replay would duplicate every turn.
+    expect(types(evs)).not.toContain("assistant_text");
+    expect(types(evs)).not.toContain("assistant_delta");
+    expect(types(evs)).not.toContain("tool_call");
+    // …and the flag is cleared afterwards, or the session would be permanently mute.
+    await turn(handle, evs, "hi");
+    expect(texts(evs)).toEqual(["Hello"]);
+    await handle.dispose();
+  });
+
+  it("loads the resumed session with cwd and mcpServers", async () => {
+    const { handle, evs } = await booted({ resume: "sess_prev" });
+    await turn(handle, evs, "REVEAL");
+    const journal = JSON.parse(texts(evs)[0]!) as { loadParams: unknown; newParams: unknown };
+    expect(journal.loadParams).toEqual({ sessionId: "sess_prev", cwd: process.cwd(), mcpServers: [] });
+    expect(journal.newParams).toBeNull(); // a successful load must not also start a fresh session
+    await handle.dispose();
+  });
+
+  it("starts a new session when the agent does not advertise loadSession", async () => {
+    const { handle, evs } = await booted({ resume: "sess_prev" }, { env: { FAKE_ACP_NOLOAD: "1" } });
+    expect(of(evs, "init")[0]!.payload.providerSessionId).toBe("sess_0");
+    await turn(handle, evs, "REVEAL");
+    const journal = JSON.parse(texts(evs)[0]!) as { loadParams: unknown; newParams: unknown };
+    expect(journal.loadParams).toBeNull();
+    expect(journal.newParams).toMatchObject({ cwd: process.cwd() });
+    await handle.dispose();
+  });
+
+  it("falls back to a new session when session/load fails", async () => {
+    const logs: string[] = [];
+    const { handle, evs } = await booted({ resume: "sess_prev", onLog: (l) => logs.push(l) }, { env: { FAKE_ACP_LOADFAIL: "1" } });
+    expect(of(evs, "init")[0]!.payload.providerSessionId).toBe("sess_0");
+    expect(errors(evs)).toEqual([]); // a failed resume is recoverable, not a session failure
+    expect(logs.join("\n")).toContain("no such session on disk");
+    // The flag is cleared by the failure too, so the fresh session is not mute.
+    await turn(handle, evs, "hi");
+    expect(texts(evs)).toEqual(["Hello"]);
+    await handle.dispose();
+  });
+
+  it("surfaces an auth failure with the agent label, its auth methods and the login hint", async () => {
+    const { evs, done } = await booted({}, { env: { FAKE_ACP_AUTHFAIL: "1" } });
+    await done;
+    const msg = errors(evs)[0]!;
+    expect(msg).toContain("Cursor");
+    expect(msg).toContain("This client is no longer supported for individuals.");
+    expect(msg).toContain("Fake Login");
+    expect(msg).toContain("Run `cursor-agent login`.");
+    expect(statuses(evs)).toEqual(["error", "ended"]);
+    expect(types(evs)).not.toContain("init");
+  });
+
+  it("surfaces Cursor's generic -32603 startup failure verbatim, hint included", async () => {
+    const { evs, done } = await booted({}, { env: { FAKE_ACP_STARTFAIL: "1" } });
+    await done;
+    const msg = errors(evs)[0]!;
+    expect(msg).toContain("Failed to initialize session services");
+    expect(msg).toContain("[unauthenticated] Error");
+    expect(msg).toContain("Run `cursor-agent login`.");
+  });
+
+  it("reports a binary that does not exist without the login hint", async () => {
+    const { evs, done } = await booted({}, { bin: "/nonexistent/acp-bin" });
+    await done;
+    expect(errors(evs)[0]).toContain("/nonexistent/acp-bin");
+    expect(errors(evs)[0]).not.toContain("cursor-agent login");
+  });
+
+  it("serves fs/read_text_file, honouring line and limit", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "realm-acp-"));
+    const path = join(dir, "NOTES.txt");
+    await writeFile(path, "one\ntwo\nthree\nfour\n");
+    const { handle, evs } = await booted();
+    await turn(handle, evs, `READFILE ${path}`);
+    expect(texts(evs)[0]).toBe("read:one\ntwo\nthree\nfour\n");
+    await turn(handle, evs, `READFILE ${path} 2 2`);
+    expect(texts(evs)[1]).toBe("read:two\nthree");
+    await turn(handle, evs, `READFILE ${join(dir, "missing.txt")}`);
+    expect(texts(evs)[2]).toContain("read failed:");
+    await handle.dispose();
+  });
+
+  it("serves fs/write_text_file", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "realm-acp-"));
+    const path = join(dir, "OUT.txt");
+    const { handle, evs } = await booted();
+    await turn(handle, evs, `WRITEFILE ${path} written by the agent`);
+    expect(texts(evs)[0]).toBe("write:ok");
+    expect(await readFile(path, "utf8")).toBe("written by the agent");
+    await handle.dispose();
+  });
+
+  it("answers an undeclared client method with -32601 instead of stalling the turn", async () => {
+    const logs: string[] = [];
+    const { handle, evs } = await booted({ onLog: (l) => logs.push(l) });
+    // terminal/* is probed even though clientCapabilities.terminal is false; an unanswered request would
+    // leave this turn pending forever, so reaching idle at all is the assertion.
+    await turn(handle, evs, "ODDBALL");
+    expect(texts(evs)[0]).toBe("terminal refused: -32601");
+    expect(logs.join("\n")).toContain("terminal/create");
+    await handle.dispose();
+  });
+
+  it("declares the fs capabilities and no terminal in initialize", async () => {
+    const { handle, evs } = await booted();
+    await turn(handle, evs, "REVEAL");
+    const journal = JSON.parse(texts(evs)[0]!) as { calls: { method: string; params: Record<string, unknown> }[] };
+    expect(journal.calls[0]).toEqual({
+      method: "initialize",
+      params: { protocolVersion: 1, clientCapabilities: { fs: { readTextFile: true, writeTextFile: true }, terminal: false } },
+    });
+    await handle.dispose();
+  });
+
+  it("sends mcp servers with env as name/value pairs, not a record", async () => {
+    const { handle, evs } = await booted({ mcpServers: [{ name: "realm", command: "/usr/bin/node", args: ["/abs/realm-mcp.mjs"], env: { A: "1", B: "2" } }] });
+    await turn(handle, evs, "REVEAL");
+    const journal = JSON.parse(texts(evs)[0]!) as { newParams: { cwd: string; mcpServers: unknown[] } };
+    expect(journal.newParams.mcpServers).toEqual([
+      { name: "realm", command: "/usr/bin/node", args: ["/abs/realm-mcp.mjs"], env: [{ name: "A", value: "1" }, { name: "B", value: "2" }] },
+    ]);
+    await handle.dispose();
+  });
+
+  it("sends an empty mcpServers array when there is nothing to configure", async () => {
+    const { handle, evs } = await booted();
+    await turn(handle, evs, "REVEAL");
+    const journal = JSON.parse(texts(evs)[0]!) as { newParams: { mcpServers: unknown[] } };
+    expect(journal.newParams.mcpServers).toEqual([]); // required, not optional
+    await handle.dispose();
+  });
+
+  it("inlines image attachments as base64 when the agent accepts images", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "realm-acp-"));
+    const png = join(dir, "shot.png");
+    await writeFile(png, Buffer.from([1, 2, 3, 4]));
+    const { handle, evs } = await booted();
+    await handle.send({ text: "ECHO", attachments: [{ path: png, mime: "image/png" }] });
+    await vi.waitFor(() => expect(texts(evs)).toHaveLength(1));
+    const prompt = JSON.parse(texts(evs)[0]!) as Record<string, unknown>[];
+    expect(prompt[0]).toEqual({ type: "text", text: "ECHO" });
+    expect(prompt[1]).toEqual({ type: "image", data: Buffer.from([1, 2, 3, 4]).toString("base64"), mimeType: "image/png" });
+    await handle.dispose();
+  });
+
+  it("links images instead of inlining them when the agent does not accept images", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "realm-acp-"));
+    const png = join(dir, "shot.png");
+    await writeFile(png, Buffer.from([1, 2, 3, 4]));
+    const { handle, evs } = await booted({}, { env: { FAKE_ACP_NOIMAGE: "1" } });
+    await turn(handle, evs, "ECHO");
+    const prompt = JSON.parse(texts(evs)[0]!) as Record<string, unknown>[];
+    expect(prompt).toHaveLength(1);
+    const linked = await booted({}, { env: { FAKE_ACP_NOIMAGE: "1" } });
+    await linked.handle.send({ text: "ECHO", attachments: [{ path: png, mime: "image/png" }] });
+    await vi.waitFor(() => expect(texts(linked.evs)).toHaveLength(1));
+    expect((JSON.parse(texts(linked.evs)[0]!) as Record<string, unknown>[])[1])
+      .toEqual({ type: "resource_link", uri: `file://${png}`, name: "shot.png", mimeType: "image/png" });
+    await handle.dispose();
+    await linked.handle.dispose();
+  });
+
+  it("links non-image attachments rather than embedding them", async () => {
+    const { handle, evs } = await booted();
+    // Cursor reports embeddedContext:false, so a `resource` block would be rejected outright.
+    await handle.send({ text: "ECHO", attachments: [{ path: "/tmp/notes.txt", mime: "text/plain" }] });
+    await vi.waitFor(() => expect(texts(evs)).toHaveLength(1));
+    const prompt = JSON.parse(texts(evs)[0]!) as Record<string, unknown>[];
+    expect(prompt[1]).toEqual({ type: "resource_link", uri: "file:///tmp/notes.txt", name: "notes.txt", mimeType: "text/plain" });
+    await handle.dispose();
+  });
+
+  it("gives refusal and max_tokens their own copy and stays quiet for the rest", async () => {
+    const { handle, evs } = await booted();
+    await turn(handle, evs, "STOP:refusal");
+    expect(errors(evs)[0]).toMatch(/refus/i);
+    await turn(handle, evs, "STOP:max_tokens");
+    expect(errors(evs)[1]).toMatch(/token/i);
+    await turn(handle, evs, "STOP:end_turn");
+    await turn(handle, evs, "STOP:cancelled");
+    expect(errors(evs)).toHaveLength(2); // end_turn and cancelled are normal outcomes, not failures
+    expect(statuses(evs).filter((s) => s === "idle")).toHaveLength(5);
+    await handle.dispose();
+  });
+
+  it("reports a failed prompt and settles back to idle", async () => {
+    const { handle, evs } = await booted();
+    await handle.send({ text: "FAIL", attachments: [] });
+    await vi.waitFor(() => expect(statuses(evs).at(-1)).toBe("idle"));
+    expect(errors(evs)[0]).toContain("prompt exploded");
+    await handle.dispose();
+  });
+
+  it("applies setOptions best-effort and swallows what the agent refuses", async () => {
+    const logs: string[] = [];
+    const { handle, evs } = await booted({ onLog: (l) => logs.push(l) });
+    await handle.setOptions({ model: "fake-model-2", permissionMode: "plan" });
+    await turn(handle, evs, "REVEAL");
+    const journal = JSON.parse(texts(evs)[0]!) as { calls: { method: string; params: Record<string, unknown> }[] };
+    const calls = Object.fromEntries(journal.calls.map((c) => [c.method, c.params]));
+    expect(calls["session/set_mode"]).toEqual({ sessionId: "sess_0", modeId: "plan" });
+    expect(calls["session/set_model"]).toEqual({ sessionId: "sess_0", modelId: "fake-model-2" });
+    // session/set_model is unstable in 0.4.5; its rejection is a log line, not a session error.
+    expect(errors(evs)).toEqual([]);
+    expect(logs.join("\n")).toContain("session/set_model");
+    await handle.dispose();
+  });
+
+  it("emits no error on a deliberate dispose, and ends the stream", async () => {
+    const { handle, evs, done } = await booted();
+    await handle.dispose();
+    await done;
+    expect(types(evs)).not.toContain("error");
+    expect(statuses(evs)).toEqual(["idle", "ended"]);
+    await handle.dispose(); // idempotent
+    expect(statuses(evs)).toEqual(["idle", "ended"]);
+  });
+
+  it("closes an open tool call and reports an error when the child dies unexpectedly", async () => {
+    const { handle, evs, done } = await booted();
+    await handle.send({ text: "DIE", attachments: [] });
+    await done;
+    expect(errors(evs)[0]).toMatch(/exited/);
+    expect(of(evs, "tool_result")[0]!.payload).toMatchObject({ isError: true });
+    expect(statuses(evs)).toEqual(["idle", "running", "error", "ended"]);
+    await handle.dispose();
+  });
+
+  it("refuses a message once the session has ended", async () => {
+    const { handle, evs } = await booted();
+    await handle.dispose();
+    await handle.send({ text: "hi", attachments: [] });
+    expect(errors(evs)).toEqual([]); // the stream is closed; nothing can be pushed onto it any more
+  });
+
+  it("serves fs callbacks during a replay but cancels permission requests raised by it", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "realm-acp-"));
+    const path = join(dir, "REPLAY.txt");
+    await writeFile(path, "replayed content");
+    const { handle, evs } = await booted(
+      { resume: "sess_prev" },
+      { env: { FAKE_ACP_LOAD_ASKS: "1", FAKE_ACP_LOAD_ASKS_PATH: path } },
+    );
+    await turn(handle, evs, "REVEAL");
+    const journal = JSON.parse(texts(evs)[0]!) as { replayAsks: { read: { result?: { content: string } }; permission: { result?: { outcome: { outcome: string } } } } };
+    expect(journal.replayAsks.read.result).toEqual({ content: "replayed content" });
+    // There is no live turn behind a replayed permission request and no user watching for it, so it is
+    // answered `cancelled` and never reaches the transcript.
+    expect(journal.replayAsks.permission.result).toEqual({ outcome: { outcome: "cancelled" } });
+    expect(types(evs)).not.toContain("permission_request");
+    expect(statuses(evs)).not.toContain("waiting_permission");
+    await handle.dispose();
+  });
+});

--- a/packages/adapters/src/acp/acp-adapter.test.ts
+++ b/packages/adapters/src/acp/acp-adapter.test.ts
@@ -583,6 +583,17 @@ describe("AcpAdapter", () => {
     expect(of(evs, "permission_response").map((e) => e.payload)).toEqual([{ requestId, decision: "deny" }]);
   });
 
+  it("cancels a permission that arrives while the session is being torn down", async () => {
+    const { handle, evs, done } = await booted({}, { env: { FAKE_ACP_IGNORE_EOF: "1" } });
+    await handle.send({ text: "LATEPERMIT", attachments: [] });
+    // dispose() only resolves once the child is gone, so the late request has certainly arrived by then.
+    await handle.dispose();
+    await done;
+    expect(types(evs)).not.toContain("permission_request");
+    expect(statuses(evs)).not.toContain("waiting_permission");
+    expect(statuses(evs).at(-1)).toBe("ended");
+  });
+
   it("closes a tool call that is still open when the session is disposed", async () => {
     const { handle, evs, done } = await booted();
     await handle.send({ text: "OPENTOOL", attachments: [] });

--- a/packages/adapters/src/acp/acp-adapter.ts
+++ b/packages/adapters/src/acp/acp-adapter.ts
@@ -201,10 +201,11 @@ export class AcpAdapter implements AgentAdapter {
     };
 
     const requestPermission = (id: JsonRpcId, p: Bag): void => {
-      // A replayed permission request belongs to a turn that finished long ago: there is no live tool call
-      // behind it and nobody watching for a card, so it is answered `cancelled` and kept out of the transcript.
-      if (replaying) {
-        log("cancelling a permission request raised during session/load replay");
+      // Nobody is left to answer either of these, so both get `cancelled` — the only other legal answer (§4) —
+      // and stay out of the transcript: a replayed request belongs to a turn that finished long ago, and one
+      // that arrives while the child is being torn down would leave a card waiting after the session ended.
+      if (replaying || disposed) {
+        log(`cancelling a permission request raised during ${replaying ? "session/load replay" : "shutdown"}`);
         rpc?.respond(id, { outcome: { outcome: "cancelled" } });
         return;
       }

--- a/packages/adapters/src/acp/acp-adapter.ts
+++ b/packages/adapters/src/acp/acp-adapter.ts
@@ -2,7 +2,7 @@ import { basename } from "node:path";
 import { readFile, writeFile } from "node:fs/promises";
 import { sessionEvent, type AgentKind, type SessionEvent } from "@realm/contracts";
 import { AsyncQueue } from "../event-queue";
-import { JsonRpcCallError, StdioJsonRpc, type JsonRpcId } from "../jsonrpc/stdio";
+import { JsonRpcCallError, StdioJsonRpc, withTimeout, type JsonRpcId } from "../jsonrpc/stdio";
 import { createAcpMapper } from "./map-acp";
 import { probeAcp } from "./probe";
 import type { AgentAdapter, AgentHandle, McpStdioConfig, PermissionDecision, ProbeResult, StartOptions, UserMessage } from "../types";
@@ -23,7 +23,16 @@ export type AcpAgentSpec = {
   /** What the user should run out of band to log in — Realm never calls `authenticate` itself (§2.2). */
   loginHint: string;
   env?: Record<string, string>;
+  /** Overridable for tests. Bounds every boot call: initialize, session/new and session/load. */
+  bootTimeoutMs?: number;
 };
+
+/** Copies ClaudeAdapter: app quit awaits every dispose(), so no dispose may depend on a healthy child. */
+const DISPOSE_TIMEOUT_MS = 3000;
+/** `initialize` is a local handshake. */
+const INITIALIZE_TIMEOUT_MS = 10_000;
+/** `session/new`/`session/load` can go to the network — Cursor signs in and spins up session services here. */
+const SESSION_TIMEOUT_MS = 30_000;
 
 /** `RequestError.authRequired`. Gemini uses it on `session/new`; Cursor returns a generic -32603 instead (§7). */
 const AUTH_REQUIRED = -32000;
@@ -256,10 +265,18 @@ export class AcpAdapter implements AgentAdapter {
         });
         rpc = transport;
 
-        const init = obj(await transport.request("initialize", {
+        // Bounded: ACP gives none of these calls a deadline, and a child that spawns and then answers nothing
+        // would otherwise leave `boot` — and every send()/setOptions()/dispose() behind it — pending for the
+        // life of the process.
+        const ask = (method: string, params: Bag, fallbackMs: number): Promise<unknown> => {
+          const ms = spec.bootTimeoutMs ?? fallbackMs;
+          return withTimeout(transport.request(method, params), ms, `${spec.label} did not answer ${method} within ${ms}ms`);
+        };
+
+        const init = obj(await ask("initialize", {
           protocolVersion: 1,
           clientCapabilities: { fs: { readTextFile: true, writeTextFile: true }, terminal: false },
-        }));
+        }, INITIALIZE_TIMEOUT_MS));
         const caps = obj(init.agentCapabilities);
         imagesAllowed = obj(caps.promptCapabilities).image === true;
         authMethods = Array.isArray(init.authMethods) ? init.authMethods : [];
@@ -273,7 +290,7 @@ export class AcpAdapter implements AgentAdapter {
           try {
             // The whole prior conversation arrives as session/update notifications before this resolves (§2.3).
             // Realm has already persisted every one of them, so they are dropped rather than appended.
-            session = obj(await transport.request("session/load", { sessionId: opts.resume, cwd: opts.cwd, mcpServers }));
+            session = obj(await ask("session/load", { sessionId: opts.resume, cwd: opts.cwd, mcpServers }, SESSION_TIMEOUT_MS));
             id = opts.resume;
           } catch (e) {
             log(`session/load failed (${message(e)}); starting a new session instead`);
@@ -282,7 +299,7 @@ export class AcpAdapter implements AgentAdapter {
           }
         }
         if (id === null) {
-          session = obj(await transport.request("session/new", { cwd: opts.cwd, mcpServers }));
+          session = obj(await ask("session/new", { cwd: opts.cwd, mcpServers }, SESSION_TIMEOUT_MS));
           id = str(session.sessionId);
           if (!id) throw new Error(`${spec.label} did not return a session id`);
         }
@@ -362,7 +379,14 @@ export class AcpAdapter implements AgentAdapter {
         if (o.model !== undefined) await attempt("session/set_model", { sessionId, modelId: o.model });
       },
       dispose: async () => {
-        await boot; // never tear down a half-open connection behind a dispose that raced the boot
+        // Waiting for boot keeps a dispose that raced it from tearing down a half-open connection — but the
+        // wait is bounded, because SessionService.closeAll() -> App.close() -> app quit is what is behind it.
+        // An unbounded wait here is how the desktop main process ends up SIGTERMing a server that still owns
+        // live agent children. shutdown() closes the transport either way: `rpc` is assigned before the
+        // handshake, so the child dies even when the timeout is what got us here.
+        let timer: ReturnType<typeof setTimeout> | undefined;
+        await Promise.race([boot, new Promise<void>((res) => { timer = setTimeout(res, DISPOSE_TIMEOUT_MS); })]);
+        clearTimeout(timer);
         await shutdown();
       },
     };

--- a/packages/adapters/src/acp/acp-adapter.ts
+++ b/packages/adapters/src/acp/acp-adapter.ts
@@ -1,0 +1,370 @@
+import { basename } from "node:path";
+import { readFile, writeFile } from "node:fs/promises";
+import { sessionEvent, type AgentKind, type SessionEvent } from "@realm/contracts";
+import { AsyncQueue } from "../event-queue";
+import { JsonRpcCallError, StdioJsonRpc, type JsonRpcId } from "../jsonrpc/stdio";
+import { createAcpMapper } from "./map-acp";
+import { probeAcp } from "./probe";
+import type { AgentAdapter, AgentHandle, McpStdioConfig, PermissionDecision, ProbeResult, StartOptions, UserMessage } from "../types";
+
+type Bag = Record<string, unknown>;
+const obj = (v: unknown): Bag => (v && typeof v === "object" ? (v as Bag) : {});
+const str = (v: unknown): string => (typeof v === "string" ? v : "");
+const num = (v: unknown): number | null => (typeof v === "number" && Number.isFinite(v) ? v : null);
+const message = (e: unknown): string => (e instanceof Error ? e.message : String(e));
+
+/** One registered ACP agent. The class is generic; a spec is what makes it Cursor or Gemini. */
+export type AcpAgentSpec = {
+  kind: AgentKind;
+  bin: string;
+  args: string[];
+  /** Human name for error copy — "Cursor", "Gemini". */
+  label: string;
+  /** What the user should run out of band to log in — Realm never calls `authenticate` itself (§2.2). */
+  loginHint: string;
+  env?: Record<string, string>;
+};
+
+/** `RequestError.authRequired`. Gemini uses it on `session/new`; Cursor returns a generic -32603 instead (§7). */
+const AUTH_REQUIRED = -32000;
+
+/**
+ * `PermissionOption.kind`s Realm will accept for a decision, most preferred first.
+ *
+ * `optionId`s are agent-defined strings (§4), so the only stable thing to match on is `kind`.
+ */
+const OPTION_PREFERENCES: Record<PermissionDecision, readonly string[]> = {
+  allow: ["allow_once", "allow_always"],
+  allow_always: ["allow_always", "allow_once"],
+  deny: ["reject_once", "reject_always"],
+};
+
+/**
+ * Picks the `optionId` to echo back for `decision`, or `null` when the agent offered nothing that means it.
+ *
+ * `null` is answered with `{outcome:{outcome:"cancelled"}}` by the caller. There is deliberately no fallback to
+ * `options[0]`: on an allow-only list that would turn a user's *deny* into running the tool call.
+ */
+export function pickAcpOption(decision: PermissionDecision, options: readonly unknown[]): string | null {
+  const offered = options.map(obj).filter((o) => typeof o.optionId === "string");
+  for (const kind of OPTION_PREFERENCES[decision]) {
+    const hit = offered.find((o) => o.kind === kind);
+    if (hit) return str(hit.optionId);
+  }
+  return null;
+}
+
+/** `McpServer[]` for `session/new`/`session/load`. Stdio `env` is an array of pairs, NOT a record (§2.3). */
+export function acpMcpServers(servers: McpStdioConfig[]): Bag[] {
+  return servers.map((s) => ({
+    name: s.name,
+    command: s.command,
+    args: s.args ?? [],
+    env: Object.entries(s.env ?? {}).map(([name, value]) => ({ name, value })),
+  }));
+}
+
+/** User-visible copy for the stop reasons that are outcomes rather than plain completions (§3). */
+const STOP_REASON_ERRORS: Record<string, string> = {
+  refusal: "the agent refused to continue this turn",
+  max_tokens: "the turn stopped early: the agent hit its maximum token count",
+  max_turn_requests: "the turn stopped early: the agent hit its maximum number of model requests",
+};
+
+/** `null` for `end_turn` and `cancelled` — both are normal endings, not failures. */
+export function stopReasonError(stopReason: string): string | null {
+  return STOP_REASON_ERRORS[stopReason] ?? null;
+}
+
+/** `fs/read_text_file`'s optional window: `line` is 1-based, `limit` is a line count (§5). */
+export function sliceLines(content: string, line: unknown, limit: unknown): string {
+  const from = num(line);
+  const count = num(limit);
+  if (from === null && count === null) return content;
+  const lines = content.split("\n");
+  const start = from === null ? 0 : Math.max(0, from - 1);
+  return lines.slice(start, count === null ? undefined : start + count).join("\n");
+}
+
+/**
+ * Copy for a `session/new`/`session/load` rejection.
+ *
+ * Cursor returns a generic `-32603 Internal error` for *any* startup failure and hides the real reason in
+ * `data` (§7), so the data is echoed verbatim and the login hint is appended whatever the code — the user
+ * cannot be told apart "not logged in" from "bad cwd" by the code alone.
+ */
+export function acpBootFailureMessage(e: unknown, spec: Pick<AcpAgentSpec, "label" | "loginHint">, authMethods: readonly unknown[]): string {
+  if (!(e instanceof JsonRpcCallError)) return message(e); // spawn failure, transport death: not a login problem
+  const data = obj(e.data);
+  const detail = [str(data.message), str(data.details)].filter(Boolean).join(" — ");
+  const names = authMethods.map((m) => str(obj(m).name) || str(obj(m).id)).filter(Boolean);
+  const head = e.code === AUTH_REQUIRED
+    ? `${spec.label} needs you to sign in: ${e.message}`
+    : `${spec.label} could not start a session: ${e.message}`;
+  return [head, detail, names.length ? `Sign-in methods it offers: ${names.join(", ")}.` : "", spec.loginHint].filter(Boolean).join(" ");
+}
+
+/**
+ * One generic ACP adapter, instantiated once per registered agent kind.
+ *
+ * Unlike Codex's multiplexed app-server, an ACP session belongs to its connection, so this spawns **one child
+ * per session** and `dispose()` takes that child down.
+ */
+export class AcpAdapter implements AgentAdapter {
+  readonly kind: AgentKind;
+
+  constructor(private readonly spec: AcpAgentSpec) {
+    this.kind = spec.kind;
+  }
+
+  async probe(): Promise<ProbeResult> {
+    return { kind: this.kind, ...(await probeAcp(this.spec.bin)) };
+  }
+
+  start(opts: StartOptions): AgentHandle {
+    const spec = this.spec;
+    const events = new AsyncQueue<SessionEvent>();
+    const mapper = createAcpMapper();
+    const pending = new Map<string, { id: JsonRpcId; options: unknown[] }>();
+    let rpc: StdioJsonRpc | null = null;
+    let sessionId: string | null = null;
+    let imagesAllowed = false;
+    let authMethods: unknown[] = [];
+    /** True only for the duration of `session/load`, whose replay Realm has already persisted. */
+    let replaying = false;
+    let disposed = false;
+
+    const log = (line: string) => opts.onLog?.(`[${spec.kind}] ${line}`);
+    const fail = (text: string) => {
+      events.push(sessionEvent("error", { message: text }));
+      events.push(sessionEvent("status", { status: "error" }));
+    };
+
+    const answer = (requestId: string, outcome: Bag) => {
+      const p = pending.get(requestId);
+      if (!p) return false;
+      pending.delete(requestId);
+      rpc?.respond(p.id, { outcome });
+      return true;
+    };
+
+    const respond = (requestId: string, decision: PermissionDecision) => {
+      const p = pending.get(requestId);
+      if (!p) return;
+      const optionId = pickAcpOption(decision, p.options);
+      // No option carries this decision. `cancelled` is the only other legal answer (§4) and is the safe one:
+      // it never runs the tool call.
+      if (optionId === null) log(`no option matched decision ${decision}; answering cancelled`);
+      answer(requestId, optionId === null ? { outcome: "cancelled" } : { outcome: "selected", optionId });
+      events.push(sessionEvent("permission_response", { requestId, decision }));
+      // Several tools can be waiting at once; the turn is only unblocked when the last one is answered. The
+      // prompt's own resolution is what settles the status back to idle.
+      if (pending.size === 0) events.push(sessionEvent("status", { status: "running" }));
+    };
+
+    /**
+     * §6: every in-flight permission MUST be answered `cancelled` when the turn is cancelled. The transcript
+     * still records a decision so the card stops waiting; `deny` is what actually happened to the tool call.
+     */
+    const cancelAllPending = () => {
+      for (const requestId of [...pending.keys()]) {
+        answer(requestId, { outcome: "cancelled" });
+        events.push(sessionEvent("permission_response", { requestId, decision: "deny" }));
+      }
+    };
+
+    /** Ends the session and the child. Idempotent; the only path that closes the stream. */
+    const shutdown = async (): Promise<void> => {
+      if (disposed) return;
+      disposed = true;
+      cancelAllPending();
+      for (const e of mapper.flush()) events.push(e);
+      for (const e of mapper.closeOpenCalls("session closed")) events.push(e);
+      events.push(sessionEvent("status", { status: "ended" }));
+      events.close();
+      await rpc?.dispose();
+    };
+
+    const serveFs = async (id: JsonRpcId, method: string, p: Bag): Promise<void> => {
+      try {
+        if (method === "fs/read_text_file") {
+          const content = await readFile(str(p.path), "utf8");
+          rpc?.respond(id, { content: sliceLines(content, p.line, p.limit) });
+        } else {
+          await writeFile(str(p.path), str(p.content), "utf8");
+          rpc?.respond(id, {});
+        }
+      } catch (e) {
+        rpc?.respondError(id, -32603, message(e));
+      }
+    };
+
+    const requestPermission = (id: JsonRpcId, p: Bag): void => {
+      // A replayed permission request belongs to a turn that finished long ago: there is no live tool call
+      // behind it and nobody watching for a card, so it is answered `cancelled` and kept out of the transcript.
+      if (replaying) {
+        log("cancelling a permission request raised during session/load replay");
+        rpc?.respond(id, { outcome: { outcome: "cancelled" } });
+        return;
+      }
+      const patch = obj(p.toolCall);
+      const toolCallId = str(patch.toolCallId);
+      // `toolCall` is a ToolCallUpdate: only `toolCallId` is guaranteed (§4), so the card is rendered from the
+      // merged call the mapper recorded, with whatever the patch does carry laid over it.
+      const merged = mapper.callOf(toolCallId);
+      const toolName = str(patch.title) || merged?.title || toolCallId;
+      const input = { ...(merged?.input ?? {}), ...obj(patch.rawInput) };
+      const options = Array.isArray(p.options) ? p.options : [];
+      const requestId = String(id);
+      if (pending.size === 0) events.push(sessionEvent("status", { status: "waiting_permission" }));
+      pending.set(requestId, { id, options });
+      events.push(sessionEvent("permission_request", { requestId, toolName, input, title: toolName, suggestions: options }));
+    };
+
+    const boot = (async () => {
+      try {
+        const transport = new StdioJsonRpc({
+          command: spec.bin,
+          args: spec.args,
+          cwd: opts.cwd,
+          env: { ...spec.env, ...opts.env },
+          onNotification: ({ method, params }) => {
+            if (method !== "session/update" || replaying) return;
+            for (const e of mapper.map(obj(params).update)) events.push(e);
+          },
+          onServerRequest: ({ id, method, params }) => {
+            const p = obj(params);
+            if (method === "session/request_permission") { requestPermission(id, p); return; }
+            if (method === "fs/read_text_file" || method === "fs/write_text_file") { void serveFs(id, method, p); return; }
+            // Agents probe for capabilities we never declared (terminal/*), and an unanswered request stalls
+            // the turn permanently (§5).
+            log(`refusing unsupported client method ${method}`);
+            rpc?.respondError(id, -32601, `realm does not support ${method}`);
+          },
+          onStderr: (line) => log(line),
+          onExit: ({ reason, disposed: wasDisposed }) => {
+            // `wasDisposed` means Realm took the child down; only an actual crash is an error to report.
+            if (!wasDisposed) {
+              for (const e of mapper.closeOpenCalls(reason)) events.push(e);
+              const tail = rpc?.stderrTail ?? [];
+              fail(tail.length ? `${reason}\n--- stderr (last ${tail.length} lines) ---\n${tail.join("\n")}` : reason);
+            }
+            void shutdown();
+          },
+        });
+        rpc = transport;
+
+        const init = obj(await transport.request("initialize", {
+          protocolVersion: 1,
+          clientCapabilities: { fs: { readTextFile: true, writeTextFile: true }, terminal: false },
+        }));
+        const caps = obj(init.agentCapabilities);
+        imagesAllowed = obj(caps.promptCapabilities).image === true;
+        authMethods = Array.isArray(init.authMethods) ? init.authMethods : [];
+        if (disposed) return;
+
+        const mcpServers = acpMcpServers(opts.mcpServers);
+        let id: string | null = null;
+        let session: Bag = {};
+        if (opts.resume && caps.loadSession === true) {
+          replaying = true;
+          try {
+            // The whole prior conversation arrives as session/update notifications before this resolves (§2.3).
+            // Realm has already persisted every one of them, so they are dropped rather than appended.
+            session = obj(await transport.request("session/load", { sessionId: opts.resume, cwd: opts.cwd, mcpServers }));
+            id = opts.resume;
+          } catch (e) {
+            log(`session/load failed (${message(e)}); starting a new session instead`);
+          } finally {
+            replaying = false;
+          }
+        }
+        if (id === null) {
+          session = obj(await transport.request("session/new", { cwd: opts.cwd, mcpServers }));
+          id = str(session.sessionId);
+          if (!id) throw new Error(`${spec.label} did not return a session id`);
+        }
+        if (disposed) return;
+        sessionId = id;
+        events.push(sessionEvent("init", {
+          providerSessionId: id,
+          model: str(obj(session.models).currentModelId) || str(opts.model),
+          tools: [],
+          cwd: opts.cwd,
+        }));
+        events.push(sessionEvent("status", { status: "idle" }));
+      } catch (e) {
+        if (disposed) return;
+        fail(acpBootFailureMessage(e, spec, authMethods));
+        // SessionService drops the handle when the stream ends and never calls dispose(), so a boot failure
+        // has to take its own child down.
+        await shutdown();
+      }
+    })();
+
+    /** `prompt: ContentBlock[]` (§3). Images inline only where the agent accepts them; everything else links. */
+    const promptFor = async (m: UserMessage): Promise<Bag[]> => {
+      const blocks: Bag[] = [{ type: "text", text: m.text }];
+      for (const a of m.attachments) {
+        // Cursor reports embeddedContext:false, so a `resource` block is never an option — a link it is.
+        const link = { type: "resource_link", uri: `file://${a.path}`, name: basename(a.path), mimeType: a.mime };
+        if (!imagesAllowed || !a.mime.startsWith("image/")) { blocks.push(link); continue; }
+        try { blocks.push({ type: "image", data: (await readFile(a.path)).toString("base64"), mimeType: a.mime }); }
+        catch (e) { log(`could not read ${a.path} (${message(e)}); sending it as a link`); blocks.push(link); }
+      }
+      return blocks;
+    };
+
+    const settle = (events_: SessionEvent[]) => { for (const e of events_) events.push(e); };
+
+    return {
+      events,
+      send: async (m: UserMessage) => {
+        await boot; // boot reports its own failures; it never rejects
+        if (disposed || !rpc || !sessionId) { events.push(sessionEvent("error", { message: "session ended" })); return; }
+        const prompt = await promptFor(m);
+        events.push(sessionEvent("status", { status: "running" }));
+        // NOT awaited: session/prompt stays pending for the entire turn, and SessionService.send() — and the
+        // WebSocket call behind it — awaits this function. The turn is settled in the background instead.
+        void rpc.request("session/prompt", { sessionId, prompt }).then(
+          (res) => {
+            if (disposed) return;
+            settle(mapper.flush());
+            const failure = stopReasonError(str(obj(res).stopReason));
+            if (failure) events.push(sessionEvent("error", { message: failure }));
+            events.push(sessionEvent("status", { status: "idle" }));
+          },
+          (e) => {
+            if (disposed) return; // the exit handler already reported why the turn died
+            settle(mapper.flush());
+            events.push(sessionEvent("error", { message: message(e) }));
+            events.push(sessionEvent("status", { status: "idle" }));
+          },
+        );
+      },
+      respondPermission: respond,
+      interrupt: async () => {
+        cancelAllPending();
+        if (!rpc || !sessionId) return;
+        // A notification, not a request (§6). The connection stays up: the agent flushes its remaining updates
+        // and still resolves the prompt with stopReason "cancelled", which is what returns the session to idle.
+        rpc.notify("session/cancel", { sessionId });
+      },
+      setOptions: async (o) => {
+        await boot;
+        if (!rpc || !sessionId) return;
+        const attempt = async (method: string, params: Bag) => {
+          // Both calls are optional in ACP 0.4.5 (set_model is flagged unstable), so a rejection is a log line.
+          try { await rpc!.request(method, params); }
+          catch (e) { log(`${method} failed: ${message(e)}`); }
+        };
+        if (o.permissionMode !== undefined) await attempt("session/set_mode", { sessionId, modeId: o.permissionMode });
+        if (o.model !== undefined) await attempt("session/set_model", { sessionId, modelId: o.model });
+      },
+      dispose: async () => {
+        await boot; // never tear down a half-open connection behind a dispose that raced the boot
+        await shutdown();
+      },
+    };
+  }
+}

--- a/packages/adapters/src/acp/acp-adapter.ts
+++ b/packages/adapters/src/acp/acp-adapter.ts
@@ -1,5 +1,5 @@
-import { basename } from "node:path";
-import { readFile, writeFile } from "node:fs/promises";
+import { basename, dirname, join, resolve, sep } from "node:path";
+import { readFile, realpath, stat, writeFile } from "node:fs/promises";
 import { sessionEvent, type AgentKind, type SessionEvent } from "@realm/contracts";
 import { AsyncQueue } from "../event-queue";
 import { JsonRpcCallError, StdioJsonRpc, withTimeout, type JsonRpcId } from "../jsonrpc/stdio";
@@ -93,6 +93,50 @@ export function sliceLines(content: string, line: unknown, limit: unknown): stri
   const lines = content.split("\n");
   const start = from === null ? 0 : Math.max(0, from - 1);
   return lines.slice(start, count === null ? undefined : start + count).join("\n");
+}
+
+/** Cap on `fs/read_text_file`: the content crosses a JSON-RPC frame and lands in the model's context. */
+export const MAX_FS_READ_BYTES = 10 * 1024 * 1024;
+
+/**
+ * `realpath` for a path whose tail may not exist yet: resolves the deepest ancestor that does, then re-attaches
+ * the missing segments. A plain `realpath` throws ENOENT for a not-yet-created write target.
+ */
+async function realpathOfDeepestExisting(p: string): Promise<string> {
+  const tail: string[] = [];
+  let cur = p;
+  for (;;) {
+    try { return join(await realpath(cur), ...tail); }
+    catch { /* does not exist yet — keep walking up */ }
+    const parent = dirname(cur);
+    if (parent === cur) return p; // ran out of ancestors; nothing left to resolve
+    tail.unshift(basename(cur));
+    cur = parent;
+  }
+}
+
+/**
+ * Resolves `target` for the session rooted at `root`, and refuses anything that escapes it.
+ *
+ * §5 is right that declaring `fs:false` would not remove the capability — the agent just does its own disk I/O.
+ * But that cuts the other way for containment: confining *our* handlers costs a well-behaved agent nothing (it
+ * falls back to that same I/O) and stops Realm from being the instrument of an unconstrained read of
+ * `~/.ssh/id_rsa` or write to `~/.zshrc`, neither of which ever reaches a permission card.
+ *
+ * Both sides are resolved through `realpath` before they are compared, so a symlink inside the session
+ * directory cannot point out of it — and neither side may be compared literally, because on macOS the session
+ * cwd itself routinely arrives as a symlinked `/var/...` path for a real `/private/var/...` one.
+ *
+ * The caller reports a missing file: this returns a resolved path, not the promise that anything is there.
+ */
+export async function containedPath(root: string, target: string): Promise<string> {
+  const rootReal = await realpath(root);
+  // An absolute target is kept as-is; a relative one starts at the session directory.
+  const real = await realpathOfDeepestExisting(resolve(rootReal, target));
+  if (real !== rootReal && !real.startsWith(rootReal + sep)) {
+    throw new Error(`${target} is outside this session's working directory`);
+  }
+  return real;
 }
 
 /**
@@ -196,15 +240,21 @@ export class AcpAdapter implements AgentAdapter {
     };
 
     const serveFs = async (id: JsonRpcId, method: string, p: Bag): Promise<void> => {
+      const target = str(p.path);
       try {
         if (method === "fs/read_text_file") {
-          const content = await readFile(str(p.path), "utf8");
+          const path = await containedPath(opts.cwd, target);
+          const { size } = await stat(path);
+          if (size > MAX_FS_READ_BYTES) throw new Error(`${target} is ${size} bytes, too large to read (limit ${MAX_FS_READ_BYTES})`);
+          const content = await readFile(path, "utf8");
           rpc?.respond(id, { content: sliceLines(content, p.line, p.limit) });
         } else {
-          await writeFile(str(p.path), str(p.content), "utf8");
+          const path = await containedPath(opts.cwd, target);
+          await writeFile(path, str(p.content), "utf8");
           rpc?.respond(id, {});
         }
       } catch (e) {
+        log(`${method} ${target}: ${message(e)}`);
         rpc?.respondError(id, -32603, message(e));
       }
     };

--- a/packages/adapters/src/acp/acp-adapter.ts
+++ b/packages/adapters/src/acp/acp-adapter.ts
@@ -140,12 +140,11 @@ export class AcpAdapter implements AgentAdapter {
       events.push(sessionEvent("status", { status: "error" }));
     };
 
-    const answer = (requestId: string, outcome: Bag) => {
+    const answer = (requestId: string, outcome: Bag): void => {
       const p = pending.get(requestId);
-      if (!p) return false;
+      if (!p) return;
       pending.delete(requestId);
       rpc?.respond(p.id, { outcome });
-      return true;
     };
 
     const respond = (requestId: string, decision: PermissionDecision) => {
@@ -178,11 +177,13 @@ export class AcpAdapter implements AgentAdapter {
       if (disposed) return;
       disposed = true;
       cancelAllPending();
+      // The child goes first, and the stream stays open across its death: whatever the agent flushes on its
+      // way out still reaches the transcript, and `ended` stays the last event anyone sees.
+      await rpc?.dispose();
       for (const e of mapper.flush()) events.push(e);
       for (const e of mapper.closeOpenCalls("session closed")) events.push(e);
       events.push(sessionEvent("status", { status: "ended" }));
       events.close();
-      await rpc?.dispose();
     };
 
     const serveFs = async (id: JsonRpcId, method: string, p: Bag): Promise<void> => {
@@ -315,8 +316,6 @@ export class AcpAdapter implements AgentAdapter {
       return blocks;
     };
 
-    const settle = (events_: SessionEvent[]) => { for (const e of events_) events.push(e); };
-
     return {
       events,
       send: async (m: UserMessage) => {
@@ -329,14 +328,14 @@ export class AcpAdapter implements AgentAdapter {
         void rpc.request("session/prompt", { sessionId, prompt }).then(
           (res) => {
             if (disposed) return;
-            settle(mapper.flush());
+            for (const e of mapper.flush()) events.push(e);
             const failure = stopReasonError(str(obj(res).stopReason));
             if (failure) events.push(sessionEvent("error", { message: failure }));
             events.push(sessionEvent("status", { status: "idle" }));
           },
           (e) => {
             if (disposed) return; // the exit handler already reported why the turn died
-            settle(mapper.flush());
+            for (const e of mapper.flush()) events.push(e);
             events.push(sessionEvent("error", { message: message(e) }));
             events.push(sessionEvent("status", { status: "idle" }));
           },

--- a/packages/adapters/src/acp/fixtures/fake-acp-agent.mjs
+++ b/packages/adapters/src/acp/fixtures/fake-acp-agent.mjs
@@ -31,6 +31,7 @@
  * fail -32603 with data (Cursor's shape), FAKE_ACP_LOADFAIL=1 makes session/load fail, FAKE_ACP_NOLOAD=1 drops
  * the loadSession capability, FAKE_ACP_NOIMAGE=1 drops the image prompt capability, FAKE_ACP_ALLOWONLY=1 offers no reject option, and FAKE_ACP_LOAD_ASKS=1
  * makes session/load call fs/read_text_file and session/request_permission back on us mid-replay.
+ * FAKE_ACP_MUTE_INITIALIZE=1, FAKE_ACP_MUTE_SESSION_NEW=1 and FAKE_ACP_MUTE_SESSION_LOAD=1 leave that request unanswered forever.
  * FAKE_ACP_IGNORE_EOF=1 keeps the child alive after its stdin closes, FAKE_ACP_NOSESSIONID=1 answers session/new without a sessionId, FAKE_ACP_BADAUTH=1 sends a non-array
  * `authMethods`, and FAKE_ACP_EXIT_MARKER=<path> writes that file when our stdin closes.
  */
@@ -169,6 +170,8 @@ async function loadSession(id, params) {
 function handleRequest(id, method, params) {
   switch (method) {
     case "initialize":
+      // Spawned and mute: an unbounded initialize leaves boot pending forever.
+      if (process.env.FAKE_ACP_MUTE_INITIALIZE) return;
       journal.calls.push({ method, params });
       ok(id, {
         protocolVersion: 1,
@@ -182,6 +185,7 @@ function handleRequest(id, method, params) {
       });
       return;
     case "session/new":
+      if (process.env.FAKE_ACP_MUTE_SESSION_NEW) return; // handshakes, then never opens a session
       if (process.env.FAKE_ACP_AUTHFAIL) { fail(id, -32000, "This client is no longer supported for individuals."); return; }
       if (process.env.FAKE_ACP_STARTFAIL) { fail(id, -32603, "Internal error", { message: "Failed to initialize session services", details: "[unauthenticated] Error" }); return; }
       journal.newParams = params;
@@ -189,6 +193,7 @@ function handleRequest(id, method, params) {
       ok(id, { sessionId: `sess_${nextSessionN++}`, models: { currentModelId: "fake-model-1", availableModels: [{ modelId: "fake-model-1", name: "Fake 1" }] } });
       return;
     case "session/load":
+      if (process.env.FAKE_ACP_MUTE_SESSION_LOAD) return; // never replies: the resume has to time out and fall back
       if (process.env.FAKE_ACP_LOADFAIL) { fail(id, -32603, "no such session on disk"); return; }
       void loadSession(id, params);
       return;

--- a/packages/adapters/src/acp/fixtures/fake-acp-agent.mjs
+++ b/packages/adapters/src/acp/fixtures/fake-acp-agent.mjs
@@ -12,6 +12,8 @@
  * What a turn does is selected by the text of the prompt's text blocks:
  *
  *   HANG              never resolves on its own                     (send()-must-not-await, interrupt)
+ *   OPENTEXT          streams one message chunk and never ends the turn (open text run at dispose)
+ *   OPENTOOL          opens a tool call and then never ends the turn (tool cards still open at dispose)
  *   PERMIT            one tool call gated on session/request_permission
  *   PERMIT2           two tool calls whose permissions are open at once (waiting_permission bookkeeping)
  *   READFILE p [l][n] calls fs/read_text_file back on us and echoes the content
@@ -28,7 +30,11 @@
  * fail -32603 with data (Cursor's shape), FAKE_ACP_LOADFAIL=1 makes session/load fail, FAKE_ACP_NOLOAD=1 drops
  * the loadSession capability, FAKE_ACP_NOIMAGE=1 drops the image prompt capability, FAKE_ACP_ALLOWONLY=1 offers no reject option, and FAKE_ACP_LOAD_ASKS=1
  * makes session/load call fs/read_text_file and session/request_permission back on us mid-replay.
+ * FAKE_ACP_NOSESSIONID=1 answers session/new without a sessionId, FAKE_ACP_BADAUTH=1 sends a non-array
+ * `authMethods`, and FAKE_ACP_EXIT_MARKER=<path> writes that file when our stdin closes.
  */
+
+import { writeFileSync } from "node:fs";
 
 let nextSessionN = 0;
 let nextCallN = 0;
@@ -36,7 +42,7 @@ let nextServerRequestId = 0; // the real agents number their own requests from 0
 const pendingRequests = new Map(); // agent request id -> (clientReply) => void
 const pendingPrompts = new Map(); // sessionId -> prompt request id
 /** Everything the client asked of us, echoed back by a REVEAL turn. */
-const journal = { newParams: null, loadParams: null, calls: [], replayAsks: null };
+const journal = { cwd: process.cwd(), newParams: null, loadParams: null, calls: [], replayAsks: null };
 let stdinBuf = "";
 
 const send = (frame) => process.stdout.write(JSON.stringify(frame) + "\n");
@@ -111,6 +117,11 @@ async function runTurn(id, sessionId, prompt) {
     setTimeout(() => process.exit(9), 25);
     return;
   }
+  if (text.includes("OPENTEXT")) { message(sessionId, "partial"); return; } // a message run left open
+  if (text.includes("OPENTOOL")) { // a tool card left open, and a turn that never ends
+    update(sessionId, { sessionUpdate: "tool_call", toolCallId: `call_${nextCallN++}`, title: "Never finishes", kind: "execute", status: "in_progress" });
+    return;
+  }
   if (text.includes("HANG")) return; // resolved only by session/cancel
   if (text.includes("ECHO")) message(sessionId, JSON.stringify(prompt));
   else if (text.includes("REVEAL")) message(sessionId, JSON.stringify(journal));
@@ -158,13 +169,15 @@ function handleRequest(id, method, params) {
           mcpCapabilities: { http: true, sse: true },
           promptCapabilities: { image: !process.env.FAKE_ACP_NOIMAGE, audio: false, embeddedContext: false },
         },
-        authMethods: [{ id: "fake_login", name: "Fake Login", description: "Run `fake login` first." }],
+        // FAKE_ACP_BADAUTH: a real agent may send anything here; a non-array must not crash the error path.
+        authMethods: process.env.FAKE_ACP_BADAUTH ? "not-an-array" : [{ id: "fake_login", name: "Fake Login", description: "Run `fake login` first." }],
       });
       return;
     case "session/new":
       if (process.env.FAKE_ACP_AUTHFAIL) { fail(id, -32000, "This client is no longer supported for individuals."); return; }
       if (process.env.FAKE_ACP_STARTFAIL) { fail(id, -32603, "Internal error", { message: "Failed to initialize session services", details: "[unauthenticated] Error" }); return; }
       journal.newParams = params;
+      if (process.env.FAKE_ACP_NOSESSIONID) { ok(id, {}); return; }
       ok(id, { sessionId: `sess_${nextSessionN++}`, models: { currentModelId: "fake-model-1", availableModels: [{ modelId: "fake-model-1", name: "Fake 1" }] } });
       return;
     case "session/load":
@@ -228,4 +241,8 @@ process.stdin.on("data", (chunk) => {
     if (line.trim()) handleFrame(line);
   }
 });
-process.stdin.on("end", () => process.exit(0));
+process.stdin.on("end", () => {
+  // Proof for the tests that closing our stdin really did take this child down.
+  if (process.env.FAKE_ACP_EXIT_MARKER) writeFileSync(process.env.FAKE_ACP_EXIT_MARKER, "bye");
+  process.exit(0);
+});

--- a/packages/adapters/src/acp/fixtures/fake-acp-agent.mjs
+++ b/packages/adapters/src/acp/fixtures/fake-acp-agent.mjs
@@ -1,0 +1,231 @@
+#!/usr/bin/env node
+/**
+ * Fake ACP agent — speaks the subset of ACP 0.4.5 that AcpAdapter exercises. Frame shapes are copied from
+ * docs/dev/acp-protocol.md:
+ *
+ *   - newline-delimited JSON-RPC 2.0, one object per line, no Content-Length headers
+ *   - agent -> client request ids start at 0 and therefore collide with client request ids on purpose (§1)
+ *   - `session/load` replays the prior conversation as `session/update` notifications BEFORE it responds (§2.3)
+ *   - `session/prompt` is one request that stays pending for the whole turn (§3)
+ *   - `session/cancel` is a NOTIFICATION; the pending prompt still resolves, with `stopReason:"cancelled"` (§6)
+ *
+ * What a turn does is selected by the text of the prompt's text blocks:
+ *
+ *   HANG              never resolves on its own                     (send()-must-not-await, interrupt)
+ *   PERMIT            one tool call gated on session/request_permission
+ *   PERMIT2           two tool calls whose permissions are open at once (waiting_permission bookkeeping)
+ *   READFILE p [l][n] calls fs/read_text_file back on us and echoes the content
+ *   WRITEFILE p text  calls fs/write_text_file back on us and echoes the outcome
+ *   ODDBALL           asks terminal/create, a method we never declared  (-32601 catch-all)
+ *   ECHO              echoes the raw `prompt` array back as the agent message (prompt-shape assertions)
+ *   REVEAL            echoes the journal of everything the client has asked of us
+ *   STOP:<reason>     resolves with that stopReason (refusal, max_tokens, …)
+ *   FAIL              rejects session/prompt outright
+ *   DIE               opens a tool call and then dies without warning
+ *   anything else      a thought chunk, then "Hel" + "lo", then stopReason:"end_turn"
+ *
+ * Env hooks: FAKE_ACP_AUTHFAIL=1 makes session/new fail -32000 (Gemini's shape), FAKE_ACP_STARTFAIL=1 makes it
+ * fail -32603 with data (Cursor's shape), FAKE_ACP_LOADFAIL=1 makes session/load fail, FAKE_ACP_NOLOAD=1 drops
+ * the loadSession capability, FAKE_ACP_NOIMAGE=1 drops the image prompt capability, FAKE_ACP_ALLOWONLY=1 offers no reject option, and FAKE_ACP_LOAD_ASKS=1
+ * makes session/load call fs/read_text_file and session/request_permission back on us mid-replay.
+ */
+
+let nextSessionN = 0;
+let nextCallN = 0;
+let nextServerRequestId = 0; // the real agents number their own requests from 0
+const pendingRequests = new Map(); // agent request id -> (clientReply) => void
+const pendingPrompts = new Map(); // sessionId -> prompt request id
+/** Everything the client asked of us, echoed back by a REVEAL turn. */
+const journal = { newParams: null, loadParams: null, calls: [], replayAsks: null };
+let stdinBuf = "";
+
+const send = (frame) => process.stdout.write(JSON.stringify(frame) + "\n");
+const ok = (id, result) => send({ jsonrpc: "2.0", id, result });
+const fail = (id, code, message, data) => send({ jsonrpc: "2.0", id, error: { code, message, ...(data === undefined ? {} : { data }) } });
+const notify = (method, params) => send({ jsonrpc: "2.0", method, params });
+const update = (sessionId, u) => notify("session/update", { sessionId, update: u });
+const textBlock = (text) => ({ type: "text", text });
+/** Sends an agent -> client request and hands back a promise for the client's reply. */
+const ask = (method, params) => {
+  const id = nextServerRequestId++;
+  send({ jsonrpc: "2.0", id, method, params });
+  return new Promise((resolve) => pendingRequests.set(id, resolve));
+};
+const promptText = (prompt) => (Array.isArray(prompt) ? prompt : []).map((b) => (b && typeof b.text === "string" ? b.text : "")).join(" ");
+
+// FAKE_ACP_ALLOWONLY drops the reject options, the case where no optionId can carry a deny.
+const PERMISSION_OPTIONS = [
+  { optionId: "allow-once", name: "Allow once", kind: "allow_once" },
+  { optionId: "allow-always", name: "Always allow", kind: "allow_always" },
+  ...(process.env.FAKE_ACP_ALLOWONLY ? [] : [{ optionId: "reject-once", name: "Reject", kind: "reject_once" }]),
+];
+
+function message(sessionId, text) {
+  update(sessionId, { sessionUpdate: "agent_message_chunk", content: textBlock(text) });
+}
+
+/** One tool call, blocked on a permission request, completed according to what the client picked. */
+async function permitTurn(sessionId, n) {
+  const toolCallId = `call_${nextCallN++}`;
+  update(sessionId, { sessionUpdate: "tool_call", toolCallId, title: `Run step ${n}`, kind: "execute", status: "pending", rawInput: { command: `echo ${n}` } });
+  // Only `toolCallId` is guaranteed on this ToolCallUpdate (§4) — the client must merge it against the
+  // tool_call above to render a useful card.
+  const reply = await ask("session/request_permission", { sessionId, toolCall: { toolCallId }, options: PERMISSION_OPTIONS });
+  const outcome = reply.result?.outcome ?? {};
+  const picked = outcome.outcome === "selected" ? outcome.optionId : outcome.outcome;
+  const allowed = outcome.outcome === "selected" && String(outcome.optionId).startsWith("allow");
+  update(sessionId, {
+    sessionUpdate: "tool_call_update", toolCallId,
+    status: allowed ? "completed" : "failed",
+    content: [{ type: "content", content: textBlock(`outcome:${picked}`) }],
+  });
+}
+
+async function readFileTurn(sessionId, text) {
+  const [, path, line, limit] = text.split(/\s+/);
+  const params = { sessionId, path };
+  if (line !== undefined) params.line = Number(line);
+  if (limit !== undefined) params.limit = Number(limit);
+  const reply = await ask("fs/read_text_file", params);
+  message(sessionId, reply.error ? `read failed: ${reply.error.message}` : `read:${reply.result.content}`);
+}
+
+async function writeFileTurn(sessionId, text) {
+  const [, path, ...rest] = text.split(/\s+/);
+  const reply = await ask("fs/write_text_file", { sessionId, path, content: rest.join(" ") });
+  message(sessionId, reply.error ? `write failed: ${reply.error.message}` : "write:ok");
+}
+
+async function oddballTurn(sessionId) {
+  // A method the client never declared. The turn only ends once it is answered, so an unanswered probe
+  // would stall this forever.
+  const reply = await ask("terminal/create", { sessionId, command: "true", args: [] });
+  message(sessionId, `terminal refused: ${reply.error?.code ?? "none"}`);
+}
+
+async function runTurn(id, sessionId, prompt) {
+  const text = promptText(prompt);
+  if (text.includes("FAIL")) { pendingPrompts.delete(sessionId); fail(id, -32603, "prompt exploded"); return; }
+  if (text.includes("DIE")) {
+    update(sessionId, { sessionUpdate: "tool_call", toolCallId: `call_${nextCallN++}`, title: "Doomed", kind: "execute", status: "in_progress" });
+    setTimeout(() => process.exit(9), 25);
+    return;
+  }
+  if (text.includes("HANG")) return; // resolved only by session/cancel
+  if (text.includes("ECHO")) message(sessionId, JSON.stringify(prompt));
+  else if (text.includes("REVEAL")) message(sessionId, JSON.stringify(journal));
+  else if (text.includes("PERMIT2")) await Promise.all([permitTurn(sessionId, 0), permitTurn(sessionId, 1)]);
+  else if (text.includes("PERMIT")) await permitTurn(sessionId, 0);
+  else if (text.includes("READFILE")) await readFileTurn(sessionId, text);
+  else if (text.includes("WRITEFILE")) await writeFileTurn(sessionId, text);
+  else if (text.includes("ODDBALL")) await oddballTurn(sessionId);
+  else {
+    update(sessionId, { sessionUpdate: "agent_thought_chunk", content: textBlock("pondering") });
+    message(sessionId, "Hel");
+    message(sessionId, "lo");
+  }
+  const stop = /STOP:(\w+)/.exec(text);
+  if (!pendingPrompts.has(sessionId)) return; // cancelled while we were streaming
+  pendingPrompts.delete(sessionId);
+  ok(id, { stopReason: stop ? stop[1] : "end_turn" });
+}
+
+/** Replays the prior conversation as notifications, then responds — the order §2.3 mandates. */
+async function loadSession(id, params) {
+  journal.loadParams = params;
+  const sessionId = params.sessionId;
+  update(sessionId, { sessionUpdate: "user_message_chunk", content: textBlock("what did we do yesterday?") });
+  update(sessionId, { sessionUpdate: "agent_message_chunk", content: textBlock("we replayed history") });
+  update(sessionId, { sessionUpdate: "tool_call", toolCallId: "call_old", title: "Old tool", kind: "read", status: "completed" });
+  if (process.env.FAKE_ACP_LOAD_ASKS) {
+    const [read, permission] = await Promise.all([
+      ask("fs/read_text_file", { sessionId, path: process.env.FAKE_ACP_LOAD_ASKS_PATH ?? "/nonexistent" }),
+      ask("session/request_permission", { sessionId, toolCall: { toolCallId: "call_old" }, options: PERMISSION_OPTIONS }),
+    ]);
+    journal.replayAsks = { read, permission };
+  }
+  ok(id, {});
+}
+
+function handleRequest(id, method, params) {
+  switch (method) {
+    case "initialize":
+      journal.calls.push({ method, params });
+      ok(id, {
+        protocolVersion: 1,
+        agentCapabilities: {
+          ...(process.env.FAKE_ACP_NOLOAD ? {} : { loadSession: true }),
+          mcpCapabilities: { http: true, sse: true },
+          promptCapabilities: { image: !process.env.FAKE_ACP_NOIMAGE, audio: false, embeddedContext: false },
+        },
+        authMethods: [{ id: "fake_login", name: "Fake Login", description: "Run `fake login` first." }],
+      });
+      return;
+    case "session/new":
+      if (process.env.FAKE_ACP_AUTHFAIL) { fail(id, -32000, "This client is no longer supported for individuals."); return; }
+      if (process.env.FAKE_ACP_STARTFAIL) { fail(id, -32603, "Internal error", { message: "Failed to initialize session services", details: "[unauthenticated] Error" }); return; }
+      journal.newParams = params;
+      ok(id, { sessionId: `sess_${nextSessionN++}`, models: { currentModelId: "fake-model-1", availableModels: [{ modelId: "fake-model-1", name: "Fake 1" }] } });
+      return;
+    case "session/load":
+      if (process.env.FAKE_ACP_LOADFAIL) { fail(id, -32603, "no such session on disk"); return; }
+      void loadSession(id, params);
+      return;
+    case "session/prompt":
+      pendingPrompts.set(params.sessionId, id);
+      void runTurn(id, params.sessionId, params.prompt);
+      return;
+    case "session/set_mode":
+      journal.calls.push({ method, params });
+      ok(id, {});
+      return;
+    case "session/set_model":
+      journal.calls.push({ method, params });
+      fail(id, -32601, "session/set_model is unstable and not implemented");
+      return;
+    default:
+      journal.calls.push({ method, params });
+      fail(id, -32601, `unknown method: ${method}`);
+  }
+}
+
+function handleNotification(method, params) {
+  journal.calls.push({ method, params });
+  if (method !== "session/cancel") return;
+  const id = pendingPrompts.get(params.sessionId);
+  if (id === undefined) return;
+  pendingPrompts.delete(params.sessionId);
+  // §6: the agent MAY keep sending updates but MUST flush them before replying, and MUST still resolve the
+  // original prompt with `cancelled`.
+  message(params.sessionId, "bye");
+  ok(id, { stopReason: "cancelled" });
+}
+
+function handleFrame(line) {
+  let msg;
+  try { msg = JSON.parse(line); } catch { return; }
+  // A client RESPONSE to one of our requests: no method, an id, and result/error. Must be checked before the
+  // request dispatcher, since the two id spaces overlap.
+  if (msg.method === undefined && msg.id !== undefined && ("result" in msg || "error" in msg)) {
+    const resolve = pendingRequests.get(msg.id);
+    if (!resolve) return;
+    pendingRequests.delete(msg.id);
+    resolve({ result: msg.result, error: msg.error });
+    return;
+  }
+  if (typeof msg.method !== "string") return;
+  if (msg.id === undefined || msg.id === null) { handleNotification(msg.method, msg.params ?? {}); return; }
+  handleRequest(msg.id, msg.method, msg.params ?? {});
+}
+
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (chunk) => {
+  stdinBuf += chunk;
+  let i;
+  while ((i = stdinBuf.indexOf("\n")) >= 0) {
+    const line = stdinBuf.slice(0, i);
+    stdinBuf = stdinBuf.slice(i + 1);
+    if (line.trim()) handleFrame(line);
+  }
+});
+process.stdin.on("end", () => process.exit(0));

--- a/packages/adapters/src/acp/fixtures/fake-acp-agent.mjs
+++ b/packages/adapters/src/acp/fixtures/fake-acp-agent.mjs
@@ -12,6 +12,7 @@
  * What a turn does is selected by the text of the prompt's text blocks:
  *
  *   HANG              never resolves on its own                     (send()-must-not-await, interrupt)
+ *   LATEPERMIT        asks for permission 30ms in, then exits    (permission racing the teardown)
  *   OPENTEXT          streams one message chunk and never ends the turn (open text run at dispose)
  *   OPENTOOL          opens a tool call and then never ends the turn (tool cards still open at dispose)
  *   PERMIT            one tool call gated on session/request_permission
@@ -30,7 +31,7 @@
  * fail -32603 with data (Cursor's shape), FAKE_ACP_LOADFAIL=1 makes session/load fail, FAKE_ACP_NOLOAD=1 drops
  * the loadSession capability, FAKE_ACP_NOIMAGE=1 drops the image prompt capability, FAKE_ACP_ALLOWONLY=1 offers no reject option, and FAKE_ACP_LOAD_ASKS=1
  * makes session/load call fs/read_text_file and session/request_permission back on us mid-replay.
- * FAKE_ACP_NOSESSIONID=1 answers session/new without a sessionId, FAKE_ACP_BADAUTH=1 sends a non-array
+ * FAKE_ACP_IGNORE_EOF=1 keeps the child alive after its stdin closes, FAKE_ACP_NOSESSIONID=1 answers session/new without a sessionId, FAKE_ACP_BADAUTH=1 sends a non-array
  * `authMethods`, and FAKE_ACP_EXIT_MARKER=<path> writes that file when our stdin closes.
  */
 
@@ -115,6 +116,13 @@ async function runTurn(id, sessionId, prompt) {
   if (text.includes("DIE")) {
     update(sessionId, { sessionUpdate: "tool_call", toolCallId: `call_${nextCallN++}`, title: "Doomed", kind: "execute", status: "in_progress" });
     setTimeout(() => process.exit(9), 25);
+    return;
+  }
+  if (text.includes("LATEPERMIT")) { // asks only once the client has started tearing the session down
+    setTimeout(() => {
+      void permitTurn(sessionId, 9);
+      setTimeout(() => process.exit(0), 30);
+    }, 30);
     return;
   }
   if (text.includes("OPENTEXT")) { message(sessionId, "partial"); return; } // a message run left open
@@ -242,6 +250,7 @@ process.stdin.on("data", (chunk) => {
   }
 });
 process.stdin.on("end", () => {
+  if (process.env.FAKE_ACP_IGNORE_EOF) return; // outlive the client's stdin close, like an agent mid-tool-call
   // Proof for the tests that closing our stdin really did take this child down.
   if (process.env.FAKE_ACP_EXIT_MARKER) writeFileSync(process.env.FAKE_ACP_EXIT_MARKER, "bye");
   process.exit(0);

--- a/packages/adapters/src/acp/map-acp.test.ts
+++ b/packages/adapters/src/acp/map-acp.test.ts
@@ -1,0 +1,252 @@
+import { describe, it, expect } from "vitest";
+import { createAcpMapper } from "./map-acp";
+import type { SessionEvent } from "@realm/contracts";
+
+const types = (evs: SessionEvent[]) => evs.map((e) => e.type);
+const payload = <T>(e: SessionEvent | undefined) => (e as unknown as { payload: T }).payload;
+const msgId = (e: SessionEvent | undefined) => payload<{ messageId: string }>(e).messageId;
+const body = (e: SessionEvent | undefined) => payload<{ content: string }>(e).content;
+
+/** A completed tool call whose result content is the only thing under test. */
+function resultFor(update: Record<string, unknown>): string {
+  const m = createAcpMapper();
+  m.map({ sessionUpdate: "tool_call", toolCallId: "t", title: "T" });
+  return body(m.map({ sessionUpdate: "tool_call_update", toolCallId: "t", status: "completed", ...update })[0]);
+}
+
+describe("createAcpMapper", () => {
+  it("groups a contiguous message run under one id and flushes it as assistant_text", () => {
+    const m = createAcpMapper();
+    const a = m.map({ sessionUpdate: "agent_message_chunk", content: { type: "text", text: "Hel" } });
+    const b = m.map({ sessionUpdate: "agent_message_chunk", content: { type: "text", text: "lo" } });
+    expect(types(a)).toEqual(["assistant_delta"]);
+    const idA = (a[0] as { payload: { messageId: string } }).payload.messageId;
+    expect((b[0] as { payload: { messageId: string } }).payload.messageId).toBe(idA);
+    const flushed = m.flush();
+    expect(flushed[0]).toMatchObject({ type: "assistant_text", payload: { messageId: idA, text: "Hello" } });
+    expect(m.flush()).toEqual([]); // idempotent
+  });
+
+  it("flushes the message run before an interleaved tool call", () => {
+    const m = createAcpMapper();
+    m.map({ sessionUpdate: "agent_message_chunk", content: { type: "text", text: "Reading " } });
+    const out = m.map({ sessionUpdate: "tool_call", toolCallId: "call_1", title: "Read NOTES.txt", kind: "read", status: "pending", rawInput: { path: "/tmp/NOTES.txt" } });
+    expect(types(out)).toEqual(["assistant_text", "tool_call"]);
+    expect(out[1]).toMatchObject({ payload: { toolUseId: "call_1", name: "Read NOTES.txt", input: { path: "/tmp/NOTES.txt" }, parentToolUseId: null } });
+  });
+
+  it("emits thinking from a thought run", () => {
+    const m = createAcpMapper();
+    m.map({ sessionUpdate: "agent_thought_chunk", content: { type: "text", text: "I should " } });
+    m.map({ sessionUpdate: "agent_thought_chunk", content: { type: "text", text: "read it." } });
+    expect(m.flush()[0]).toMatchObject({ type: "thinking", payload: { text: "I should read it." } });
+  });
+
+  it("treats tool_call_update as a sparse patch and only completes once", () => {
+    const m = createAcpMapper();
+    m.map({ sessionUpdate: "tool_call", toolCallId: "c1", title: "Read", kind: "read", status: "pending" });
+    expect(m.map({ sessionUpdate: "tool_call_update", toolCallId: "c1", status: "in_progress" })).toEqual([]);
+    const done = m.map({
+      sessionUpdate: "tool_call_update", toolCallId: "c1", status: "completed",
+      content: [{ type: "content", content: { type: "text", text: "hello from realm\n" } }],
+    });
+    expect(done[0]).toMatchObject({ type: "tool_result", payload: { toolUseId: "c1", content: "hello from realm\n", isError: false } });
+    // A trailing patch must not emit a second result.
+    expect(m.map({ sessionUpdate: "tool_call_update", toolCallId: "c1", status: "completed" })).toEqual([]);
+  });
+
+  it("marks a failed tool call as an error result", () => {
+    const m = createAcpMapper();
+    m.map({ sessionUpdate: "tool_call", toolCallId: "c2", title: "Run", kind: "execute" });
+    expect(m.map({ sessionUpdate: "tool_call_update", toolCallId: "c2", status: "failed" })[0])
+      .toMatchObject({ type: "tool_result", payload: { isError: true } });
+  });
+
+  it("renders diff and terminal tool content", () => {
+    const m = createAcpMapper();
+    m.map({ sessionUpdate: "tool_call", toolCallId: "c3", title: "Edit", kind: "edit" });
+    const out = m.map({
+      sessionUpdate: "tool_call_update", toolCallId: "c3", status: "completed",
+      content: [{ type: "diff", path: "/tmp/a.txt", oldText: "a\n", newText: "b\n" }, { type: "terminal", terminalId: "t1" }],
+    });
+    const content = (out[0] as { payload: { content: string } }).payload.content;
+    expect(content).toContain("/tmp/a.txt");
+    expect(content).toContain("[terminal t1]");
+  });
+
+  it("does not clear a title when a patch omits it", () => {
+    const m = createAcpMapper();
+    m.map({ sessionUpdate: "tool_call", toolCallId: "c4", title: "Original", kind: "read" });
+    m.map({ sessionUpdate: "tool_call_update", toolCallId: "c4", status: "in_progress" });
+    expect(m.titleOf("c4")).toBe("Original");
+  });
+
+  it("drops plan, command-list, mode and user-echo updates", () => {
+    const m = createAcpMapper();
+    for (const u of [
+      { sessionUpdate: "plan", entries: [] },
+      { sessionUpdate: "available_commands_update", availableCommands: [] },
+      { sessionUpdate: "current_mode_update", currentModeId: "agent" },
+      { sessionUpdate: "user_message_chunk", content: { type: "text", text: "echo" } },
+    ]) expect(m.map(u)).toEqual([]);
+  });
+  // ---- run grouping ----------------------------------------------------------------------------------------
+
+  it("emits each chunk as its own delta, not the run so far", () => {
+    const m = createAcpMapper();
+    const a = m.map({ sessionUpdate: "agent_message_chunk", content: { type: "text", text: "Hel" } });
+    const b = m.map({ sessionUpdate: "agent_message_chunk", content: { type: "text", text: "lo" } });
+    expect(payload<{ delta: string }>(a[0]).delta).toBe("Hel");
+    expect(payload<{ delta: string }>(b[0]).delta).toBe("lo");
+  });
+
+  it("gives every run a fresh id", () => {
+    const m = createAcpMapper();
+    m.map({ sessionUpdate: "agent_message_chunk", content: { type: "text", text: "one" } });
+    const first = m.flush();
+    m.map({ sessionUpdate: "agent_message_chunk", content: { type: "text", text: "two" } });
+    const second = m.flush();
+    m.map({ sessionUpdate: "agent_thought_chunk", content: { type: "text", text: "three" } });
+    const third = m.flush();
+    expect(msgId(first[0])).not.toBe(msgId(second[0]));
+    expect(msgId(third[0])).not.toBe(msgId(second[0]));
+  });
+
+  it("closes an open thought run when a message chunk interrupts it", () => {
+    const m = createAcpMapper();
+    m.map({ sessionUpdate: "agent_thought_chunk", content: { type: "text", text: "hmm" } });
+    const out = m.map({ sessionUpdate: "agent_message_chunk", content: { type: "text", text: "Hi" } });
+    expect(types(out)).toEqual(["thinking", "assistant_delta"]);
+    expect(out[0]).toMatchObject({ payload: { text: "hmm" } });
+    expect(msgId(out[0])).not.toBe(msgId(out[1]));
+  });
+
+  it("closes an open message run when a thought chunk interrupts it", () => {
+    const m = createAcpMapper();
+    m.map({ sessionUpdate: "agent_message_chunk", content: { type: "text", text: "Hi" } });
+    const out = m.map({ sessionUpdate: "agent_thought_chunk", content: { type: "text", text: "hmm" } });
+    expect(types(out)).toEqual(["assistant_text"]);
+    expect(out[0]).toMatchObject({ payload: { text: "Hi" } });
+  });
+
+  it("flushes a thought run only once", () => {
+    const m = createAcpMapper();
+    m.map({ sessionUpdate: "agent_thought_chunk", content: { type: "text", text: "hmm" } });
+    expect(types(m.flush())).toEqual(["thinking"]);
+    expect(m.flush()).toEqual([]);
+  });
+
+  it("never persists an empty run", () => {
+    // An unrecognised block contributes no text, so the run has nothing worth persisting. Separate mappers, so
+    // each run is flushed by flush() itself rather than by the other chunk kind's cross-flush.
+    const a = createAcpMapper();
+    expect(types(a.map({ sessionUpdate: "agent_message_chunk", content: { type: "video", data: "…" } }))).toEqual(["assistant_delta"]);
+    expect(a.flush()).toEqual([]);
+    const b = createAcpMapper();
+    expect(b.map({ sessionUpdate: "agent_thought_chunk", content: { type: "video", data: "…" } })).toEqual([]);
+    expect(b.flush()).toEqual([]);
+  });
+
+  it("flushes an open run before a dropped update too", () => {
+    const m = createAcpMapper();
+    m.map({ sessionUpdate: "agent_message_chunk", content: { type: "text", text: "Hi" } });
+    expect(types(m.map({ sessionUpdate: "plan", entries: [] }))).toEqual(["assistant_text"]);
+  });
+
+  // ---- content blocks --------------------------------------------------------------------------------------
+
+  it("renders every ACP content-block variant", () => {
+    expect(resultFor({ content: [
+      { type: "content", content: { type: "text", text: "plain" } },
+      { type: "content", content: { type: "image", data: "…", mimeType: "image/png" } },
+      { type: "content", content: { type: "audio", data: "…", mimeType: "audio/wav" } },
+      { type: "content", content: { type: "resource_link", uri: "file:///u", name: "NOTES.txt" } },
+      { type: "content", content: { type: "resource_link", uri: "file:///only" } },
+      { type: "content", content: { type: "resource", resource: { uri: "file:///r", text: "x" } } },
+      { type: "content", content: { type: "video", data: "…" } },
+      { type: "bogus" },
+    ] })).toBe("plain\n[image]\n[audio]\n[NOTES.txt]\n[file:///only]\n[resource file:///r]");
+  });
+
+  it("renders a diff with and without a prior version", () => {
+    expect(resultFor({ content: [{ type: "diff", path: "/tmp/a.txt", oldText: "a\n", newText: "b\n" }] }))
+      .toBe("--- /tmp/a.txt\n- a\n+ b");
+    // `oldText: null` means the file is new — there is no previous line to show.
+    expect(resultFor({ content: [{ type: "diff", path: "/tmp/new.txt", oldText: null, newText: "b\n" }] }))
+      .toBe("--- /tmp/new.txt\n+ b");
+  });
+
+  it("falls back to rawOutput only when the content array yields nothing", () => {
+    expect(resultFor({ rawOutput: { bytes: 23 } })).toBe('{"bytes":23}');
+    expect(resultFor({ content: "not-an-array", rawOutput: { bytes: 23 } })).toBe('{"bytes":23}');
+    expect(resultFor({ content: [{ type: "content", content: { type: "text", text: "real" } }], rawOutput: { bytes: 23 } })).toBe("real");
+    expect(resultFor({ rawOutput: null })).toBe("");
+    expect(resultFor({})).toBe("");
+  });
+
+  // ---- sparse-patch merge ----------------------------------------------------------------------------------
+
+  it("keeps kind and rawInput when a patch omits them", () => {
+    const m = createAcpMapper();
+    m.map({ sessionUpdate: "tool_call", toolCallId: "k1", title: "Read", kind: "read", rawInput: { path: "/tmp/x" } });
+    m.map({ sessionUpdate: "tool_call_update", toolCallId: "k1", status: "in_progress" });
+    expect(m.callOf("k1")).toMatchObject({ title: "Read", kind: "read", input: { path: "/tmp/x" } });
+    // A patch that does carry them still wins.
+    m.map({ sessionUpdate: "tool_call_update", toolCallId: "k1", title: "Read more", kind: "search", rawInput: { path: "/tmp/y" } });
+    expect(m.callOf("k1")).toMatchObject({ title: "Read more", kind: "search", input: { path: "/tmp/y" } });
+  });
+
+  it("records a patch for a call it never saw created", () => {
+    const m = createAcpMapper();
+    m.map({ sessionUpdate: "tool_call_update", toolCallId: "ghost", title: "Ghost", status: "in_progress" });
+    expect(m.titleOf("ghost")).toBe("Ghost");
+    m.map({ sessionUpdate: "tool_call_update", toolCallId: "orphan", status: "in_progress" });
+    expect(m.titleOf("orphan")).toBe("orphan"); // the id is the only label available
+  });
+
+  it("defaults a tool call's name and kind when the agent omits them", () => {
+    const m = createAcpMapper();
+    const out = m.map({ sessionUpdate: "tool_call", toolCallId: "d1" });
+    expect(out[0]).toMatchObject({ payload: { toolUseId: "d1", name: "d1", input: {} } });
+    expect(m.callOf("d1")).toMatchObject({ kind: "other" });
+  });
+
+  it("emits no result while a call is only pending or in progress", () => {
+    const m = createAcpMapper();
+    m.map({ sessionUpdate: "tool_call", toolCallId: "p1", title: "Read" });
+    expect(m.map({ sessionUpdate: "tool_call_update", toolCallId: "p1", status: "pending" })).toEqual([]);
+    expect(m.map({ sessionUpdate: "tool_call_update", toolCallId: "p1" })).toEqual([]);
+  });
+
+  // ---- closeOpenCalls --------------------------------------------------------------------------------------
+
+  it("closes only the calls still open, once", () => {
+    const m = createAcpMapper();
+    m.map({ sessionUpdate: "tool_call", toolCallId: "done1", title: "Done" });
+    m.map({ sessionUpdate: "tool_call_update", toolCallId: "done1", status: "completed" });
+    m.map({ sessionUpdate: "tool_call", toolCallId: "open1", title: "Open" });
+    const out = m.closeOpenCalls("agent exited mid-turn");
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({ type: "tool_result", payload: { toolUseId: "open1", content: "agent exited mid-turn", isError: true } });
+    expect(m.closeOpenCalls("again")).toEqual([]);
+    // A late patch for a force-closed call must not produce a second result.
+    expect(m.map({ sessionUpdate: "tool_call_update", toolCallId: "open1", status: "completed" })).toEqual([]);
+  });
+
+  // ---- defensive parsing -----------------------------------------------------------------------------------
+
+  it("ignores malformed updates instead of throwing", () => {
+    const m = createAcpMapper();
+    expect(m.map(null)).toEqual([]);
+    expect(m.map(undefined)).toEqual([]);
+    expect(m.map("nonsense")).toEqual([]);
+    expect(m.map({})).toEqual([]);
+  });
+
+  it("ignores non-string fields rather than coercing them", () => {
+    const m = createAcpMapper();
+    const out = m.map({ sessionUpdate: "tool_call", toolCallId: "n1", title: 42, kind: 7 });
+    expect(out[0]).toMatchObject({ payload: { name: "n1" } });
+    expect(m.callOf("n1")).toMatchObject({ kind: "other" });
+  });
+});

--- a/packages/adapters/src/acp/map-acp.ts
+++ b/packages/adapters/src/acp/map-acp.ts
@@ -1,0 +1,145 @@
+import { newId, sessionEvent, type SessionEvent } from "@realm/contracts";
+
+type Bag = Record<string, unknown>;
+const obj = (v: unknown): Bag => (v && typeof v === "object" ? (v as Bag) : {});
+const str = (v: unknown): string => (typeof v === "string" ? v : "");
+
+/** Text out of an ACP ContentBlock; non-text blocks render as a short marker. */
+function blockText(block: unknown): string {
+  const b = obj(block);
+  switch (str(b.type)) {
+    case "text": return str(b.text);
+    case "image": return "[image]";
+    case "audio": return "[audio]";
+    case "resource_link": return `[${str(b.name) || str(b.uri)}]`;
+    case "resource": return `[resource ${str(obj(b.resource).uri)}]`;
+    default: return "";
+  }
+}
+
+/** ToolCallContent[] → a single string for Realm's `tool_result.content`. */
+function renderToolContent(content: unknown): string {
+  if (!Array.isArray(content)) return "";
+  return content.map((raw) => {
+    const c = obj(raw);
+    switch (str(c.type)) {
+      case "content": return blockText(c.content);
+      case "diff": {
+        const old = c.oldText === null || c.oldText === undefined ? "" : str(c.oldText);
+        return `--- ${str(c.path)}\n${old ? `- ${old.trimEnd()}\n` : ""}+ ${str(c.newText).trimEnd()}`;
+      }
+      case "terminal": return `[terminal ${str(c.terminalId)}]`;
+      default: return "";
+    }
+  }).filter(Boolean).join("\n");
+}
+
+/** The merged state of one ACP tool call. `input`/`kind` feed §4 permission-card rendering. */
+export type AcpCall = { title: string; kind: string; input: Record<string, unknown>; done: boolean };
+
+/**
+ * Pure, stateful mapper from ACP `session/update` payloads to Realm SessionEvents.
+ *
+ * ACP has no message ids and no end-of-message marker, so a contiguous run of `agent_message_chunk`s is grouped
+ * under one generated id: every chunk emits an ephemeral `assistant_delta`, and the run is flushed to a single
+ * persisted `assistant_text` when any other update arrives or the turn ends. Thought runs work identically, minus
+ * the deltas — Realm's `thinking` event has no streaming variant. Agents interleave thought and message chunks
+ * freely, so a chunk of either kind closes an open run of the other.
+ *
+ * `tool_call_update` is a SPARSE PATCH — only `toolCallId` is guaranteed and other fields are optional AND
+ * nullable, so a missing field must never clear stored state.
+ */
+export function createAcpMapper() {
+  const calls = new Map<string, AcpCall>();
+  let msg: { id: string; text: string } | null = null;
+  let thought: { id: string; text: string } | null = null;
+
+  // At most one of `msg`/`thought` is ever open: each chunk branch cross-flushes the other before opening its own
+  // run, so the order of the two blocks below is unobservable — they never both fire in the same call.
+  const flushRuns = (): SessionEvent[] => {
+    const out: SessionEvent[] = [];
+    if (msg) { if (msg.text) out.push(sessionEvent("assistant_text", { messageId: msg.id, text: msg.text })); msg = null; }
+    if (thought) { if (thought.text) out.push(sessionEvent("thinking", { messageId: thought.id, text: thought.text })); thought = null; }
+    return out;
+  };
+
+  return {
+    map(rawUpdate: unknown): SessionEvent[] {
+      const u = obj(rawUpdate);
+      const kind = str(u.sessionUpdate);
+
+      if (kind === "agent_message_chunk") {
+        const text = blockText(u.content);
+        const out: SessionEvent[] = [];
+        if (thought) out.push(...flushRuns());
+        if (!msg) msg = { id: newId(), text: "" };
+        msg.text += text;
+        out.push(sessionEvent("assistant_delta", { messageId: msg.id, delta: text }));
+        return out;
+      }
+
+      if (kind === "agent_thought_chunk") {
+        const text = blockText(u.content);
+        const out: SessionEvent[] = [];
+        if (msg) out.push(...flushRuns());
+        if (!thought) thought = { id: newId(), text: "" };
+        thought.text += text;
+        return out;
+      }
+
+      const out = flushRuns();
+
+      if (kind === "tool_call") {
+        const id = str(u.toolCallId);
+        const call: AcpCall = { title: str(u.title) || id, kind: str(u.kind) || "other", input: obj(u.rawInput), done: false };
+        calls.set(id, call);
+        out.push(sessionEvent("tool_call", { toolUseId: id, name: call.title, input: call.input, parentToolUseId: null }));
+        return out;
+      }
+
+      if (kind === "tool_call_update") {
+        const id = str(u.toolCallId);
+        const call = calls.get(id) ?? { title: id, kind: "other", input: {}, done: false };
+        // Sparse patch: only overwrite fields that are actually present.
+        if (typeof u.title === "string") call.title = u.title;
+        if (typeof u.kind === "string") call.kind = u.kind;
+        if (u.rawInput !== undefined && u.rawInput !== null) call.input = obj(u.rawInput);
+        calls.set(id, call);
+        const status = str(u.status);
+        if ((status === "completed" || status === "failed") && !call.done) {
+          call.done = true;
+          const body = renderToolContent(u.content);
+          const raw = u.rawOutput === undefined || u.rawOutput === null ? "" : JSON.stringify(u.rawOutput);
+          out.push(sessionEvent("tool_result", { toolUseId: id, content: body || raw, isError: status === "failed" }));
+        }
+        return out;
+      }
+
+      // plan / available_commands_update / current_mode_update / user_message_chunk are parsed and dropped in v1.
+      return out;
+    },
+
+    /** Flush any open text runs — call on prompt resolution, cancellation, and dispose. */
+    flush(): SessionEvent[] { return flushRuns(); },
+
+    /** Close any tool call still open, e.g. when the child dies mid-turn. */
+    closeOpenCalls(reason: string): SessionEvent[] {
+      const out: SessionEvent[] = [];
+      for (const [id, call] of calls) {
+        if (call.done) continue;
+        call.done = true;
+        out.push(sessionEvent("tool_result", { toolUseId: id, content: reason, isError: true }));
+      }
+      return out;
+    },
+
+    /**
+     * The merged state held for a call. `session/request_permission` carries a `ToolCallUpdate` where only
+     * `toolCallId` is guaranteed (protocol reference §4), so the adapter renders its card from this, not the patch.
+     */
+    callOf(id: string): Readonly<AcpCall> | undefined { return calls.get(id); },
+
+    /** Visible for tests: the merged title currently held for a call. */
+    titleOf(id: string): string | undefined { return calls.get(id)?.title; },
+  };
+}

--- a/packages/adapters/src/acp/probe.test.ts
+++ b/packages/adapters/src/acp/probe.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { probeAcp } from "./probe";
+
+describe("probeAcp", () => {
+  it("reports unavailable with a reason when the binary is missing", async () => {
+    const r = await probeAcp("/definitely/not/a/binary");
+    expect(r).toMatchObject({ available: false, version: null, loggedIn: null });
+    expect(r.reason).toBeTruthy();
+  });
+
+  it("reports available with a version and an unknown login state", async () => {
+    const r = await probeAcp(process.execPath, ["-e", "console.log('2026.07.25-e42b078')"]);
+    expect(r).toMatchObject({ available: true, version: "2026.07.25-e42b078", loggedIn: null });
+    expect(r.reason).toBe("unknown until a session starts");
+  });
+
+  it("takes only the first line of multi-line --version output", async () => {
+    const r = await probeAcp(process.execPath, ["-e", "console.log('2026.07.25-e42b078\\nextra diagnostic line')"]);
+    expect(r.version).toBe("2026.07.25-e42b078");
+  });
+
+  it("coerces empty --version output to a null version", async () => {
+    const r = await probeAcp(process.execPath, ["-e", "console.log('')"]);
+    expect(r.available).toBe(true);
+    expect(r.version).toBeNull();
+  });
+
+  it("never reports loggedIn as anything but null, even when the binary is available", async () => {
+    const r = await probeAcp(process.execPath, ["-e", "console.log('v1')"]);
+    expect(r.loggedIn).toBeNull();
+  });
+});

--- a/packages/adapters/src/acp/probe.ts
+++ b/packages/adapters/src/acp/probe.ts
@@ -1,0 +1,25 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const run = promisify(execFile);
+
+/**
+ * Checks an ACP agent CLI is runnable.
+ *
+ * `loggedIn` is deliberately `null`: neither Cursor nor Gemini exposes a trustworthy offline login check.
+ * `cursor-agent status` was observed printing "Login successful" and "unable to fetch user details" in the same
+ * breath, and Gemini's credentials file can exist for a tier that no longer accepts sessions. Auth failures
+ * surface at `session/new` and AcpAdapter turns them into an actionable error event.
+ */
+export async function probeAcp(
+  bin: string,
+  versionArgs: string[] = ["--version"],
+): Promise<{ available: boolean; version: string | null; loggedIn: boolean | null; reason: string | null }> {
+  try {
+    const { stdout } = await run(bin, versionArgs, { timeout: 5000 });
+    const version = stdout.trim().split("\n")[0]?.trim() || null;
+    return { available: true, version, loggedIn: null, reason: "unknown until a session starts" };
+  } catch (e) {
+    return { available: false, version: null, loggedIn: null, reason: (e as Error).message };
+  }
+}

--- a/packages/adapters/src/codex/codex-adapter.test.ts
+++ b/packages/adapters/src/codex/codex-adapter.test.ts
@@ -362,6 +362,26 @@ describe("CodexAdapter", () => {
     await handle.dispose();
   });
 
+  it("persists a half-streamed message when the turn is interrupted", async () => {
+    const { handle, evs } = await booted();
+    await handle.send({ text: "PARTIAL", attachments: [] });
+    await vi.waitFor(() => expect(of(evs, "assistant_delta")).toHaveLength(2));
+    await handle.interrupt();
+    await vi.waitFor(() => expect(statuses(evs).at(-1)).toBe("idle"));
+    // assistant_delta is ephemeral: without the flush the streamed answer never reaches the transcript at all.
+    expect(texts(evs)).toEqual(["half an answer"]);
+    await handle.dispose();
+  });
+
+  it("persists a half-streamed message when the session is disposed mid-stream", async () => {
+    const { handle, evs, done } = await booted();
+    await handle.send({ text: "PARTIAL", attachments: [] });
+    await vi.waitFor(() => expect(of(evs, "assistant_delta")).toHaveLength(2));
+    await handle.dispose();
+    await done;
+    expect(texts(evs)).toEqual(["half an answer"]);
+  });
+
   it("records setOptions but reports that it only applies at the next thread start", async () => {
     const logs: string[] = [];
     const { handle, evs } = await booted({ onLog: (l) => logs.push(l) });

--- a/packages/adapters/src/codex/codex-adapter.test.ts
+++ b/packages/adapters/src/codex/codex-adapter.test.ts
@@ -103,6 +103,15 @@ describe("CodexAdapter", () => {
     expect(adapter.processCount).toBe(0);
   });
 
+  it("emits init first even when a notification beat the thread/start response", async () => {
+    const { handle, evs } = await booted({ model: "eager" });
+    // attach() flushes the thread's buffer synchronously, so init has to be pushed before attaching or the
+    // transcript opens with a status change out of nowhere.
+    expect(types(evs)[0]).toBe("init");
+    await vi.waitFor(() => expect(statuses(evs)).toEqual(["idle", "running"]));
+    await handle.dispose();
+  });
+
   it("accepts a send that arrives before the boot has finished", async () => {
     const adapter = newAdapter();
     const handle = adapter.start(startOpts());
@@ -189,6 +198,32 @@ describe("CodexAdapter", () => {
     await handle.interrupt();
     await vi.waitFor(() => expect(of(evs, "tool_result")).toHaveLength(1));
     expect(of(evs, "tool_result")[0]!.payload.content).toBe("interrupted");
+    await handle.dispose();
+  });
+
+  it("bridges a fileChange approval as apply_patch with the itemId and grantRoot", async () => {
+    const { handle, evs } = await booted();
+    await handle.send({ text: "PATCH", attachments: [] });
+    await vi.waitFor(() => expect(of(evs, "permission_request")).toHaveLength(1));
+    const req = of(evs, "permission_request")[0]!.payload;
+    expect(req.toolName).toBe("apply_patch");
+    expect(req.input).toEqual({ itemId: of(evs, "tool_call")[0]!.payload.toolUseId, grantRoot: "/repo" });
+    expect(req.title).toBe("Apply 1 edit to a.ts");
+    expect(req.suggestions).toEqual(["accept", "acceptForSession", "decline", "cancel"]);
+
+    handle.respondPermission(req.requestId, "allow");
+    await vi.waitFor(() => expect(of(evs, "tool_result")).toHaveLength(1));
+    expect(of(evs, "tool_result")[0]!.payload).toMatchObject({ content: "edit /repo/src/a.ts\n@@\n-old\n+new", isError: false });
+    await handle.dispose();
+  });
+
+  it("denies a fileChange approval with decline, which this request does offer", async () => {
+    const { handle, evs } = await booted();
+    await handle.send({ text: "PATCH", attachments: [] });
+    await vi.waitFor(() => expect(of(evs, "permission_request")).toHaveLength(1));
+    handle.respondPermission(of(evs, "permission_request")[0]!.payload.requestId, "deny");
+    await vi.waitFor(() => expect(of(evs, "tool_result")).toHaveLength(1));
+    expect(of(evs, "tool_result")[0]!.payload.isError).toBe(true);
     await handle.dispose();
   });
 
@@ -349,6 +384,39 @@ describe("CodexAdapter", () => {
     await handle.dispose();
   });
 
+  it("does not blame the login for a boot failure that is not a login problem", async () => {
+    const adapter = newAdapter();
+    const handle = adapter.start(startOpts({ model: "nope" }));
+    const { evs, done } = drain(handle);
+    await done;
+    const text = of(evs, "error")[0]!.payload.message;
+    expect(text).toMatch(/unknown model/);
+    // Telling someone to re-run `codex login` over a bad model name sends them down the wrong path entirely.
+    expect(text).not.toMatch(/codex login/);
+    expect(adapter.processCount).toBe(0);
+  });
+
+  it("reports a failed turn/start instead of leaving the session stuck on running", async () => {
+    const { handle, evs } = await booted();
+    await handle.send({ text: "REFUSE", attachments: [] });
+    await vi.waitFor(() => expect(statuses(evs)).toEqual(["idle", "running", "idle"]));
+    expect(of(evs, "error")[0]!.payload.message).toMatch(/the model refused this turn/);
+    await handle.dispose();
+  });
+
+  it("reports a steer failure that is not the stale-turn race instead of starting a second turn", async () => {
+    const { handle, evs } = await booted();
+    await handle.send({ text: "HANG", attachments: [] });
+    await vi.waitFor(() => expect(of(evs, "tool_call")).toHaveLength(1));
+    await handle.send({ text: "BADSTEER", attachments: [] });
+    await vi.waitFor(() => expect(of(evs, "error")).toHaveLength(1));
+    expect(of(evs, "error")[0]!.payload.message).toMatch(/internal error while steering/);
+    // Retrying this as turn/start would silently run a SECOND concurrent turn against the same thread.
+    expect(texts(evs)).toEqual([]);
+    expect(of(evs, "tool_call")).toHaveLength(1);
+    await handle.dispose();
+  });
+
   it("reports a failed spawn as an error rather than hanging", async () => {
     const adapter = new CodexAdapter({ bin: "/definitely/not/a/codex/binary" });
     const handle = adapter.start(startOpts());
@@ -402,7 +470,45 @@ describe("CodexAdapter", () => {
     await vi.waitFor(() => expect(texts(b.evs)).toEqual(["hello"]));
     expect(types(a.evs)).not.toContain("assistant_text"); // and the disposed one hears nothing
 
+    const conn = (await adapter.connection)!;
     await two.dispose();
+    expect(adapter.processCount).toBe(0);
+    expect(adapter.sessionCount).toBe(0);
+    expect(conn.alive).toBe(false);
+  });
+
+  it("detaches from the shared process so a disposed session stops being reachable", async () => {
+    const adapter = newAdapter();
+    const one = adapter.start(startOpts());
+    const two = adapter.start(startOpts());
+    const a = drain(one);
+    const b = drain(two);
+    await vi.waitFor(() => {
+      expect(types(a.evs)).toContain("init");
+      expect(types(b.evs)).toContain("init");
+    });
+    const conn = (await adapter.connection)!;
+    expect(conn.threadCount).toBe(2);
+
+    await one.dispose();
+    // Without detach the listener, its mapper and the whole start() closure stay reachable from the
+    // connection for the life of the process.
+    expect(conn.threadCount).toBe(1);
+
+    await two.dispose();
+    expect(conn.threadCount).toBe(0);
+    expect(conn.alive).toBe(false); // the refcount reaching zero has to actually kill the child
+  });
+
+  it("ends a still-attached session quietly when the shared process is deliberately torn down", async () => {
+    const { adapter, evs, done } = await booted();
+    const conn = (await adapter.connection)!;
+    // onGone(reason, disposed: true) with a listener still attached: this is app quit. Reporting it would
+    // spray "codex app-server exited" across every open Codex session.
+    await conn.dispose();
+    await done;
+    expect(types(evs)).not.toContain("error");
+    expect(statuses(evs)).toEqual(["idle", "ended"]);
     expect(adapter.processCount).toBe(0);
     expect(adapter.sessionCount).toBe(0);
   });
@@ -438,14 +544,28 @@ describe("CodexAdapter", () => {
     expect(types(evs)).not.toContain("error");
   });
 
-  it("reports an unexpected process death as an error", async () => {
+  it("reports an unexpected process death as an error and blames the crash on the open tool card", async () => {
     const { adapter, handle, evs, done } = await booted();
     await handle.send({ text: "CRASH", attachments: [] });
+    await vi.waitFor(() => expect(of(evs, "tool_call")).toHaveLength(1));
     await done;
     expect(of(evs, "error")).toHaveLength(1);
     expect(of(evs, "error")[0]!.payload.message).toMatch(/exited/);
+    // "session closed" would be a lie here — the card has to say what actually happened to it.
+    expect(of(evs, "tool_result")[0]!.payload).toMatchObject({ content: expect.stringMatching(/exited/) as unknown as string, isError: true });
     expect(statuses(evs).slice(-2)).toEqual(["error", "ended"]);
     expect(adapter.processCount).toBe(0);
+  });
+
+  it("resolves a pending permission card when the session is disposed under it", async () => {
+    const { handle, evs, done } = await booted();
+    await handle.send({ text: "APPROVE", attachments: [] });
+    await vi.waitFor(() => expect(of(evs, "permission_request")).toHaveLength(1));
+    await handle.dispose();
+    await done;
+    // An unanswered request leaves a dangling card in the UI and wedges that thread on a shared process.
+    expect(of(evs, "permission_response")[0]!.payload).toMatchObject({ requestId: of(evs, "permission_request")[0]!.payload.requestId, decision: "deny" });
+    expect(statuses(evs).at(-1)).toBe("ended");
   });
 
   it("fails a send once the session is gone instead of throwing at the caller", async () => {

--- a/packages/adapters/src/codex/codex-adapter.test.ts
+++ b/packages/adapters/src/codex/codex-adapter.test.ts
@@ -1,19 +1,32 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, afterEach, vi } from "vitest";
 import { fileURLToPath } from "node:url";
 import type { SessionEvent, SessionEventOf, SessionEventType } from "@realm/contracts";
 import { CodexAdapter, codexPolicyFor, pickCodexDecision } from "./codex-adapter";
 import type { AgentHandle, StartOptions } from "../types";
 
+/**
+ * Every assertion in this file is gated on a real child process: node cold start, module load and at least one
+ * round trip. vitest's 1000 ms default is routinely too tight for that on a loaded two-core CI runner, and a
+ * longer bound costs nothing when the assertion passes.
+ */
+const waitFor = <T>(fn: () => T | Promise<T>) => vi.waitFor(fn, { timeout: 10_000, interval: 25 });
+
 const FAKE = fileURLToPath(new URL("./fixtures/fake-codex-server.mjs", import.meta.url));
 const newAdapter = (o: { bootTimeoutMs?: number } = {}) => new CodexAdapter({ bin: process.execPath, args: [FAKE], ...o });
 const startOpts = (o: Partial<StartOptions> = {}): StartOptions => ({ cwd: process.cwd(), mcpServers: [], ...o });
 
-/** Drains the handle's event stream into an array the assertions poll with `vi.waitFor`. */
+/** Drains the handle's event stream into an array the assertions poll with `waitFor`. */
 function drain(h: AgentHandle) {
+  live.push(h);
   const evs: SessionEvent[] = [];
   const done = (async () => { for await (const e of h.events) evs.push(e); })();
   return { evs, done };
 }
+
+/** Every handle a test drained. A failing assertion skips the test's own dispose(); this stops that leaking a
+ *  child process (and, with it, the shared app-server) into the rest of the run. */
+const live: AgentHandle[] = [];
+afterEach(async () => { for (const h of live.splice(0)) await h.dispose().catch(() => {}); });
 const types = (evs: SessionEvent[]) => evs.map((e) => e.type);
 const statuses = (evs: SessionEvent[]) => evs.filter((e) => e.type === "status").map((e) => e.payload.status);
 const of = <T extends SessionEventType>(evs: SessionEvent[], t: T) => evs.filter((e) => e.type === t) as SessionEventOf<T>[];
@@ -24,7 +37,7 @@ async function booted(o: Partial<StartOptions> = {}) {
   const adapter = newAdapter();
   const handle = adapter.start(startOpts(o));
   const { evs, done } = drain(handle);
-  await vi.waitFor(() => expect(types(evs)).toContain("init"));
+  await waitFor(() => expect(types(evs)).toContain("init"));
   return { adapter, handle, evs, done };
 }
 
@@ -90,8 +103,8 @@ describe("CodexAdapter", () => {
     expect(statuses(evs)).toEqual(["idle"]);
 
     await handle.send({ text: "hi", attachments: [] });
-    await vi.waitFor(() => expect(of(evs, "usage")).toHaveLength(1));
-    await vi.waitFor(() => expect(statuses(evs).at(-1)).toBe("idle"));
+    await waitFor(() => expect(of(evs, "usage")).toHaveLength(1));
+    await waitFor(() => expect(statuses(evs).at(-1)).toBe("idle"));
 
     expect(of(evs, "assistant_delta").map((e) => e.payload.delta)).toEqual(["hel", "lo"]);
     expect(texts(evs)).toEqual(["hello"]);
@@ -108,7 +121,7 @@ describe("CodexAdapter", () => {
     // attach() flushes the thread's buffer synchronously, so init has to be pushed before attaching or the
     // transcript opens with a status change out of nowhere.
     expect(types(evs)[0]).toBe("init");
-    await vi.waitFor(() => expect(statuses(evs)).toEqual(["idle", "running"]));
+    await waitFor(() => expect(statuses(evs)).toEqual(["idle", "running"]));
     await handle.dispose();
   });
 
@@ -117,7 +130,7 @@ describe("CodexAdapter", () => {
     const handle = adapter.start(startOpts());
     const { evs } = drain(handle);
     await handle.send({ text: "hi", attachments: [] }); // no wait for init
-    await vi.waitFor(() => expect(texts(evs)).toEqual(["hello"]));
+    await waitFor(() => expect(texts(evs)).toEqual(["hello"]));
     expect(types(evs).indexOf("init")).toBeLessThan(types(evs).indexOf("assistant_text"));
     await handle.dispose();
   });
@@ -128,7 +141,7 @@ describe("CodexAdapter", () => {
       text: "ECHO please",
       attachments: [{ path: "/tmp/shot.png", mime: "image/png" }, { path: "/tmp/notes.txt", mime: "text/plain" }],
     });
-    await vi.waitFor(() => expect(texts(evs)).toHaveLength(1));
+    await waitFor(() => expect(texts(evs)).toHaveLength(1));
     const input = JSON.parse(texts(evs)[0]!) as Array<Record<string, unknown>>;
     expect(input).toHaveLength(2);
     // text_elements is a non-optional array in UserInput; omitting it is a deserialize error on the real server.
@@ -143,7 +156,7 @@ describe("CodexAdapter", () => {
   it("sends only a text block when there are no attachments", async () => {
     const { handle, evs } = await booted();
     await handle.send({ text: "ECHO", attachments: [] });
-    await vi.waitFor(() => expect(texts(evs)).toHaveLength(1));
+    await waitFor(() => expect(texts(evs)).toHaveLength(1));
     expect(JSON.parse(texts(evs)[0]!)).toEqual([{ type: "text", text: "ECHO", text_elements: [] }]);
     await handle.dispose();
   });
@@ -193,10 +206,10 @@ describe("CodexAdapter", () => {
 
   it("rejoins a turn that was already running when the thread was resumed", async () => {
     const { handle, evs } = await booted({ resume: "th_busy" });
-    await vi.waitFor(() => expect(of(evs, "tool_call")).toHaveLength(1));
+    await waitFor(() => expect(of(evs, "tool_call")).toHaveLength(1));
     // Nothing here ever called turn/start, so turn/started is the only place the turn id came from.
     await handle.interrupt();
-    await vi.waitFor(() => expect(of(evs, "tool_result")).toHaveLength(1));
+    await waitFor(() => expect(of(evs, "tool_result")).toHaveLength(1));
     expect(of(evs, "tool_result")[0]!.payload.content).toBe("interrupted");
     await handle.dispose();
   });
@@ -204,7 +217,7 @@ describe("CodexAdapter", () => {
   it("bridges a fileChange approval as apply_patch with the itemId and grantRoot", async () => {
     const { handle, evs } = await booted();
     await handle.send({ text: "PATCH", attachments: [] });
-    await vi.waitFor(() => expect(of(evs, "permission_request")).toHaveLength(1));
+    await waitFor(() => expect(of(evs, "permission_request")).toHaveLength(1));
     const req = of(evs, "permission_request")[0]!.payload;
     expect(req.toolName).toBe("apply_patch");
     expect(req.input).toEqual({ itemId: of(evs, "tool_call")[0]!.payload.toolUseId, grantRoot: "/repo" });
@@ -212,7 +225,7 @@ describe("CodexAdapter", () => {
     expect(req.suggestions).toEqual(["accept", "acceptForSession", "decline", "cancel"]);
 
     handle.respondPermission(req.requestId, "allow");
-    await vi.waitFor(() => expect(of(evs, "tool_result")).toHaveLength(1));
+    await waitFor(() => expect(of(evs, "tool_result")).toHaveLength(1));
     expect(of(evs, "tool_result")[0]!.payload).toMatchObject({ content: "edit /repo/src/a.ts\n@@\n-old\n+new", isError: false });
     await handle.dispose();
   });
@@ -220,9 +233,9 @@ describe("CodexAdapter", () => {
   it("denies a fileChange approval with decline, which this request does offer", async () => {
     const { handle, evs } = await booted();
     await handle.send({ text: "PATCH", attachments: [] });
-    await vi.waitFor(() => expect(of(evs, "permission_request")).toHaveLength(1));
+    await waitFor(() => expect(of(evs, "permission_request")).toHaveLength(1));
     handle.respondPermission(of(evs, "permission_request")[0]!.payload.requestId, "deny");
-    await vi.waitFor(() => expect(of(evs, "tool_result")).toHaveLength(1));
+    await waitFor(() => expect(of(evs, "tool_result")).toHaveLength(1));
     expect(of(evs, "tool_result")[0]!.payload.isError).toBe(true);
     await handle.dispose();
   });
@@ -230,7 +243,7 @@ describe("CodexAdapter", () => {
   it("bridges a command approval and produces the tool_result once allowed", async () => {
     const { handle, evs } = await booted();
     await handle.send({ text: "APPROVE", attachments: [] });
-    await vi.waitFor(() => expect(of(evs, "permission_request")).toHaveLength(1));
+    await waitFor(() => expect(of(evs, "permission_request")).toHaveLength(1));
     expect(statuses(evs).at(-1)).toBe("waiting_permission");
 
     const req = of(evs, "permission_request")[0]!.payload;
@@ -240,7 +253,7 @@ describe("CodexAdapter", () => {
     expect(of(evs, "tool_call")[0]!.payload.name).toBe("exec_command");
 
     handle.respondPermission(req.requestId, "allow");
-    await vi.waitFor(() => expect(of(evs, "tool_result")).toHaveLength(1));
+    await waitFor(() => expect(of(evs, "tool_result")).toHaveLength(1));
     expect(of(evs, "permission_response")[0]!.payload).toEqual({ requestId: req.requestId, decision: "allow" });
     // exitCode 0 only happens if "accept" actually reached the child.
     expect(of(evs, "tool_result")[0]!.payload).toMatchObject({ content: "hi\n", isError: false });
@@ -252,31 +265,31 @@ describe("CodexAdapter", () => {
   it("denies a command approval with a decision the server actually offers", async () => {
     const { handle, evs } = await booted();
     await handle.send({ text: "APPROVE", attachments: [] });
-    await vi.waitFor(() => expect(of(evs, "permission_request")).toHaveLength(1));
+    await waitFor(() => expect(of(evs, "permission_request")).toHaveLength(1));
     handle.respondPermission(of(evs, "permission_request")[0]!.payload.requestId, "deny");
-    await vi.waitFor(() => expect(of(evs, "tool_result")).toHaveLength(1));
+    await waitFor(() => expect(of(evs, "tool_result")).toHaveLength(1));
     // The fixture only accepts "accept"/"cancel"; a hard-coded "decline" would leave the turn wedged.
     expect(of(evs, "tool_result")[0]!.payload).toMatchObject({ isError: true });
-    await vi.waitFor(() => expect(statuses(evs).at(-1)).toBe("idle"));
+    await waitFor(() => expect(statuses(evs).at(-1)).toBe("idle"));
     await handle.dispose();
   });
 
   it("flips to waiting_permission only for the first open request, and back only after the last", async () => {
     const { handle, evs } = await booted();
     await handle.send({ text: "APPROVE2", attachments: [] });
-    await vi.waitFor(() => expect(of(evs, "permission_request")).toHaveLength(2));
+    await waitFor(() => expect(of(evs, "permission_request")).toHaveLength(2));
     expect(statuses(evs).filter((s) => s === "waiting_permission")).toHaveLength(1);
 
     const [first, second] = of(evs, "permission_request").map((e) => e.payload.requestId);
     const beforeAnswers = statuses(evs).length;
     handle.respondPermission(first!, "allow");
-    await vi.waitFor(() => expect(of(evs, "permission_response")).toHaveLength(1));
+    await waitFor(() => expect(of(evs, "permission_response")).toHaveLength(1));
     expect(statuses(evs)).toHaveLength(beforeAnswers); // one still open: status must not be restored yet
 
     handle.respondPermission(second!, "allow");
-    await vi.waitFor(() => expect(of(evs, "tool_result")).toHaveLength(2));
+    await waitFor(() => expect(of(evs, "tool_result")).toHaveLength(2));
     expect(statuses(evs)[beforeAnswers]).toBe("running"); // restored exactly once, when the last one closed
-    await vi.waitFor(() => expect(statuses(evs).at(-1)).toBe("idle"));
+    await waitFor(() => expect(statuses(evs).at(-1)).toBe("idle"));
     await handle.dispose();
   });
 
@@ -285,7 +298,7 @@ describe("CodexAdapter", () => {
     const { handle, evs } = await booted({ onLog: (l) => logs.push(l) });
     await handle.send({ text: "ODDBALL", attachments: [] });
     // The fixture only finishes the turn once its odd request is answered.
-    await vi.waitFor(() => expect(texts(evs)).toEqual(["refused: -32601"]));
+    await waitFor(() => expect(texts(evs)).toEqual(["refused: -32601"]));
     expect(types(evs)).not.toContain("permission_request");
     expect(logs.some((l) => l.includes("item/tool/requestUserInput"))).toBe(true);
     await handle.dispose();
@@ -294,9 +307,9 @@ describe("CodexAdapter", () => {
   it("steers into a live turn rather than starting a second one", async () => {
     const { handle, evs } = await booted();
     await handle.send({ text: "HANG", attachments: [] });
-    await vi.waitFor(() => expect(of(evs, "tool_call")).toHaveLength(1));
+    await waitFor(() => expect(of(evs, "tool_call")).toHaveLength(1));
     await handle.send({ text: "and also this", attachments: [] });
-    await vi.waitFor(() => expect(texts(evs)).toEqual(["steered:and also this"]));
+    await waitFor(() => expect(texts(evs)).toEqual(["steered:and also this"]));
     await handle.dispose();
   });
 
@@ -304,7 +317,7 @@ describe("CodexAdapter", () => {
     const { handle, evs } = await booted();
     await handle.send({ text: "HANG SLOW", attachments: [] }); // notifications are 60ms behind the response
     await handle.send({ text: "immediately", attachments: [] });
-    await vi.waitFor(() => expect(texts(evs)).toEqual(["steered:immediately"]));
+    await waitFor(() => expect(texts(evs)).toEqual(["steered:immediately"]));
     await handle.dispose();
   });
 
@@ -312,20 +325,20 @@ describe("CodexAdapter", () => {
     const { handle, evs } = await booted();
     await handle.send({ text: "GHOST", attachments: [] }); // opens a turn the server does not consider steerable
     await handle.send({ text: "second", attachments: [] });
-    await vi.waitFor(() => expect(texts(evs)).toEqual(["hello"]));
+    await waitFor(() => expect(texts(evs)).toEqual(["hello"]));
     expect(texts(evs).some((t) => t.startsWith("steered:"))).toBe(false);
-    await vi.waitFor(() => expect(statuses(evs).at(-1)).toBe("idle"));
+    await waitFor(() => expect(statuses(evs).at(-1)).toBe("idle"));
     await handle.dispose();
   });
 
   it("force-closes an open tool card on interrupt and returns to idle", async () => {
     const { handle, evs } = await booted();
     await handle.send({ text: "HANG", attachments: [] });
-    await vi.waitFor(() => expect(of(evs, "tool_call")).toHaveLength(1));
+    await waitFor(() => expect(of(evs, "tool_call")).toHaveLength(1));
     expect(types(evs)).not.toContain("tool_result");
 
     await handle.interrupt();
-    await vi.waitFor(() => expect(of(evs, "tool_result")).toHaveLength(1));
+    await waitFor(() => expect(of(evs, "tool_result")).toHaveLength(1));
     expect(of(evs, "tool_result")[0]!.payload).toMatchObject({ toolUseId: of(evs, "tool_call")[0]!.payload.toolUseId, content: "interrupted", isError: true });
     expect(statuses(evs).at(-1)).toBe("idle");
     await handle.dispose();
@@ -334,10 +347,10 @@ describe("CodexAdapter", () => {
   it("denies pending permissions on interrupt", async () => {
     const { handle, evs } = await booted();
     await handle.send({ text: "APPROVE", attachments: [] });
-    await vi.waitFor(() => expect(of(evs, "permission_request")).toHaveLength(1));
+    await waitFor(() => expect(of(evs, "permission_request")).toHaveLength(1));
     await handle.interrupt();
     expect(of(evs, "permission_response")[0]!.payload.decision).toBe("deny");
-    await vi.waitFor(() => expect(of(evs, "tool_result")).toHaveLength(1));
+    await waitFor(() => expect(of(evs, "tool_result")).toHaveLength(1));
     await handle.dispose();
   });
 
@@ -353,21 +366,24 @@ describe("CodexAdapter", () => {
   it("does not interrupt a turn that already completed", async () => {
     const { handle, evs } = await booted();
     await handle.send({ text: "hi", attachments: [] });
-    await vi.waitFor(() => expect(of(evs, "usage")).toHaveLength(1));
-    await vi.waitFor(() => expect(statuses(evs).at(-1)).toBe("idle"));
-    const before = statuses(evs).length;
+    const done = ["idle", "running", "running", "idle", "idle"];
+    await waitFor(() => expect(statuses(evs)).toEqual(done));
     await handle.interrupt();
-    await new Promise((r) => setTimeout(r, 40));
-    expect(statuses(evs)).toHaveLength(before); // a stray turn/interrupt would add idle + turn/completed
+    // A positive signal rather than a sleep: run a second turn to completion. A stray turn/interrupt is
+    // written to the child ahead of this turn's own frames, so anything it produced is already in `evs` by
+    // the time the second answer lands — and the exact sequence below has no room for it.
+    await handle.send({ text: "again", attachments: [] });
+    await waitFor(() => expect(texts(evs)).toEqual(["hello", "hello"]));
+    await waitFor(() => expect(statuses(evs)).toEqual([...done, "running", "running", "idle", "idle"]));
     await handle.dispose();
   });
 
   it("persists a half-streamed message when the turn is interrupted", async () => {
     const { handle, evs } = await booted();
     await handle.send({ text: "PARTIAL", attachments: [] });
-    await vi.waitFor(() => expect(of(evs, "assistant_delta")).toHaveLength(2));
+    await waitFor(() => expect(of(evs, "assistant_delta")).toHaveLength(2));
     await handle.interrupt();
-    await vi.waitFor(() => expect(statuses(evs).at(-1)).toBe("idle"));
+    await waitFor(() => expect(statuses(evs).at(-1)).toBe("idle"));
     // assistant_delta is ephemeral: without the flush the streamed answer never reaches the transcript at all.
     expect(texts(evs)).toEqual(["half an answer"]);
     await handle.dispose();
@@ -376,7 +392,7 @@ describe("CodexAdapter", () => {
   it("persists a half-streamed message when the session is disposed mid-stream", async () => {
     const { handle, evs, done } = await booted();
     await handle.send({ text: "PARTIAL", attachments: [] });
-    await vi.waitFor(() => expect(of(evs, "assistant_delta")).toHaveLength(2));
+    await waitFor(() => expect(of(evs, "assistant_delta")).toHaveLength(2));
     await handle.dispose();
     await done;
     expect(texts(evs)).toEqual(["half an answer"]);
@@ -419,7 +435,7 @@ describe("CodexAdapter", () => {
   it("reports a failed turn/start instead of leaving the session stuck on running", async () => {
     const { handle, evs } = await booted();
     await handle.send({ text: "REFUSE", attachments: [] });
-    await vi.waitFor(() => expect(statuses(evs)).toEqual(["idle", "running", "idle"]));
+    await waitFor(() => expect(statuses(evs)).toEqual(["idle", "running", "idle"]));
     expect(of(evs, "error")[0]!.payload.message).toMatch(/the model refused this turn/);
     await handle.dispose();
   });
@@ -427,9 +443,9 @@ describe("CodexAdapter", () => {
   it("reports a steer failure that is not the stale-turn race instead of starting a second turn", async () => {
     const { handle, evs } = await booted();
     await handle.send({ text: "HANG", attachments: [] });
-    await vi.waitFor(() => expect(of(evs, "tool_call")).toHaveLength(1));
+    await waitFor(() => expect(of(evs, "tool_call")).toHaveLength(1));
     await handle.send({ text: "BADSTEER", attachments: [] });
-    await vi.waitFor(() => expect(of(evs, "error")).toHaveLength(1));
+    await waitFor(() => expect(of(evs, "error")).toHaveLength(1));
     expect(of(evs, "error")[0]!.payload.message).toMatch(/internal error while steering/);
     // Retrying this as turn/start would silently run a SECOND concurrent turn against the same thread.
     expect(texts(evs)).toEqual([]);
@@ -476,7 +492,7 @@ describe("CodexAdapter", () => {
     const two = adapter.start(startOpts());
     const a = drain(one);
     const b = drain(two);
-    await vi.waitFor(() => {
+    await waitFor(() => {
       expect(types(a.evs)).toContain("init");
       expect(types(b.evs)).toContain("init");
     });
@@ -487,7 +503,7 @@ describe("CodexAdapter", () => {
     expect(adapter.processCount).toBe(1); // the surviving session still owns the process
 
     await two.send({ text: "hi", attachments: [] });
-    await vi.waitFor(() => expect(texts(b.evs)).toEqual(["hello"]));
+    await waitFor(() => expect(texts(b.evs)).toEqual(["hello"]));
     expect(types(a.evs)).not.toContain("assistant_text"); // and the disposed one hears nothing
 
     const conn = (await adapter.connection)!;
@@ -503,7 +519,7 @@ describe("CodexAdapter", () => {
     const two = adapter.start(startOpts());
     const a = drain(one);
     const b = drain(two);
-    await vi.waitFor(() => {
+    await waitFor(() => {
       expect(types(a.evs)).toContain("init");
       expect(types(b.evs)).toContain("init");
     });
@@ -556,7 +572,7 @@ describe("CodexAdapter", () => {
   it("closes open tool cards when the session is disposed mid-turn", async () => {
     const { handle, evs, done } = await booted();
     await handle.send({ text: "HANG", attachments: [] });
-    await vi.waitFor(() => expect(of(evs, "tool_call")).toHaveLength(1));
+    await waitFor(() => expect(of(evs, "tool_call")).toHaveLength(1));
     await handle.dispose();
     await done;
     expect(of(evs, "tool_result")).toHaveLength(1);
@@ -567,7 +583,7 @@ describe("CodexAdapter", () => {
   it("reports an unexpected process death as an error and blames the crash on the open tool card", async () => {
     const { adapter, handle, evs, done } = await booted();
     await handle.send({ text: "CRASH", attachments: [] });
-    await vi.waitFor(() => expect(of(evs, "tool_call")).toHaveLength(1));
+    await waitFor(() => expect(of(evs, "tool_call")).toHaveLength(1));
     await done;
     expect(of(evs, "error")).toHaveLength(1);
     expect(of(evs, "error")[0]!.payload.message).toMatch(/exited/);
@@ -580,7 +596,7 @@ describe("CodexAdapter", () => {
   it("resolves a pending permission card when the session is disposed under it", async () => {
     const { handle, evs, done } = await booted();
     await handle.send({ text: "APPROVE", attachments: [] });
-    await vi.waitFor(() => expect(of(evs, "permission_request")).toHaveLength(1));
+    await waitFor(() => expect(of(evs, "permission_request")).toHaveLength(1));
     await handle.dispose();
     await done;
     // An unanswered request leaves a dangling card in the UI and wedges that thread on a shared process.
@@ -640,7 +656,7 @@ describe("CodexAdapter", () => {
     const { done } = drain(handle);
     await handle.dispose();
     await done;
-    await vi.waitFor(() => expect(adapter.processCount).toBe(0), { timeout: 10_000, interval: 25 });
+    await waitFor(() => expect(adapter.processCount).toBe(0));
     expect(adapter.sessionCount).toBe(0);
     expect((await conn).alive).toBe(false);
   });

--- a/packages/adapters/src/codex/codex-adapter.test.ts
+++ b/packages/adapters/src/codex/codex-adapter.test.ts
@@ -1,0 +1,457 @@
+import { describe, it, expect, vi } from "vitest";
+import { fileURLToPath } from "node:url";
+import type { SessionEvent, SessionEventOf, SessionEventType } from "@realm/contracts";
+import { CodexAdapter, codexPolicyFor, pickCodexDecision } from "./codex-adapter";
+import type { AgentHandle, StartOptions } from "../types";
+
+const FAKE = fileURLToPath(new URL("./fixtures/fake-codex-server.mjs", import.meta.url));
+const newAdapter = () => new CodexAdapter({ bin: process.execPath, args: [FAKE] });
+const startOpts = (o: Partial<StartOptions> = {}): StartOptions => ({ cwd: process.cwd(), mcpServers: [], ...o });
+
+/** Drains the handle's event stream into an array the assertions poll with `vi.waitFor`. */
+function drain(h: AgentHandle) {
+  const evs: SessionEvent[] = [];
+  const done = (async () => { for await (const e of h.events) evs.push(e); })();
+  return { evs, done };
+}
+const types = (evs: SessionEvent[]) => evs.map((e) => e.type);
+const statuses = (evs: SessionEvent[]) => evs.filter((e) => e.type === "status").map((e) => e.payload.status);
+const of = <T extends SessionEventType>(evs: SessionEvent[], t: T) => evs.filter((e) => e.type === t) as SessionEventOf<T>[];
+const texts = (evs: SessionEvent[]) => of(evs, "assistant_text").map((e) => e.payload.text);
+
+/** Boots a session and waits for `init`, the point after which every other call is meaningful. */
+async function booted(o: Partial<StartOptions> = {}) {
+  const adapter = newAdapter();
+  const handle = adapter.start(startOpts(o));
+  const { evs, done } = drain(handle);
+  await vi.waitFor(() => expect(types(evs)).toContain("init"));
+  return { adapter, handle, evs, done };
+}
+
+describe("pickCodexDecision", () => {
+  // The live capture offered ["accept", {acceptWithExecpolicyAmendment:…}, "cancel"] — no "decline" at all.
+  const LIVE = ["accept", { acceptWithExecpolicyAmendment: { execpolicy_amendment: {} } }, "cancel"];
+
+  it("maps deny to cancel when the server does not offer decline", () => {
+    expect(pickCodexDecision("deny", LIVE)).toBe("cancel");
+  });
+
+  it("prefers decline over cancel when decline is offered", () => {
+    expect(pickCodexDecision("deny", ["accept", "decline", "cancel"])).toBe("decline");
+  });
+
+  it("prefers acceptForSession for allow_always and falls back to accept", () => {
+    expect(pickCodexDecision("allow_always", ["accept", "acceptForSession", "cancel"])).toBe("acceptForSession");
+    expect(pickCodexDecision("allow_always", ["accept", "cancel"])).toBe("accept");
+  });
+
+  it("maps allow to accept", () => {
+    expect(pickCodexDecision("allow", LIVE)).toBe("accept");
+    expect(pickCodexDecision("allow", [])).toBe("accept");
+  });
+
+  it("never turns a deny into an accept, whatever is on offer", () => {
+    expect(pickCodexDecision("deny", [])).toBe("cancel");
+    expect(pickCodexDecision("deny", [{ applyNetworkPolicyAmendment: {} }])).toBe("cancel");
+    expect(pickCodexDecision("deny", ["accept", "acceptForSession"])).toBe("cancel");
+  });
+
+  it("ignores non-string entries when matching", () => {
+    expect(pickCodexDecision("allow_always", [{ acceptForSession: true }, "accept"])).toBe("accept");
+  });
+});
+
+describe("codexPolicyFor", () => {
+  it("maps plan to a read-only, untrusted thread", () => {
+    expect(codexPolicyFor("plan")).toEqual({ approvalPolicy: "untrusted", sandbox: "read-only" });
+  });
+  it("maps bypassPermissions to never/danger-full-access", () => {
+    expect(codexPolicyFor("bypassPermissions")).toEqual({ approvalPolicy: "never", sandbox: "danger-full-access" });
+  });
+  it("maps everything else to on-request/workspace-write", () => {
+    for (const m of ["default", "acceptEdits", undefined, "", "nonsense"]) {
+      expect(codexPolicyFor(m)).toEqual({ approvalPolicy: "on-request", sandbox: "workspace-write" });
+    }
+  });
+});
+
+describe("CodexAdapter", () => {
+  it("is registered as the codex agent kind", () => {
+    expect(newAdapter().kind).toBe("codex");
+  });
+
+  it("emits init then a full streaming turn, and never a user_message", async () => {
+    const { adapter, handle, evs } = await booted();
+    const init = of(evs, "init")[0]!;
+    expect(init.payload.providerSessionId).toMatch(/^th_/);
+    expect(init.payload.model).toBe("gpt-5.2");
+    expect(init.payload.cwd).toBe(process.cwd());
+    expect(init.payload.tools).toEqual([]);
+    expect(statuses(evs)).toEqual(["idle"]);
+
+    await handle.send({ text: "hi", attachments: [] });
+    await vi.waitFor(() => expect(of(evs, "usage")).toHaveLength(1));
+    await vi.waitFor(() => expect(statuses(evs).at(-1)).toBe("idle"));
+
+    expect(of(evs, "assistant_delta").map((e) => e.payload.delta)).toEqual(["hel", "lo"]);
+    expect(texts(evs)).toEqual(["hello"]);
+    expect(of(evs, "usage")[0]!.payload).toMatchObject({ inputTokens: 10, outputTokens: 2, numTurns: 1 });
+    // SessionService emits user_message itself; a second one from the adapter would double every message.
+    expect(types(evs)).not.toContain("user_message");
+    expect(statuses(evs)).toEqual(["idle", "running", "running", "idle", "idle"]);
+    await handle.dispose();
+    expect(adapter.processCount).toBe(0);
+  });
+
+  it("accepts a send that arrives before the boot has finished", async () => {
+    const adapter = newAdapter();
+    const handle = adapter.start(startOpts());
+    const { evs } = drain(handle);
+    await handle.send({ text: "hi", attachments: [] }); // no wait for init
+    await vi.waitFor(() => expect(texts(evs)).toEqual(["hello"]));
+    expect(types(evs).indexOf("init")).toBeLessThan(types(evs).indexOf("assistant_text"));
+    await handle.dispose();
+  });
+
+  it("sends text with the mandatory text_elements and maps attachments", async () => {
+    const { handle, evs } = await booted();
+    await handle.send({
+      text: "ECHO please",
+      attachments: [{ path: "/tmp/shot.png", mime: "image/png" }, { path: "/tmp/notes.txt", mime: "text/plain" }],
+    });
+    await vi.waitFor(() => expect(texts(evs)).toHaveLength(1));
+    const input = JSON.parse(texts(evs)[0]!) as Array<Record<string, unknown>>;
+    expect(input).toHaveLength(2);
+    // text_elements is a non-optional array in UserInput; omitting it is a deserialize error on the real server.
+    expect(input[0]).toMatchObject({ type: "text", text_elements: [] });
+    expect(input[0]!.text).toContain("ECHO please");
+    expect(input[0]!.text).toContain("/tmp/notes.txt"); // non-images are appended to the text as a file list
+    expect(input[0]!.text).not.toContain("/tmp/shot.png");
+    expect(input[1]).toEqual({ type: "localImage", path: "/tmp/shot.png" });
+    await handle.dispose();
+  });
+
+  it("sends only a text block when there are no attachments", async () => {
+    const { handle, evs } = await booted();
+    await handle.send({ text: "ECHO", attachments: [] });
+    await vi.waitFor(() => expect(texts(evs)).toHaveLength(1));
+    expect(JSON.parse(texts(evs)[0]!)).toEqual([{ type: "text", text: "ECHO", text_elements: [] }]);
+    await handle.dispose();
+  });
+
+  it("maps Realm permission modes onto thread/start's approvalPolicy and sandbox", async () => {
+    const cases = [
+      ["plan", { approvalPolicy: "untrusted", sandbox: "read-only" }],
+      ["bypassPermissions", { approvalPolicy: "never", sandbox: "danger-full-access" }],
+      ["default", { approvalPolicy: "on-request", sandbox: "workspace-write" }],
+    ] as const;
+    for (const [permissionMode, expected] of cases) {
+      const { handle, evs } = await booted({ permissionMode, model: "reflect" });
+      // `sandbox` is the SandboxMode *string* on thread/start (the structured object is turn/start's `sandboxPolicy`).
+      expect(JSON.parse(of(evs, "init")[0]!.payload.model)).toMatchObject({ ...expected, sessionStartSource: "startup", cwd: process.cwd() });
+      await handle.dispose();
+    }
+  });
+
+  it("omits model when unset and config when there are no mcp servers", async () => {
+    const { handle, evs } = await booted({ model: "reflect" });
+    const params = JSON.parse(of(evs, "init")[0]!.payload.model) as Record<string, unknown>;
+    expect(params.config).toBeUndefined();
+    const plain = await booted();
+    expect(of(plain.evs, "init")[0]!.payload.model).toBe("gpt-5.2"); // fixture default: no model was sent
+    await handle.dispose();
+    await plain.handle.dispose();
+  });
+
+  it("passes mcp servers through config.mcp_servers", async () => {
+    const { handle, evs } = await booted({
+      model: "reflect",
+      mcpServers: [{ name: "realm", command: "/usr/bin/node", args: ["/abs/realm-mcp.mjs"], env: { A: "1" } }],
+    });
+    const params = JSON.parse(of(evs, "init")[0]!.payload.model) as { config: { mcp_servers: Record<string, unknown> } };
+    expect(params.config.mcp_servers).toEqual({ realm: { command: "/usr/bin/node", args: ["/abs/realm-mcp.mjs"], env: { A: "1" } } });
+    await handle.dispose();
+  });
+
+  it("resumes an existing thread instead of starting a new one", async () => {
+    const { handle, evs } = await booted({ resume: "th_previous", model: "reflect" });
+    expect(of(evs, "init")[0]!.payload.providerSessionId).toBe("th_previous");
+    const params = JSON.parse(of(evs, "init")[0]!.payload.model) as Record<string, unknown>;
+    expect(params.threadId).toBe("th_previous");
+    expect(params.sessionStartSource).toBeUndefined(); // thread/resume rejoins; it is not a new session start
+    await handle.dispose();
+  });
+
+  it("rejoins a turn that was already running when the thread was resumed", async () => {
+    const { handle, evs } = await booted({ resume: "th_busy" });
+    await vi.waitFor(() => expect(of(evs, "tool_call")).toHaveLength(1));
+    // Nothing here ever called turn/start, so turn/started is the only place the turn id came from.
+    await handle.interrupt();
+    await vi.waitFor(() => expect(of(evs, "tool_result")).toHaveLength(1));
+    expect(of(evs, "tool_result")[0]!.payload.content).toBe("interrupted");
+    await handle.dispose();
+  });
+
+  it("bridges a command approval and produces the tool_result once allowed", async () => {
+    const { handle, evs } = await booted();
+    await handle.send({ text: "APPROVE", attachments: [] });
+    await vi.waitFor(() => expect(of(evs, "permission_request")).toHaveLength(1));
+    expect(statuses(evs).at(-1)).toBe("waiting_permission");
+
+    const req = of(evs, "permission_request")[0]!.payload;
+    expect(req.toolName).toBe("exec_command");
+    expect(req.input).toMatchObject({ command: "/bin/zsh -lc 'echo hi'", cwd: process.cwd() });
+    expect(req.suggestions).toEqual(["accept", "cancel"]);
+    expect(of(evs, "tool_call")[0]!.payload.name).toBe("exec_command");
+
+    handle.respondPermission(req.requestId, "allow");
+    await vi.waitFor(() => expect(of(evs, "tool_result")).toHaveLength(1));
+    expect(of(evs, "permission_response")[0]!.payload).toEqual({ requestId: req.requestId, decision: "allow" });
+    // exitCode 0 only happens if "accept" actually reached the child.
+    expect(of(evs, "tool_result")[0]!.payload).toMatchObject({ content: "hi\n", isError: false });
+    expect(statuses(evs)).toContain("waiting_permission");
+    expect(statuses(evs).at(-1)).toBe("idle");
+    await handle.dispose();
+  });
+
+  it("denies a command approval with a decision the server actually offers", async () => {
+    const { handle, evs } = await booted();
+    await handle.send({ text: "APPROVE", attachments: [] });
+    await vi.waitFor(() => expect(of(evs, "permission_request")).toHaveLength(1));
+    handle.respondPermission(of(evs, "permission_request")[0]!.payload.requestId, "deny");
+    await vi.waitFor(() => expect(of(evs, "tool_result")).toHaveLength(1));
+    // The fixture only accepts "accept"/"cancel"; a hard-coded "decline" would leave the turn wedged.
+    expect(of(evs, "tool_result")[0]!.payload).toMatchObject({ isError: true });
+    await vi.waitFor(() => expect(statuses(evs).at(-1)).toBe("idle"));
+    await handle.dispose();
+  });
+
+  it("flips to waiting_permission only for the first open request, and back only after the last", async () => {
+    const { handle, evs } = await booted();
+    await handle.send({ text: "APPROVE2", attachments: [] });
+    await vi.waitFor(() => expect(of(evs, "permission_request")).toHaveLength(2));
+    expect(statuses(evs).filter((s) => s === "waiting_permission")).toHaveLength(1);
+
+    const [first, second] = of(evs, "permission_request").map((e) => e.payload.requestId);
+    const beforeAnswers = statuses(evs).length;
+    handle.respondPermission(first!, "allow");
+    await vi.waitFor(() => expect(of(evs, "permission_response")).toHaveLength(1));
+    expect(statuses(evs)).toHaveLength(beforeAnswers); // one still open: status must not be restored yet
+
+    handle.respondPermission(second!, "allow");
+    await vi.waitFor(() => expect(of(evs, "tool_result")).toHaveLength(2));
+    expect(statuses(evs)[beforeAnswers]).toBe("running"); // restored exactly once, when the last one closed
+    await vi.waitFor(() => expect(statuses(evs).at(-1)).toBe("idle"));
+    await handle.dispose();
+  });
+
+  it("answers an unknown server request with -32601 instead of stalling the turn", async () => {
+    const logs: string[] = [];
+    const { handle, evs } = await booted({ onLog: (l) => logs.push(l) });
+    await handle.send({ text: "ODDBALL", attachments: [] });
+    // The fixture only finishes the turn once its odd request is answered.
+    await vi.waitFor(() => expect(texts(evs)).toEqual(["refused: -32601"]));
+    expect(types(evs)).not.toContain("permission_request");
+    expect(logs.some((l) => l.includes("item/tool/requestUserInput"))).toBe(true);
+    await handle.dispose();
+  });
+
+  it("steers into a live turn rather than starting a second one", async () => {
+    const { handle, evs } = await booted();
+    await handle.send({ text: "HANG", attachments: [] });
+    await vi.waitFor(() => expect(of(evs, "tool_call")).toHaveLength(1));
+    await handle.send({ text: "and also this", attachments: [] });
+    await vi.waitFor(() => expect(texts(evs)).toEqual(["steered:and also this"]));
+    await handle.dispose();
+  });
+
+  it("steers with the turn id from the turn/start response, before any notification arrives", async () => {
+    const { handle, evs } = await booted();
+    await handle.send({ text: "HANG SLOW", attachments: [] }); // notifications are 60ms behind the response
+    await handle.send({ text: "immediately", attachments: [] });
+    await vi.waitFor(() => expect(texts(evs)).toEqual(["steered:immediately"]));
+    await handle.dispose();
+  });
+
+  it("falls back to turn/start when the turn ended between the check and the steer", async () => {
+    const { handle, evs } = await booted();
+    await handle.send({ text: "GHOST", attachments: [] }); // opens a turn the server does not consider steerable
+    await handle.send({ text: "second", attachments: [] });
+    await vi.waitFor(() => expect(texts(evs)).toEqual(["hello"]));
+    expect(texts(evs).some((t) => t.startsWith("steered:"))).toBe(false);
+    await vi.waitFor(() => expect(statuses(evs).at(-1)).toBe("idle"));
+    await handle.dispose();
+  });
+
+  it("force-closes an open tool card on interrupt and returns to idle", async () => {
+    const { handle, evs } = await booted();
+    await handle.send({ text: "HANG", attachments: [] });
+    await vi.waitFor(() => expect(of(evs, "tool_call")).toHaveLength(1));
+    expect(types(evs)).not.toContain("tool_result");
+
+    await handle.interrupt();
+    await vi.waitFor(() => expect(of(evs, "tool_result")).toHaveLength(1));
+    expect(of(evs, "tool_result")[0]!.payload).toMatchObject({ toolUseId: of(evs, "tool_call")[0]!.payload.toolUseId, content: "interrupted", isError: true });
+    expect(statuses(evs).at(-1)).toBe("idle");
+    await handle.dispose();
+  });
+
+  it("denies pending permissions on interrupt", async () => {
+    const { handle, evs } = await booted();
+    await handle.send({ text: "APPROVE", attachments: [] });
+    await vi.waitFor(() => expect(of(evs, "permission_request")).toHaveLength(1));
+    await handle.interrupt();
+    expect(of(evs, "permission_response")[0]!.payload.decision).toBe("deny");
+    await vi.waitFor(() => expect(of(evs, "tool_result")).toHaveLength(1));
+    await handle.dispose();
+  });
+
+  it("does not send turn/interrupt when no turn is live", async () => {
+    const { handle, evs } = await booted();
+    await handle.interrupt();
+    await handle.interrupt();
+    // A stray turn/interrupt would make the fixture emit idle + turn/completed.
+    expect(statuses(evs)).toEqual(["idle"]);
+    await handle.dispose();
+  });
+
+  it("does not interrupt a turn that already completed", async () => {
+    const { handle, evs } = await booted();
+    await handle.send({ text: "hi", attachments: [] });
+    await vi.waitFor(() => expect(of(evs, "usage")).toHaveLength(1));
+    await vi.waitFor(() => expect(statuses(evs).at(-1)).toBe("idle"));
+    const before = statuses(evs).length;
+    await handle.interrupt();
+    await new Promise((r) => setTimeout(r, 40));
+    expect(statuses(evs)).toHaveLength(before); // a stray turn/interrupt would add idle + turn/completed
+    await handle.dispose();
+  });
+
+  it("records setOptions but reports that it only applies at the next thread start", async () => {
+    const logs: string[] = [];
+    const { handle, evs } = await booted({ onLog: (l) => logs.push(l) });
+    await handle.setOptions({ model: "gpt-5.6-sol", permissionMode: "plan" });
+    expect(logs.some((l) => l.includes("gpt-5.6-sol") && l.includes("plan"))).toBe(true);
+    expect(types(evs)).not.toContain("error"); // it is a limitation, not a failure
+    await handle.dispose();
+  });
+
+  it("turns a revoked login into an error naming `codex login`", async () => {
+    const adapter = newAdapter();
+    const handle = adapter.start(startOpts({ model: "explode" }));
+    const { evs, done } = drain(handle);
+    await done;
+    expect(of(evs, "error")[0]!.payload.message).toMatch(/codex login/);
+    expect(of(evs, "error")[0]!.payload.message).toMatch(/failed to load configuration/);
+    expect(statuses(evs)).toEqual(["error", "ended"]);
+    expect(types(evs)).not.toContain("init");
+    expect(adapter.processCount).toBe(0); // a failed boot must not pin the process forever
+    await handle.dispose();
+  });
+
+  it("reports a failed spawn as an error rather than hanging", async () => {
+    const adapter = new CodexAdapter({ bin: "/definitely/not/a/codex/binary" });
+    const handle = adapter.start(startOpts());
+    const { evs, done } = drain(handle);
+    await done;
+    expect(of(evs, "error")).toHaveLength(1);
+    expect(statuses(evs)).toEqual(["error", "ended"]);
+    expect(adapter.processCount).toBe(0);
+  });
+
+  it("does not leave the refcount inflated when the process fails to start", async () => {
+    const adapter = new CodexAdapter({ bin: "/definitely/not/a/codex/binary" });
+    for (let i = 0; i < 2; i++) {
+      const handle = adapter.start(startOpts());
+      await drain(handle).done;
+    }
+    // A failed acquire that forgot to unwind would strand the count above zero and pin the next process,
+    // and a cached rejected promise would leave `conn` set forever.
+    expect(adapter.sessionCount).toBe(0);
+    expect(adapter.processCount).toBe(0);
+  });
+
+  it("releases the process when a dispose races the boot", async () => {
+    const adapter = newAdapter();
+    const handle = adapter.start(startOpts());
+    const { evs, done } = drain(handle);
+    await handle.dispose(); // before init has had any chance to land
+    await done;
+    expect(statuses(evs).at(-1)).toBe("ended");
+    expect(adapter.processCount).toBe(0);
+    expect(adapter.sessionCount).toBe(0);
+  });
+
+  it("shares one process across sessions and disposes it with the last one", async () => {
+    const adapter = newAdapter();
+    const one = adapter.start(startOpts());
+    const two = adapter.start(startOpts());
+    const a = drain(one);
+    const b = drain(two);
+    await vi.waitFor(() => {
+      expect(types(a.evs)).toContain("init");
+      expect(types(b.evs)).toContain("init");
+    });
+    expect(adapter.processCount).toBe(1);
+    expect(of(a.evs, "init")[0]!.payload.providerSessionId).not.toBe(of(b.evs, "init")[0]!.payload.providerSessionId);
+
+    await one.dispose();
+    expect(adapter.processCount).toBe(1); // the surviving session still owns the process
+
+    await two.send({ text: "hi", attachments: [] });
+    await vi.waitFor(() => expect(texts(b.evs)).toEqual(["hello"]));
+    expect(types(a.evs)).not.toContain("assistant_text"); // and the disposed one hears nothing
+
+    await two.dispose();
+    expect(adapter.processCount).toBe(0);
+    expect(adapter.sessionCount).toBe(0);
+  });
+
+  it("ends quietly on a deliberate dispose", async () => {
+    const { adapter, handle, evs, done } = await booted();
+    await handle.dispose();
+    await done;
+    // onGone(reason, disposed: true) is us quitting; spraying "codex app-server exited" here would light up
+    // every open Codex session on app quit.
+    expect(types(evs)).not.toContain("error");
+    expect(statuses(evs)).toEqual(["idle", "ended"]);
+    expect(adapter.processCount).toBe(0);
+  });
+
+  it("is idempotent on dispose", async () => {
+    const { adapter, handle, evs, done } = await booted();
+    await handle.dispose();
+    await handle.dispose();
+    await done;
+    expect(statuses(evs).filter((s) => s === "ended")).toHaveLength(1);
+    expect(adapter.processCount).toBe(0);
+  });
+
+  it("closes open tool cards when the session is disposed mid-turn", async () => {
+    const { handle, evs, done } = await booted();
+    await handle.send({ text: "HANG", attachments: [] });
+    await vi.waitFor(() => expect(of(evs, "tool_call")).toHaveLength(1));
+    await handle.dispose();
+    await done;
+    expect(of(evs, "tool_result")).toHaveLength(1);
+    expect(of(evs, "tool_result")[0]!.payload.isError).toBe(true);
+    expect(types(evs)).not.toContain("error");
+  });
+
+  it("reports an unexpected process death as an error", async () => {
+    const { adapter, handle, evs, done } = await booted();
+    await handle.send({ text: "CRASH", attachments: [] });
+    await done;
+    expect(of(evs, "error")).toHaveLength(1);
+    expect(of(evs, "error")[0]!.payload.message).toMatch(/exited/);
+    expect(statuses(evs).slice(-2)).toEqual(["error", "ended"]);
+    expect(adapter.processCount).toBe(0);
+  });
+
+  it("fails a send once the session is gone instead of throwing at the caller", async () => {
+    const { handle, evs } = await booted();
+    await handle.dispose();
+    await expect(handle.send({ text: "hi", attachments: [] })).resolves.toBeUndefined();
+    expect(types(evs)).not.toContain("assistant_text");
+  });
+});

--- a/packages/adapters/src/codex/codex-adapter.test.ts
+++ b/packages/adapters/src/codex/codex-adapter.test.ts
@@ -5,7 +5,7 @@ import { CodexAdapter, codexPolicyFor, pickCodexDecision } from "./codex-adapter
 import type { AgentHandle, StartOptions } from "../types";
 
 const FAKE = fileURLToPath(new URL("./fixtures/fake-codex-server.mjs", import.meta.url));
-const newAdapter = () => new CodexAdapter({ bin: process.execPath, args: [FAKE] });
+const newAdapter = (o: { bootTimeoutMs?: number } = {}) => new CodexAdapter({ bin: process.execPath, args: [FAKE], ...o });
 const startOpts = (o: Partial<StartOptions> = {}): StartOptions => ({ cwd: process.cwd(), mcpServers: [], ...o });
 
 /** Drains the handle's event stream into an array the assertions poll with `vi.waitFor`. */
@@ -566,6 +566,63 @@ describe("CodexAdapter", () => {
     // An unanswered request leaves a dangling card in the UI and wedges that thread on a shared process.
     expect(of(evs, "permission_response")[0]!.payload).toMatchObject({ requestId: of(evs, "permission_request")[0]!.payload.requestId, decision: "deny" });
     expect(statuses(evs).at(-1)).toBe("ended");
+  });
+
+  it("bounds thread/start so a child that spawns and then answers nothing cannot hang the session", async () => {
+    // No timeout here and boot stays pending forever: dispose() -> App.close() never returns and the desktop
+    // main process SIGTERMs the server out from under its agent children.
+    const adapter = newAdapter({ bootTimeoutMs: 200 });
+    const handle = adapter.start(startOpts({ env: { FAKE_CODEX_MUTE_THREAD_START: "1" } }));
+    const conn = adapter.connection!;
+    const { evs, done } = drain(handle);
+    // send() awaits boot too, so a bounded boot is what stops it hanging the WebSocket call as well.
+    await expect(handle.send({ text: "hi", attachments: [] })).resolves.toBeUndefined();
+    await done;
+    expect(of(evs, "error")[0]!.payload.message).toMatch(/thread\/start within 200ms/);
+    expect(statuses(evs)).toEqual(["error", "ended"]);
+    expect(adapter.processCount).toBe(0);
+    expect(adapter.sessionCount).toBe(0);
+    expect((await conn).alive).toBe(false); // and the child it already spawned is gone with it
+    await handle.dispose();
+  });
+
+  it("bounds thread/resume the same way", async () => {
+    const adapter = newAdapter({ bootTimeoutMs: 200 });
+    const handle = adapter.start(startOpts({ resume: "th_old", env: { FAKE_CODEX_MUTE_THREAD_START: "1" } }));
+    const { evs, done } = drain(handle);
+    await done;
+    expect(of(evs, "error")[0]!.payload.message).toMatch(/thread\/resume within 200ms/);
+    expect(adapter.processCount).toBe(0);
+  });
+
+  it("completes dispose even when the boot itself never settles", async () => {
+    // The boot timeout is deliberately far longer than DISPOSE_TIMEOUT_MS here, so the only thing that can
+    // resolve this dispose is the race in dispose() itself.
+    const adapter = newAdapter({ bootTimeoutMs: 60_000 });
+    const handle = adapter.start(startOpts({ env: { FAKE_CODEX_MUTE_THREAD_START: "1" } }));
+    const conn = adapter.connection!;
+    const { done } = drain(handle);
+    const t0 = Date.now();
+    await handle.dispose();
+    expect(Date.now() - t0).toBeLessThan(10_000);
+    await done;
+    expect((await conn).alive).toBe(false); // the ref was handed back, so the shared process really died
+    expect(adapter.processCount).toBe(0);
+    expect(adapter.sessionCount).toBe(0);
+  });
+
+  it("hands the shared process back when the boot lands after dispose gave up waiting for it", async () => {
+    // The window the dispose race opens: shutdown() runs before acquire() resolves, so the ref start() already
+    // took is still outstanding when the process finally comes up — and nothing else will ever return it.
+    const adapter = newAdapter({ bootTimeoutMs: 60_000 });
+    const handle = adapter.start(startOpts({ env: { FAKE_CODEX_INITIALIZE_DELAY_MS: "3500" } }));
+    const conn = adapter.connection!;
+    const { done } = drain(handle);
+    await handle.dispose();
+    await done;
+    await vi.waitFor(() => expect(adapter.processCount).toBe(0), { timeout: 10_000, interval: 25 });
+    expect(adapter.sessionCount).toBe(0);
+    expect((await conn).alive).toBe(false);
   });
 
   it("fails a send once the session is gone instead of throwing at the caller", async () => {

--- a/packages/adapters/src/codex/codex-adapter.ts
+++ b/packages/adapters/src/codex/codex-adapter.ts
@@ -86,6 +86,12 @@ export class CodexAdapter implements AgentAdapter {
   get processCount(): number { return this.conn === null ? 0 : 1; }
   /** Visible for tests: sessions currently holding the process. A leak here strands the child forever. */
   get sessionCount(): number { return this.refs; }
+  /**
+   * Visible for tests: the shared process itself, once a session has acquired it. Lets tests assert what the
+   * refcount alone cannot — that the child is really dead, that a disposed session really detached, and how a
+   * still-attached session reacts when the process is deliberately torn down under it.
+   */
+  get connection(): Promise<CodexConnection> | null { return this.conn; }
 
   async probe(): Promise<ProbeResult> {
     const p = await probeCodex(this.bin);
@@ -132,7 +138,6 @@ export class CodexAdapter implements AgentAdapter {
     let conn: CodexConnection | null = null;
     let threadId: string | null = null;
     let activeTurnId: string | null = null;
-    let running = false;
     let acquired = false;
     let disposed = false;
 
@@ -148,8 +153,9 @@ export class CodexAdapter implements AgentAdapter {
       conn?.respond(p.id, { decision: pickCodexDecision(decision, p.decisions) });
       events.push(sessionEvent("permission_response", { requestId, decision }));
       // Several tools can be waiting at once (parallel tool calls): the status only comes back when the last
-      // one is answered.
-      if (pending.size === 0) events.push(sessionEvent("status", { status: running ? "running" : "idle" }));
+      // one is answered. An approval only exists inside a live turn, so that status is always `running`; the
+      // turn's own `turn/completed` is what settles it back to idle.
+      if (pending.size === 0) events.push(sessionEvent("status", { status: "running" }));
     };
     const denyAllPending = () => { for (const id of [...pending.keys()]) respond(id, "deny"); };
 
@@ -168,8 +174,10 @@ export class CodexAdapter implements AgentAdapter {
     const listener: ThreadListener = {
       onNotification: (method, params) => {
         const p = obj(params);
-        if (method === "turn/started") { activeTurnId = str(obj(p.turn).id) || activeTurnId; running = true; }
-        if (method === "turn/completed") { activeTurnId = null; running = false; }
+        // thread/resume rejoins a turn that is already running, and its response carries no turn id — this
+        // notification is the only place a rejoined session learns one.
+        if (method === "turn/started") activeTurnId = str(obj(p.turn).id) || activeTurnId;
+        if (method === "turn/completed") activeTurnId = null;
         for (const e of mapper.map(method, params)) events.push(e);
       },
       onServerRequest: (id, method, params) => {
@@ -210,6 +218,8 @@ export class CodexAdapter implements AgentAdapter {
         conn = c;
         const { approvalPolicy, sandbox } = codexPolicyFor(opts.permissionMode);
         const config = mcpConfig(opts.mcpServers);
+        // `opts.effort` is deliberately dropped: Codex takes reasoning effort per turn, not per thread, and
+        // Realm has no per-turn effort control yet. Claude passes it through; this asymmetry is intentional.
         const common = {
           cwd: opts.cwd,
           approvalPolicy,
@@ -224,9 +234,12 @@ export class CodexAdapter implements AgentAdapter {
         const id = str(obj(res.thread).id) || str(opts.resume);
         if (!id) throw new Error("codex did not return a thread id");
         threadId = id;
-        c.attach(id, listener);
+        // Both before attach(): attach flushes the thread's buffer synchronously, and notifications that beat
+        // the thread/start response would otherwise be mapped into the stream ahead of init. Nothing is lost by
+        // waiting — the connection buffers by threadId until someone attaches.
         events.push(sessionEvent("init", { providerSessionId: id, model: str(res.model) || str(opts.model), tools: [], cwd: str(res.cwd) || opts.cwd }));
         events.push(sessionEvent("status", { status: "idle" }));
+        c.attach(id, listener);
       } catch (e) {
         if (disposed) return;
         fail(bootFailureMessage(e));
@@ -251,7 +264,6 @@ export class CodexAdapter implements AgentAdapter {
         await boot; // boot reports its own failures; it never rejects
         if (disposed || !conn || !threadId) { events.push(sessionEvent("error", { message: "session ended" })); return; }
         const input = inputFor(m);
-        running = true;
         events.push(sessionEvent("status", { status: "running" }));
         try {
           if (activeTurnId) {
@@ -269,7 +281,6 @@ export class CodexAdapter implements AgentAdapter {
           const started = obj(await conn.request("turn/start", { threadId, input }));
           activeTurnId = str(obj(started.turn).id) || null;
         } catch (e) {
-          running = false;
           events.push(sessionEvent("error", { message: message(e) }));
           events.push(sessionEvent("status", { status: "idle" }));
         }

--- a/packages/adapters/src/codex/codex-adapter.ts
+++ b/packages/adapters/src/codex/codex-adapter.ts
@@ -11,6 +11,11 @@ const obj = (v: unknown): Bag => (v && typeof v === "object" ? (v as Bag) : {});
 const str = (v: unknown): string => (typeof v === "string" ? v : "");
 const message = (e: unknown): string => (e instanceof Error ? e.message : String(e));
 
+/** Copies ClaudeAdapter: app quit awaits every dispose(), so no dispose may depend on a healthy child. */
+const DISPOSE_TIMEOUT_MS = 3000;
+/** thread/start loads config, resolves the model and checks auth — slower than initialize, never unbounded. */
+const BOOT_TIMEOUT_MS = 30_000;
+
 const APPROVAL_METHODS: Record<string, { toolName: string; title: string }> = {
   "item/commandExecution/requestApproval": { toolName: "exec_command", title: "Run this command?" },
   "item/fileChange/requestApproval": { toolName: "apply_patch", title: "Apply these edits?" },
@@ -74,12 +79,15 @@ export class CodexAdapter implements AgentAdapter {
   readonly kind = "codex" as const;
   private readonly bin?: string;
   private readonly args?: string[];
+  /** Overridable for tests. Bounds every boot call: initialize, thread/start and thread/resume. */
+  private readonly bootTimeoutMs?: number;
   private conn: Promise<CodexConnection> | null = null;
   private refs = 0;
 
-  constructor(deps: { bin?: string; args?: string[] } = {}) {
+  constructor(deps: { bin?: string; args?: string[]; bootTimeoutMs?: number } = {}) {
     this.bin = deps.bin;
     this.args = deps.args;
+    this.bootTimeoutMs = deps.bootTimeoutMs;
   }
 
   /** Visible for tests: 0 or 1 — the whole point of the refcount is that it never exceeds one. */
@@ -110,6 +118,7 @@ export class CodexAdapter implements AgentAdapter {
       cwd: opts.cwd,
       env: opts.env,
       onLog: opts.onLog,
+      initializeTimeoutMs: this.bootTimeoutMs,
     }));
     try {
       return await pending;
@@ -139,11 +148,25 @@ export class CodexAdapter implements AgentAdapter {
     let threadId: string | null = null;
     let activeTurnId: string | null = null;
     let acquired = false;
+    let released = false;
     let disposed = false;
 
     const fail = (text: string) => {
       events.push(sessionEvent("error", { message: text }));
       events.push(sessionEvent("status", { status: "error" }));
+    };
+
+    /**
+     * Hands the shared process back exactly once.
+     *
+     * `acquire()` takes the ref synchronously inside `start()`, but this closure only learns it succeeded when
+     * the open resolves — and dispose() no longer waits for that. So whichever of shutdown() and boot gets here
+     * once `acquired` is set is the one that releases; the other is a no-op.
+     */
+    const releaseOnce = async (): Promise<void> => {
+      if (!acquired || released) return;
+      released = true;
+      await this.release();
     };
 
     const respond = (requestId: string, decision: PermissionDecision) => {
@@ -168,7 +191,7 @@ export class CodexAdapter implements AgentAdapter {
       for (const e of mapper.closeOpenTools("session closed")) events.push(e);
       events.push(sessionEvent("status", { status: "ended" }));
       events.close();
-      if (acquired) { acquired = false; await this.release(); }
+      await releaseOnce();
     };
 
     const listener: ThreadListener = {
@@ -214,7 +237,9 @@ export class CodexAdapter implements AgentAdapter {
       try {
         const c = await this.acquire(opts);
         acquired = true;
-        if (disposed) return; // disposed while the process was still coming up; shutdown() releases the ref
+        // Disposed while the process was still coming up. shutdown() has already run and found nothing to hand
+        // back (it no longer waits for a boot that may never settle), so the ref is returned here instead.
+        if (disposed) { await releaseOnce(); return; }
         conn = c;
         const { approvalPolicy, sandbox } = codexPolicyFor(opts.permissionMode);
         const config = mcpConfig(opts.mcpServers);
@@ -227,9 +252,13 @@ export class CodexAdapter implements AgentAdapter {
           ...(opts.model ? { model: opts.model } : {}),
           ...(config ? { config } : {}),
         };
+        // Bounded: neither call has a protocol-level deadline, and a child that spawns and then answers
+        // nothing would otherwise leave `boot` — and every send()/setOptions()/dispose() behind it — pending
+        // for the life of the process.
+        const bootMs = this.bootTimeoutMs ?? BOOT_TIMEOUT_MS;
         const res = obj(opts.resume
-          ? await c.request("thread/resume", { threadId: opts.resume, ...common })
-          : await c.request("thread/start", { ...common, sessionStartSource: "startup" }));
+          ? await c.request("thread/resume", { threadId: opts.resume, ...common }, bootMs)
+          : await c.request("thread/start", { ...common, sessionStartSource: "startup" }, bootMs));
         if (disposed) return;
         const id = str(obj(res.thread).id) || str(opts.resume);
         if (!id) throw new Error("codex did not return a thread id");
@@ -304,7 +333,13 @@ export class CodexAdapter implements AgentAdapter {
         opts.onLog?.(`[codex] ${parts.join(" ")} recorded; codex fixes these at thread start, so it applies the next time this session starts`);
       },
       dispose: async () => {
-        await boot; // never leave a half-attached thread behind a dispose that raced the boot
+        // Waiting for boot keeps a dispose that raced it from leaving a half-attached thread behind — but the
+        // wait is bounded, because SessionService.closeAll() -> App.close() -> app quit is what is behind it.
+        // An unbounded wait here is how the desktop main process ends up SIGTERMing a server that still owns
+        // live agent children.
+        let timer: ReturnType<typeof setTimeout> | undefined;
+        await Promise.race([boot, new Promise<void>((res) => { timer = setTimeout(res, DISPOSE_TIMEOUT_MS); })]);
+        clearTimeout(timer);
         await shutdown();
       },
     };

--- a/packages/adapters/src/codex/codex-adapter.ts
+++ b/packages/adapters/src/codex/codex-adapter.ts
@@ -1,0 +1,301 @@
+import { sessionEvent, type SessionEvent } from "@realm/contracts";
+import { AsyncQueue } from "../event-queue";
+import { JsonRpcCallError, type JsonRpcId } from "../jsonrpc/stdio";
+import { CodexConnection, type ThreadListener } from "./connection";
+import { createCodexMapper } from "./map-codex";
+import { probeCodex } from "./probe";
+import type { AgentAdapter, AgentHandle, McpStdioConfig, PermissionDecision, ProbeResult, StartOptions, UserMessage } from "../types";
+
+type Bag = Record<string, unknown>;
+const obj = (v: unknown): Bag => (v && typeof v === "object" ? (v as Bag) : {});
+const str = (v: unknown): string => (typeof v === "string" ? v : "");
+const message = (e: unknown): string => (e instanceof Error ? e.message : String(e));
+
+const APPROVAL_METHODS: Record<string, { toolName: string; title: string }> = {
+  "item/commandExecution/requestApproval": { toolName: "exec_command", title: "Run this command?" },
+  "item/fileChange/requestApproval": { toolName: "apply_patch", title: "Apply these edits?" },
+};
+
+/**
+ * Codex decisions Realm will send, most preferred first.
+ *
+ * The live capture offered `["accept", {acceptWithExecpolicyAmendment:…}, "cancel"]` — with **no `"decline"`**,
+ * even though the generated bindings list it. Sending a decision the server did not offer fails the request and
+ * wedges the turn, so the wire list wins and these are only a preference order over it.
+ */
+const DECISION_PREFERENCES: Record<PermissionDecision, readonly string[]> = {
+  allow: ["accept"],
+  allow_always: ["acceptForSession", "accept"],
+  deny: ["decline", "cancel"],
+};
+
+/**
+ * Picks the first offered decision from the preference list for `decision`.
+ *
+ * `availableDecisions` comes straight off the wire and may contain objects (`{acceptWithExecpolicyAmendment}`) —
+ * only string variants are candidates. When nothing matches (or the server sent no list at all) the *last*
+ * preference is used, which is the most conservative one: a deny can never degrade into an accept.
+ */
+export function pickCodexDecision(decision: PermissionDecision, availableDecisions: readonly unknown[]): string {
+  const prefs = DECISION_PREFERENCES[decision];
+  const offered = new Set(availableDecisions.filter((d): d is string => typeof d === "string"));
+  return prefs.find((p) => offered.has(p)) ?? prefs[prefs.length - 1]!;
+}
+
+/** Realm's permission modes onto Codex's two independent knobs. Both are `thread/start` params. */
+export function codexPolicyFor(permissionMode: string | undefined): { approvalPolicy: string; sandbox: string } {
+  if (permissionMode === "plan") return { approvalPolicy: "untrusted", sandbox: "read-only" };
+  if (permissionMode === "bypassPermissions") return { approvalPolicy: "never", sandbox: "danger-full-access" };
+  return { approvalPolicy: "on-request", sandbox: "workspace-write" };
+}
+
+function mcpConfig(servers: McpStdioConfig[]): Bag | undefined {
+  if (servers.length === 0) return undefined;
+  const entries = servers.map((s) => [s.name, { command: s.command, ...(s.args ? { args: s.args } : {}), ...(s.env ? { env: s.env } : {}) }] as const);
+  return { mcp_servers: Object.fromEntries(entries) };
+}
+
+/** `thread/start` rejects a stale login here, long after `initialize` and `codex login status` both said fine. */
+function bootFailureMessage(e: unknown): string {
+  if (e instanceof JsonRpcCallError && obj(e.data).action === "relogin") {
+    return `${e.message} — your Codex login has expired or was revoked. Run \`codex login\` in a terminal, then send the message again.`;
+  }
+  return message(e);
+}
+
+/**
+ * Codex adapter over one shared `codex app-server` process.
+ *
+ * The protocol multiplexes any number of threads on a single process (protocol reference §8 gotcha 4), so the
+ * adapter refcounts one `CodexConnection` across all its sessions instead of spawning one per session; the last
+ * `dispose()` takes the process down.
+ */
+export class CodexAdapter implements AgentAdapter {
+  readonly kind = "codex" as const;
+  private readonly bin?: string;
+  private readonly args?: string[];
+  private conn: Promise<CodexConnection> | null = null;
+  private refs = 0;
+
+  constructor(deps: { bin?: string; args?: string[] } = {}) {
+    this.bin = deps.bin;
+    this.args = deps.args;
+  }
+
+  /** Visible for tests: 0 or 1 — the whole point of the refcount is that it never exceeds one. */
+  get processCount(): number { return this.conn === null ? 0 : 1; }
+  /** Visible for tests: sessions currently holding the process. A leak here strands the child forever. */
+  get sessionCount(): number { return this.refs; }
+
+  async probe(): Promise<ProbeResult> {
+    const p = await probeCodex(this.bin);
+    return { kind: this.kind, ...p };
+  }
+
+  /**
+   * `cwd`/`env`/`onLog` only shape the process the *first* session spawns; every later session rides the same
+   * one and carries its own `cwd` on `thread/start`, which is the value that actually matters.
+   */
+  private async acquire(opts: StartOptions): Promise<CodexConnection> {
+    this.refs += 1;
+    const pending = this.conn ?? (this.conn = CodexConnection.open({
+      bin: this.bin ?? process.env.REALM_CODEX_BIN ?? "codex",
+      args: this.args,
+      cwd: opts.cwd,
+      env: opts.env,
+      onLog: opts.onLog,
+    }));
+    try {
+      return await pending;
+    } catch (e) {
+      // A failed open must not pin the refcount (nothing will ever call release for it) nor cache the rejected
+      // promise, or every later session in this process inherits the same failure.
+      this.refs -= 1;
+      if (this.conn === pending) this.conn = null;
+      throw e;
+    }
+  }
+
+  private async release(): Promise<void> {
+    this.refs -= 1;
+    if (this.refs > 0) return;
+    const pending = this.conn;
+    this.conn = null;
+    if (!pending) return;
+    try { await (await pending).dispose(); } catch { /* open() already tore down its own child */ }
+  }
+
+  start(opts: StartOptions): AgentHandle {
+    const events = new AsyncQueue<SessionEvent>();
+    const mapper = createCodexMapper();
+    const pending = new Map<string, { id: JsonRpcId; decisions: unknown[] }>();
+    let conn: CodexConnection | null = null;
+    let threadId: string | null = null;
+    let activeTurnId: string | null = null;
+    let running = false;
+    let acquired = false;
+    let disposed = false;
+
+    const fail = (text: string) => {
+      events.push(sessionEvent("error", { message: text }));
+      events.push(sessionEvent("status", { status: "error" }));
+    };
+
+    const respond = (requestId: string, decision: PermissionDecision) => {
+      const p = pending.get(requestId);
+      if (!p) return;
+      pending.delete(requestId);
+      conn?.respond(p.id, { decision: pickCodexDecision(decision, p.decisions) });
+      events.push(sessionEvent("permission_response", { requestId, decision }));
+      // Several tools can be waiting at once (parallel tool calls): the status only comes back when the last
+      // one is answered.
+      if (pending.size === 0) events.push(sessionEvent("status", { status: running ? "running" : "idle" }));
+    };
+    const denyAllPending = () => { for (const id of [...pending.keys()]) respond(id, "deny"); };
+
+    /** Detaches, closes the transcript and hands the process back. Idempotent; the only path that ends a session. */
+    const shutdown = async (): Promise<void> => {
+      if (disposed) return;
+      disposed = true;
+      denyAllPending();
+      if (conn && threadId) conn.detach(threadId);
+      for (const e of mapper.closeOpenTools("session closed")) events.push(e);
+      events.push(sessionEvent("status", { status: "ended" }));
+      events.close();
+      if (acquired) { acquired = false; await this.release(); }
+    };
+
+    const listener: ThreadListener = {
+      onNotification: (method, params) => {
+        const p = obj(params);
+        if (method === "turn/started") { activeTurnId = str(obj(p.turn).id) || activeTurnId; running = true; }
+        if (method === "turn/completed") { activeTurnId = null; running = false; }
+        for (const e of mapper.map(method, params)) events.push(e);
+      },
+      onServerRequest: (id, method, params) => {
+        const approval = APPROVAL_METHODS[method];
+        if (!approval) {
+          // Every server request must be answered or the turn stalls forever (protocol reference §9).
+          opts.onLog?.(`[codex] refusing unsupported server request ${method}`);
+          conn?.respondError(id, -32601, `realm does not support ${method}`);
+          return;
+        }
+        const p = obj(params);
+        const requestId = String(id);
+        const input = approval.toolName === "exec_command"
+          ? { command: str(p.command), cwd: str(p.cwd) }
+          : { itemId: str(p.itemId), grantRoot: p.grantRoot ?? null };
+        const decisions = Array.isArray(p.availableDecisions) ? p.availableDecisions : [];
+        if (pending.size === 0) events.push(sessionEvent("status", { status: "waiting_permission" }));
+        pending.set(requestId, { id, decisions });
+        events.push(sessionEvent("permission_request", { requestId, toolName: approval.toolName, input, title: str(p.reason) || approval.title, suggestions: decisions }));
+      },
+      onGone: (reason, wasDisposed) => {
+        // `wasDisposed` means Realm shut the process down (app quit, last session closed). Only an actual crash
+        // is an error; reporting the quiet path would spray "codex app-server exited" over every open session.
+        if (!wasDisposed) {
+          for (const e of mapper.closeOpenTools(reason)) events.push(e);
+          const tail = conn?.stderrTail ?? [];
+          fail(tail.length ? `${reason}\n--- stderr (last ${tail.length} lines) ---\n${tail.join("\n")}` : reason);
+        }
+        void shutdown();
+      },
+    };
+
+    const boot = (async () => {
+      try {
+        const c = await this.acquire(opts);
+        acquired = true;
+        if (disposed) return; // disposed while the process was still coming up; shutdown() releases the ref
+        conn = c;
+        const { approvalPolicy, sandbox } = codexPolicyFor(opts.permissionMode);
+        const config = mcpConfig(opts.mcpServers);
+        const common = {
+          cwd: opts.cwd,
+          approvalPolicy,
+          sandbox, // a SandboxMode STRING here; the structured object is turn/start's `sandboxPolicy` (§8 gotcha 5)
+          ...(opts.model ? { model: opts.model } : {}),
+          ...(config ? { config } : {}),
+        };
+        const res = obj(opts.resume
+          ? await c.request("thread/resume", { threadId: opts.resume, ...common })
+          : await c.request("thread/start", { ...common, sessionStartSource: "startup" }));
+        if (disposed) return;
+        const id = str(obj(res.thread).id) || str(opts.resume);
+        if (!id) throw new Error("codex did not return a thread id");
+        threadId = id;
+        c.attach(id, listener);
+        events.push(sessionEvent("init", { providerSessionId: id, model: str(res.model) || str(opts.model), tools: [], cwd: str(res.cwd) || opts.cwd }));
+        events.push(sessionEvent("status", { status: "idle" }));
+      } catch (e) {
+        if (disposed) return;
+        fail(bootFailureMessage(e));
+        // SessionService drops the handle when the stream ends and never calls dispose(), so the boot failure
+        // has to hand the process back itself.
+        await shutdown();
+      }
+    })();
+
+    const inputFor = (m: UserMessage): Bag[] => {
+      const images = m.attachments.filter((a) => a.mime.startsWith("image/"));
+      const files = m.attachments.filter((a) => !a.mime.startsWith("image/"));
+      // Codex reads local images off disk, so no base64. Anything else is named in the text and left for the
+      // agent to open with its own tools.
+      const text = files.length ? `${m.text}\n\nAttached files:\n${files.map((a) => `- ${a.path}`).join("\n")}` : m.text;
+      return [{ type: "text", text, text_elements: [] }, ...images.map((a) => ({ type: "localImage", path: a.path }))];
+    };
+
+    return {
+      events,
+      send: async (m: UserMessage) => {
+        await boot; // boot reports its own failures; it never rejects
+        if (disposed || !conn || !threadId) { events.push(sessionEvent("error", { message: "session ended" })); return; }
+        const input = inputFor(m);
+        running = true;
+        events.push(sessionEvent("status", { status: "running" }));
+        try {
+          if (activeTurnId) {
+            try {
+              const steered = obj(await conn.request("turn/steer", { threadId, expectedTurnId: activeTurnId, input }));
+              activeTurnId = str(steered.turnId) || activeTurnId;
+              return;
+            } catch (e) {
+              // The turn ended between the check and the call; `expectedTurnId` is a precondition, so this is
+              // a race, not a failure. Retried once as a fresh turn — never in a loop.
+              if (!(e instanceof JsonRpcCallError) || !/no active turn/i.test(e.message)) throw e;
+              activeTurnId = null;
+            }
+          }
+          const started = obj(await conn.request("turn/start", { threadId, input }));
+          activeTurnId = str(obj(started.turn).id) || null;
+        } catch (e) {
+          running = false;
+          events.push(sessionEvent("error", { message: message(e) }));
+          events.push(sessionEvent("status", { status: "idle" }));
+        }
+      },
+      respondPermission: respond,
+      interrupt: async () => {
+        denyAllPending();
+        if (!conn || !threadId || !activeTurnId) return;
+        try { await conn.request("turn/interrupt", { threadId, turnId: activeTurnId }); }
+        catch (e) { opts.onLog?.(`[codex] interrupt failed: ${message(e)}`); }
+      },
+      /**
+       * Known limitation: `model` and `approvalPolicy` are `thread/start` parameters and cannot be applied to a
+       * running Codex thread — there is no protocol call for it. So this only reports the change. SessionService
+       * has already persisted it to the session row, which is what the next `start()` reads, so the change takes
+       * effect the next time this session starts a thread.
+       */
+      setOptions: async (o) => {
+        const parts = [o.model === undefined ? null : `model=${o.model}`, o.permissionMode === undefined ? null : `permissionMode=${o.permissionMode}`].filter(Boolean);
+        if (parts.length === 0) return;
+        opts.onLog?.(`[codex] ${parts.join(" ")} recorded; codex fixes these at thread start, so it applies the next time this session starts`);
+      },
+      dispose: async () => {
+        await boot; // never leave a half-attached thread behind a dispose that raced the boot
+        await shutdown();
+      },
+    };
+  }
+}

--- a/packages/adapters/src/codex/connection.test.ts
+++ b/packages/adapters/src/codex/connection.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi } from "vitest";
+import { fileURLToPath } from "node:url";
+import { CodexConnection } from "./connection";
+
+const FAKE = fileURLToPath(new URL("./fixtures/fake-codex-server.mjs", import.meta.url));
+const open = () => CodexConnection.open({ bin: process.execPath, args: [FAKE], cwd: process.cwd() });
+const startThread = (c: CodexConnection) => c.request<{ thread: { id: string } }>("thread/start", { cwd: "/tmp" });
+const say = (c: CodexConnection, threadId: string, text: string) =>
+  c.request("turn/start", { threadId, input: [{ type: "text", text, text_elements: [] }] });
+const silent = { onNotification: () => {}, onServerRequest: () => {}, onGone: () => {} };
+
+describe("CodexConnection", () => {
+  it("initializes and starts a thread", async () => {
+    const c = await open();
+    const r = await startThread(c);
+    expect(r.thread.id).toMatch(/^th_/);
+    await c.dispose();
+  });
+
+  it("routes notifications to the attached thread listener only", async () => {
+    const c = await open();
+    const a = await startThread(c);
+    const b = await startThread(c);
+    const seenA: string[] = []; const seenB: string[] = [];
+    c.attach(a.thread.id, { ...silent, onNotification: (m) => seenA.push(m) });
+    c.attach(b.thread.id, { ...silent, onNotification: (m) => seenB.push(m) });
+    await say(c, a.thread.id, "hi");
+    await vi.waitFor(() => expect(seenA).toContain("turn/completed"));
+    expect(seenB).toEqual([]);
+    await c.dispose();
+  });
+
+  it("buffers frames that arrive before attach and flushes them", async () => {
+    const c = await open();
+    const t = await startThread(c);
+    await say(c, t.thread.id, "hi");
+    await new Promise((r) => setTimeout(r, 50)); // let the whole turn stream out unattached
+    const seen: string[] = [];
+    c.attach(t.thread.id, { ...silent, onNotification: (m) => seen.push(m) });
+    await vi.waitFor(() => expect(seen).toContain("turn/completed"));
+    await c.dispose();
+  });
+
+  it("buffers a server request that arrives before any thread has attached", async () => {
+    const c = await open();
+    const rejected: unknown[] = [];
+    c.onUnroutedReply = (id, code) => rejected.push({ id, code });
+    const t = await startThread(c);
+    await say(c, t.thread.id, "APPROVE");
+    await new Promise((r) => setTimeout(r, 50)); // approval request arrives while nothing is attached
+    expect(rejected).toEqual([]);
+    const seen: string[] = [];
+    c.attach(t.thread.id, {
+      ...silent,
+      onNotification: (m) => seen.push(m),
+      onServerRequest: (id, method) => { seen.push(method); c.respond(id, { decision: "accept" }); },
+    });
+    await vi.waitFor(() => expect(seen).toContain("turn/completed"));
+    expect(seen).toContain("item/commandExecution/requestApproval");
+    await c.dispose();
+  });
+
+  it("answers unroutable server requests with -32601 so turns never stall", async () => {
+    const c = await open();
+    const replies: unknown[] = [];
+    c.onUnroutedReply = (id, code) => replies.push({ id, code });
+    // A decoy thread is attached, so the buffering path (which only applies before ANY thread attaches) is off
+    // and an approval for a second, unattached thread must be rejected rather than queued.
+    const decoy = await startThread(c);
+    c.attach(decoy.thread.id, { ...silent });
+    const orphan = await startThread(c);
+    await say(c, orphan.thread.id, "APPROVE");
+    await vi.waitFor(() => expect(replies).toHaveLength(1));
+    expect(replies[0]).toMatchObject({ code: -32601 });
+    await c.dispose();
+  });
+
+  it("stops buffering once the per-thread cap is reached, and still answers requests it cannot queue", async () => {
+    const c = await open();
+    const rejected: number[] = [];
+    c.onUnroutedReply = (_id, code) => rejected.push(code);
+    const t = await startThread(c);
+    // Each turn streams exactly 10 notifications, so 25 turns overrun the 200-frame cap.
+    for (let i = 0; i < 25; i++) await say(c, t.thread.id, "hi");
+    await new Promise((r) => setTimeout(r, 400));
+    // The buffer is full, so this approval cannot be queued — dropping it would stall the turn forever.
+    await say(c, t.thread.id, "APPROVE");
+    await vi.waitFor(() => expect(rejected).toEqual([-32601]));
+    const seen: string[] = [];
+    c.attach(t.thread.id, { ...silent, onNotification: (m) => seen.push(m) });
+    expect(seen).toHaveLength(200);
+    await c.dispose();
+  });
+
+  it("drops a thread's buffer on detach", async () => {
+    const c = await open();
+    const t = await startThread(c);
+    await say(c, t.thread.id, "hi");
+    await new Promise((r) => setTimeout(r, 50));
+    c.detach(t.thread.id);
+    const seen: string[] = [];
+    c.attach(t.thread.id, { ...silent, onNotification: (m) => seen.push(m) });
+    expect(seen).toEqual([]);
+    await c.dispose();
+  });
+
+  it("does not replay an already-flushed buffer to a later listener", async () => {
+    const c = await open();
+    const t = await startThread(c);
+    await say(c, t.thread.id, "hi");
+    await new Promise((r) => setTimeout(r, 50));
+    const first: string[] = [];
+    c.attach(t.thread.id, { ...silent, onNotification: (m) => first.push(m) });
+    expect(first).toContain("turn/completed");
+    const second: string[] = [];
+    c.attach(t.thread.id, { ...silent, onNotification: (m) => second.push(m) });
+    expect(second).toEqual([]);
+    await c.dispose();
+  });
+
+  it("tells every attached thread when the process dies, flagging an intentional dispose", async () => {
+    const c = await open();
+    const t = await startThread(c);
+    const gone: { reason: string; disposed: boolean }[] = [];
+    c.attach(t.thread.id, { ...silent, onGone: (reason, disposed) => gone.push({ reason, disposed }) });
+    await c.dispose();
+    await vi.waitFor(() => expect(gone).toHaveLength(1));
+    expect(gone[0]).toMatchObject({ disposed: true });
+    expect(c.threadCount).toBe(0);
+    expect(c.alive).toBe(false);
+  });
+
+  it("reports an unexpected death as not disposed", async () => {
+    const c = await open();
+    const t = await startThread(c);
+    const gone: { reason: string; disposed: boolean }[] = [];
+    c.attach(t.thread.id, { ...silent, onGone: (reason, disposed) => gone.push({ reason, disposed }) });
+    void c.request("$test/exit").catch(() => {}); // the fixture exits without replying
+    await vi.waitFor(() => expect(gone).toHaveLength(1));
+    expect(gone[0]).toMatchObject({ disposed: false, reason: expect.stringContaining("exited") });
+    const late: boolean[] = [];
+    c.attach(t.thread.id, { ...silent, onGone: (_reason, disposed) => late.push(disposed) });
+    expect(late).toEqual([false]); // a crash stays a crash for listeners that arrive afterwards
+    await c.dispose();
+  });
+
+  it("tells a listener that attaches after the process is already gone", async () => {
+    const c = await open();
+    const t = await startThread(c);
+    await c.dispose();
+    const gone: boolean[] = [];
+    c.attach(t.thread.id, { ...silent, onGone: (_reason, disposed) => gone.push(disposed) });
+    expect(gone).toEqual([true]);
+    expect(c.threadCount).toBe(0);
+  });
+});

--- a/packages/adapters/src/codex/connection.test.ts
+++ b/packages/adapters/src/codex/connection.test.ts
@@ -1,13 +1,23 @@
 import { describe, it, expect, vi } from "vitest";
 import { fileURLToPath } from "node:url";
-import { CodexConnection } from "./connection";
+import { CodexConnection, type CodexConnectionOptions } from "./connection";
 
 const FAKE = fileURLToPath(new URL("./fixtures/fake-codex-server.mjs", import.meta.url));
-const open = () => CodexConnection.open({ bin: process.execPath, args: [FAKE], cwd: process.cwd() });
+const open = (extra: Partial<CodexConnectionOptions> = {}) =>
+  CodexConnection.open({ bin: process.execPath, args: [FAKE], cwd: process.cwd(), ...extra });
 const startThread = (c: CodexConnection) => c.request<{ thread: { id: string } }>("thread/start", { cwd: "/tmp" });
 const say = (c: CodexConnection, threadId: string, text: string) =>
   c.request("turn/start", { threadId, input: [{ type: "text", text, text_elements: [] }] });
 const silent = { onNotification: () => {}, onServerRequest: () => {}, onGone: () => {} };
+
+/** The fixture's plain turn, in order. Buffer flushes must preserve it: the mapper needs deltas before item/completed. */
+const MESSAGE_TURN = [
+  "thread/status/changed", "turn/started", "item/started", "item/started",
+  "item/agentMessage/delta", "item/agentMessage/delta", "item/completed",
+  "thread/tokenUsage/updated", "thread/status/changed", "turn/completed",
+];
+/** The approval turn buffers 4 notifications plus the approval request before it blocks. */
+const APPROVAL_PREFIX = 5;
 
 describe("CodexConnection", () => {
   it("initializes and starts a thread", async () => {
@@ -15,6 +25,12 @@ describe("CodexConnection", () => {
     const r = await startThread(c);
     expect(r.thread.id).toMatch(/^th_/);
     await c.dispose();
+  });
+
+  it("rejects instead of hanging when the server never answers initialize", async () => {
+    await expect(
+      open({ env: { FAKE_CODEX_MUTE_INITIALIZE: "1" }, initializeTimeoutMs: 150 }),
+    ).rejects.toThrow(/did not answer initialize/);
   });
 
   it("routes notifications to the attached thread listener only", async () => {
@@ -30,14 +46,39 @@ describe("CodexConnection", () => {
     await c.dispose();
   });
 
-  it("buffers frames that arrive before attach and flushes them", async () => {
+  it("delivers an approval to its attached thread and answers nothing itself", async () => {
+    const c = await open();
+    const unrouted: number[] = [];
+    c.onUnroutedReply = (_id, code) => unrouted.push(code);
+    const t = await startThread(c);
+    const seen: string[] = [];
+    const completed: { exitCode?: number; status?: string }[] = [];
+    c.attach(t.thread.id, {
+      ...silent,
+      onNotification: (m, p) => {
+        seen.push(m);
+        if (m === "item/completed") completed.push((p as { item: { exitCode?: number; status?: string } }).item);
+      },
+      onServerRequest: (id, method) => { seen.push(method); c.respond(id, { decision: "accept" }); },
+    });
+    await say(c, t.thread.id, "APPROVE");
+    await vi.waitFor(() => expect(seen).toContain("turn/completed"));
+    expect(seen).toContain("item/commandExecution/requestApproval");
+    // exitCode 0 only happens if the listener's "accept" actually reached the child.
+    expect(completed).toHaveLength(1);
+    expect(completed[0]).toMatchObject({ status: "completed", exitCode: 0 });
+    expect(unrouted).toEqual([]); // the connection must not also refuse a request it delivered
+    await c.dispose();
+  });
+
+  it("buffers frames that arrive before attach and flushes them in order", async () => {
     const c = await open();
     const t = await startThread(c);
     await say(c, t.thread.id, "hi");
-    await new Promise((r) => setTimeout(r, 50)); // let the whole turn stream out unattached
+    await vi.waitFor(() => expect(c.bufferedCount(t.thread.id)).toBe(MESSAGE_TURN.length));
     const seen: string[] = [];
     c.attach(t.thread.id, { ...silent, onNotification: (m) => seen.push(m) });
-    await vi.waitFor(() => expect(seen).toContain("turn/completed"));
+    expect(seen).toEqual(MESSAGE_TURN);
     await c.dispose();
   });
 
@@ -47,7 +88,7 @@ describe("CodexConnection", () => {
     c.onUnroutedReply = (id, code) => rejected.push({ id, code });
     const t = await startThread(c);
     await say(c, t.thread.id, "APPROVE");
-    await new Promise((r) => setTimeout(r, 50)); // approval request arrives while nothing is attached
+    await vi.waitFor(() => expect(c.bufferedCount(t.thread.id)).toBe(APPROVAL_PREFIX));
     expect(rejected).toEqual([]);
     const seen: string[] = [];
     c.attach(t.thread.id, {
@@ -72,6 +113,12 @@ describe("CodexConnection", () => {
     await say(c, orphan.thread.id, "APPROVE");
     await vi.waitFor(() => expect(replies).toHaveLength(1));
     expect(replies[0]).toMatchObject({ code: -32601 });
+    // The reply must reach the child, not just the spy: the fixture unblocks, fails the command and ends
+    // the turn. 4 opening frames + 4 more once the refusal lands.
+    await vi.waitFor(() => expect(c.bufferedCount(orphan.thread.id)).toBe(8));
+    const seen: string[] = [];
+    c.attach(orphan.thread.id, { ...silent, onNotification: (m) => seen.push(m) });
+    expect(seen.slice(4)).toEqual(["serverRequest/resolved", "item/completed", "thread/status/changed", "turn/completed"]);
     await c.dispose();
   });
 
@@ -82,7 +129,7 @@ describe("CodexConnection", () => {
     const t = await startThread(c);
     // Each turn streams exactly 10 notifications, so 25 turns overrun the 200-frame cap.
     for (let i = 0; i < 25; i++) await say(c, t.thread.id, "hi");
-    await new Promise((r) => setTimeout(r, 400));
+    await vi.waitFor(() => expect(c.bufferedCount(t.thread.id)).toBe(200));
     // The buffer is full, so this approval cannot be queued — dropping it would stall the turn forever.
     await say(c, t.thread.id, "APPROVE");
     await vi.waitFor(() => expect(rejected).toEqual([-32601]));
@@ -92,15 +139,65 @@ describe("CodexConnection", () => {
     await c.dispose();
   });
 
-  it("drops a thread's buffer on detach", async () => {
+  it("stops delivering to a detached listener and drops its buffer", async () => {
     const c = await open();
     const t = await startThread(c);
-    await say(c, t.thread.id, "hi");
-    await new Promise((r) => setTimeout(r, 50));
-    c.detach(t.thread.id);
     const seen: string[] = [];
     c.attach(t.thread.id, { ...silent, onNotification: (m) => seen.push(m) });
+    c.detach(t.thread.id);
+    await say(c, t.thread.id, "hi");
+    await vi.waitFor(() => expect(c.bufferedCount(t.thread.id)).toBe(MESSAGE_TURN.length));
     expect(seen).toEqual([]);
+    c.detach(t.thread.id);
+    const later: string[] = [];
+    c.attach(t.thread.id, { ...silent, onNotification: (m) => later.push(m) });
+    expect(later).toEqual([]); // detach dropped the queue rather than leaving it for the next listener
+    await c.dispose();
+  });
+
+  it("answers buffered server requests when their thread detaches", async () => {
+    const c = await open();
+    const replies: number[] = [];
+    c.onUnroutedReply = (_id, code) => replies.push(code);
+    const t = await startThread(c);
+    await say(c, t.thread.id, "APPROVE");
+    await vi.waitFor(() => expect(c.bufferedCount(t.thread.id)).toBe(APPROVAL_PREFIX));
+    c.detach(t.thread.id);
+    expect(replies).toEqual([-32601]);
+    // The child is still alive; abandoning the request silently would wedge its turn forever.
+    await vi.waitFor(() => expect(c.bufferedCount(t.thread.id)).toBe(4));
+    await c.dispose();
+  });
+
+  it("survives a listener that throws on a notification", async () => {
+    const logs: string[] = [];
+    const c = await open({ onLog: (l) => logs.push(l) });
+    const t = await startThread(c);
+    const seen: string[] = [];
+    c.attach(t.thread.id, { ...silent, onNotification: (m) => { seen.push(m); throw new Error("listener boom"); } });
+    await say(c, t.thread.id, "hi");
+    await vi.waitFor(() => expect(seen).toEqual(MESSAGE_TURN)); // every later frame still lands
+    expect(logs.some((l) => l.includes("listener boom"))).toBe(true);
+    expect(c.alive).toBe(true);
+    await c.dispose();
+  });
+
+  it("answers -32603 when a listener throws on a server request", async () => {
+    const logs: string[] = [];
+    const c = await open({ onLog: (l) => logs.push(l) });
+    const replies: number[] = [];
+    c.onUnroutedReply = (_id, code) => replies.push(code);
+    const t = await startThread(c);
+    const seen: string[] = [];
+    c.attach(t.thread.id, {
+      ...silent,
+      onNotification: (m) => seen.push(m),
+      onServerRequest: () => { throw new Error("approval boom"); },
+    });
+    await say(c, t.thread.id, "APPROVE");
+    await vi.waitFor(() => expect(seen).toContain("turn/completed")); // the turn is not wedged
+    expect(replies).toEqual([-32603]);
+    expect(logs.some((l) => l.includes("approval boom"))).toBe(true);
     await c.dispose();
   });
 
@@ -108,10 +205,10 @@ describe("CodexConnection", () => {
     const c = await open();
     const t = await startThread(c);
     await say(c, t.thread.id, "hi");
-    await new Promise((r) => setTimeout(r, 50));
+    await vi.waitFor(() => expect(c.bufferedCount(t.thread.id)).toBe(MESSAGE_TURN.length));
     const first: string[] = [];
     c.attach(t.thread.id, { ...silent, onNotification: (m) => first.push(m) });
-    expect(first).toContain("turn/completed");
+    expect(first).toEqual(MESSAGE_TURN);
     const second: string[] = [];
     c.attach(t.thread.id, { ...silent, onNotification: (m) => second.push(m) });
     expect(second).toEqual([]);
@@ -142,6 +239,19 @@ describe("CodexConnection", () => {
     c.attach(t.thread.id, { ...silent, onGone: (_reason, disposed) => late.push(disposed) });
     expect(late).toEqual([false]); // a crash stays a crash for listeners that arrive afterwards
     await c.dispose();
+  });
+
+  it("keeps fanning out when a listener throws on gone", async () => {
+    const logs: string[] = [];
+    const c = await open({ onLog: (l) => logs.push(l) });
+    const a = await startThread(c);
+    const b = await startThread(c);
+    c.attach(a.thread.id, { ...silent, onGone: () => { throw new Error("gone boom"); } });
+    const second: boolean[] = [];
+    c.attach(b.thread.id, { ...silent, onGone: (_reason, disposed) => second.push(disposed) });
+    await c.dispose();
+    expect(second).toEqual([true]); // one session's broken teardown must not strand its neighbours
+    expect(logs.some((l) => l.includes("gone boom"))).toBe(true);
   });
 
   it("tells a listener that attaches after the process is already gone", async () => {

--- a/packages/adapters/src/codex/connection.test.ts
+++ b/packages/adapters/src/codex/connection.test.ts
@@ -2,6 +2,13 @@ import { describe, it, expect, vi } from "vitest";
 import { fileURLToPath } from "node:url";
 import { CodexConnection, type CodexConnectionOptions } from "./connection";
 
+/**
+ * Every assertion in this file is gated on a real child process: node cold start, module load and at least one
+ * round trip. vitest's 1000 ms default is routinely too tight for that on a loaded two-core CI runner, and a
+ * longer bound costs nothing when the assertion passes.
+ */
+const waitFor = <T>(fn: () => T | Promise<T>) => vi.waitFor(fn, { timeout: 10_000, interval: 25 });
+
 const FAKE = fileURLToPath(new URL("./fixtures/fake-codex-server.mjs", import.meta.url));
 const open = (extra: Partial<CodexConnectionOptions> = {}) =>
   CodexConnection.open({ bin: process.execPath, args: [FAKE], cwd: process.cwd(), ...extra });
@@ -41,7 +48,7 @@ describe("CodexConnection", () => {
     c.attach(a.thread.id, { ...silent, onNotification: (m) => seenA.push(m) });
     c.attach(b.thread.id, { ...silent, onNotification: (m) => seenB.push(m) });
     await say(c, a.thread.id, "hi");
-    await vi.waitFor(() => expect(seenA).toContain("turn/completed"));
+    await waitFor(() => expect(seenA).toContain("turn/completed"));
     expect(seenB).toEqual([]);
     await c.dispose();
   });
@@ -62,7 +69,7 @@ describe("CodexConnection", () => {
       onServerRequest: (id, method) => { seen.push(method); c.respond(id, { decision: "accept" }); },
     });
     await say(c, t.thread.id, "APPROVE");
-    await vi.waitFor(() => expect(seen).toContain("turn/completed"));
+    await waitFor(() => expect(seen).toContain("turn/completed"));
     expect(seen).toContain("item/commandExecution/requestApproval");
     // exitCode 0 only happens if the listener's "accept" actually reached the child.
     expect(completed).toHaveLength(1);
@@ -75,7 +82,7 @@ describe("CodexConnection", () => {
     const c = await open();
     const t = await startThread(c);
     await say(c, t.thread.id, "hi");
-    await vi.waitFor(() => expect(c.bufferedCount(t.thread.id)).toBe(MESSAGE_TURN.length));
+    await waitFor(() => expect(c.bufferedCount(t.thread.id)).toBe(MESSAGE_TURN.length));
     const seen: string[] = [];
     c.attach(t.thread.id, { ...silent, onNotification: (m) => seen.push(m) });
     expect(seen).toEqual(MESSAGE_TURN);
@@ -88,7 +95,7 @@ describe("CodexConnection", () => {
     c.onUnroutedReply = (id, code) => rejected.push({ id, code });
     const t = await startThread(c);
     await say(c, t.thread.id, "APPROVE");
-    await vi.waitFor(() => expect(c.bufferedCount(t.thread.id)).toBe(APPROVAL_PREFIX));
+    await waitFor(() => expect(c.bufferedCount(t.thread.id)).toBe(APPROVAL_PREFIX));
     expect(rejected).toEqual([]);
     const seen: string[] = [];
     c.attach(t.thread.id, {
@@ -96,7 +103,7 @@ describe("CodexConnection", () => {
       onNotification: (m) => seen.push(m),
       onServerRequest: (id, method) => { seen.push(method); c.respond(id, { decision: "accept" }); },
     });
-    await vi.waitFor(() => expect(seen).toContain("turn/completed"));
+    await waitFor(() => expect(seen).toContain("turn/completed"));
     expect(seen).toContain("item/commandExecution/requestApproval");
     await c.dispose();
   });
@@ -111,11 +118,11 @@ describe("CodexConnection", () => {
     c.attach(decoy.thread.id, { ...silent });
     const orphan = await startThread(c);
     await say(c, orphan.thread.id, "APPROVE");
-    await vi.waitFor(() => expect(replies).toHaveLength(1));
+    await waitFor(() => expect(replies).toHaveLength(1));
     expect(replies[0]).toMatchObject({ code: -32601 });
     // The reply must reach the child, not just the spy: the fixture unblocks, fails the command and ends
     // the turn. 4 opening frames + 4 more once the refusal lands.
-    await vi.waitFor(() => expect(c.bufferedCount(orphan.thread.id)).toBe(8));
+    await waitFor(() => expect(c.bufferedCount(orphan.thread.id)).toBe(8));
     const seen: string[] = [];
     c.attach(orphan.thread.id, { ...silent, onNotification: (m) => seen.push(m) });
     expect(seen.slice(4)).toEqual(["serverRequest/resolved", "item/completed", "thread/status/changed", "turn/completed"]);
@@ -129,10 +136,10 @@ describe("CodexConnection", () => {
     const t = await startThread(c);
     // Each turn streams exactly 10 notifications, so 25 turns overrun the 200-frame cap.
     for (let i = 0; i < 25; i++) await say(c, t.thread.id, "hi");
-    await vi.waitFor(() => expect(c.bufferedCount(t.thread.id)).toBe(200));
+    await waitFor(() => expect(c.bufferedCount(t.thread.id)).toBe(200));
     // The buffer is full, so this approval cannot be queued — dropping it would stall the turn forever.
     await say(c, t.thread.id, "APPROVE");
-    await vi.waitFor(() => expect(rejected).toEqual([-32601]));
+    await waitFor(() => expect(rejected).toEqual([-32601]));
     const seen: string[] = [];
     c.attach(t.thread.id, { ...silent, onNotification: (m) => seen.push(m) });
     expect(seen).toHaveLength(200);
@@ -146,7 +153,7 @@ describe("CodexConnection", () => {
     c.attach(t.thread.id, { ...silent, onNotification: (m) => seen.push(m) });
     c.detach(t.thread.id);
     await say(c, t.thread.id, "hi");
-    await vi.waitFor(() => expect(c.bufferedCount(t.thread.id)).toBe(MESSAGE_TURN.length));
+    await waitFor(() => expect(c.bufferedCount(t.thread.id)).toBe(MESSAGE_TURN.length));
     expect(seen).toEqual([]);
     c.detach(t.thread.id);
     const later: string[] = [];
@@ -161,11 +168,11 @@ describe("CodexConnection", () => {
     c.onUnroutedReply = (_id, code) => replies.push(code);
     const t = await startThread(c);
     await say(c, t.thread.id, "APPROVE");
-    await vi.waitFor(() => expect(c.bufferedCount(t.thread.id)).toBe(APPROVAL_PREFIX));
+    await waitFor(() => expect(c.bufferedCount(t.thread.id)).toBe(APPROVAL_PREFIX));
     c.detach(t.thread.id);
     expect(replies).toEqual([-32601]);
     // The child is still alive; abandoning the request silently would wedge its turn forever.
-    await vi.waitFor(() => expect(c.bufferedCount(t.thread.id)).toBe(4));
+    await waitFor(() => expect(c.bufferedCount(t.thread.id)).toBe(4));
     await c.dispose();
   });
 
@@ -176,7 +183,7 @@ describe("CodexConnection", () => {
     const seen: string[] = [];
     c.attach(t.thread.id, { ...silent, onNotification: (m) => { seen.push(m); throw new Error("listener boom"); } });
     await say(c, t.thread.id, "hi");
-    await vi.waitFor(() => expect(seen).toEqual(MESSAGE_TURN)); // every later frame still lands
+    await waitFor(() => expect(seen).toEqual(MESSAGE_TURN)); // every later frame still lands
     expect(logs.some((l) => l.includes("listener boom"))).toBe(true);
     expect(c.alive).toBe(true);
     await c.dispose();
@@ -195,7 +202,7 @@ describe("CodexConnection", () => {
       onServerRequest: () => { throw new Error("approval boom"); },
     });
     await say(c, t.thread.id, "APPROVE");
-    await vi.waitFor(() => expect(seen).toContain("turn/completed")); // the turn is not wedged
+    await waitFor(() => expect(seen).toContain("turn/completed")); // the turn is not wedged
     expect(replies).toEqual([-32603]);
     expect(logs.some((l) => l.includes("approval boom"))).toBe(true);
     await c.dispose();
@@ -205,7 +212,7 @@ describe("CodexConnection", () => {
     const c = await open();
     const t = await startThread(c);
     await say(c, t.thread.id, "hi");
-    await vi.waitFor(() => expect(c.bufferedCount(t.thread.id)).toBe(MESSAGE_TURN.length));
+    await waitFor(() => expect(c.bufferedCount(t.thread.id)).toBe(MESSAGE_TURN.length));
     const first: string[] = [];
     c.attach(t.thread.id, { ...silent, onNotification: (m) => first.push(m) });
     expect(first).toEqual(MESSAGE_TURN);
@@ -221,7 +228,7 @@ describe("CodexConnection", () => {
     const gone: { reason: string; disposed: boolean }[] = [];
     c.attach(t.thread.id, { ...silent, onGone: (reason, disposed) => gone.push({ reason, disposed }) });
     await c.dispose();
-    await vi.waitFor(() => expect(gone).toHaveLength(1));
+    await waitFor(() => expect(gone).toHaveLength(1));
     expect(gone[0]).toMatchObject({ disposed: true });
     expect(c.threadCount).toBe(0);
     expect(c.alive).toBe(false);
@@ -233,7 +240,7 @@ describe("CodexConnection", () => {
     const gone: { reason: string; disposed: boolean }[] = [];
     c.attach(t.thread.id, { ...silent, onGone: (reason, disposed) => gone.push({ reason, disposed }) });
     void c.request("$test/exit").catch(() => {}); // the fixture exits without replying
-    await vi.waitFor(() => expect(gone).toHaveLength(1));
+    await waitFor(() => expect(gone).toHaveLength(1));
     expect(gone[0]).toMatchObject({ disposed: false, reason: expect.stringContaining("exited") });
     const late: boolean[] = [];
     c.attach(t.thread.id, { ...silent, onGone: (_reason, disposed) => late.push(disposed) });

--- a/packages/adapters/src/codex/connection.ts
+++ b/packages/adapters/src/codex/connection.ts
@@ -2,7 +2,7 @@ import { StdioJsonRpc, type JsonRpcId } from "../jsonrpc/stdio";
 
 export type ThreadListener = {
   onNotification: (method: string, params: unknown) => void;
-  /** MUST answer via connection.respond()/respondError(). */
+  /** MUST answer via connection.respond()/respondError(). If this throws, the connection answers -32603 for you. */
   onServerRequest: (id: JsonRpcId, method: string, params: unknown) => void;
   /** `disposed` is true when Realm shut the process down on purpose — only `disposed: false` is an error. */
   onGone: (reason: string, disposed: boolean) => void;
@@ -14,16 +14,28 @@ export type CodexConnectionOptions = {
   cwd: string;
   env?: Record<string, string>;
   onLog?: (line: string) => void;
+  /** Overridable for tests. A spawned-but-mute `codex app-server` must not hang session creation forever. */
+  initializeTimeoutMs?: number;
 };
 
 type Buffered = { kind: "note"; method: string; params: unknown } | { kind: "req"; id: JsonRpcId; method: string; params: unknown };
 
 const MAX_BUFFERED_PER_THREAD = 200;
+const INITIALIZE_TIMEOUT_MS = 10_000;
 
 const threadIdOf = (params: unknown): string | null => {
   const t = (params as { threadId?: unknown } | null)?.threadId;
   return typeof t === "string" ? t : null;
 };
+
+const reason = (e: unknown): string => (e instanceof Error ? e.message : String(e));
+
+function withTimeout<T>(p: Promise<T>, ms: number, message: string): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(message)), ms);
+    p.then(resolve, reject).finally(() => clearTimeout(timer));
+  });
+}
 
 /**
  * One `codex app-server` process, shared by every Codex session and fanned out by `threadId`.
@@ -36,6 +48,10 @@ const threadIdOf = (params: unknown): string | null => {
  * thread is attached, a request for an unknown thread is a genuine orphan and is answered -32601 rather
  * than queued: an unanswered server request stalls that turn forever, whereas a rejected one fails it
  * cleanly. Do not widen this to "always buffer".
+ *
+ * That invariant holds through every exit: a listener that throws, a thread that detaches with an approval
+ * still queued, and a full buffer all answer the request rather than dropping it. One session's bug must
+ * never wedge a turn or take down its neighbours, so listener callbacks are never trusted to not throw.
  */
 export class CodexConnection {
   private readonly threads = new Map<string, ThreadListener>();
@@ -44,7 +60,7 @@ export class CodexConnection {
   private readonly onLog?: (line: string) => void;
   private gone: { reason: string; disposed: boolean } | null = null;
 
-  /** Visible for tests: called when a server request cannot be routed to any thread. */
+  /** Visible for tests: fires whenever the connection itself answers a server request instead of a listener. */
   onUnroutedReply?: (id: JsonRpcId, code: number) => void;
 
   private constructor(opts: CodexConnectionOptions) {
@@ -60,17 +76,24 @@ export class CodexConnection {
       onNotification: (n) => this.routeNotification(n.method, n.params),
       onServerRequest: (r) => this.routeServerRequest(r.id, r.method, r.params),
       onStderr: (l) => this.onLog?.(l),
-      onExit: ({ reason, disposed }) => this.fanOutGone(reason, disposed),
+      onExit: ({ reason: why, disposed }) => this.fanOutGone(why, disposed),
     });
   }
 
   static async open(opts: CodexConnectionOptions): Promise<CodexConnection> {
     const conn = new CodexConnection(opts);
+    const ms = opts.initializeTimeoutMs ?? INITIALIZE_TIMEOUT_MS;
     try {
-      await conn.rpc.request("initialize", {
-        clientInfo: { name: "realm", title: "Realm", version: "0.0.1" },
-        capabilities: { experimentalApi: true, requestAttestation: false },
-      });
+      // A child that spawns but never answers would otherwise leave this promise pending forever, hanging
+      // session creation with nothing to show the user.
+      await withTimeout(
+        conn.rpc.request("initialize", {
+          clientInfo: { name: "realm", title: "Realm", version: "0.0.1" },
+          capabilities: { experimentalApi: true, requestAttestation: false },
+        }),
+        ms,
+        `${opts.bin} did not answer initialize within ${ms}ms`,
+      );
     } catch (e) {
       await conn.dispose(); // never leave a half-spawned child behind
       throw e;
@@ -83,22 +106,30 @@ export class CodexConnection {
   get alive(): boolean { return this.rpc.alive; }
   get stderrTail(): readonly string[] { return this.rpc.stderrTail; }
 
+  /** Visible for tests: frames queued for a thread that has not attached yet. */
+  bufferedCount(threadId: string): number { return this.buffer.get(threadId)?.length ?? 0; }
+
   request<T = unknown>(method: string, params?: unknown): Promise<T> { return this.rpc.request<T>(method, params); }
   respond(id: JsonRpcId, result: unknown): void { this.rpc.respond(id, result); }
   respondError(id: JsonRpcId, code: number, message: string): void { this.rpc.respondError(id, code, message); }
 
   attach(threadId: string, listener: ThreadListener): void {
-    if (this.gone) { listener.onGone(this.gone.reason, this.gone.disposed); return; }
+    if (this.gone) { this.deliverGone(listener, this.gone.reason, this.gone.disposed); return; }
     this.threads.set(threadId, listener);
     const queued = this.buffer.get(threadId);
     this.buffer.delete(threadId); // before the flush, so re-entrant pushes are not replayed or lost
     for (const f of queued ?? []) {
-      if (f.kind === "note") listener.onNotification(f.method, f.params);
-      else listener.onServerRequest(f.id, f.method, f.params);
+      if (f.kind === "note") this.deliverNotification(listener, f.method, f.params);
+      else this.deliverServerRequest(listener, f.id, f.method, f.params);
     }
   }
 
-  detach(threadId: string): void { this.threads.delete(threadId); this.buffer.delete(threadId); }
+  detach(threadId: string): void {
+    this.threads.delete(threadId);
+    // Anything still queued for this thread will never be delivered, and the child is still alive waiting
+    // on it — so answer the requests before dropping them.
+    this.drainBuffer(threadId, "thread detached");
+  }
 
   async dispose(): Promise<void> { await this.rpc.dispose(); }
 
@@ -106,37 +137,69 @@ export class CodexConnection {
     const threadId = threadIdOf(params);
     if (!threadId) { this.onLog?.(`[codex] ${method}`); return; } // global advisory: rate limits, config warnings
     const l = this.threads.get(threadId);
-    if (l) { l.onNotification(method, params); return; }
+    if (l) { this.deliverNotification(l, method, params); return; }
     this.push(threadId, { kind: "note", method, params });
   }
 
   private routeServerRequest(id: JsonRpcId, method: string, params: unknown): void {
     const threadId = threadIdOf(params);
     const l = threadId ? this.threads.get(threadId) : undefined;
-    if (l) { l.onServerRequest(id, method, params); return; }
+    if (l) { this.deliverServerRequest(l, id, method, params); return; }
     if (threadId && this.threads.size === 0) { this.push(threadId, { kind: "req", id, method, params }); return; }
     this.onLog?.(`[codex] unroutable server request ${method} (thread ${threadId ?? "none"})`);
-    this.rpc.respondError(id, -32601, "no client for this thread");
-    this.onUnroutedReply?.(id, -32601);
+    this.refuse(id, -32601, "no client for this thread");
+  }
+
+  /** A listener throwing is a bug in one session; it must not escape into the stdout handler and crash the app. */
+  private deliverNotification(l: ThreadListener, method: string, params: unknown): void {
+    try { l.onNotification(method, params); }
+    catch (e) { this.onLog?.(`[codex] listener threw on ${method}: ${reason(e)}`); }
+  }
+
+  private deliverServerRequest(l: ThreadListener, id: JsonRpcId, method: string, params: unknown): void {
+    try { l.onServerRequest(id, method, params); }
+    catch (e) {
+      // If the listener already answered before throwing, the child ignores this second frame; a duplicate
+      // reply is strictly better than a turn wedged forever on a half-handled request.
+      this.onLog?.(`[codex] listener threw on ${method}: ${reason(e)}`);
+      this.refuse(id, -32603, "client failed to handle this request");
+    }
+  }
+
+  private deliverGone(l: ThreadListener, why: string, disposed: boolean): void {
+    try { l.onGone(why, disposed); }
+    catch (e) { this.onLog?.(`[codex] listener threw on gone: ${reason(e)}`); }
+  }
+
+  private refuse(id: JsonRpcId, code: number, message: string): void {
+    this.rpc.respondError(id, code, message);
+    this.onUnroutedReply?.(id, code);
   }
 
   private push(threadId: string, f: Buffered): void {
     const q = this.buffer.get(threadId) ?? [];
     if (q.length >= MAX_BUFFERED_PER_THREAD) {
-      if (f.kind === "req") { this.rpc.respondError(f.id, -32601, "buffer overflow"); this.onUnroutedReply?.(f.id, -32601); }
+      if (f.kind === "req") this.refuse(f.id, -32601, "buffer overflow");
       return;
     }
     q.push(f);
     this.buffer.set(threadId, q);
   }
 
-  private fanOutGone(reason: string, disposed: boolean): void {
-    this.gone = { reason, disposed };
+  private drainBuffer(threadId: string, why: string): void {
+    const q = this.buffer.get(threadId);
+    this.buffer.delete(threadId);
+    for (const f of q ?? []) if (f.kind === "req") this.refuse(f.id, -32601, why);
+  }
+
+  private fanOutGone(why: string, disposed: boolean): void {
+    this.gone = { reason: why, disposed };
     const listeners = [...this.threads.values()];
     // Cleared before the fan-out so a listener that calls detach() (or re-enters routing) from onGone sees
     // an already-empty connection instead of resurrecting state. Map.delete on a missing key is a no-op.
     this.threads.clear();
+    // Not drained: the peer is gone, so there is nothing left to answer (respondError is a no-op once dead).
     this.buffer.clear();
-    for (const l of listeners) l.onGone(reason, disposed);
+    for (const l of listeners) this.deliverGone(l, why, disposed);
   }
 }

--- a/packages/adapters/src/codex/connection.ts
+++ b/packages/adapters/src/codex/connection.ts
@@ -1,0 +1,142 @@
+import { StdioJsonRpc, type JsonRpcId } from "../jsonrpc/stdio";
+
+export type ThreadListener = {
+  onNotification: (method: string, params: unknown) => void;
+  /** MUST answer via connection.respond()/respondError(). */
+  onServerRequest: (id: JsonRpcId, method: string, params: unknown) => void;
+  /** `disposed` is true when Realm shut the process down on purpose — only `disposed: false` is an error. */
+  onGone: (reason: string, disposed: boolean) => void;
+};
+
+export type CodexConnectionOptions = {
+  bin: string;
+  args?: string[];
+  cwd: string;
+  env?: Record<string, string>;
+  onLog?: (line: string) => void;
+};
+
+type Buffered = { kind: "note"; method: string; params: unknown } | { kind: "req"; id: JsonRpcId; method: string; params: unknown };
+
+const MAX_BUFFERED_PER_THREAD = 200;
+
+const threadIdOf = (params: unknown): string | null => {
+  const t = (params as { threadId?: unknown } | null)?.threadId;
+  return typeof t === "string" ? t : null;
+};
+
+/**
+ * One `codex app-server` process, shared by every Codex session and fanned out by `threadId`.
+ *
+ * Notifications for a thread with no listener yet are buffered (bounded) and flushed on `attach`, because
+ * they can beat the `thread/start` response that tells us the id.
+ *
+ * Server requests are only buffered while NO thread is attached at all — that is the one window where an
+ * unknown thread id really means "the startup race, our `thread/start` has not returned yet". Once any
+ * thread is attached, a request for an unknown thread is a genuine orphan and is answered -32601 rather
+ * than queued: an unanswered server request stalls that turn forever, whereas a rejected one fails it
+ * cleanly. Do not widen this to "always buffer".
+ */
+export class CodexConnection {
+  private readonly threads = new Map<string, ThreadListener>();
+  private readonly buffer = new Map<string, Buffered[]>();
+  private readonly rpc: StdioJsonRpc;
+  private readonly onLog?: (line: string) => void;
+  private gone: { reason: string; disposed: boolean } | null = null;
+
+  /** Visible for tests: called when a server request cannot be routed to any thread. */
+  onUnroutedReply?: (id: JsonRpcId, code: number) => void;
+
+  private constructor(opts: CodexConnectionOptions) {
+    this.onLog = opts.onLog;
+    // `this` is fully initialized here (field initializers run first) and StdioJsonRpc never invokes a
+    // callback synchronously from its constructor, but binding through `this` rather than a `let` declared
+    // after the call keeps that from mattering.
+    this.rpc = new StdioJsonRpc({
+      command: opts.bin,
+      args: opts.args ?? ["app-server"],
+      cwd: opts.cwd,
+      env: opts.env,
+      onNotification: (n) => this.routeNotification(n.method, n.params),
+      onServerRequest: (r) => this.routeServerRequest(r.id, r.method, r.params),
+      onStderr: (l) => this.onLog?.(l),
+      onExit: ({ reason, disposed }) => this.fanOutGone(reason, disposed),
+    });
+  }
+
+  static async open(opts: CodexConnectionOptions): Promise<CodexConnection> {
+    const conn = new CodexConnection(opts);
+    try {
+      await conn.rpc.request("initialize", {
+        clientInfo: { name: "realm", title: "Realm", version: "0.0.1" },
+        capabilities: { experimentalApi: true, requestAttestation: false },
+      });
+    } catch (e) {
+      await conn.dispose(); // never leave a half-spawned child behind
+      throw e;
+    }
+    conn.rpc.notify("initialized");
+    return conn;
+  }
+
+  get threadCount(): number { return this.threads.size; }
+  get alive(): boolean { return this.rpc.alive; }
+  get stderrTail(): readonly string[] { return this.rpc.stderrTail; }
+
+  request<T = unknown>(method: string, params?: unknown): Promise<T> { return this.rpc.request<T>(method, params); }
+  respond(id: JsonRpcId, result: unknown): void { this.rpc.respond(id, result); }
+  respondError(id: JsonRpcId, code: number, message: string): void { this.rpc.respondError(id, code, message); }
+
+  attach(threadId: string, listener: ThreadListener): void {
+    if (this.gone) { listener.onGone(this.gone.reason, this.gone.disposed); return; }
+    this.threads.set(threadId, listener);
+    const queued = this.buffer.get(threadId);
+    this.buffer.delete(threadId); // before the flush, so re-entrant pushes are not replayed or lost
+    for (const f of queued ?? []) {
+      if (f.kind === "note") listener.onNotification(f.method, f.params);
+      else listener.onServerRequest(f.id, f.method, f.params);
+    }
+  }
+
+  detach(threadId: string): void { this.threads.delete(threadId); this.buffer.delete(threadId); }
+
+  async dispose(): Promise<void> { await this.rpc.dispose(); }
+
+  private routeNotification(method: string, params: unknown): void {
+    const threadId = threadIdOf(params);
+    if (!threadId) { this.onLog?.(`[codex] ${method}`); return; } // global advisory: rate limits, config warnings
+    const l = this.threads.get(threadId);
+    if (l) { l.onNotification(method, params); return; }
+    this.push(threadId, { kind: "note", method, params });
+  }
+
+  private routeServerRequest(id: JsonRpcId, method: string, params: unknown): void {
+    const threadId = threadIdOf(params);
+    const l = threadId ? this.threads.get(threadId) : undefined;
+    if (l) { l.onServerRequest(id, method, params); return; }
+    if (threadId && this.threads.size === 0) { this.push(threadId, { kind: "req", id, method, params }); return; }
+    this.onLog?.(`[codex] unroutable server request ${method} (thread ${threadId ?? "none"})`);
+    this.rpc.respondError(id, -32601, "no client for this thread");
+    this.onUnroutedReply?.(id, -32601);
+  }
+
+  private push(threadId: string, f: Buffered): void {
+    const q = this.buffer.get(threadId) ?? [];
+    if (q.length >= MAX_BUFFERED_PER_THREAD) {
+      if (f.kind === "req") { this.rpc.respondError(f.id, -32601, "buffer overflow"); this.onUnroutedReply?.(f.id, -32601); }
+      return;
+    }
+    q.push(f);
+    this.buffer.set(threadId, q);
+  }
+
+  private fanOutGone(reason: string, disposed: boolean): void {
+    this.gone = { reason, disposed };
+    const listeners = [...this.threads.values()];
+    // Cleared before the fan-out so a listener that calls detach() (or re-enters routing) from onGone sees
+    // an already-empty connection instead of resurrecting state. Map.delete on a missing key is a no-op.
+    this.threads.clear();
+    this.buffer.clear();
+    for (const l of listeners) l.onGone(reason, disposed);
+  }
+}

--- a/packages/adapters/src/codex/connection.ts
+++ b/packages/adapters/src/codex/connection.ts
@@ -1,4 +1,4 @@
-import { StdioJsonRpc, type JsonRpcId } from "../jsonrpc/stdio";
+import { StdioJsonRpc, withTimeout, type JsonRpcId } from "../jsonrpc/stdio";
 
 export type ThreadListener = {
   onNotification: (method: string, params: unknown) => void;
@@ -29,13 +29,6 @@ const threadIdOf = (params: unknown): string | null => {
 };
 
 const reason = (e: unknown): string => (e instanceof Error ? e.message : String(e));
-
-function withTimeout<T>(p: Promise<T>, ms: number, message: string): Promise<T> {
-  return new Promise<T>((resolve, reject) => {
-    const timer = setTimeout(() => reject(new Error(message)), ms);
-    p.then(resolve, reject).finally(() => clearTimeout(timer));
-  });
-}
 
 /**
  * One `codex app-server` process, shared by every Codex session and fanned out by `threadId`.
@@ -109,7 +102,11 @@ export class CodexConnection {
   /** Visible for tests: frames queued for a thread that has not attached yet. */
   bufferedCount(threadId: string): number { return this.buffer.get(threadId)?.length ?? 0; }
 
-  request<T = unknown>(method: string, params?: unknown): Promise<T> { return this.rpc.request<T>(method, params); }
+  /** `timeoutMs` bounds the wait; without it the call is only settled by an answer or the process dying. */
+  request<T = unknown>(method: string, params?: unknown, timeoutMs?: number): Promise<T> {
+    const p = this.rpc.request<T>(method, params);
+    return timeoutMs === undefined ? p : withTimeout(p, timeoutMs, `codex app-server did not answer ${method} within ${timeoutMs}ms`);
+  }
   respond(id: JsonRpcId, result: unknown): void { this.rpc.respond(id, result); }
   respondError(id: JsonRpcId, code: number, message: string): void { this.rpc.respondError(id, code, message); }
 

--- a/packages/adapters/src/codex/fixtures/fake-codex-server.mjs
+++ b/packages/adapters/src/codex/fixtures/fake-codex-server.mjs
@@ -13,6 +13,7 @@
  * by the text of `turn/start`'s input:
  *
  *   HANG      opens a command item and never finishes the turn        (interrupt / steer tests)
+ *   PARTIAL   streams message deltas and never finishes the item      (partial-text flush tests)
  *   SLOW      (modifier) delays the turn's notifications by 60ms      (turn-id-from-response tests)
  *   GHOST     opens a turn the server does not register as steerable  (turn/steer -> turn/start fallback)
  *   APPROVE   runs one command that needs an approval decision
@@ -189,6 +190,15 @@ async function streamMessageTurn(threadId, turnId, text) {
   endTurn(threadId, turnId);
 }
 
+/** Streams message deltas and then stops: the item never completes, so only a flush can persist the text. */
+async function streamPartialTurn(threadId, turnId, text) {
+  const itemId = `msg_${nextItemN++}`;
+  await openTurn(threadId, turnId, text);
+  notify("item/started", { threadId, turnId, startedAtMs: Date.now(), item: { type: "agentMessage", id: itemId, text: "", phase: null, memoryCitation: null } });
+  notify("item/agentMessage/delta", { threadId, turnId, itemId, delta: "half " });
+  notify("item/agentMessage/delta", { threadId, turnId, itemId, delta: "an answer" });
+}
+
 /** Opens a command item and then stops: the turn never completes on its own. */
 async function streamHangTurn(threadId, turnId, text) {
   const cwd = threads.get(threadId)?.cwd ?? process.cwd();
@@ -274,6 +284,7 @@ function handleRequest(id, method, params) {
       // Dies with a tool card still open, so the crash has something to force-close.
       if (text.includes("CRASH")) { void streamHangTurn(params.threadId, turnId, text); setTimeout(() => process.exit(9), 25); return; }
       if (text.includes("GHOST")) { void openTurn(params.threadId, turnId, text); return; }
+      if (text.includes("PARTIAL")) { void streamPartialTurn(params.threadId, turnId, text); return; }
       if (text.includes("HANG")) { void streamHangTurn(params.threadId, turnId, text); return; }
       if (text.includes("APPROVE2")) { void streamTwoApprovalsTurn(params.threadId, turnId, text); return; }
       if (text.includes("PATCH")) { void streamPatchTurn(params.threadId, turnId, text); return; }

--- a/packages/adapters/src/codex/fixtures/fake-codex-server.mjs
+++ b/packages/adapters/src/codex/fixtures/fake-codex-server.mjs
@@ -8,11 +8,13 @@
  *   - server -> client request ids start at 0 and therefore collide with client request ids on purpose
  *   - every thread-scoped notification carries `threadId`; turn-scoped ones add `turnId`
  *
- * Turn behaviour is selected by the text of `turn/start`'s input: "APPROVE" runs a command that needs an
- * approval decision, "HANG" streams nothing at all, anything else streams a short agent message.
+ * Every turn opens with the sequence the real server was captured emitting (protocol reference §2.4):
+ * `thread/status/changed{active}` -> `turn/started` -> `item/started(userMessage)`. What follows is selected
+ * by the text of `turn/start`'s input: "APPROVE" runs a command that needs an approval decision, "HANG" stops
+ * after the opening and never completes the turn, anything else streams a short agent message.
  *
- * `$test/exit` is a test-only notification that kills the process, letting tests tell an unexpected death
- * apart from an intentional dispose.
+ * Two test-only hooks: the `$test/exit` request kills the process (so tests can tell an unexpected death from
+ * an intentional dispose), and FAKE_CODEX_MUTE_INITIALIZE=1 makes `initialize` go unanswered.
  */
 
 let nextThreadN = 0;
@@ -35,11 +37,21 @@ const ask = (method, params) => {
 const tick = () => new Promise((resolve) => setTimeout(resolve, 1));
 const inputText = (input) => (Array.isArray(input) ? input : []).map((p) => (p && typeof p.text === "string" ? p.text : "")).join(" ");
 
-async function streamApprovalTurn(threadId, turnId) {
+async function openTurn(threadId, turnId, text) {
+  await tick();
+  notify("thread/status/changed", { threadId, status: { type: "active", activeFlags: [] } });
+  notify("turn/started", { threadId, turn: { id: turnId, status: "inProgress", items: [] } });
+  notify("item/started", {
+    threadId, turnId, startedAtMs: Date.now(),
+    item: { type: "userMessage", id: `usr_${nextItemN++}`, clientId: null, content: [{ type: "text", text, text_elements: [] }] },
+  });
+}
+
+async function streamApprovalTurn(threadId, turnId, text) {
   const itemId = `call_${nextItemN++}`;
   const cwd = threads.get(threadId)?.cwd ?? process.cwd();
   const command = "/bin/zsh -lc 'echo hi'";
-  await tick();
+  await openTurn(threadId, turnId, text);
   notify("item/started", {
     threadId, turnId, startedAtMs: Date.now(),
     item: { type: "commandExecution", id: itemId, command, cwd, status: "inProgress", commandActions: [], aggregatedOutput: null, exitCode: null },
@@ -65,16 +77,9 @@ async function streamApprovalTurn(threadId, turnId) {
   notify("turn/completed", { threadId, turn: { id: turnId, itemsView: "summary", items: [], status: "completed", error: null } });
 }
 
-async function streamMessageTurn(threadId, turnId) {
+async function streamMessageTurn(threadId, turnId, text) {
   const itemId = `msg_${nextItemN++}`;
-  const userItemId = `usr_${nextItemN++}`;
-  await tick();
-  notify("thread/status/changed", { threadId, status: { type: "active", activeFlags: [] } });
-  notify("turn/started", { threadId, turn: { id: turnId, status: "inProgress", items: [] } });
-  notify("item/started", {
-    threadId, turnId, startedAtMs: Date.now(),
-    item: { type: "userMessage", id: userItemId, clientId: null, content: [{ type: "text", text: "hi", text_elements: [] }] },
-  });
+  await openTurn(threadId, turnId, text);
   notify("item/started", { threadId, turnId, startedAtMs: Date.now(), item: { type: "agentMessage", id: itemId, text: "", phase: null, memoryCitation: null } });
   notify("item/agentMessage/delta", { threadId, turnId, itemId, delta: "hel" });
   notify("item/agentMessage/delta", { threadId, turnId, itemId, delta: "lo" });
@@ -109,6 +114,7 @@ function startThread(id, params, threadId) {
 function handleRequest(id, method, params) {
   switch (method) {
     case "initialize":
+      if (process.env.FAKE_CODEX_MUTE_INITIALIZE) return; // spawned but mute: drives the open() timeout test
       ok(id, { userAgent: "fake-codex/0.146.0", codexHome: "/tmp/fake-codex-home" });
       return;
     case "thread/start":
@@ -125,8 +131,9 @@ function handleRequest(id, method, params) {
       const turnId = `tu_${nextTurnN++}`;
       ok(id, { turn: { id: turnId, status: "inProgress", items: [] } });
       const text = inputText(params.input);
-      if (text.includes("HANG")) return; // never completes: drives interrupt tests
-      void (text.includes("APPROVE") ? streamApprovalTurn(params.threadId, turnId) : streamMessageTurn(params.threadId, turnId));
+      // HANG opens the turn like any other and then simply never finishes it: drives interrupt tests.
+      if (text.includes("HANG")) { void openTurn(params.threadId, turnId, text); return; }
+      void (text.includes("APPROVE") ? streamApprovalTurn(params.threadId, turnId, text) : streamMessageTurn(params.threadId, turnId, text));
       return;
     }
     case "turn/interrupt":

--- a/packages/adapters/src/codex/fixtures/fake-codex-server.mjs
+++ b/packages/adapters/src/codex/fixtures/fake-codex-server.mjs
@@ -1,0 +1,171 @@
+#!/usr/bin/env node
+/**
+ * Fake `codex app-server` — speaks the subset of the real protocol that CodexConnection and the Codex
+ * adapter exercise. Frame shapes are copied from docs/dev/codex-app-server-protocol.md:
+ *
+ *   - newline-delimited JSON, one object per line, no Content-Length headers
+ *   - responses OMIT `jsonrpc` (the real server does), so nothing may validate on it
+ *   - server -> client request ids start at 0 and therefore collide with client request ids on purpose
+ *   - every thread-scoped notification carries `threadId`; turn-scoped ones add `turnId`
+ *
+ * Turn behaviour is selected by the text of `turn/start`'s input: "APPROVE" runs a command that needs an
+ * approval decision, "HANG" streams nothing at all, anything else streams a short agent message.
+ *
+ * `$test/exit` is a test-only notification that kills the process, letting tests tell an unexpected death
+ * apart from an intentional dispose.
+ */
+
+let nextThreadN = 0;
+let nextTurnN = 0;
+let nextItemN = 0;
+let nextServerRequestId = 0; // the real server numbers its own requests from 0
+const threads = new Map(); // threadId -> { cwd }
+const pendingApprovals = new Map(); // server request id -> (decision) => void
+let stdinBuf = "";
+
+const send = (frame) => process.stdout.write(JSON.stringify(frame) + "\n");
+const ok = (id, result) => send({ id, result });
+const fail = (id, code, message, data) => send({ id, error: { code, message, ...(data === undefined ? {} : { data }) } });
+const notify = (method, params) => send({ method, params, emittedAtMs: Date.now() });
+const ask = (method, params) => {
+  const id = nextServerRequestId++;
+  send({ method, id, params });
+  return id;
+};
+const tick = () => new Promise((resolve) => setTimeout(resolve, 1));
+const inputText = (input) => (Array.isArray(input) ? input : []).map((p) => (p && typeof p.text === "string" ? p.text : "")).join(" ");
+
+async function streamApprovalTurn(threadId, turnId) {
+  const itemId = `call_${nextItemN++}`;
+  const cwd = threads.get(threadId)?.cwd ?? process.cwd();
+  const command = "/bin/zsh -lc 'echo hi'";
+  await tick();
+  notify("item/started", {
+    threadId, turnId, startedAtMs: Date.now(),
+    item: { type: "commandExecution", id: itemId, command, cwd, status: "inProgress", commandActions: [], aggregatedOutput: null, exitCode: null },
+  });
+  const requestId = ask("item/commandExecution/requestApproval", {
+    threadId, turnId, itemId, startedAtMs: Date.now(), environmentId: "local",
+    reason: "fake approval", command, cwd, commandActions: [],
+    availableDecisions: ["accept", "cancel"],
+  });
+  const decision = await new Promise((resolve) => pendingApprovals.set(requestId, resolve));
+  const accepted = decision === "accept";
+  notify("serverRequest/resolved", { threadId, requestId });
+  notify("item/completed", {
+    threadId, turnId, completedAtMs: Date.now(),
+    item: {
+      type: "commandExecution", id: itemId, command, cwd, commandActions: [],
+      status: accepted ? "completed" : "failed",
+      aggregatedOutput: accepted ? "hi\n" : "",
+      exitCode: accepted ? 0 : 1,
+    },
+  });
+  notify("thread/status/changed", { threadId, status: { type: "idle" } });
+  notify("turn/completed", { threadId, turn: { id: turnId, itemsView: "summary", items: [], status: "completed", error: null } });
+}
+
+async function streamMessageTurn(threadId, turnId) {
+  const itemId = `msg_${nextItemN++}`;
+  const userItemId = `usr_${nextItemN++}`;
+  await tick();
+  notify("thread/status/changed", { threadId, status: { type: "active", activeFlags: [] } });
+  notify("turn/started", { threadId, turn: { id: turnId, status: "inProgress", items: [] } });
+  notify("item/started", {
+    threadId, turnId, startedAtMs: Date.now(),
+    item: { type: "userMessage", id: userItemId, clientId: null, content: [{ type: "text", text: "hi", text_elements: [] }] },
+  });
+  notify("item/started", { threadId, turnId, startedAtMs: Date.now(), item: { type: "agentMessage", id: itemId, text: "", phase: null, memoryCitation: null } });
+  notify("item/agentMessage/delta", { threadId, turnId, itemId, delta: "hel" });
+  notify("item/agentMessage/delta", { threadId, turnId, itemId, delta: "lo" });
+  notify("item/completed", { threadId, turnId, completedAtMs: Date.now(), item: { type: "agentMessage", id: itemId, text: "hello", phase: null, memoryCitation: null } });
+  notify("thread/tokenUsage/updated", {
+    threadId, turnId,
+    tokenUsage: {
+      total: { totalTokens: 12, inputTokens: 10, cachedInputTokens: 0, cacheWriteInputTokens: 0, outputTokens: 2, reasoningOutputTokens: 0 },
+      last: { totalTokens: 12, inputTokens: 10, cachedInputTokens: 0, cacheWriteInputTokens: 0, outputTokens: 2, reasoningOutputTokens: 0 },
+      modelContextWindow: 258400,
+    },
+  });
+  notify("thread/status/changed", { threadId, status: { type: "idle" } });
+  notify("turn/completed", { threadId, turn: { id: turnId, itemsView: "summary", items: [{ type: "agentMessage", id: itemId, text: "hello" }], status: "completed", error: null } });
+}
+
+async function streamInterrupt(threadId, turnId) {
+  await tick();
+  notify("thread/status/changed", { threadId, status: { type: "idle" } });
+  notify("turn/completed", { threadId, turn: { id: turnId, itemsView: "summary", items: [], status: "interrupted", error: null } });
+}
+
+function startThread(id, params, threadId) {
+  threads.set(threadId, { cwd: params.cwd });
+  ok(id, {
+    thread: { id: threadId, status: { type: "idle" }, cwd: params.cwd, turns: [] },
+    model: params.model ?? "gpt-5.2",
+    cwd: params.cwd,
+  });
+}
+
+function handleRequest(id, method, params) {
+  switch (method) {
+    case "initialize":
+      ok(id, { userAgent: "fake-codex/0.146.0", codexHome: "/tmp/fake-codex-home" });
+      return;
+    case "thread/start":
+      if (params.model === "explode") {
+        fail(id, -32600, "failed to load configuration", { action: "relogin", statusCode: 401 });
+        return;
+      }
+      startThread(id, params, `th_${nextThreadN++}`);
+      return;
+    case "thread/resume":
+      startThread(id, params, params.threadId);
+      return;
+    case "turn/start": {
+      const turnId = `tu_${nextTurnN++}`;
+      ok(id, { turn: { id: turnId, status: "inProgress", items: [] } });
+      const text = inputText(params.input);
+      if (text.includes("HANG")) return; // never completes: drives interrupt tests
+      void (text.includes("APPROVE") ? streamApprovalTurn(params.threadId, turnId) : streamMessageTurn(params.threadId, turnId));
+      return;
+    }
+    case "turn/interrupt":
+      ok(id, {});
+      void streamInterrupt(params.threadId, params.turnId);
+      return;
+    default:
+      fail(id, -32600, `unknown method: ${method}`);
+  }
+}
+
+function handleFrame(line) {
+  let msg;
+  try { msg = JSON.parse(line); } catch { return; }
+
+  // A client RESPONSE to one of our server requests: no method, an id, and result/error. Must be checked
+  // before the request dispatcher, since the two id spaces overlap.
+  if (msg.method === undefined && msg.id !== undefined && ("result" in msg || "error" in msg)) {
+    const resolve = pendingApprovals.get(msg.id);
+    if (!resolve) return;
+    pendingApprovals.delete(msg.id);
+    resolve(msg.result?.decision ?? null); // an error response counts as "not accepted"
+    return;
+  }
+
+  if (typeof msg.method !== "string") return;
+  if (msg.method === "$test/exit") process.exit(9);
+  if (msg.id === undefined || msg.id === null) return; // notification (e.g. `initialized`): ignore
+  handleRequest(msg.id, msg.method, msg.params ?? {});
+}
+
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (chunk) => {
+  stdinBuf += chunk;
+  let i;
+  while ((i = stdinBuf.indexOf("\n")) >= 0) {
+    const line = stdinBuf.slice(0, i);
+    stdinBuf = stdinBuf.slice(i + 1);
+    if (line.trim()) handleFrame(line);
+  }
+});
+process.stdin.on("end", () => process.exit(0)); // the real server exits when its stdin closes

--- a/packages/adapters/src/codex/fixtures/fake-codex-server.mjs
+++ b/packages/adapters/src/codex/fixtures/fake-codex-server.mjs
@@ -32,8 +32,9 @@
  * an intentional dispose), `model: "explode"` fails `thread/start` with the revoked-login error shape,
  * `model: "reflect"` echoes the whole `thread/start`/`thread/resume` params object back as the model string
  * (the only field of the start response the adapter surfaces), a resumed thread id containing "busy" rejoins a
- * turn that is already running, and FAKE_CODEX_MUTE_INITIALIZE=1 makes
- * `initialize` go unanswered.
+ * turn that is already running, FAKE_CODEX_MUTE_INITIALIZE=1 makes
+ * `initialize` go unanswered, FAKE_CODEX_INITIALIZE_DELAY_MS=<ms> delays the answer, and FAKE_CODEX_MUTE_THREAD_START=1 makes `thread/start`/`thread/resume` go
+ * unanswered (a child that spawns and handshakes but never opens a thread).
  */
 
 let nextThreadN = 0;
@@ -227,11 +228,17 @@ function startThread(id, params, threadId) {
 
 function handleRequest(id, method, params) {
   switch (method) {
-    case "initialize":
+    case "initialize": {
       if (process.env.FAKE_CODEX_MUTE_INITIALIZE) return; // spawned but mute: drives the open() timeout test
-      ok(id, { userAgent: "fake-codex/0.146.0", codexHome: "/tmp/fake-codex-home" });
+      const reply = () => ok(id, { userAgent: "fake-codex/0.146.0", codexHome: "/tmp/fake-codex-home" });
+      // A handshake slow enough to land after a dispose has already given up waiting for it.
+      const delay = Number(process.env.FAKE_CODEX_INITIALIZE_DELAY_MS ?? 0);
+      if (delay > 0) setTimeout(reply, delay); else reply();
       return;
+    }
     case "thread/start": {
+      // Spawned, handshaken and then mute: an unbounded thread/start leaves boot pending forever.
+      if (process.env.FAKE_CODEX_MUTE_THREAD_START) return;
       if (params.model === "explode") {
         fail(id, -32600, "failed to load configuration", { action: "relogin", statusCode: 401 });
         return;
@@ -248,6 +255,7 @@ function handleRequest(id, method, params) {
       return;
     }
     case "thread/resume":
+      if (process.env.FAKE_CODEX_MUTE_THREAD_START) return;
       startThread(id, params, params.threadId);
       // A thread id containing "busy" was mid-turn when the client went away: resuming rejoins the live turn,
       // whose id the client can only learn from turn/started (the resume response does not carry it).

--- a/packages/adapters/src/codex/fixtures/fake-codex-server.mjs
+++ b/packages/adapters/src/codex/fixtures/fake-codex-server.mjs
@@ -16,10 +16,13 @@
  *   SLOW      (modifier) delays the turn's notifications by 60ms      (turn-id-from-response tests)
  *   GHOST     opens a turn the server does not register as steerable  (turn/steer -> turn/start fallback)
  *   APPROVE   runs one command that needs an approval decision
+ *   PATCH     edits a file and asks for a fileChange approval instead
+ *   REFUSE    fails `turn/start` outright
  *   APPROVE2  runs two commands whose approvals are open at once      (waiting_permission bookkeeping)
  *   ODDBALL   asks a server request no client is expected to support  (-32601 answer path)
  *   ECHO      replies with the raw `input` array as the agent message (input-shape assertions)
- *   CRASH     answers, then dies without warning                      (unexpected-death path)
+ *   CRASH     opens a command item, then dies without warning          (unexpected-death path)
+ *   BADSTEER  (on turn/steer) fails the steer with something other than "no active turn"
  *   anything  streams a short agent message
  *
  * `text_elements` is validated on text input exactly as the real server does — omitting it is a deserialize
@@ -148,6 +151,25 @@ async function streamTwoApprovalsTurn(threadId, turnId, text) {
   endTurn(threadId, turnId);
 }
 
+/** One fileChange item, blocked on the fileChange flavour of approval. */
+async function streamPatchTurn(threadId, turnId, text) {
+  const itemId = `patch_${nextItemN++}`;
+  const changes = [{ path: "/repo/src/a.ts", kind: { type: "edit" }, diff: "@@\n-old\n+new" }];
+  await openTurn(threadId, turnId, text);
+  notify("item/started", { threadId, turnId, startedAtMs: Date.now(), item: { type: "fileChange", id: itemId, changes, status: "inProgress" } });
+  const { reply } = ask("item/fileChange/requestApproval", {
+    threadId, turnId, itemId, startedAtMs: Date.now(), reason: "Apply 1 edit to a.ts", grantRoot: "/repo",
+    // FileChangeApprovalDecision, unlike the captured command flavour, does offer "decline".
+    availableDecisions: ["accept", "acceptForSession", "decline", "cancel"],
+  });
+  const decision = (await reply).result?.decision;
+  notify("item/completed", {
+    threadId, turnId, completedAtMs: Date.now(),
+    item: { type: "fileChange", id: itemId, changes, status: decision === "accept" ? "completed" : "failed", decision: decision ?? null },
+  });
+  endTurn(threadId, turnId);
+}
+
 async function streamMessageTurn(threadId, turnId, text) {
   const itemId = `msg_${nextItemN++}`;
   await openTurn(threadId, turnId, text);
@@ -209,13 +231,22 @@ function handleRequest(id, method, params) {
       if (process.env.FAKE_CODEX_MUTE_INITIALIZE) return; // spawned but mute: drives the open() timeout test
       ok(id, { userAgent: "fake-codex/0.146.0", codexHome: "/tmp/fake-codex-home" });
       return;
-    case "thread/start":
+    case "thread/start": {
       if (params.model === "explode") {
         fail(id, -32600, "failed to load configuration", { action: "relogin", statusCode: 401 });
         return;
       }
-      startThread(id, params, `th_${nextThreadN++}`);
+      if (params.model === "nope") {
+        fail(id, -32600, "unknown model `nope`", { statusCode: 400 }); // no `action`: not a login problem
+        return;
+      }
+      const threadId = `th_${nextThreadN++}`;
+      // `model: "eager"` reproduces the race CodexConnection's buffer exists for: a thread-scoped notification
+      // emitted before the response that tells the client the thread id.
+      if (params.model === "eager") notify("thread/status/changed", { threadId, status: { type: "active", activeFlags: [] } });
+      startThread(id, params, threadId);
       return;
+    }
     case "thread/resume":
       startThread(id, params, params.threadId);
       // A thread id containing "busy" was mid-turn when the client went away: resuming rejoins the live turn,
@@ -225,16 +256,19 @@ function handleRequest(id, method, params) {
     case "turn/start": {
       const bad = inputError(params.input);
       if (bad) { fail(id, -32602, `invalid params: ${bad}`); return; }
+      const text = inputText(params.input);
+      if (text.includes("REFUSE")) { fail(id, -32600, "the model refused this turn"); return; }
       const turnId = `tu_${nextTurnN++}`;
       ok(id, { turn: { id: turnId, status: "inProgress", items: [] } });
-      const text = inputText(params.input);
       // GHOST is the only turn the server will not accept a steer for, so the adapter's stale-turn fallback
       // has something to trip over.
       if (!text.includes("GHOST")) activeTurns.set(params.threadId, turnId);
-      if (text.includes("CRASH")) { setTimeout(() => process.exit(9), 5); return; }
+      // Dies with a tool card still open, so the crash has something to force-close.
+      if (text.includes("CRASH")) { void streamHangTurn(params.threadId, turnId, text); setTimeout(() => process.exit(9), 25); return; }
       if (text.includes("GHOST")) { void openTurn(params.threadId, turnId, text); return; }
       if (text.includes("HANG")) { void streamHangTurn(params.threadId, turnId, text); return; }
       if (text.includes("APPROVE2")) { void streamTwoApprovalsTurn(params.threadId, turnId, text); return; }
+      if (text.includes("PATCH")) { void streamPatchTurn(params.threadId, turnId, text); return; }
       if (text.includes("APPROVE")) { void streamApprovalTurn(params.threadId, turnId, text); return; }
       if (text.includes("ODDBALL")) { void streamOddballTurn(params.threadId, turnId, text); return; }
       if (text.includes("ECHO")) { void streamEchoTurn(params.threadId, turnId, text, params.input); return; }
@@ -244,6 +278,7 @@ function handleRequest(id, method, params) {
     case "turn/steer": {
       const bad = inputError(params.input);
       if (bad) { fail(id, -32602, `invalid params: ${bad}`); return; }
+      if (inputText(params.input).includes("BADSTEER")) { fail(id, -32603, "internal error while steering"); return; }
       const active = activeTurns.get(params.threadId);
       if (!active || active !== params.expectedTurnId) { fail(id, -32600, "no active turn to steer"); return; }
       ok(id, { turnId: active });

--- a/packages/adapters/src/codex/fixtures/fake-codex-server.mjs
+++ b/packages/adapters/src/codex/fixtures/fake-codex-server.mjs
@@ -10,11 +10,27 @@
  *
  * Every turn opens with the sequence the real server was captured emitting (protocol reference §2.4):
  * `thread/status/changed{active}` -> `turn/started` -> `item/started(userMessage)`. What follows is selected
- * by the text of `turn/start`'s input: "APPROVE" runs a command that needs an approval decision, "HANG" stops
- * after the opening and never completes the turn, anything else streams a short agent message.
+ * by the text of `turn/start`'s input:
  *
- * Two test-only hooks: the `$test/exit` request kills the process (so tests can tell an unexpected death from
- * an intentional dispose), and FAKE_CODEX_MUTE_INITIALIZE=1 makes `initialize` go unanswered.
+ *   HANG      opens a command item and never finishes the turn        (interrupt / steer tests)
+ *   SLOW      (modifier) delays the turn's notifications by 60ms      (turn-id-from-response tests)
+ *   GHOST     opens a turn the server does not register as steerable  (turn/steer -> turn/start fallback)
+ *   APPROVE   runs one command that needs an approval decision
+ *   APPROVE2  runs two commands whose approvals are open at once      (waiting_permission bookkeeping)
+ *   ODDBALL   asks a server request no client is expected to support  (-32601 answer path)
+ *   ECHO      replies with the raw `input` array as the agent message (input-shape assertions)
+ *   CRASH     answers, then dies without warning                      (unexpected-death path)
+ *   anything  streams a short agent message
+ *
+ * `text_elements` is validated on text input exactly as the real server does — omitting it is a deserialize
+ * error there, and silently accepting it here would let that regression through.
+ *
+ * Test-only hooks: the `$test/exit` request kills the process (so tests can tell an unexpected death from
+ * an intentional dispose), `model: "explode"` fails `thread/start` with the revoked-login error shape,
+ * `model: "reflect"` echoes the whole `thread/start`/`thread/resume` params object back as the model string
+ * (the only field of the start response the adapter surfaces), a resumed thread id containing "busy" rejoins a
+ * turn that is already running, and FAKE_CODEX_MUTE_INITIALIZE=1 makes
+ * `initialize` go unanswered.
  */
 
 let nextThreadN = 0;
@@ -22,23 +38,53 @@ let nextTurnN = 0;
 let nextItemN = 0;
 let nextServerRequestId = 0; // the real server numbers its own requests from 0
 const threads = new Map(); // threadId -> { cwd }
-const pendingApprovals = new Map(); // server request id -> (decision) => void
+const activeTurns = new Map(); // threadId -> turnId, the precondition turn/steer checks
+const pendingRequests = new Map(); // server request id -> (clientReply) => void
 let stdinBuf = "";
 
 const send = (frame) => process.stdout.write(JSON.stringify(frame) + "\n");
 const ok = (id, result) => send({ id, result });
 const fail = (id, code, message, data) => send({ id, error: { code, message, ...(data === undefined ? {} : { data }) } });
 const notify = (method, params) => send({ method, params, emittedAtMs: Date.now() });
+/** Sends a server -> client request and hands back its id plus a promise for the client's reply. */
 const ask = (method, params) => {
   const id = nextServerRequestId++;
   send({ method, id, params });
-  return id;
+  return { id, reply: new Promise((resolve) => pendingRequests.set(id, resolve)) };
 };
-const tick = () => new Promise((resolve) => setTimeout(resolve, 1));
+const tick = (ms = 1) => new Promise((resolve) => setTimeout(resolve, ms));
 const inputText = (input) => (Array.isArray(input) ? input : []).map((p) => (p && typeof p.text === "string" ? p.text : "")).join(" ");
 
+/** Mirrors the real server's deserialization: `text_elements` is a non-optional array on text input. */
+function inputError(input) {
+  if (!Array.isArray(input) || input.length === 0) return "input must be a non-empty array";
+  for (const part of input) {
+    if (!part || typeof part !== "object") return "input part must be an object";
+    if (part.type === "text" && !Array.isArray(part.text_elements)) return "missing field `text_elements`";
+    if (part.type === "localImage" && typeof part.path !== "string") return "missing field `path`";
+  }
+  return null;
+}
+
+const commandItem = (id, command, cwd) =>
+  ({ type: "commandExecution", id, command, cwd, status: "inProgress", commandActions: [], aggregatedOutput: null, exitCode: null });
+
+function endTurn(threadId, turnId, status = "completed") {
+  activeTurns.delete(threadId);
+  notify("thread/status/changed", { threadId, status: { type: "idle" } });
+  notify("turn/completed", { threadId, turn: { id: turnId, itemsView: "summary", items: [], status, error: null } });
+}
+
+function agentMessage(threadId, turnId, text) {
+  const itemId = `msg_${nextItemN++}`;
+  notify("item/started", { threadId, turnId, startedAtMs: Date.now(), item: { type: "agentMessage", id: itemId, text: "", phase: null, memoryCitation: null } });
+  notify("item/completed", { threadId, turnId, completedAtMs: Date.now(), item: { type: "agentMessage", id: itemId, text, phase: null, memoryCitation: null } });
+}
+
 async function openTurn(threadId, turnId, text) {
-  await tick();
+  // SLOW widens the gap between the turn/start response and the first notification, so tests can act in the
+  // window where the response is the only source of the turn id.
+  await tick(text.includes("SLOW") ? 60 : 1);
   notify("thread/status/changed", { threadId, status: { type: "active", activeFlags: [] } });
   notify("turn/started", { threadId, turn: { id: turnId, status: "inProgress", items: [] } });
   notify("item/started", {
@@ -47,22 +93,19 @@ async function openTurn(threadId, turnId, text) {
   });
 }
 
+/** One command item, blocked on an approval, then completed according to the decision. */
 async function streamApprovalTurn(threadId, turnId, text) {
   const itemId = `call_${nextItemN++}`;
   const cwd = threads.get(threadId)?.cwd ?? process.cwd();
   const command = "/bin/zsh -lc 'echo hi'";
   await openTurn(threadId, turnId, text);
-  notify("item/started", {
-    threadId, turnId, startedAtMs: Date.now(),
-    item: { type: "commandExecution", id: itemId, command, cwd, status: "inProgress", commandActions: [], aggregatedOutput: null, exitCode: null },
-  });
-  const requestId = ask("item/commandExecution/requestApproval", {
+  notify("item/started", { threadId, turnId, startedAtMs: Date.now(), item: commandItem(itemId, command, cwd) });
+  const { id: requestId, reply } = ask("item/commandExecution/requestApproval", {
     threadId, turnId, itemId, startedAtMs: Date.now(), environmentId: "local",
     reason: "fake approval", command, cwd, commandActions: [],
     availableDecisions: ["accept", "cancel"],
   });
-  const decision = await new Promise((resolve) => pendingApprovals.set(requestId, resolve));
-  const accepted = decision === "accept";
+  const accepted = (await reply).result?.decision === "accept";
   notify("serverRequest/resolved", { threadId, requestId });
   notify("item/completed", {
     threadId, turnId, completedAtMs: Date.now(),
@@ -73,8 +116,36 @@ async function streamApprovalTurn(threadId, turnId, text) {
       exitCode: accepted ? 0 : 1,
     },
   });
-  notify("thread/status/changed", { threadId, status: { type: "idle" } });
-  notify("turn/completed", { threadId, turn: { id: turnId, itemsView: "summary", items: [], status: "completed", error: null } });
+  endTurn(threadId, turnId);
+}
+
+/** Two command items whose approvals are outstanding at the same time (parallel tool calls). */
+async function streamTwoApprovalsTurn(threadId, turnId, text) {
+  const cwd = threads.get(threadId)?.cwd ?? process.cwd();
+  await openTurn(threadId, turnId, text);
+  const asked = [0, 1].map((n) => {
+    const itemId = `call_${nextItemN++}`;
+    const command = `/bin/zsh -lc 'echo ${n}'`;
+    notify("item/started", { threadId, turnId, startedAtMs: Date.now(), item: commandItem(itemId, command, cwd) });
+    const { reply } = ask("item/commandExecution/requestApproval", {
+      threadId, turnId, itemId, startedAtMs: Date.now(), environmentId: "local",
+      reason: "fake approval", command, cwd, commandActions: [],
+      availableDecisions: ["accept", "cancel"],
+    });
+    return { itemId, command, reply };
+  });
+  const replies = await Promise.all(asked.map((a) => a.reply));
+  asked.forEach((a, n) => {
+    const accepted = replies[n].result?.decision === "accept";
+    notify("item/completed", {
+      threadId, turnId, completedAtMs: Date.now(),
+      item: {
+        type: "commandExecution", id: a.itemId, command: a.command, cwd, commandActions: [],
+        status: accepted ? "completed" : "failed", aggregatedOutput: accepted ? `${n}\n` : "", exitCode: accepted ? 0 : 1,
+      },
+    });
+  });
+  endTurn(threadId, turnId);
 }
 
 async function streamMessageTurn(threadId, turnId, text) {
@@ -92,21 +163,42 @@ async function streamMessageTurn(threadId, turnId, text) {
       modelContextWindow: 258400,
     },
   });
-  notify("thread/status/changed", { threadId, status: { type: "idle" } });
-  notify("turn/completed", { threadId, turn: { id: turnId, itemsView: "summary", items: [{ type: "agentMessage", id: itemId, text: "hello" }], status: "completed", error: null } });
+  endTurn(threadId, turnId);
+}
+
+/** Opens a command item and then stops: the turn never completes on its own. */
+async function streamHangTurn(threadId, turnId, text) {
+  const cwd = threads.get(threadId)?.cwd ?? process.cwd();
+  await openTurn(threadId, turnId, text);
+  notify("item/started", { threadId, turnId, startedAtMs: Date.now(), item: commandItem(`call_${nextItemN++}`, "/bin/zsh -lc 'sleep 999'", cwd) });
+}
+
+/** Echoes the raw input array so tests can assert the exact wire shape the adapter built. */
+async function streamEchoTurn(threadId, turnId, text, input) {
+  await openTurn(threadId, turnId, text);
+  agentMessage(threadId, turnId, JSON.stringify(input));
+  endTurn(threadId, turnId);
+}
+
+/** A server request no client is expected to understand; the turn only ends once it is answered. */
+async function streamOddballTurn(threadId, turnId, text) {
+  await openTurn(threadId, turnId, text);
+  const { reply } = ask("item/tool/requestUserInput", { threadId, turnId, itemId: `q_${nextItemN++}`, questions: [], autoResolutionMs: null });
+  const answer = await reply;
+  agentMessage(threadId, turnId, `refused: ${answer.error?.code ?? answer.result?.decision ?? "none"}`);
+  endTurn(threadId, turnId);
 }
 
 async function streamInterrupt(threadId, turnId) {
   await tick();
-  notify("thread/status/changed", { threadId, status: { type: "idle" } });
-  notify("turn/completed", { threadId, turn: { id: turnId, itemsView: "summary", items: [], status: "interrupted", error: null } });
+  endTurn(threadId, turnId, "interrupted");
 }
 
 function startThread(id, params, threadId) {
   threads.set(threadId, { cwd: params.cwd });
   ok(id, {
     thread: { id: threadId, status: { type: "idle" }, cwd: params.cwd, turns: [] },
-    model: params.model ?? "gpt-5.2",
+    model: params.model === "reflect" ? JSON.stringify(params) : (params.model ?? "gpt-5.2"),
     cwd: params.cwd,
   });
 }
@@ -126,14 +218,36 @@ function handleRequest(id, method, params) {
       return;
     case "thread/resume":
       startThread(id, params, params.threadId);
+      // A thread id containing "busy" was mid-turn when the client went away: resuming rejoins the live turn,
+      // whose id the client can only learn from turn/started (the resume response does not carry it).
+      if (String(params.threadId).includes("busy")) void streamHangTurn(params.threadId, `tu_${nextTurnN++}`, "resumed");
       return;
     case "turn/start": {
+      const bad = inputError(params.input);
+      if (bad) { fail(id, -32602, `invalid params: ${bad}`); return; }
       const turnId = `tu_${nextTurnN++}`;
       ok(id, { turn: { id: turnId, status: "inProgress", items: [] } });
       const text = inputText(params.input);
-      // HANG opens the turn like any other and then simply never finishes it: drives interrupt tests.
-      if (text.includes("HANG")) { void openTurn(params.threadId, turnId, text); return; }
-      void (text.includes("APPROVE") ? streamApprovalTurn(params.threadId, turnId, text) : streamMessageTurn(params.threadId, turnId, text));
+      // GHOST is the only turn the server will not accept a steer for, so the adapter's stale-turn fallback
+      // has something to trip over.
+      if (!text.includes("GHOST")) activeTurns.set(params.threadId, turnId);
+      if (text.includes("CRASH")) { setTimeout(() => process.exit(9), 5); return; }
+      if (text.includes("GHOST")) { void openTurn(params.threadId, turnId, text); return; }
+      if (text.includes("HANG")) { void streamHangTurn(params.threadId, turnId, text); return; }
+      if (text.includes("APPROVE2")) { void streamTwoApprovalsTurn(params.threadId, turnId, text); return; }
+      if (text.includes("APPROVE")) { void streamApprovalTurn(params.threadId, turnId, text); return; }
+      if (text.includes("ODDBALL")) { void streamOddballTurn(params.threadId, turnId, text); return; }
+      if (text.includes("ECHO")) { void streamEchoTurn(params.threadId, turnId, text, params.input); return; }
+      void streamMessageTurn(params.threadId, turnId, text);
+      return;
+    }
+    case "turn/steer": {
+      const bad = inputError(params.input);
+      if (bad) { fail(id, -32602, `invalid params: ${bad}`); return; }
+      const active = activeTurns.get(params.threadId);
+      if (!active || active !== params.expectedTurnId) { fail(id, -32600, "no active turn to steer"); return; }
+      ok(id, { turnId: active });
+      agentMessage(params.threadId, active, `steered:${inputText(params.input)}`);
       return;
     }
     case "turn/interrupt":
@@ -152,10 +266,10 @@ function handleFrame(line) {
   // A client RESPONSE to one of our server requests: no method, an id, and result/error. Must be checked
   // before the request dispatcher, since the two id spaces overlap.
   if (msg.method === undefined && msg.id !== undefined && ("result" in msg || "error" in msg)) {
-    const resolve = pendingApprovals.get(msg.id);
+    const resolve = pendingRequests.get(msg.id);
     if (!resolve) return;
-    pendingApprovals.delete(msg.id);
-    resolve(msg.result?.decision ?? null); // an error response counts as "not accepted"
+    pendingRequests.delete(msg.id);
+    resolve({ result: msg.result, error: msg.error });
     return;
   }
 

--- a/packages/adapters/src/codex/fixtures/fake-codex.mjs
+++ b/packages/adapters/src/codex/fixtures/fake-codex.mjs
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+// Fixture CLI for probe.test.ts. Behavior is driven by argv/env so tests can exercise every branch
+// of probeCodex without touching the real `codex` binary.
+const args = process.argv.slice(2);
+
+if (args[0] === "--version") {
+  if (process.env.FAKE_CODEX_EMPTY_VERSION) {
+    process.stdout.write("\n");
+  } else {
+    process.stdout.write("codex-cli 1.2.3\n");
+  }
+  process.exit(0);
+}
+
+if (args[0] === "login" && args[1] === "status") {
+  const mode = process.env.FAKE_CODEX_LOGIN ?? "ok";
+  if (mode === "ok") {
+    process.stdout.write("Logged in using ChatGPT\n");
+    process.exit(0);
+  }
+  if (mode === "logged-out") {
+    process.stderr.write("Not logged in\n");
+    process.exit(1);
+  }
+  if (mode === "other-error") {
+    process.stderr.write("Error loading configuration: bogus\n");
+    process.exit(1);
+  }
+}
+
+process.stderr.write(`fake-codex: unhandled args ${JSON.stringify(args)}\n`);
+process.exit(1);

--- a/packages/adapters/src/codex/map-codex.test.ts
+++ b/packages/adapters/src/codex/map-codex.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from "vitest";
+import { createCodexMapper } from "./map-codex";
+import type { SessionEvent } from "@realm/contracts";
+
+const types = (evs: SessionEvent[]) => evs.map((e) => e.type);
+
+describe("createCodexMapper", () => {
+  it("drops the userMessage echo so the transcript isn't duplicated", () => {
+    const m = createCodexMapper();
+    const out = m.map("item/started", { item: { type: "userMessage", id: "u1", content: [{ type: "text", text: "hi" }] } });
+    expect(out).toEqual([]);
+  });
+
+  it("maps agent message deltas and the final text", () => {
+    const m = createCodexMapper();
+    expect(m.map("item/started", { item: { type: "agentMessage", id: "msg_1", text: "" } })).toEqual([]);
+    const d = m.map("item/agentMessage/delta", { itemId: "msg_1", delta: "Run" });
+    expect(d[0]).toMatchObject({ type: "assistant_delta", payload: { messageId: "msg_1", delta: "Run" } });
+    const f = m.map("item/completed", { item: { type: "agentMessage", id: "msg_1", text: "Running it." } });
+    expect(f[0]).toMatchObject({ type: "assistant_text", payload: { messageId: "msg_1", text: "Running it." } });
+  });
+
+  it("emits thinking once, from the completed reasoning item", () => {
+    const m = createCodexMapper();
+    m.map("item/started", { item: { type: "reasoning", id: "rs_1", summary: [], content: [] } });
+    expect(m.map("item/reasoning/summaryTextDelta", { itemId: "rs_1", delta: "Check", summaryIndex: 0 })).toEqual([]);
+    const done = m.map("item/completed", { item: { type: "reasoning", id: "rs_1", summary: ["Checking the request."], content: [] } });
+    expect(done[0]).toMatchObject({ type: "thinking", payload: { messageId: "rs_1", text: "Checking the request." } });
+  });
+
+  it("maps commandExecution to tool_call then tool_result", () => {
+    const m = createCodexMapper();
+    const start = m.map("item/started", { item: { type: "commandExecution", id: "call_1", command: "/bin/zsh -lc 'echo hi'", cwd: "/tmp", status: "inProgress" } });
+    expect(start[0]).toMatchObject({ type: "tool_call", payload: { toolUseId: "call_1", name: "exec_command", input: { command: "/bin/zsh -lc 'echo hi'", cwd: "/tmp" }, parentToolUseId: null } });
+    const done = m.map("item/completed", { item: { type: "commandExecution", id: "call_1", status: "completed", aggregatedOutput: "hi\n", exitCode: 0 } });
+    expect(done[0]).toMatchObject({ type: "tool_result", payload: { toolUseId: "call_1", content: "hi\n", isError: false } });
+  });
+
+  it("marks a failed command as an error result", () => {
+    const m = createCodexMapper();
+    m.map("item/started", { item: { type: "commandExecution", id: "c2", command: "false", cwd: "/tmp" } });
+    const done = m.map("item/completed", { item: { type: "commandExecution", id: "c2", status: "failed", aggregatedOutput: "", exitCode: 1 } });
+    expect(done[0]).toMatchObject({ type: "tool_result", payload: { isError: true } });
+  });
+
+  it("maps fileChange to a tool_call with a readable diff summary", () => {
+    const m = createCodexMapper();
+    const start = m.map("item/started", { item: { type: "fileChange", id: "p1", status: "inProgress", changes: [{ path: "/tmp/a.txt", kind: { type: "add" }, diff: "hello\n" }] } });
+    expect(start[0]).toMatchObject({ type: "tool_call", payload: { toolUseId: "p1", name: "apply_patch" } });
+    const done = m.map("item/completed", { item: { type: "fileChange", id: "p1", status: "completed", changes: [{ path: "/tmp/a.txt", kind: { type: "add" }, diff: "hello\n" }] } });
+    expect(done[0]!.type).toBe("tool_result");
+    expect((done[0] as { payload: { content: string } }).payload.content).toContain("add /tmp/a.txt");
+  });
+
+  it("force-closes open items when an interrupted turn completes", () => {
+    const m = createCodexMapper();
+    m.map("turn/started", { turn: { id: "t1" } });
+    m.map("item/started", { item: { type: "commandExecution", id: "c9", command: "sleep 60", cwd: "/tmp" } });
+    const out = m.map("turn/completed", { turn: { id: "t1", status: "interrupted", items: [] } });
+    expect(types(out)).toEqual(["tool_result", "status"]);
+    expect(out[0]).toMatchObject({ type: "tool_result", payload: { toolUseId: "c9", isError: true, content: "interrupted" } });
+    expect(out[1]).toMatchObject({ type: "status", payload: { status: "idle" } });
+  });
+
+  it("reports a failed turn as an error before going idle", () => {
+    const m = createCodexMapper();
+    m.map("turn/started", { turn: { id: "t1" } });
+    const out = m.map("turn/completed", { turn: { id: "t1", status: "failed", error: { message: "model exploded" }, items: [] } });
+    expect(types(out)).toEqual(["error", "status"]);
+    expect(out[0]).toMatchObject({ payload: { message: "model exploded" } });
+  });
+
+  it("uses tokenUsage.total, not last, and counts turns", () => {
+    const m = createCodexMapper();
+    m.map("turn/started", { turn: { id: "t1" } });
+    const out = m.map("thread/tokenUsage/updated", {
+      tokenUsage: { total: { totalTokens: 154, inputTokens: 120, outputTokens: 34 }, last: { inputTokens: 1, outputTokens: 1 }, modelContextWindow: 258400 },
+    });
+    expect(out[0]).toMatchObject({ type: "usage", payload: { costUsd: 0, inputTokens: 120, outputTokens: 34, numTurns: 1 } });
+  });
+
+  it("maps thread status changes", () => {
+    const m = createCodexMapper();
+    expect(m.map("thread/status/changed", { status: { type: "active", activeFlags: [] } })[0]).toMatchObject({ type: "status", payload: { status: "running" } });
+    expect(m.map("thread/status/changed", { status: { type: "idle" } })[0]).toMatchObject({ type: "status", payload: { status: "idle" } });
+  });
+
+  it("maps the error notification", () => {
+    const m = createCodexMapper();
+    const out = m.map("error", { error: { message: "rate limited" }, willRetry: true });
+    expect(out[0]).toMatchObject({ type: "error", payload: { message: "rate limited (retrying)" } });
+  });
+
+  it("maps mcpToolCall to tool_call then tool_result, using server.tool as the name", () => {
+    const m = createCodexMapper();
+    const start = m.map("item/started", { item: { type: "mcpToolCall", id: "mcp1", server: "figma", tool: "get_file", arguments: { fileId: "abc" } } });
+    expect(start[0]).toMatchObject({ type: "tool_call", payload: { toolUseId: "mcp1", name: "figma.get_file", input: { fileId: "abc" }, parentToolUseId: null } });
+    const done = m.map("item/completed", { item: { type: "mcpToolCall", id: "mcp1", status: "completed", result: "ok" } });
+    expect(done[0]).toMatchObject({ type: "tool_result", payload: { toolUseId: "mcp1", content: "ok", isError: false } });
+  });
+
+  it("surfaces the mcpToolCall error field as the result content when the call fails", () => {
+    const m = createCodexMapper();
+    m.map("item/started", { item: { type: "mcpToolCall", id: "mcp2", server: "notion", tool: "search", arguments: {} } });
+    const done = m.map("item/completed", { item: { type: "mcpToolCall", id: "mcp2", status: "failed", error: "401 unauthorized" } });
+    expect(done[0]).toMatchObject({ type: "tool_result", payload: { toolUseId: "mcp2", content: "401 unauthorized", isError: true } });
+  });
+
+  it("appends the exit code to a nonzero-exit command's output", () => {
+    const m = createCodexMapper();
+    m.map("item/started", { item: { type: "commandExecution", id: "c3", command: "false", cwd: "/tmp" } });
+    const done = m.map("item/completed", { item: { type: "commandExecution", id: "c3", status: "failed", aggregatedOutput: "boom", exitCode: 1 } });
+    expect((done[0] as { payload: { content: string } }).payload.content).toBe("boom\n[exit 1]");
+  });
+
+  it("closeOpenTools force-closes items awaiting item/completed and clears them", () => {
+    const m = createCodexMapper();
+    m.map("item/started", { item: { type: "commandExecution", id: "c4", command: "sleep 5", cwd: "/tmp" } });
+    m.map("item/started", { item: { type: "fileChange", id: "p2", status: "inProgress", changes: [] } });
+    const closed = m.closeOpenTools("process exited");
+    expect(closed).toHaveLength(2);
+    expect(closed).toContainEqual({ type: "tool_result", ts: expect.any(Number), payload: { toolUseId: "c4", content: "process exited", isError: true } });
+    expect(closed).toContainEqual({ type: "tool_result", ts: expect.any(Number), payload: { toolUseId: "p2", content: "process exited", isError: true } });
+    // calling it again finds nothing left open
+    expect(m.closeOpenTools("again")).toEqual([]);
+  });
+
+  it("drops advisory and firehose notifications", () => {
+    const m = createCodexMapper();
+    for (const method of ["warning", "configWarning", "deprecationNotice", "mcpServer/startupStatus/updated", "account/rateLimits/updated", "rawResponse/completed", "serverRequest/resolved", "thread/started"]) {
+      expect(m.map(method, {})).toEqual([]);
+    }
+  });
+});

--- a/packages/adapters/src/codex/map-codex.test.ts
+++ b/packages/adapters/src/codex/map-codex.test.ts
@@ -85,6 +85,69 @@ describe("createCodexMapper", () => {
     expect(types(out)).toEqual(["status"]);
   });
 
+  it("persists a half-streamed message when an interrupted turn completes", () => {
+    // assistant_delta is ephemeral (not in PERSISTED_EVENT_TYPES) and assistant_text only ever comes from
+    // item/completed — which an interrupt never sends. Without a flush the answer is live-only and gone on reload.
+    const m = createCodexMapper();
+    m.map("turn/started", { turn: { id: "t1" } });
+    m.map("item/started", { item: { type: "agentMessage", id: "msg_9", text: "" } });
+    m.map("item/agentMessage/delta", { itemId: "msg_9", delta: "half " });
+    m.map("item/agentMessage/delta", { itemId: "msg_9", delta: "an answer" });
+    const out = m.map("turn/completed", { turn: { id: "t1", status: "interrupted", items: [] } });
+    expect(types(out)).toEqual(["assistant_text", "status"]);
+    expect(out[0]).toMatchObject({ type: "assistant_text", payload: { messageId: "msg_9", text: "half an answer" } });
+  });
+
+  it("persists half-streamed reasoning the same way", () => {
+    const m = createCodexMapper();
+    m.map("turn/started", { turn: { id: "t1" } });
+    m.map("item/started", { item: { type: "reasoning", id: "rs_9", summary: [], content: [] } });
+    m.map("item/reasoning/summaryTextDelta", { itemId: "rs_9", delta: "Checking ", summaryIndex: 0 });
+    m.map("item/reasoning/summaryTextDelta", { itemId: "rs_9", delta: "the request", summaryIndex: 0 });
+    const out = m.map("turn/completed", { turn: { id: "t1", status: "interrupted", items: [] } });
+    expect(types(out)).toEqual(["thinking", "status"]);
+    expect(out[0]).toMatchObject({ type: "thinking", payload: { messageId: "rs_9", text: "Checking the request" } });
+  });
+
+  it("emits exactly one assistant_text on a normal completion — never a second from the flush", () => {
+    // If item/completed stopped clearing the run, every message in every turn would be persisted twice.
+    const m = createCodexMapper();
+    m.map("turn/started", { turn: { id: "t1" } });
+    m.map("item/started", { item: { type: "agentMessage", id: "msg_1", text: "" } });
+    m.map("item/agentMessage/delta", { itemId: "msg_1", delta: "hel" });
+    m.map("item/agentMessage/delta", { itemId: "msg_1", delta: "lo" });
+    const done = m.map("item/completed", { item: { type: "agentMessage", id: "msg_1", text: "hello" } });
+    expect(types(done)).toEqual(["assistant_text"]);
+    const out = m.map("turn/completed", { turn: { id: "t1", status: "completed", items: [] } });
+    expect(types(out)).toEqual(["status"]);
+  });
+
+  it("emits exactly one thinking on a normal reasoning completion", () => {
+    const m = createCodexMapper();
+    m.map("turn/started", { turn: { id: "t1" } });
+    m.map("item/started", { item: { type: "reasoning", id: "rs_1", summary: [], content: [] } });
+    m.map("item/reasoning/summaryTextDelta", { itemId: "rs_1", delta: "Check", summaryIndex: 0 });
+    const done = m.map("item/completed", { item: { type: "reasoning", id: "rs_1", summary: ["Checking the request."], content: [] } });
+    expect(types(done)).toEqual(["thinking"]);
+    expect(types(m.map("turn/completed", { turn: { id: "t1", status: "completed", items: [] } }))).toEqual(["status"]);
+  });
+
+  it("flushes an open message run when the process dies mid-stream", () => {
+    const m = createCodexMapper();
+    m.map("item/started", { item: { type: "agentMessage", id: "msg_2", text: "" } });
+    m.map("item/agentMessage/delta", { itemId: "msg_2", delta: "cut off" });
+    const closed = m.closeOpenTools("process exited");
+    expect(closed).toContainEqual({ type: "assistant_text", ts: expect.any(Number), payload: { messageId: "msg_2", text: "cut off" } });
+    expect(m.closeOpenTools("again")).toEqual([]); // and the run is cleared, not replayed
+  });
+
+  it("does not manufacture an empty assistant_text for a run that streamed nothing", () => {
+    const m = createCodexMapper();
+    m.map("turn/started", { turn: { id: "t1" } });
+    m.map("item/started", { item: { type: "agentMessage", id: "msg_3", text: "" } });
+    expect(types(m.map("turn/completed", { turn: { id: "t1", status: "interrupted", items: [] } }))).toEqual(["status"]);
+  });
+
   it("reports a failed turn as an error before going idle", () => {
     const m = createCodexMapper();
     m.map("turn/started", { turn: { id: "t1" } });

--- a/packages/adapters/src/codex/map-codex.test.ts
+++ b/packages/adapters/src/codex/map-codex.test.ts
@@ -62,6 +62,29 @@ describe("createCodexMapper", () => {
     expect(out[1]).toMatchObject({ type: "status", payload: { status: "idle" } });
   });
 
+  it("labels a force-closed item with the turn status when the turn wasn't interrupted", () => {
+    // Pins the non-interrupted branch of the force-close wording: it should never read as if the
+    // turn itself succeeded/failed with that word as its result — it should say what actually happened
+    // (the item never got its own item/completed).
+    const m = createCodexMapper();
+    m.map("turn/started", { turn: { id: "t1" } });
+    m.map("item/started", { item: { type: "commandExecution", id: "c10", command: "sleep 60", cwd: "/tmp" } });
+    const out = m.map("turn/completed", { turn: { id: "t1", status: "completed", items: [] } });
+    expect(out[0]).toMatchObject({ type: "tool_result", payload: { toolUseId: "c10", isError: true, content: "turn ended without a result (completed)" } });
+  });
+
+  it("emits only status on a normal completion — no leftover tool_result once item/completed already closed the item", () => {
+    // Regression guard for the openTools bookkeeping: if item/completed stopped deleting the id from
+    // openTools, turn/completed would force-close it a second time and every tool call in every turn
+    // would get a spurious extra error tool_result.
+    const m = createCodexMapper();
+    m.map("turn/started", { turn: { id: "t1" } });
+    m.map("item/started", { item: { type: "commandExecution", id: "c11", command: "echo hi", cwd: "/tmp" } });
+    m.map("item/completed", { item: { type: "commandExecution", id: "c11", status: "completed", aggregatedOutput: "hi\n", exitCode: 0 } });
+    const out = m.map("turn/completed", { turn: { id: "t1", status: "completed", items: [] } });
+    expect(types(out)).toEqual(["status"]);
+  });
+
   it("reports a failed turn as an error before going idle", () => {
     const m = createCodexMapper();
     m.map("turn/started", { turn: { id: "t1" } });
@@ -123,6 +146,17 @@ describe("createCodexMapper", () => {
     expect(closed).toContainEqual({ type: "tool_result", ts: expect.any(Number), payload: { toolUseId: "p2", content: "process exited", isError: true } });
     // calling it again finds nothing left open
     expect(m.closeOpenTools("again")).toEqual([]);
+  });
+
+  it("returns no event for item/commandExecution/outputDelta (streamed stdout, coalesced by item/completed)", () => {
+    const m = createCodexMapper();
+    m.map("item/started", { item: { type: "commandExecution", id: "c12", command: "echo hi", cwd: "/tmp" } });
+    expect(m.map("item/commandExecution/outputDelta", { itemId: "c12", delta: "hi\n" })).toEqual([]);
+  });
+
+  it("maps a systemError thread status to the error status", () => {
+    const m = createCodexMapper();
+    expect(m.map("thread/status/changed", { status: { type: "systemError" } })[0]).toMatchObject({ type: "status", payload: { status: "error" } });
   });
 
   it("drops advisory and firehose notifications", () => {

--- a/packages/adapters/src/codex/map-codex.ts
+++ b/packages/adapters/src/codex/map-codex.ts
@@ -54,8 +54,8 @@ function toolOutputFor(item: Bag): string {
  * - Advisory notifications return `[]` — the adapter logs them instead of putting them in the transcript.
  */
 export function createCodexMapper() {
-  /** itemId -> tool name, for items still awaiting item/completed. */
-  const openTools = new Map<string, string>();
+  /** itemIds of tool items still awaiting item/completed. */
+  const openTools = new Set<string>();
   let numTurns = 0;
 
   return {
@@ -68,7 +68,7 @@ export function createCodexMapper() {
           const item = obj(p.item);
           const id = str(item.id);
           const name = toolNameFor(item);
-          if (name) { openTools.set(id, name); out.push(sessionEvent("tool_call", { toolUseId: id, name, input: toolInputFor(item), parentToolUseId: null })); }
+          if (name) { openTools.add(id); out.push(sessionEvent("tool_call", { toolUseId: id, name, input: toolInputFor(item), parentToolUseId: null })); }
           return out; // userMessage / agentMessage / reasoning starts carry no Realm event
         }
 
@@ -105,7 +105,8 @@ export function createCodexMapper() {
         case "turn/completed": {
           const turn = obj(p.turn);
           const status = str(turn.status);
-          for (const [id] of openTools) out.push(sessionEvent("tool_result", { toolUseId: id, content: status === "interrupted" ? "interrupted" : status, isError: true }));
+          // An item still open here never got its own item/completed (an interrupt skips it entirely).
+          for (const id of openTools) out.push(sessionEvent("tool_result", { toolUseId: id, content: status === "interrupted" ? "interrupted" : `turn ended without a result (${status})`, isError: true }));
           openTools.clear();
           if (status === "failed") out.push(sessionEvent("error", { message: str(obj(turn.error).message) || "turn failed" }));
           out.push(sessionEvent("status", { status: "idle" }));
@@ -137,7 +138,7 @@ export function createCodexMapper() {
 
     /** Close anything still open — used when the process dies mid-turn. */
     closeOpenTools(reason: string): SessionEvent[] {
-      const out = [...openTools.keys()].map((id) => sessionEvent("tool_result", { toolUseId: id, content: reason, isError: true }));
+      const out = [...openTools].map((id) => sessionEvent("tool_result", { toolUseId: id, content: reason, isError: true }));
       openTools.clear();
       return out;
     },

--- a/packages/adapters/src/codex/map-codex.ts
+++ b/packages/adapters/src/codex/map-codex.ts
@@ -1,0 +1,145 @@
+import { sessionEvent, type SessionEvent } from "@realm/contracts";
+
+type Bag = Record<string, unknown>;
+const obj = (v: unknown): Bag => (v && typeof v === "object" ? (v as Bag) : {});
+const str = (v: unknown): string => (typeof v === "string" ? v : "");
+const num = (v: unknown): number => (typeof v === "number" ? v : 0);
+
+/** Item types Realm renders as a tool card, and the tool name it shows. */
+function toolNameFor(item: Bag): string | null {
+  switch (str(item.type)) {
+    case "commandExecution": return "exec_command";
+    case "fileChange": return "apply_patch";
+    case "mcpToolCall": return `${str(item.server) || "mcp"}.${str(item.tool) || "tool"}`;
+    case "dynamicToolCall": case "collabAgentToolCall": case "webSearch": return str(item.type);
+    default: return null;
+  }
+}
+
+function toolInputFor(item: Bag): Record<string, unknown> {
+  switch (str(item.type)) {
+    case "commandExecution": return { command: str(item.command), cwd: str(item.cwd) };
+    case "fileChange": return { changes: item.changes ?? [] };
+    case "mcpToolCall": return obj(item.arguments);
+    default: { const { id: _id, type: _type, ...rest } = item; return rest; }
+  }
+}
+
+function toolOutputFor(item: Bag): string {
+  switch (str(item.type)) {
+    case "commandExecution": {
+      const out = str(item.aggregatedOutput);
+      const code = item.exitCode;
+      return typeof code === "number" && code !== 0 ? `${out}\n[exit ${code}]`.trim() : out;
+    }
+    case "fileChange": {
+      const changes = Array.isArray(item.changes) ? (item.changes as Bag[]) : [];
+      return changes.map((c) => `${str(obj(c.kind).type) || "change"} ${str(c.path)}\n${str(c.diff)}`.trimEnd()).join("\n\n");
+    }
+    case "mcpToolCall": {
+      const err = str(item.error);
+      if (err) return err;
+      return typeof item.result === "string" ? item.result : JSON.stringify(item.result ?? null);
+    }
+    default: return JSON.stringify(item);
+  }
+}
+
+/**
+ * Pure, stateful mapper from `codex app-server` notifications to Realm SessionEvents.
+ *
+ * - Codex's `userMessage` item is dropped: SessionService already emits `user_message` on send.
+ * - Reasoning is emitted once, on `item/completed`, because Realm's `thinking` event has no delta variant.
+ * - Open tool items are force-closed on `turn/completed`; an interrupt never sends their `item/completed`.
+ * - Advisory notifications return `[]` — the adapter logs them instead of putting them in the transcript.
+ */
+export function createCodexMapper() {
+  /** itemId -> tool name, for items still awaiting item/completed. */
+  const openTools = new Map<string, string>();
+  let numTurns = 0;
+
+  return {
+    map(method: string, rawParams: unknown): SessionEvent[] {
+      const p = obj(rawParams);
+      const out: SessionEvent[] = [];
+
+      switch (method) {
+        case "item/started": {
+          const item = obj(p.item);
+          const id = str(item.id);
+          const name = toolNameFor(item);
+          if (name) { openTools.set(id, name); out.push(sessionEvent("tool_call", { toolUseId: id, name, input: toolInputFor(item), parentToolUseId: null })); }
+          return out; // userMessage / agentMessage / reasoning starts carry no Realm event
+        }
+
+        case "item/completed": {
+          const item = obj(p.item);
+          const id = str(item.id);
+          const type = str(item.type);
+          if (type === "agentMessage") { out.push(sessionEvent("assistant_text", { messageId: id, text: str(item.text) })); return out; }
+          if (type === "reasoning") {
+            const summary = Array.isArray(item.summary) ? (item.summary as unknown[]).map(str) : [];
+            const content = Array.isArray(item.content) ? (item.content as unknown[]).map(str) : [];
+            const text = [...summary, ...content].filter(Boolean).join("\n\n");
+            if (text) out.push(sessionEvent("thinking", { messageId: id, text }));
+            return out;
+          }
+          if (openTools.has(id)) {
+            openTools.delete(id);
+            out.push(sessionEvent("tool_result", { toolUseId: id, content: toolOutputFor(item), isError: str(item.status) !== "completed" }));
+          }
+          return out;
+        }
+
+        case "item/agentMessage/delta":
+          return [sessionEvent("assistant_delta", { messageId: str(p.itemId), delta: str(p.delta) })];
+
+        case "item/commandExecution/outputDelta":
+          // Streamed stdout. Realm has no partial-tool-result event in v1; the full output arrives on item/completed.
+          return [];
+
+        case "turn/started":
+          numTurns += 1;
+          return [];
+
+        case "turn/completed": {
+          const turn = obj(p.turn);
+          const status = str(turn.status);
+          for (const [id] of openTools) out.push(sessionEvent("tool_result", { toolUseId: id, content: status === "interrupted" ? "interrupted" : status, isError: true }));
+          openTools.clear();
+          if (status === "failed") out.push(sessionEvent("error", { message: str(obj(turn.error).message) || "turn failed" }));
+          out.push(sessionEvent("status", { status: "idle" }));
+          return out;
+        }
+
+        case "thread/status/changed": {
+          const t = str(obj(p.status).type);
+          if (t === "active") return [sessionEvent("status", { status: "running" })];
+          if (t === "idle") return [sessionEvent("status", { status: "idle" })];
+          if (t === "systemError") return [sessionEvent("status", { status: "error" })];
+          return [];
+        }
+
+        case "thread/tokenUsage/updated": {
+          const total = obj(obj(p.tokenUsage).total);
+          return [sessionEvent("usage", { costUsd: 0, inputTokens: num(total.inputTokens), outputTokens: num(total.outputTokens), numTurns })];
+        }
+
+        case "error": {
+          const message = str(obj(p.error).message) || "agent error";
+          return [sessionEvent("error", { message: p.willRetry === true ? `${message} (retrying)` : message })];
+        }
+
+        default:
+          return []; // advisory + firehose notifications; the adapter logs them
+      }
+    },
+
+    /** Close anything still open — used when the process dies mid-turn. */
+    closeOpenTools(reason: string): SessionEvent[] {
+      const out = [...openTools.keys()].map((id) => sessionEvent("tool_result", { toolUseId: id, content: reason, isError: true }));
+      openTools.clear();
+      return out;
+    },
+  };
+}

--- a/packages/adapters/src/codex/map-codex.ts
+++ b/packages/adapters/src/codex/map-codex.ts
@@ -51,12 +51,33 @@ function toolOutputFor(item: Bag): string {
  * - Codex's `userMessage` item is dropped: SessionService already emits `user_message` on send.
  * - Reasoning is emitted once, on `item/completed`, because Realm's `thinking` event has no delta variant.
  * - Open tool items are force-closed on `turn/completed`; an interrupt never sends their `item/completed`.
+ * - Open message/reasoning runs are flushed to their persisted event there too, for the same reason: an
+ *   interrupt stops in-flight items dead, and `assistant_delta` is ephemeral.
  * - Advisory notifications return `[]` — the adapter logs them instead of putting them in the transcript.
  */
 export function createCodexMapper() {
   /** itemIds of tool items still awaiting item/completed. */
   const openTools = new Set<string>();
+  /** Delta text accumulated for message and reasoning items still awaiting item/completed. */
+  const openText = new Map<string, string>();
+  const openThought = new Map<string, string>();
   let numTurns = 0;
+
+  /**
+   * Persists whatever a message or reasoning item streamed before it stopped.
+   *
+   * `assistant_delta` is ephemeral — not in PERSISTED_EVENT_TYPES — and the persisted `assistant_text` only
+   * ever comes from `item/completed`, which an interrupt never sends (protocol reference §8). Without this the
+   * streamed answer is visible live and gone after a reload.
+   */
+  const flushOpenRuns = (): SessionEvent[] => {
+    const out: SessionEvent[] = [];
+    for (const [id, text] of openText) if (text) out.push(sessionEvent("assistant_text", { messageId: id, text }));
+    for (const [id, text] of openThought) if (text) out.push(sessionEvent("thinking", { messageId: id, text }));
+    openText.clear();
+    openThought.clear();
+    return out;
+  };
 
   return {
     map(method: string, rawParams: unknown): SessionEvent[] {
@@ -67,17 +88,23 @@ export function createCodexMapper() {
         case "item/started": {
           const item = obj(p.item);
           const id = str(item.id);
+          const type = str(item.type);
+          // No Realm event of their own, but the run has to be open before its first delta can be kept.
+          if (type === "agentMessage") { openText.set(id, ""); return out; }
+          if (type === "reasoning") { openThought.set(id, ""); return out; }
           const name = toolNameFor(item);
           if (name) { openTools.add(id); out.push(sessionEvent("tool_call", { toolUseId: id, name, input: toolInputFor(item), parentToolUseId: null })); }
-          return out; // userMessage / agentMessage / reasoning starts carry no Realm event
+          return out; // userMessage starts carry no Realm event
         }
 
         case "item/completed": {
           const item = obj(p.item);
           const id = str(item.id);
           const type = str(item.type);
-          if (type === "agentMessage") { out.push(sessionEvent("assistant_text", { messageId: id, text: str(item.text) })); return out; }
+          // Clearing the run is what keeps the flush from persisting a normal message a second time.
+          if (type === "agentMessage") { openText.delete(id); out.push(sessionEvent("assistant_text", { messageId: id, text: str(item.text) })); return out; }
           if (type === "reasoning") {
+            openThought.delete(id);
             const summary = Array.isArray(item.summary) ? (item.summary as unknown[]).map(str) : [];
             const content = Array.isArray(item.content) ? (item.content as unknown[]).map(str) : [];
             const text = [...summary, ...content].filter(Boolean).join("\n\n");
@@ -91,8 +118,21 @@ export function createCodexMapper() {
           return out;
         }
 
-        case "item/agentMessage/delta":
-          return [sessionEvent("assistant_delta", { messageId: str(p.itemId), delta: str(p.delta) })];
+        case "item/agentMessage/delta": {
+          const id = str(p.itemId);
+          const delta = str(p.delta);
+          openText.set(id, (openText.get(id) ?? "") + delta);
+          return [sessionEvent("assistant_delta", { messageId: id, delta })];
+        }
+
+        case "item/reasoning/summaryTextDelta":
+        case "item/reasoning/textDelta": {
+          // Accumulated but never emitted: Realm's `thinking` event has no streaming variant, so these only
+          // exist so an interrupted reasoning item still has something to persist.
+          const id = str(p.itemId);
+          openThought.set(id, (openThought.get(id) ?? "") + str(p.delta));
+          return [];
+        }
 
         case "item/commandExecution/outputDelta":
           // Streamed stdout. Realm has no partial-tool-result event in v1; the full output arrives on item/completed.
@@ -105,7 +145,9 @@ export function createCodexMapper() {
         case "turn/completed": {
           const turn = obj(p.turn);
           const status = str(turn.status);
-          // An item still open here never got its own item/completed (an interrupt skips it entirely).
+          // An item still open here never got its own item/completed (an interrupt skips it entirely) — that
+          // goes for the turn's message and reasoning runs as much as for its tool calls.
+          out.push(...flushOpenRuns());
           for (const id of openTools) out.push(sessionEvent("tool_result", { toolUseId: id, content: status === "interrupted" ? "interrupted" : `turn ended without a result (${status})`, isError: true }));
           openTools.clear();
           if (status === "failed") out.push(sessionEvent("error", { message: str(obj(turn.error).message) || "turn failed" }));
@@ -136,9 +178,10 @@ export function createCodexMapper() {
       }
     },
 
-    /** Close anything still open — used when the process dies mid-turn. */
+    /** Close anything still open — used when the process dies mid-turn or the session is disposed. */
     closeOpenTools(reason: string): SessionEvent[] {
-      const out = [...openTools].map((id) => sessionEvent("tool_result", { toolUseId: id, content: reason, isError: true }));
+      const out = flushOpenRuns();
+      for (const id of openTools) out.push(sessionEvent("tool_result", { toolUseId: id, content: reason, isError: true }));
       openTools.clear();
       return out;
     },

--- a/packages/adapters/src/codex/probe.test.ts
+++ b/packages/adapters/src/codex/probe.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "vitest";
+import { fileURLToPath } from "node:url";
+import { probeCodex } from "./probe";
+
+const FAKE_CODEX = fileURLToPath(new URL("./fixtures/fake-codex.mjs", import.meta.url));
+
+describe("probeCodex", () => {
+  it("reports unavailable with a reason when the binary is missing", async () => {
+    const r = await probeCodex("/definitely/not/a/binary");
+    expect(r.available).toBe(false);
+    expect(r.version).toBeNull();
+    expect(r.reason).toBeTruthy();
+  });
+
+  it("reports unavailable when the binary exists but --version itself fails", async () => {
+    // Distinguishes "missing binary" (ENOENT) from "present but broken" — both must land on available:false.
+    const r = await probeCodex(FAKE_CODEX, ["--not-a-real-flag"]);
+    expect(r.available).toBe(false);
+    expect(r.version).toBeNull();
+    expect(r.loggedIn).toBeNull();
+    expect(r.reason).toBeTruthy();
+  });
+
+  it("reports the version and a login verdict when the binary runs", async () => {
+    // A stub that answers both `--version` and `login status`.
+    const stub = process.execPath;
+    const r = await probeCodex(stub, ["-e", "console.log('codex-cli 9.9.9')"]);
+    expect(r.available).toBe(true);
+    expect(r.version).toBe("codex-cli 9.9.9");
+  });
+
+  it("reports loggedIn: true when login status succeeds", async () => {
+    const r = await probeCodex(FAKE_CODEX, ["--version"]);
+    expect(r).toMatchObject({ available: true, version: "codex-cli 1.2.3", loggedIn: true, reason: null });
+  });
+
+  it("coerces an empty --version output to a null version, not an empty string", async () => {
+    const prev = process.env.FAKE_CODEX_EMPTY_VERSION;
+    process.env.FAKE_CODEX_EMPTY_VERSION = "1";
+    try {
+      const r = await probeCodex(FAKE_CODEX, ["--version"]);
+      expect(r.available).toBe(true);
+      expect(r.version).toBeNull();
+    } finally {
+      if (prev === undefined) delete process.env.FAKE_CODEX_EMPTY_VERSION;
+      else process.env.FAKE_CODEX_EMPTY_VERSION = prev;
+    }
+  });
+
+  it("reports loggedIn: false only when login status says it's actually logged out", async () => {
+    const prev = process.env.FAKE_CODEX_LOGIN;
+    process.env.FAKE_CODEX_LOGIN = "logged-out";
+    try {
+      const r = await probeCodex(FAKE_CODEX, ["--version"]);
+      expect(r.available).toBe(true);
+      expect(r.loggedIn).toBe(false);
+      expect(r.reason).toBe("not logged in — run `codex login`");
+    } finally {
+      if (prev === undefined) delete process.env.FAKE_CODEX_LOGIN;
+      else process.env.FAKE_CODEX_LOGIN = prev;
+    }
+  });
+
+  it("does not report loggedIn: false when login status fails for an unrelated reason", async () => {
+    // Mirrors a real, reproduced case: a malformed config.toml makes `codex login status` fail with a
+    // config-loading error (not "Not logged in") while `--version` still succeeds. Telling an already-logged-in
+    // user to re-run `codex login` here would be wrong advice, so this must land on loggedIn: null, not false.
+    const prev = process.env.FAKE_CODEX_LOGIN;
+    process.env.FAKE_CODEX_LOGIN = "other-error";
+    try {
+      const r = await probeCodex(FAKE_CODEX, ["--version"]);
+      expect(r.available).toBe(true);
+      expect(r.loggedIn).toBeNull();
+      expect(r.reason).not.toBe("not logged in — run `codex login`");
+      expect(r.reason).toMatch(/could not determine login status/);
+    } finally {
+      if (prev === undefined) delete process.env.FAKE_CODEX_LOGIN;
+      else process.env.FAKE_CODEX_LOGIN = prev;
+    }
+  });
+});

--- a/packages/adapters/src/codex/probe.ts
+++ b/packages/adapters/src/codex/probe.ts
@@ -1,0 +1,50 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const run = promisify(execFile);
+
+/** True when the failure text looks like codex's own "you're not logged in" message, not some other error. */
+function looksLoggedOut(output: string): boolean {
+  return /not logged in/i.test(output);
+}
+
+/**
+ * Checks the local `codex` CLI is runnable and whether a login exists.
+ *
+ * `loggedIn: true` means "credentials are on disk", NOT "credentials work": both `codex login status` and the
+ * protocol's `getAuthStatus` were verified to report a healthy ChatGPT login on a machine whose refresh token had
+ * been revoked server-side. That failure only surfaces at `thread/start`, as `error.data.action === "relogin"`,
+ * which CodexAdapter turns into an `error` event telling the user to re-run `codex login`.
+ *
+ * A failing `codex login status` is only reported as `loggedIn: false` when its output actually says so (verified
+ * against the real CLI: a logged-out `codex login status` exits 1 with "Not logged in" on stderr). Any other
+ * failure — observed in practice from a malformed `config.toml`, which fails `login status` with a config-loading
+ * error while `--version` still succeeds — is reported as `loggedIn: null` rather than guessed, so the UI doesn't
+ * tell an already-logged-in user to re-run `codex login` for an unrelated problem.
+ *
+ * `versionArgs` exists so tests can point at a stub binary.
+ */
+export async function probeCodex(
+  bin = process.env.REALM_CODEX_BIN ?? "codex",
+  versionArgs: string[] = ["--version"],
+): Promise<{ available: boolean; version: string | null; loggedIn: boolean | null; reason: string | null }> {
+  let version: string;
+  try {
+    const { stdout } = await run(bin, versionArgs, { timeout: 5000 });
+    version = stdout.trim();
+  } catch (e) {
+    return { available: false, version: null, loggedIn: null, reason: (e as Error).message };
+  }
+  try {
+    await run(bin, ["login", "status"], { timeout: 5000 });
+    return { available: true, version: version || null, loggedIn: true, reason: null };
+  } catch (e) {
+    const err = e as NodeJS.ErrnoException & { stderr?: string; stdout?: string };
+    const output = `${err.stdout ?? ""}${err.stderr ?? ""}`;
+    if (looksLoggedOut(output)) {
+      return { available: true, version: version || null, loggedIn: false, reason: "not logged in — run `codex login`" };
+    }
+    const detail = output.trim().split("\n")[0] || err.message;
+    return { available: true, version: version || null, loggedIn: null, reason: `could not determine login status: ${detail}` };
+  }
+}

--- a/packages/adapters/src/index.ts
+++ b/packages/adapters/src/index.ts
@@ -4,3 +4,8 @@ export { FakeAdapter, type FakeScript, type FakeStep } from "./fake/fake-adapter
 export { createSdkMapper } from "./claude/map-sdk-message";
 export { ClaudeAdapter } from "./claude/claude-adapter";
 export { probeClaude } from "./claude/probe";
+export { StdioJsonRpc, JsonRpcCallError, type JsonRpcId } from "./jsonrpc/stdio";
+export { CodexConnection, type ThreadListener } from "./codex/connection";
+export { createCodexMapper } from "./codex/map-codex";
+export { CodexAdapter, pickCodexDecision, codexPolicyFor } from "./codex/codex-adapter";
+export { probeCodex } from "./codex/probe";

--- a/packages/adapters/src/index.ts
+++ b/packages/adapters/src/index.ts
@@ -9,3 +9,4 @@ export { CodexConnection, type ThreadListener } from "./codex/connection";
 export { createCodexMapper } from "./codex/map-codex";
 export { CodexAdapter, pickCodexDecision, codexPolicyFor } from "./codex/codex-adapter";
 export { probeCodex } from "./codex/probe";
+export { AcpAdapter, pickAcpOption, type AcpAgentSpec } from "./acp/acp-adapter";

--- a/packages/adapters/src/jsonrpc/stdio.test.ts
+++ b/packages/adapters/src/jsonrpc/stdio.test.ts
@@ -1,6 +1,13 @@
 import { describe, it, expect, vi } from "vitest";
 import { StdioJsonRpc, JsonRpcCallError } from "./stdio";
 
+/**
+ * Every assertion in this file is gated on a real child process: node cold start, module load and at least one
+ * round trip. vitest's 1000 ms default is routinely too tight for that on a loaded two-core CI runner, and a
+ * longer bound costs nothing when the assertion passes.
+ */
+const waitFor = <T>(fn: () => T | Promise<T>) => vi.waitFor(fn, { timeout: 10_000, interval: 25 });
+
 /** A child that echoes back one canned reply per inbound line. Written as a node -e script so the test exercises real ndjson framing. */
 const echoScript = `
 let buf = "";
@@ -72,7 +79,7 @@ describe("StdioJsonRpc", () => {
     // pending, then delays the real response ~150ms. This is a genuine race, not a coincidence of
     // disjoint id spaces: id-first dispatch would find the pending entry and settle the promise wrong.
     const inFlight = rpc.request("slowPing", { n: 1 });
-    await vi.waitFor(() => expect(serverRequests).toHaveLength(1));
+    await waitFor(() => expect(serverRequests).toHaveLength(1));
     expect(serverRequests[0]).toMatchObject({ method: "askYou" });
     const liveId = serverRequests[0]!.id;
     // The colliding server request must not have touched the pending client request: it should still
@@ -85,14 +92,14 @@ describe("StdioJsonRpc", () => {
   it("delivers notifications (which have no id)", async () => {
     const { rpc, notifications } = make();
     rpc.notify("notifyMe");
-    await vi.waitFor(() => expect(notifications).toContainEqual({ method: "tick", params: { at: 1 } }));
+    await waitFor(() => expect(notifications).toContainEqual({ method: "tick", params: { at: 1 } }));
     await rpc.dispose();
   });
 
   it("keeps a bounded stderr tail and forwards lines", async () => {
     const { rpc, stderr } = make();
     rpc.notify("loud");
-    await vi.waitFor(() => expect(stderr).toEqual(["noise-1", "noise-2"]));
+    await waitFor(() => expect(stderr).toEqual(["noise-1", "noise-2"]));
     expect(rpc.stderrTail).toEqual(["noise-1", "noise-2"]);
     await rpc.dispose();
   });
@@ -100,7 +107,7 @@ describe("StdioJsonRpc", () => {
   it("caps the stderr tail at 50 lines, dropping the oldest", async () => {
     const { rpc, stderr } = make();
     rpc.notify("spam");
-    await vi.waitFor(() => expect(stderr).toHaveLength(60));
+    await waitFor(() => expect(stderr).toHaveLength(60));
     expect(rpc.stderrTail).toHaveLength(50);
     expect(rpc.stderrTail[0]).toBe("line-11");
     expect(rpc.stderrTail[49]).toBe("line-60");
@@ -125,7 +132,7 @@ describe("StdioJsonRpc", () => {
   it("rejects in-flight requests and reports exit when the child dies", async () => {
     const { rpc, onExit } = make({ args: ["-e", "process.exit(3)"] });
     await expect(rpc.request("ping")).rejects.toThrow(/exited/);
-    await vi.waitFor(() => expect(onExit).toHaveBeenCalled());
+    await waitFor(() => expect(onExit).toHaveBeenCalled());
     expect(onExit).toHaveBeenCalledWith(expect.objectContaining({ disposed: false }));
     await rpc.dispose();
   });
@@ -133,7 +140,7 @@ describe("StdioJsonRpc", () => {
   it("reports a spawn failure as an exit rather than throwing", async () => {
     const { rpc, onExit } = make({ command: "/definitely/not/a/binary", args: [] });
     await expect(rpc.request("ping")).rejects.toThrow();
-    await vi.waitFor(() => expect(onExit).toHaveBeenCalled());
+    await waitFor(() => expect(onExit).toHaveBeenCalled());
     expect(onExit).toHaveBeenCalledWith(expect.objectContaining({ disposed: false }));
     await rpc.dispose();
   });

--- a/packages/adapters/src/jsonrpc/stdio.test.ts
+++ b/packages/adapters/src/jsonrpc/stdio.test.ts
@@ -23,6 +23,16 @@ process.stdin.on("data", (c) => {
     }
     if (msg.method === "notifyMe") process.stdout.write(JSON.stringify({ method: "tick", params: { at: 1 }, emittedAtMs: 7 }) + "\\n");
     if (msg.method === "loud") process.stderr.write("noise-1\\nnoise-2\\n");
+    if (msg.method === "spam") {
+      // 60 lines, one write each, to exercise the 50-line stderrTail cap's shift() branch.
+      for (let n = 1; n <= 60; n++) process.stderr.write("line-" + n + "\\n");
+    }
+    if (msg.method === "big") {
+      // A single large write is split across multiple stdout 'data' chunks by the OS pipe buffer
+      // (well under 500KB on any platform), exercising the outBuf reassembly loop for real.
+      const s = "x".repeat(500000);
+      process.stdout.write(JSON.stringify({ id: msg.id, result: { s: s } }) + "\\n");
+    }
   }
 });
 `;
@@ -52,11 +62,7 @@ describe("StdioJsonRpc", () => {
 
   it("rejects with a JsonRpcCallError carrying code and data", async () => {
     const { rpc } = make();
-    await expect(rpc.request("boom")).rejects.toBeInstanceOf(JsonRpcCallError);
-    await rpc.request("boom").catch((e: JsonRpcCallError) => {
-      expect(e.code).toBe(-32600);
-      expect(e.data).toEqual({ action: "relogin" });
-    });
+    await expect(rpc.request("boom")).rejects.toMatchObject({ code: -32600, data: { action: "relogin" } });
     await rpc.dispose();
   });
 
@@ -91,10 +97,36 @@ describe("StdioJsonRpc", () => {
     await rpc.dispose();
   });
 
+  it("caps the stderr tail at 50 lines, dropping the oldest", async () => {
+    const { rpc, stderr } = make();
+    rpc.notify("spam");
+    await vi.waitFor(() => expect(stderr).toHaveLength(60));
+    expect(rpc.stderrTail).toHaveLength(50);
+    expect(rpc.stderrTail[0]).toBe("line-11");
+    expect(rpc.stderrTail[49]).toBe("line-60");
+    await rpc.dispose();
+  });
+
+  it("reassembles a JSON-RPC frame split across multiple stdout chunks", async () => {
+    const { rpc } = make();
+    const result = await rpc.request<{ s: string }>("big");
+    expect(result.s).toHaveLength(500_000);
+    expect(result.s).toBe("x".repeat(500_000));
+    await rpc.dispose();
+  });
+
+  it("dispose() reports onExit exactly once with disposed: true", async () => {
+    const { rpc, onExit } = make();
+    await rpc.dispose();
+    expect(onExit).toHaveBeenCalledTimes(1);
+    expect(onExit).toHaveBeenCalledWith(expect.objectContaining({ disposed: true, reason: "disposed" }));
+  });
+
   it("rejects in-flight requests and reports exit when the child dies", async () => {
     const { rpc, onExit } = make({ args: ["-e", "process.exit(3)"] });
     await expect(rpc.request("ping")).rejects.toThrow(/exited/);
     await vi.waitFor(() => expect(onExit).toHaveBeenCalled());
+    expect(onExit).toHaveBeenCalledWith(expect.objectContaining({ disposed: false }));
     await rpc.dispose();
   });
 
@@ -102,6 +134,7 @@ describe("StdioJsonRpc", () => {
     const { rpc, onExit } = make({ command: "/definitely/not/a/binary", args: [] });
     await expect(rpc.request("ping")).rejects.toThrow();
     await vi.waitFor(() => expect(onExit).toHaveBeenCalled());
+    expect(onExit).toHaveBeenCalledWith(expect.objectContaining({ disposed: false }));
     await rpc.dispose();
   });
 });

--- a/packages/adapters/src/jsonrpc/stdio.test.ts
+++ b/packages/adapters/src/jsonrpc/stdio.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi } from "vitest";
+import { StdioJsonRpc, JsonRpcCallError } from "./stdio";
+
+/** A child that echoes back one canned reply per inbound line. Written as a node -e script so the test exercises real ndjson framing. */
+const echoScript = `
+let buf = "";
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (c) => {
+  buf += c;
+  let i;
+  while ((i = buf.indexOf("\\n")) >= 0) {
+    const line = buf.slice(0, i); buf = buf.slice(i + 1);
+    if (!line.trim()) continue;
+    const msg = JSON.parse(line);
+    if (msg.method === "ping") process.stdout.write(JSON.stringify({ id: msg.id, result: { pong: msg.params?.n ?? 0 } }) + "\\n");
+    if (msg.method === "boom") process.stdout.write(JSON.stringify({ id: msg.id, error: { code: -32600, message: "nope", data: { action: "relogin" } } }) + "\\n");
+    if (msg.method === "provoke") {
+      // server -> client request using id 0, which collides with our own client id space
+      process.stdout.write(JSON.stringify({ method: "askYou", id: 0, params: { q: "ok?" } }) + "\\n");
+    }
+    if (msg.method === "notifyMe") process.stdout.write(JSON.stringify({ method: "tick", params: { at: 1 }, emittedAtMs: 7 }) + "\\n");
+    if (msg.id === 0 && msg.result) process.stdout.write(JSON.stringify({ method: "answered", params: msg.result }) + "\\n");
+    if (msg.method === "loud") process.stderr.write("noise-1\\nnoise-2\\n");
+  }
+});
+`;
+
+const make = (over: Partial<ConstructorParameters<typeof StdioJsonRpc>[0]> = {}) => {
+  const notifications: { method: string; params: unknown }[] = [];
+  const serverRequests: { id: number | string; method: string; params: unknown }[] = [];
+  const stderr: string[] = [];
+  const onExit = vi.fn();
+  const rpc = new StdioJsonRpc({
+    command: process.execPath, args: ["-e", echoScript], cwd: process.cwd(),
+    onNotification: (n) => notifications.push(n),
+    onServerRequest: (r) => serverRequests.push(r),
+    onStderr: (l) => stderr.push(l),
+    onExit,
+    ...over,
+  });
+  return { rpc, notifications, serverRequests, stderr, onExit };
+};
+
+describe("StdioJsonRpc", () => {
+  it("round-trips a request and resolves with the result", async () => {
+    const { rpc } = make();
+    await expect(rpc.request("ping", { n: 5 })).resolves.toEqual({ pong: 5 });
+    await rpc.dispose();
+  });
+
+  it("rejects with a JsonRpcCallError carrying code and data", async () => {
+    const { rpc } = make();
+    await expect(rpc.request("boom")).rejects.toBeInstanceOf(JsonRpcCallError);
+    await rpc.request("boom").catch((e: JsonRpcCallError) => {
+      expect(e.code).toBe(-32600);
+      expect(e.data).toEqual({ action: "relogin" });
+    });
+    await rpc.dispose();
+  });
+
+  it("dispatches a server request whose id collides with a live client id", async () => {
+    const { rpc, serverRequests, notifications } = make();
+    // Burn client id 1..N so ids overlap, and keep a request in flight.
+    const inFlight = rpc.request("ping", { n: 1 });
+    rpc.notify("provoke");
+    await vi.waitFor(() => expect(serverRequests).toHaveLength(1));
+    expect(serverRequests[0]).toMatchObject({ id: 0, method: "askYou" });
+    // The in-flight client request must NOT have been resolved by the server request.
+    await expect(inFlight).resolves.toEqual({ pong: 1 });
+    rpc.respond(0, { ok: true });
+    await vi.waitFor(() => expect(notifications.map((n) => n.method)).toContain("answered"));
+    await rpc.dispose();
+  });
+
+  it("delivers notifications (which have no id)", async () => {
+    const { rpc, notifications } = make();
+    rpc.notify("notifyMe");
+    await vi.waitFor(() => expect(notifications).toContainEqual({ method: "tick", params: { at: 1 } }));
+    await rpc.dispose();
+  });
+
+  it("keeps a bounded stderr tail and forwards lines", async () => {
+    const { rpc, stderr } = make();
+    rpc.notify("loud");
+    await vi.waitFor(() => expect(stderr).toEqual(["noise-1", "noise-2"]));
+    expect(rpc.stderrTail).toEqual(["noise-1", "noise-2"]);
+    await rpc.dispose();
+  });
+
+  it("rejects in-flight requests and reports exit when the child dies", async () => {
+    const { rpc, onExit } = make({ args: ["-e", "process.exit(3)"] });
+    await expect(rpc.request("ping")).rejects.toThrow(/exited/);
+    await vi.waitFor(() => expect(onExit).toHaveBeenCalled());
+    await rpc.dispose();
+  });
+
+  it("reports a spawn failure as an exit rather than throwing", async () => {
+    const { rpc, onExit } = make({ command: "/definitely/not/a/binary", args: [] });
+    await expect(rpc.request("ping")).rejects.toThrow();
+    await vi.waitFor(() => expect(onExit).toHaveBeenCalled());
+    await rpc.dispose();
+  });
+});

--- a/packages/adapters/src/jsonrpc/stdio.test.ts
+++ b/packages/adapters/src/jsonrpc/stdio.test.ts
@@ -14,12 +14,14 @@ process.stdin.on("data", (c) => {
     const msg = JSON.parse(line);
     if (msg.method === "ping") process.stdout.write(JSON.stringify({ id: msg.id, result: { pong: msg.params?.n ?? 0 } }) + "\\n");
     if (msg.method === "boom") process.stdout.write(JSON.stringify({ id: msg.id, error: { code: -32600, message: "nope", data: { action: "relogin" } } }) + "\\n");
-    if (msg.method === "provoke") {
-      // server -> client request using id 0, which collides with our own client id space
-      process.stdout.write(JSON.stringify({ method: "askYou", id: 0, params: { q: "ok?" } }) + "\\n");
+    if (msg.method === "slowPing") {
+      // Fire a server -> client request that REUSES this same request's id while it is still pending,
+      // then deliver the real response ~150ms later. A dispatcher that resolves by id-lookup instead of
+      // frame shape would settle the client's promise from the collision, not the real response.
+      process.stdout.write(JSON.stringify({ method: "askYou", id: msg.id, params: { q: "ok?" } }) + "\\n");
+      setTimeout(() => process.stdout.write(JSON.stringify({ id: msg.id, result: { pong: msg.params?.n ?? 0 } }) + "\\n"), 150);
     }
     if (msg.method === "notifyMe") process.stdout.write(JSON.stringify({ method: "tick", params: { at: 1 }, emittedAtMs: 7 }) + "\\n");
-    if (msg.id === 0 && msg.result) process.stdout.write(JSON.stringify({ method: "answered", params: msg.result }) + "\\n");
     if (msg.method === "loud") process.stderr.write("noise-1\\nnoise-2\\n");
   }
 });
@@ -59,16 +61,18 @@ describe("StdioJsonRpc", () => {
   });
 
   it("dispatches a server request whose id collides with a live client id", async () => {
-    const { rpc, serverRequests, notifications } = make();
-    // Burn client id 1..N so ids overlap, and keep a request in flight.
-    const inFlight = rpc.request("ping", { n: 1 });
-    rpc.notify("provoke");
+    const { rpc, serverRequests } = make();
+    // The child immediately fires a server request reusing this SAME id while the request is still
+    // pending, then delays the real response ~150ms. This is a genuine race, not a coincidence of
+    // disjoint id spaces: id-first dispatch would find the pending entry and settle the promise wrong.
+    const inFlight = rpc.request("slowPing", { n: 1 });
     await vi.waitFor(() => expect(serverRequests).toHaveLength(1));
-    expect(serverRequests[0]).toMatchObject({ id: 0, method: "askYou" });
-    // The in-flight client request must NOT have been resolved by the server request.
+    expect(serverRequests[0]).toMatchObject({ method: "askYou" });
+    const liveId = serverRequests[0]!.id;
+    // The colliding server request must not have touched the pending client request: it should still
+    // resolve, ~150ms later, from the real deferred response and not from the collision.
     await expect(inFlight).resolves.toEqual({ pong: 1 });
-    rpc.respond(0, { ok: true });
-    await vi.waitFor(() => expect(notifications.map((n) => n.method)).toContain("answered"));
+    rpc.respond(liveId, { ok: true });
     await rpc.dispose();
   });
 

--- a/packages/adapters/src/jsonrpc/stdio.ts
+++ b/packages/adapters/src/jsonrpc/stdio.ts
@@ -13,6 +13,7 @@ export class JsonRpcCallError extends Error {
 }
 
 const STDERR_TAIL_LINES = 50;
+const DISPOSE_KILL_TIMEOUT_MS = 2000;
 
 export type StdioJsonRpcOptions = {
   command: string;
@@ -23,7 +24,9 @@ export type StdioJsonRpcOptions = {
   /** MUST be answered with respond()/respondError() — an unanswered server request stalls the agent's turn forever. */
   onServerRequest: (r: JsonRpcServerRequest) => void;
   onStderr?: (line: string) => void;
-  onExit: (info: { code: number | null; signal: NodeJS.Signals | null; reason: string }) => void;
+  /** `disposed` is the reliable signal for "we caused this shutdown" vs "the child actually died" —
+   *  branch on it, not on parsing `reason`, which is a free-form string for logs only. */
+  onExit: (info: { code: number | null; signal: NodeJS.Signals | null; reason: string; disposed: boolean }) => void;
 };
 
 /**
@@ -42,7 +45,8 @@ export class StdioJsonRpc {
   private outBuf = "";
   private errBuf = "";
   private dead: Error | null = null;
-  readonly stderrTail: string[] = [];
+  private childExited = false;
+  private _stderrTail: string[] = [];
 
   constructor(private o: StdioJsonRpcOptions, deps: { spawn?: typeof nodeSpawn } = {}) {
     const spawnFn = deps.spawn ?? nodeSpawn;
@@ -51,11 +55,24 @@ export class StdioJsonRpc {
     this.child.stderr?.setEncoding("utf8");
     this.child.stdout?.on("data", (c: string) => this.onStdout(c));
     this.child.stderr?.on("data", (c: string) => this.onStderrChunk(c));
-    this.child.on("error", (e: Error) => this.die(`failed to start ${o.command}: ${e.message}`, null, null));
-    this.child.on("exit", (code, signal) => this.die(`${o.command} exited (code ${code ?? "null"}, signal ${signal ?? "null"})`, code, signal));
+    // Stream 'error' (EPIPE, ERR_STREAM_WRITE_AFTER_END, ...) is otherwise unhandled and crashes the whole
+    // process with an uncaughtException. It isn't fatal to the RPC session by itself — 'exit' is what ends
+    // that — so just surface it as a diagnostic.
+    this.child.stdin?.on("error", (e: Error) => this.o.onStderr?.(`stdin error: ${e.message}`));
+    this.child.stdout?.on("error", (e: Error) => this.o.onStderr?.(`stdout error: ${e.message}`));
+    this.child.stderr?.on("error", (e: Error) => this.o.onStderr?.(`stderr error: ${e.message}`));
+    this.child.on("error", (e: Error) => {
+      this.childExited = true; // never actually started; nothing left to reap
+      this.die(`failed to start ${o.command}: ${e.message}`, null, null, false);
+    });
+    this.child.on("exit", (code, signal) => {
+      this.childExited = true;
+      this.die(`${o.command} exited (code ${code ?? "null"}, signal ${signal ?? "null"})`, code, signal, false);
+    });
   }
 
   get alive(): boolean { return this.dead === null; }
+  get stderrTail(): readonly string[] { return [...this._stderrTail]; }
 
   request<T = unknown>(method: string, params?: unknown): Promise<T> {
     if (this.dead) return Promise.reject(this.dead);
@@ -81,15 +98,32 @@ export class StdioJsonRpc {
     this.write({ jsonrpc: "2.0", id, error: { code, message } });
   }
 
+  /**
+   * Sends EOF — most CLI agents exit cleanly on stdin close — then waits briefly for the real process to
+   * go away, escalating to SIGKILL if it hasn't. The child is not spawned detached, so a hard crash of
+   * this process still orphans it; this only covers the graceful path.
+   */
   async dispose(): Promise<void> {
-    if (!this.dead) this.die("disposed", null, null);
+    if (!this.dead) this.die("disposed", null, null, true);
     this.child.stdin?.end();
-    if (this.child.exitCode === null && this.child.signalCode === null) this.child.kill("SIGTERM");
+    await this.reap();
+  }
+
+  private reap(): Promise<void> {
+    if (this.childExited) return Promise.resolve();
+    return new Promise<void>((resolve) => {
+      const finish = () => { clearTimeout(killTimer); resolve(); };
+      this.child.once("exit", finish);
+      this.child.once("error", finish); // spawn never actually started; nothing more to wait for
+      const killTimer = setTimeout(() => this.child.kill("SIGKILL"), DISPOSE_KILL_TIMEOUT_MS);
+    });
   }
 
   private write(msg: unknown): void {
+    // Guards synchronous throws only (e.g. writing after the stream is already destroyed); async write
+    // failures surface via the stdin 'error' listener registered in the constructor instead.
     try { this.child.stdin?.write(JSON.stringify(msg) + "\n"); }
-    catch { /* the exit handler already rejected everything in flight */ }
+    catch { /* swallow: the 'error'/'exit' handlers already reject everything in flight */ }
   }
 
   private onStdout(chunk: string): void {
@@ -113,7 +147,7 @@ export class StdioJsonRpc {
     if (hasId && typeof msg.method === "string") { this.o.onServerRequest({ id, method: msg.method, params: msg.params }); return; }
     if (hasId && ("result" in msg || "error" in msg)) {
       const p = this.pending.get(id);
-      if (!p) return; // a response we never asked for; ignore rather than guess
+      if (!p) { this.o.onStderr?.(`response for unknown request id ${String(id)}: ${line.slice(0, 200)}`); return; }
       this.pending.delete(id);
       if ("error" in msg) {
         const e = (msg.error ?? {}) as { code?: number; message?: string; data?: unknown };
@@ -133,16 +167,16 @@ export class StdioJsonRpc {
       this.errBuf = this.errBuf.slice(i + 1);
       if (!line.trim()) continue;
       this.o.onStderr?.(line);
-      this.stderrTail.push(line);
-      if (this.stderrTail.length > STDERR_TAIL_LINES) this.stderrTail.shift();
+      this._stderrTail.push(line);
+      if (this._stderrTail.length > STDERR_TAIL_LINES) this._stderrTail.shift();
     }
   }
 
-  private die(reason: string, code: number | null, signal: NodeJS.Signals | null): void {
+  private die(reason: string, code: number | null, signal: NodeJS.Signals | null, disposed: boolean): void {
     if (this.dead) return;
     this.dead = new Error(reason);
     for (const [, p] of this.pending) p.reject(this.dead);
     this.pending.clear();
-    this.o.onExit({ code, signal, reason });
+    this.o.onExit({ code, signal, reason, disposed });
   }
 }

--- a/packages/adapters/src/jsonrpc/stdio.ts
+++ b/packages/adapters/src/jsonrpc/stdio.ts
@@ -12,6 +12,20 @@ export class JsonRpcCallError extends Error {
   }
 }
 
+/**
+ * Rejects with `message` if `p` has not settled within `ms`.
+ *
+ * The underlying request is NOT cancelled — JSON-RPC has no cancel — it is simply abandoned; the peer's late
+ * answer lands on an already-settled promise. Every unbounded call into a child process goes through this:
+ * a child that spawns and then answers nothing must never leave a promise pending forever.
+ */
+export function withTimeout<T>(p: Promise<T>, ms: number, message: string): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(message)), ms);
+    p.then(resolve, reject).finally(() => clearTimeout(timer));
+  });
+}
+
 const STDERR_TAIL_LINES = 50;
 const DISPOSE_KILL_TIMEOUT_MS = 2000;
 

--- a/packages/adapters/src/jsonrpc/stdio.ts
+++ b/packages/adapters/src/jsonrpc/stdio.ts
@@ -1,0 +1,148 @@
+import { spawn as nodeSpawn, type ChildProcess } from "node:child_process";
+
+export type JsonRpcId = number | string;
+export type JsonRpcNotification = { method: string; params: unknown };
+export type JsonRpcServerRequest = { id: JsonRpcId; method: string; params: unknown };
+
+/** A JSON-RPC `error` response. `data` is preserved verbatim — Codex hides `{action:"relogin"}` there. */
+export class JsonRpcCallError extends Error {
+  constructor(readonly code: number, message: string, readonly data: unknown) {
+    super(message);
+    this.name = "JsonRpcCallError";
+  }
+}
+
+const STDERR_TAIL_LINES = 50;
+
+export type StdioJsonRpcOptions = {
+  command: string;
+  args: string[];
+  cwd: string;
+  env?: Record<string, string>;
+  onNotification: (n: JsonRpcNotification) => void;
+  /** MUST be answered with respond()/respondError() — an unanswered server request stalls the agent's turn forever. */
+  onServerRequest: (r: JsonRpcServerRequest) => void;
+  onStderr?: (line: string) => void;
+  onExit: (info: { code: number | null; signal: NodeJS.Signals | null; reason: string }) => void;
+};
+
+/**
+ * Newline-delimited JSON-RPC 2.0 over a child process's stdio, shared by the Codex and ACP adapters.
+ *
+ * Inbound frames are dispatched by SHAPE, never by id lookup: the peer numbers its own requests from 0 in an
+ * INDEPENDENT id space that overlaps ours (verified on both protocols). `{id, method}` is a server request;
+ * `{id, result|error}` is a response to us; `{method}` without an id is a notification.
+ *
+ * Codex responses additionally omit the `jsonrpc` field, so nothing here validates it.
+ */
+export class StdioJsonRpc {
+  private child: ChildProcess;
+  private pending = new Map<JsonRpcId, { resolve: (v: unknown) => void; reject: (e: Error) => void }>();
+  private nextId = 1;
+  private outBuf = "";
+  private errBuf = "";
+  private dead: Error | null = null;
+  readonly stderrTail: string[] = [];
+
+  constructor(private o: StdioJsonRpcOptions, deps: { spawn?: typeof nodeSpawn } = {}) {
+    const spawnFn = deps.spawn ?? nodeSpawn;
+    this.child = spawnFn(o.command, o.args, { cwd: o.cwd, stdio: ["pipe", "pipe", "pipe"], env: { ...process.env, ...o.env } });
+    this.child.stdout?.setEncoding("utf8");
+    this.child.stderr?.setEncoding("utf8");
+    this.child.stdout?.on("data", (c: string) => this.onStdout(c));
+    this.child.stderr?.on("data", (c: string) => this.onStderrChunk(c));
+    this.child.on("error", (e: Error) => this.die(`failed to start ${o.command}: ${e.message}`, null, null));
+    this.child.on("exit", (code, signal) => this.die(`${o.command} exited (code ${code ?? "null"}, signal ${signal ?? "null"})`, code, signal));
+  }
+
+  get alive(): boolean { return this.dead === null; }
+
+  request<T = unknown>(method: string, params?: unknown): Promise<T> {
+    if (this.dead) return Promise.reject(this.dead);
+    const id = this.nextId++;
+    return new Promise<T>((resolve, reject) => {
+      this.pending.set(id, { resolve: resolve as (v: unknown) => void, reject });
+      this.write({ jsonrpc: "2.0", id, method, ...(params === undefined ? {} : { params }) });
+    });
+  }
+
+  notify(method: string, params?: unknown): void {
+    if (this.dead) return;
+    this.write({ jsonrpc: "2.0", method, ...(params === undefined ? {} : { params }) });
+  }
+
+  respond(id: JsonRpcId, result: unknown): void {
+    if (this.dead) return;
+    this.write({ jsonrpc: "2.0", id, result });
+  }
+
+  respondError(id: JsonRpcId, code: number, message: string): void {
+    if (this.dead) return;
+    this.write({ jsonrpc: "2.0", id, error: { code, message } });
+  }
+
+  async dispose(): Promise<void> {
+    if (!this.dead) this.die("disposed", null, null);
+    this.child.stdin?.end();
+    if (this.child.exitCode === null && this.child.signalCode === null) this.child.kill("SIGTERM");
+  }
+
+  private write(msg: unknown): void {
+    try { this.child.stdin?.write(JSON.stringify(msg) + "\n"); }
+    catch { /* the exit handler already rejected everything in flight */ }
+  }
+
+  private onStdout(chunk: string): void {
+    this.outBuf += chunk;
+    let i: number;
+    while ((i = this.outBuf.indexOf("\n")) >= 0) {
+      const line = this.outBuf.slice(0, i);
+      this.outBuf = this.outBuf.slice(i + 1);
+      if (line.trim()) this.dispatch(line);
+    }
+  }
+
+  private dispatch(line: string): void {
+    let msg: Record<string, unknown>;
+    try { msg = JSON.parse(line) as Record<string, unknown>; }
+    catch { this.o.onStderr?.(`unparseable frame: ${line.slice(0, 200)}`); return; }
+
+    const hasId = msg.id !== undefined && msg.id !== null;
+    const id = msg.id as JsonRpcId;
+
+    if (hasId && typeof msg.method === "string") { this.o.onServerRequest({ id, method: msg.method, params: msg.params }); return; }
+    if (hasId && ("result" in msg || "error" in msg)) {
+      const p = this.pending.get(id);
+      if (!p) return; // a response we never asked for; ignore rather than guess
+      this.pending.delete(id);
+      if ("error" in msg) {
+        const e = (msg.error ?? {}) as { code?: number; message?: string; data?: unknown };
+        p.reject(new JsonRpcCallError(e.code ?? -32603, e.message ?? "request failed", e.data));
+      } else p.resolve(msg.result);
+      return;
+    }
+    if (typeof msg.method === "string") { this.o.onNotification({ method: msg.method, params: msg.params }); return; }
+    this.o.onStderr?.(`unroutable frame: ${line.slice(0, 200)}`);
+  }
+
+  private onStderrChunk(chunk: string): void {
+    this.errBuf += chunk;
+    let i: number;
+    while ((i = this.errBuf.indexOf("\n")) >= 0) {
+      const line = this.errBuf.slice(0, i);
+      this.errBuf = this.errBuf.slice(i + 1);
+      if (!line.trim()) continue;
+      this.o.onStderr?.(line);
+      this.stderrTail.push(line);
+      if (this.stderrTail.length > STDERR_TAIL_LINES) this.stderrTail.shift();
+    }
+  }
+
+  private die(reason: string, code: number | null, signal: NodeJS.Signals | null): void {
+    if (this.dead) return;
+    this.dead = new Error(reason);
+    for (const [, p] of this.pending) p.reject(this.dead);
+    this.pending.clear();
+    this.o.onExit({ code, signal, reason });
+  }
+}

--- a/packages/adapters/vitest.config.ts
+++ b/packages/adapters/vitest.config.ts
@@ -1,2 +1,11 @@
 import { defineConfig } from "vitest/config";
-export default defineConfig({ test: { name: "adapters", environment: "node" } });
+export default defineConfig({
+  test: {
+    name: "adapters",
+    environment: "node",
+    // Every assertion here is gated on a real child process, and the local `waitFor` helpers in these files
+    // poll for up to 10s. vitest's 5s default would cut those short, so a genuine hang would be reported as a
+    // bare test timeout instead of the assertion that never came true.
+    testTimeout: 20_000,
+  },
+});

--- a/packages/contracts/src/presets.test.ts
+++ b/packages/contracts/src/presets.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { SPACE_COLORS, SPACE_ICONS, pickSpaceColor, AGENT_META, AGENT_LOGIN_HINTS } from "./presets";
+import { SPACE_COLORS, SPACE_ICONS, pickSpaceColor, AGENT_META, AGENT_LOGIN_HINTS, AGENT_SUPPORTS_PERMISSION_MODES } from "./presets";
 describe("presets", () => {
   it("has at least 8 colors and icons", () => { expect(SPACE_COLORS.length).toBeGreaterThanOrEqual(8); expect(SPACE_ICONS.length).toBeGreaterThanOrEqual(8); });
   it("pickSpaceColor cycles by index", () => { expect(pickSpaceColor(0)).toBe(SPACE_COLORS[0]); expect(pickSpaceColor(SPACE_COLORS.length)).toBe(SPACE_COLORS[0]); });
@@ -15,5 +15,21 @@ describe("AGENT_LOGIN_HINTS", () => {
     expect(AGENT_LOGIN_HINTS.claude).toContain("claude auth login");
     expect(AGENT_LOGIN_HINTS.codex).toContain("codex login");
     expect(AGENT_LOGIN_HINTS["acp:cursor"]).toContain("cursor-agent login");
+  });
+});
+
+describe("AGENT_SUPPORTS_PERMISSION_MODES", () => {
+  it("has an entry for every agent kind that has display metadata", () => {
+    for (const kind of Object.keys(AGENT_META)) {
+      expect(typeof AGENT_SUPPORTS_PERMISSION_MODES[kind as keyof typeof AGENT_SUPPORTS_PERMISSION_MODES]).toBe("boolean");
+    }
+    expect(Object.keys(AGENT_SUPPORTS_PERMISSION_MODES).sort()).toEqual(Object.keys(AGENT_META).sort());
+  });
+  it("marks the ACP kinds as unable to carry Realm's permission modes", () => {
+    // ACP mode ids are agent-defined, so Realm's own ids are never transmitted by AcpAdapter.start().
+    expect(AGENT_SUPPORTS_PERMISSION_MODES["acp:cursor"]).toBe(false);
+    expect(AGENT_SUPPORTS_PERMISSION_MODES["acp:gemini"]).toBe(false);
+    expect(AGENT_SUPPORTS_PERMISSION_MODES.claude).toBe(true);
+    expect(AGENT_SUPPORTS_PERMISSION_MODES.codex).toBe(true);
   });
 });

--- a/packages/contracts/src/presets.test.ts
+++ b/packages/contracts/src/presets.test.ts
@@ -1,6 +1,19 @@
 import { describe, expect, it } from "vitest";
-import { SPACE_COLORS, SPACE_ICONS, pickSpaceColor } from "./presets";
+import { SPACE_COLORS, SPACE_ICONS, pickSpaceColor, AGENT_META, AGENT_LOGIN_HINTS } from "./presets";
 describe("presets", () => {
   it("has at least 8 colors and icons", () => { expect(SPACE_COLORS.length).toBeGreaterThanOrEqual(8); expect(SPACE_ICONS.length).toBeGreaterThanOrEqual(8); });
   it("pickSpaceColor cycles by index", () => { expect(pickSpaceColor(0)).toBe(SPACE_COLORS[0]); expect(pickSpaceColor(SPACE_COLORS.length)).toBe(SPACE_COLORS[0]); });
+});
+
+describe("AGENT_LOGIN_HINTS", () => {
+  it("has a hint for every agent kind that has display metadata", () => {
+    for (const kind of Object.keys(AGENT_META)) {
+      expect(typeof AGENT_LOGIN_HINTS[kind as keyof typeof AGENT_LOGIN_HINTS]).toBe("string");
+    }
+  });
+  it("names the exact command for each CLI", () => {
+    expect(AGENT_LOGIN_HINTS.claude).toContain("claude auth login");
+    expect(AGENT_LOGIN_HINTS.codex).toContain("codex login");
+    expect(AGENT_LOGIN_HINTS["acp:cursor"]).toContain("cursor-agent login");
+  });
 });

--- a/packages/contracts/src/presets.ts
+++ b/packages/contracts/src/presets.ts
@@ -7,6 +7,20 @@ export const AGENT_MODELS = {
   codex: [], "acp:gemini": [], "acp:cursor": [], fake: [{ id: "fake", label: "Fake" }],
 } as const;
 export const EFFORT_LEVELS = ["low", "medium", "high", "xhigh", "max"] as const;
+/**
+ * Agent kinds whose permission model Realm can actually control.
+ *
+ * ACP mode ids are agent-defined (Cursor uses `agent`/`plan`/`ask`), so Realm's own Claude-derived ids are
+ * never transmitted: `AcpAdapter.start()` does not read `permissionMode` at all, and `session/set_mode` with a
+ * foreign id is rejected. Offering the picker there would be a lie about what the agent is allowed to do.
+ *
+ * Follow-up (not in this change): read the `modes.availableModes` that `session/new` returns and map Realm's
+ * modes onto them, then flip the ACP kinds to `true`.
+ */
+export const AGENT_SUPPORTS_PERMISSION_MODES = {
+  claude: true, codex: true, "acp:cursor": false, "acp:gemini": false, fake: true,
+} as const satisfies Record<import("./entities").AgentKind, boolean>;
+
 export const PERMISSION_MODES = [{ id: "default", label: "Ask" }, { id: "acceptEdits", label: "Accept edits" }, { id: "plan", label: "Plan" }, { id: "bypassPermissions", label: "Full access" }] as const;
 
 /** Display metadata per agent kind (icon names come from @realm/ui's icon set). */

--- a/packages/contracts/src/presets.ts
+++ b/packages/contracts/src/presets.ts
@@ -14,3 +14,12 @@ export const AGENT_META = {
   claude: { label: "Claude", icon: "sparkles" }, codex: { label: "Codex", icon: "bot" }, "acp:gemini": { label: "Gemini", icon: "bot" },
   "acp:cursor": { label: "Cursor", icon: "bot" }, fake: { label: "Fake agent", icon: "bot" },
 } as const satisfies Record<import("./entities").AgentKind, { label: string; icon: string }>;
+
+/** Shown under the agent picker so a signed-out agent tells the user exactly which command to run. */
+export const AGENT_LOGIN_HINTS = {
+  claude: "Uses your `claude` login — run `claude auth login` if sessions fail to authenticate.",
+  codex: "Uses your `codex` login — run `codex login` if sessions fail to authenticate.",
+  "acp:cursor": "Uses your Cursor login — run `cursor-agent login` if sessions fail to authenticate.",
+  "acp:gemini": "Google discontinued the free personal tier for the Gemini CLI; sessions need a Gemini API key or Vertex AI credentials.",
+  fake: "Scripted offline agent used for development.",
+} as const satisfies Record<import("./entities").AgentKind, string>;


### PR DESCRIPTION
## Summary

Adds Codex, Cursor and Gemini as first-class agents behind the existing `AgentAdapter` interface, so all four agents render in the same transcript with the same permission cards, interrupt and resume.

- **Shared transport** — `jsonrpc/stdio.ts`, ndjson JSON-RPC 2.0 over a child process. Both protocols are bidirectional with *independent id spaces* (the peer numbers its own requests from 0, overlapping ours), so frames are dispatched by shape, never by id lookup.
- **Codex** — one shared `codex app-server` process for all Codex sessions, fanned out by `threadId`, with approvals answered as real server→client requests.
- **ACP** — one generic adapter, one child per session, instantiated per kind for `acp:cursor` and `acp:gemini`.
- No changes to `SessionService`, the RPC contract, `session-events.ts`, or the transcript components. The adapter seam held.

Protocol references in `docs/dev/` were captured from live processes, not from type definitions — both shipped type packages were found to lag the wire.

## Verification

- 450 tests, typecheck clean across 5 projects, build succeeds.
- **Live end-to-end against the real CLIs** via `apps/server/scripts/live-agent-check.ts`: `codex` 0.146.0 and `cursor-agent` both complete a full turn through the real server stack and resume reusing the provider session id with no duplicated history.
- Every task went through independent mutation review. That repeatedly found correct code with tests that could not detect a plausible bug — e.g. 13/35 and 23/68 mutants surviving after near-perfect self-reported rates — and one review found a genuine bug in the plan itself (a routing branch that made the `-32601` reject path unreachable, which would have let an orphaned approval stall a turn forever).

## Notable

- Gemini is registered but cannot open a session: Google discontinued the free personal tier for the Gemini CLI. It fails with actionable copy pointing at an API key or Vertex AI.
- The Permissions picker is hidden for ACP kinds — `AcpAdapter` cannot honour Realm's own mode ids, and offering a control that silently does nothing was the one blocker the final review refused to ship.
- `cursor-agent acp` sits silent for a fixed ~60s after `session/prompt` before streaming. Reproducible with a bare JSON-RPC client; not something Realm can fix.

Follow-ups are recorded at the end of `docs/superpowers/plans/2026-08-22-plan-03-codex-acp-adapters.md`.

## Test plan

- [x] `pnpm test` — 450 passing
- [x] `pnpm typecheck` / `pnpm build`
- [x] `pnpm --filter @realm/server exec tsx scripts/live-agent-check.ts codex,acp:cursor`
- [ ] Manual pass in the running app (`pnpm dev`): create a Codex and a Cursor session, approve a command, interrupt mid-turn, restart and resume

🤖 Generated with [Claude Code](https://claude.com/claude-code)