### PR TITLE
Plan 8 (W1–W3) — SkillSync, MCP connections, memory manager

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -19,5 +19,10 @@
     "ws": "^8.18.0",
     "zod": "^3.24.0"
   },
-  "devDependencies": { "@types/ws": "^8.5.12", "tsup": "^8.3.0" }
+  "devDependencies": {
+    "@types/ws": "^8.5.12",
+    "tsup": "^8.3.0",
+    "tsx": "^4.19.0"
+  },
+  "//tsx": "dev-only: runs scripts/live-*-check.ts, which drive the real agent CLIs"
 }

--- a/apps/server/scripts/fixtures/marker-mcp-server.mjs
+++ b/apps/server/scripts/fixtures/marker-mcp-server.mjs
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+/**
+ * The smallest MCP stdio server that can prove it was started.
+ *
+ * `live-mcp-check.ts` hands this to a real agent CLI as a client-supplied server and then waits for the
+ * marker file. The marker is written on **startup**, before any handshake, because that is the claim
+ * under test — that the server Realm configured is the server the agent spawned — and it needs no model
+ * turn, no tokens and no cooperation from the agent's planner to establish.
+ *
+ *   argv[2]  absolute path of the marker file to write
+ *
+ * The marker records whether `REALM_MCP_PROBE_TOKEN` arrived with the expected value, which is what
+ * proves `env` survived each protocol's own shape (ACP's array-of-pairs above all). It records the
+ * VERDICT, never the token: a fixture that echoed a secret into a file the check prints would be the
+ * very leak the rest of this work is built to avoid.
+ *
+ * After the marker it speaks just enough MCP 2025-06-18 to be a well-behaved server — `initialize`,
+ * `notifications/initialized`, `tools/list`, `tools/call` — so the agent does not report a crash.
+ */
+import { writeFileSync } from "node:fs";
+
+const marker = process.argv[2];
+const expected = process.argv[3] ?? "";
+if (!marker) { process.stderr.write("marker-mcp-server: no marker path\n"); process.exit(2); }
+
+writeFileSync(marker, JSON.stringify({
+  startedAt: Date.now(),
+  args: process.argv.slice(4),
+  // A verdict, not the value.
+  token: process.env.REALM_MCP_PROBE_TOKEN === undefined ? "absent"
+    : process.env.REALM_MCP_PROBE_TOKEN === expected ? "match" : "mismatch",
+}) + "\n");
+
+const send = (msg) => process.stdout.write(JSON.stringify(msg) + "\n");
+const TOOL = { name: "realm_marker", description: "Realm live-check marker. Returns ok.", inputSchema: { type: "object", properties: {} } };
+
+let buf = "";
+process.stdin.on("data", (chunk) => {
+  buf += chunk.toString();
+  let i;
+  while ((i = buf.indexOf("\n")) >= 0) {
+    const line = buf.slice(0, i); buf = buf.slice(i + 1);
+    if (!line.trim()) continue;
+    let m; try { m = JSON.parse(line); } catch { continue; }
+    if (m.id === undefined) continue; // a notification: nothing to answer
+    if (m.method === "initialize") {
+      send({ jsonrpc: "2.0", id: m.id, result: { protocolVersion: "2025-06-18", capabilities: { tools: {} }, serverInfo: { name: "realm-marker", version: "0.0.1" } } });
+    } else if (m.method === "tools/list") {
+      send({ jsonrpc: "2.0", id: m.id, result: { tools: [TOOL] } });
+    } else if (m.method === "tools/call") {
+      send({ jsonrpc: "2.0", id: m.id, result: { content: [{ type: "text", text: "ok" }], isError: false } });
+    } else {
+      send({ jsonrpc: "2.0", id: m.id, result: {} });
+    }
+  }
+});
+process.stdin.on("end", () => process.exit(0));

--- a/apps/server/scripts/live-agent-check.ts
+++ b/apps/server/scripts/live-agent-check.ts
@@ -14,6 +14,7 @@
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { liveWorkspace } from "./live-workspace";
 import type { AgentKind, SessionEvent } from "@realm/contracts";
 import { createApp, defaultAdapters } from "../src/app";
 import { ProfilesStore } from "../src/store/profiles";
@@ -60,7 +61,10 @@ async function drain(read: () => SessionEvent[], from: number, timeoutMs: number
 
 async function main() {
   const home = mkdtempSync(join(tmpdir(), "realm-live-"));
-  const work = mkdtempSync(join(tmpdir(), "realm-work-"));
+  // A FIXED path, not a mkdtemp: codex records every cwd it starts a thread in as a trusted project in
+  // the user's ~/.codex/config.toml and offers no way to opt out, so a per-run temp directory leaves a
+  // dead entry behind on every run. See live-workspace.ts for the whole finding.
+  const work = liveWorkspace();
   writeFileSync(join(work, "NOTES.txt"), "realm live check\n");
 
   const app = await createApp({ home, port: 0, adapters: defaultAdapters() });
@@ -130,7 +134,7 @@ async function main() {
 
   await app.close();
   rmSync(home, { recursive: true, force: true });
-  rmSync(work, { recursive: true, force: true });
+  // `work` is deliberately left on disk: removing it is what turns codex's trust entry into a dead one.
   console.log(`\n${failures === 0 ? "ALL CHECKS PASSED" : `${failures} CHECK(S) FAILED`}`);
   process.exit(failures === 0 ? 0 : 1);
 }

--- a/apps/server/scripts/live-mcp-check.ts
+++ b/apps/server/scripts/live-mcp-check.ts
@@ -1,0 +1,147 @@
+/**
+ * Live check of Realm's MCP wiring against the REAL agent CLIs.
+ *
+ * W2 rests on a claim no unit test can hold up: that a server configured in Realm is a server the agent
+ * actually spawns. A unit test can only prove Realm emitted the JSON it meant to emit — and the three
+ * protocols disagree about that JSON in ways that fail silently (ACP rejects an `env` record before its
+ * own normalizer runs; Codex accepts `thread/start` `config` keys it does not recognise without a word).
+ *
+ * So this drives the whole stack — `createApp`, the real `McpService`, the real `SessionService`, the
+ * real adapters, the real CLIs — with a fixture MCP server that writes a marker file the moment it is
+ * started, and asserts:
+ *
+ *   1. the ENABLED server's marker appears (it reached the agent, and the agent ran it);
+ *   2. it carries `token: "match"` (the `env` map survived that protocol's own shape — the ACP quirk);
+ *   3. the DISABLED server's marker does NOT (per-space opt-in is real, not decorative);
+ *   4. a server enabled in ANOTHER space does not appear either (spaces do not leak into each other).
+ *
+ * It writes nothing outside its own scratch home and one fixed workspace directory, and in particular
+ * nothing under ~/.claude, ~/.codex, ~/.cursor or ~/.agents. No secret is ever printed: the fixture
+ * reports a verdict on the token, never the token.
+ *
+ *   pnpm --filter @realm/server exec tsx scripts/live-mcp-check.ts [kinds]
+ *   pnpm --filter @realm/server exec tsx scripts/live-mcp-check.ts claude,codex,acp:cursor
+ *
+ * Exits non-zero if any check fails. Requires the relevant CLIs to be installed and logged in; a CLI
+ * that is missing is reported as a skipped section, not a pass.
+ */
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { AGENT_MCP_TRANSPORTS, type AgentKind, type SessionEvent } from "@realm/contracts";
+import { createApp, defaultAdapters } from "../src/app";
+import { ProfilesStore } from "../src/store/profiles";
+import { SpacesStore } from "../src/store/spaces";
+import { McpService } from "../src/mcp/service";
+import { McpServersStore } from "../src/store/mcp";
+import { SettingsStore } from "../src/store/settings";
+import { liveWorkspace } from "./live-workspace";
+
+const KINDS = (process.argv[2] ?? "claude,codex,acp:cursor").split(",").filter(Boolean) as AgentKind[];
+/** Generous: `cursor-agent acp` takes tens of seconds to do anything at all. The marker lands at session
+ *  start, well before the turn, so this is a ceiling and not a typical wait. */
+const MARKER_TIMEOUT_MS = 120_000;
+/** Not a credential — a random string this process invents, to prove the env map arrived intact. */
+const TOKEN = `realm-probe-${Math.random().toString(36).slice(2)}`;
+const FIXTURE = join(dirname(fileURLToPath(import.meta.url)), "fixtures", "marker-mcp-server.mjs");
+
+let failures = 0;
+const ok = (label: string, cond: boolean, detail = "") => {
+  console.log(`  ${cond ? "PASS" : "FAIL"}  ${label}${detail ? ` — ${detail}` : ""}`);
+  if (!cond) failures += 1;
+};
+const skip = (label: string, detail: string) => console.log(`  SKIP  ${label} — ${detail}`);
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+type Marker = { startedAt: number; args: string[]; token: "match" | "mismatch" | "absent" };
+const readMarker = (path: string): Marker | null => {
+  if (!existsSync(path)) return null;
+  try { return JSON.parse(readFileSync(path, "utf8")) as Marker; } catch { return null; }
+};
+
+async function waitForMarker(path: string, timeoutMs: number): Promise<Marker | null> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const m = readMarker(path);
+    if (m) return m;
+    if (Date.now() >= deadline) return null;
+    await sleep(250);
+  }
+}
+
+async function main() {
+  const home = mkdtempSync(join(tmpdir(), "realm-mcp-live-"));
+  const markers = mkdtempSync(join(tmpdir(), "realm-mcp-markers-"));
+  // A fixed workspace, not a mkdtemp: codex records every cwd it starts a thread in as a trusted project
+  // in the user's ~/.codex/config.toml, with no way to opt out (see live-workspace.ts).
+  const cwd = liveWorkspace();
+
+  const app = await createApp({ home, port: 0, adapters: defaultAdapters() });
+  console.log(`server up on :${app.port}\nmarkers: ${markers}\n`);
+
+  const profile = new ProfilesStore(app.db).create({ name: "MCP live", icon: "home", color: "#7c6cff" });
+  const mine = new SpacesStore(app.db, home).create({ profileId: profile.id, name: "Mine", icon: "home" });
+  const other = new SpacesStore(app.db, home).create({ profileId: profile.id, name: "Other", icon: "home" });
+
+  // The same McpService the running app uses: same table, same settings store, same code path that
+  // SessionService reads through. Configuring the servers by hand here would prove nothing about it.
+  const mcp = new McpService({ servers: new McpServersStore(app.db), settings: new SettingsStore(app.db) });
+  const marker = (name: string) => join(markers, `${name}.json`);
+  const define = (name: string, spaceId: string | null) => mcp.add({
+    name, transport: "stdio", command: process.execPath, args: [FIXTURE, marker(name), TOKEN],
+    env: { REALM_MCP_PROBE_TOKEN: TOKEN },
+  }, spaceId);
+
+  const probes = await app.sessions.probeAll();
+
+  for (const kind of KINDS) {
+    console.log(`\n=== ${kind} ===`);
+    const probe = probes.find((p) => p.kind === kind);
+    if (!probe?.available) { ok("agent available", false, probe?.reason ?? "not registered"); continue; }
+    if (AGENT_MCP_TRANSPORTS[kind].length === 0) { skip("takes MCP servers at all", `AGENT_MCP_TRANSPORTS says ${kind} takes none`); continue; }
+
+    // Fresh server names per agent: a marker left by the previous agent's session would pass this
+    // agent's check for free.
+    const tag = kind.replace(/[^a-z0-9]/gi, "_");
+    const on = define(`on_${tag}`, mine.id);
+    const off = define(`off_${tag}`, null);
+    const elsewhere = define(`elsewhere_${tag}`, other.id);
+
+    const { session } = app.sessions.create({
+      spaceId: mine.id, agentKind: kind, projectId: null,
+      model: null, effort: null, permissionMode: "default",
+    });
+    app.db.prepare("UPDATE environments SET path = ? WHERE id = ?").run(cwd, session.environmentId);
+
+    // The prompt exists only to make SessionService boot the adapter; the marker lands at session start
+    // and nothing here waits for an answer. Claude does not connect an MCP server until something needs
+    // it, so the prompt names the tool — the point is still spawn-time, not the model's reply.
+    await app.sessions.send(session.id, { text: "List your available tools. Do not call any of them.", attachments: [] });
+    const hit = await waitForMarker(marker(on.name), MARKER_TIMEOUT_MS);
+
+    const errs = app.sessions.events(session.id, 0, 1000)
+      .map((s) => s.event as SessionEvent)
+      .filter((e) => e.type === "error")
+      .map((e) => (e.payload as { message: string }).message);
+
+    ok("the enabled server was started by the agent", hit !== null, hit ? `after ${Date.now() - hit.startedAt}ms` : "no marker");
+    ok("its env survived this protocol's own shape", hit?.token === "match", hit?.token ?? "(no marker)");
+    ok("its args survived", JSON.stringify(hit?.args ?? []) === "[]", JSON.stringify(hit?.args ?? "(no marker)"));
+    ok("a server enabled in no space was NOT started", readMarker(marker(off.name)) === null);
+    ok("a server enabled in ANOTHER space was NOT started", readMarker(marker(elsewhere.name)) === null);
+    ok("the session reported no errors", errs.length === 0, errs.join(" | ").slice(0, 240));
+
+    await app.sessions.closeAll();
+    (app.sessions as unknown as { closing: boolean }).closing = false;
+  }
+
+  await app.close();
+  rmSync(home, { recursive: true, force: true });
+  rmSync(markers, { recursive: true, force: true });
+  // `cwd` is left on disk on purpose — see live-workspace.ts.
+  console.log(`\n${failures === 0 ? "ALL CHECKS PASSED" : `${failures} CHECK(S) FAILED`}`);
+  process.exit(failures === 0 ? 0 : 1);
+}
+
+main().catch((e) => { console.error("driver crashed:", e); process.exit(2); });

--- a/apps/server/scripts/live-memory-check.ts
+++ b/apps/server/scripts/live-memory-check.ts
@@ -1,0 +1,148 @@
+/**
+ * Live check of W3's memory channel against the REAL agent CLIs.
+ *
+ * Two protocol claims here cannot be held up by unit tests, because both are about what a third-party
+ * binary does with a string:
+ *
+ *   1. Codex actually applies `thread/start` `developerInstructions` — the field its own protocol doc
+ *      lists as *unverified* — rather than accepting and ignoring it.
+ *   2. A Claude session running with `settingSources: []` (the skills-injection mode) really does see
+ *      the content Realm re-injects through `systemPrompt.append` — the W1 carry-forward that stops
+ *      enabling a skill from silently costing the user their `~/.claude/CLAUDE.md`.
+ *
+ * So this script builds a scratch Realm home and a scratch Claude user dir with marker tokens in them,
+ * derives the context with the REAL `MemoryService` (same code the server runs), starts each REAL
+ * adapter with it, and asks the model to repeat the tokens back. It costs one short model turn per
+ * agent. It writes nothing outside its own temp dirs — in particular nothing under ~/.claude, ~/.codex,
+ * ~/.cursor or ~/.agents — and it never reads the user's real memory files: the markers are scratch.
+ *
+ *   pnpm --filter @realm/server exec tsx scripts/live-memory-check.ts
+ *
+ * Exits non-zero if any check fails. Requires `claude` and `codex` installed and logged in; a CLI that
+ * is missing is reported as a failed section, not a silent pass.
+ */
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { ClaudeAdapter, CodexAdapter, type AgentHandle } from "@realm/adapters";
+import { openDatabase } from "../src/db/database";
+import { SettingsStore } from "../src/store/settings";
+import { SkillsService } from "../src/skills/service";
+import { MemoryService } from "../src/memory/service";
+import type { Environment } from "@realm/contracts";
+
+const SPACE = "01ARZ3NDEKTSV4RRFFQ69G5FAV";
+const nonce = Math.random().toString(36).slice(2, 8).toUpperCase();
+/** In the scratch user CLAUDE.md — must survive settingSources: [] via re-injection. */
+const USER_TOKEN = `USRMEM${nonce}`;
+/** In the Realm memory doc — must reach both agents. */
+const REALM_TOKEN = `RLMMEM${nonce}`;
+const TURN_TIMEOUT_MS = 180_000;
+
+let failures = 0;
+const ok = (label: string, cond: boolean, detail = "") => {
+  console.log(`  ${cond ? "PASS" : "FAIL"}  ${label}${detail ? ` — ${detail}` : ""}`);
+  if (!cond) failures += 1;
+};
+
+/** Runs one turn and returns everything the agent said, plus the init payload. */
+async function oneTurn(handle: AgentHandle, prompt: string): Promise<{ text: string; init: Record<string, unknown> | null }> {
+  let text = "";
+  let init: Record<string, unknown> | null = null;
+  const done = (async () => {
+    for await (const e of handle.events) {
+      if (e.type === "init") init = e.payload as unknown as Record<string, unknown>;
+      if (e.type === "assistant_text") text += `${e.payload.text}\n`;
+      if (e.type === "error") throw new Error(e.payload.message);
+      if (e.type === "usage" || (e.type === "status" && e.payload.status === "ended")) break;
+    }
+  })();
+  await handle.send({ text: prompt, attachments: [] });
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  await Promise.race([done, new Promise((_, rej) => { timer = setTimeout(() => rej(new Error("turn timed out")), TURN_TIMEOUT_MS); })]);
+  clearTimeout(timer);
+  return { text, init };
+}
+
+function scratchRealm() {
+  const home = mkdtempSync(join(tmpdir(), "realm-memory-live-"));
+  const claudeDir = join(home, "claude-home");
+  mkdirSync(claudeDir, { recursive: true });
+  writeFileSync(join(claudeDir, "CLAUDE.md"), `The value of PROBE_A is ${USER_TOKEN}.\n`);
+  const spaceDir = join(home, "space");
+  mkdirSync(spaceDir, { recursive: true });
+  const settings = new SettingsStore(openDatabase(join(home, "realm.db")));
+  const environments = {
+    ensurePrimary: (spaceId: string): Environment =>
+      ({ id: "env", spaceId, path: spaceDir, branch: null, kind: "primary", portBlockStart: null, createdAt: 0, updatedAt: 0 }),
+  };
+  const memory = new MemoryService({ home, settings, environments, claudeDir });
+  memory.set(SPACE, `The value of PROBE_B is ${REALM_TOKEN}.`);
+  // A staged skills library, exactly as the server would hand it over: its presence is what puts the
+  // Claude session into settingSources: [] — the mode the re-injection exists for.
+  const skills = new SkillsService({ home, settings, bundledDir: null });
+  mkdirSync(join(skills.root, "realm-probe"), { recursive: true });
+  writeFileSync(join(skills.root, "realm-probe", "SKILL.md"), "---\nname: realm-probe\ndescription: A Realm probe skill. Never invoke it.\n---\n\nprobe\n");
+  const injection = skills.injectionFor(SPACE, "claude");
+  if (!injection) throw new Error("SkillsService staged nothing — the check cannot prove anything");
+  return { home, memory, injection };
+}
+
+const PROMPT = "Without using any tools: reply with the exact values of PROBE_A and PROBE_B from your context, or the word ABSENT for any you cannot find.";
+
+async function checkClaude(memory: MemoryService, injection: { pluginPath: string; root: string }, cwd: string) {
+  console.log("\n=== claude ===");
+  const systemContext = memory.systemContextFor({ spaceId: SPACE, kind: "claude", cwd, skillsInjected: true });
+  ok("MemoryService built a context carrying both tokens", !!systemContext?.includes(USER_TOKEN) && !!systemContext?.includes(REALM_TOKEN));
+  const adapter = new ClaudeAdapter();
+  const handle = adapter.start({ cwd, mcpServers: [], skills: injection, systemContext, permissionMode: "default" });
+  try {
+    const { text } = await oneTurn(handle, PROMPT);
+    ok("the re-injected CLAUDE.md content reaches the session despite settingSources: []", text.includes(USER_TOKEN));
+    ok("the Realm memory document reaches the session", text.includes(REALM_TOKEN));
+  } finally { await handle.dispose(); }
+
+  // The control: same isolated session, no systemContext. If the tokens showed up here the assertions
+  // above would prove nothing about the channel.
+  const control = adapter.start({ cwd, mcpServers: [], skills: injection, permissionMode: "default" });
+  try {
+    const { text } = await oneTurn(control, PROMPT);
+    ok("without the re-injection the tokens are absent (so the channel above is real)", !text.includes(USER_TOKEN) && !text.includes(REALM_TOKEN));
+  } finally { await control.dispose(); }
+}
+
+async function checkCodex(memory: MemoryService, cwd: string) {
+  console.log("\n=== codex ===");
+  const systemContext = memory.systemContextFor({ spaceId: SPACE, kind: "codex", cwd, skillsInjected: false });
+  ok("MemoryService built a codex context carrying the Realm token and never CLAUDE.md", !!systemContext?.includes(REALM_TOKEN) && !systemContext?.includes(USER_TOKEN));
+  const adapter = new CodexAdapter();
+  const handle = adapter.start({ cwd, mcpServers: [], systemContext, permissionMode: "default" });
+  try {
+    const { text, init } = await oneTurn(handle, PROMPT);
+    ok("developerInstructions actually lands in the thread (PROBE_B came back)", text.includes(REALM_TOKEN));
+    const sources = init?.instructionSources;
+    ok("thread/start reported instructionSources and the adapter surfaced it on init", Array.isArray(sources), Array.isArray(sources) ? `${sources.length} file(s)` : String(sources));
+  } finally { await handle.dispose(); }
+}
+
+async function main() {
+  const { home, memory, injection } = scratchRealm();
+  const cwd = mkdtempSync(join(tmpdir(), "realm-memory-cwd-"));
+  console.log(`scratch home: ${home}`);
+  try {
+    for (const [label, fn] of [
+      ["claude", () => checkClaude(memory, injection, cwd)],
+      ["codex", () => checkCodex(memory, cwd)],
+    ] as const) {
+      try { await fn(); }
+      catch (e) { console.log(`\n=== ${label} ===`); ok(`${label} reachable`, false, e instanceof Error ? e.message : String(e)); }
+    }
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+    rmSync(cwd, { recursive: true, force: true });
+  }
+  console.log(`\n${failures === 0 ? "ALL CHECKS PASSED" : `${failures} CHECK(S) FAILED`}`);
+  process.exit(failures === 0 ? 0 : 1);
+}
+
+main().catch((e) => { console.error("driver crashed:", e); process.exit(2); });

--- a/apps/server/scripts/live-skills-check.ts
+++ b/apps/server/scripts/live-skills-check.ts
@@ -1,0 +1,129 @@
+/**
+ * Live check of Realm's skills injection against the REAL agent CLIs.
+ *
+ * The whole of W1 rests on two protocol claims that no unit test can hold up, because both are about what
+ * a third-party binary does with a directory:
+ *
+ *   1. Claude Code loads a skill from `plugins: [{ type:'local', path }]`, and `settingSources: []`
+ *      keeps the user's own installed skills out of the same session.
+ *   2. Codex's app-server accepts `skills/extraRoots/set` and then reports the skill in `skills/list`.
+ *
+ * So this script builds a scratch library with the real `SkillsService` — same staging code the server
+ * runs, symlinks and all — and asks each CLI what it sees. It writes nothing outside its own temp dirs,
+ * and in particular nothing under ~/.claude, ~/.codex, ~/.cursor or ~/.agents.
+ *
+ *   pnpm --filter @realm/server exec tsx scripts/live-skills-check.ts
+ *
+ * Exits non-zero if any check fails. Requires `claude` and `codex` to be installed and logged in; a CLI
+ * that is missing is reported as a skipped section, not a pass.
+ */
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { query } from "@anthropic-ai/claude-agent-sdk";
+import { CodexConnection } from "@realm/adapters";
+import { openDatabase } from "../src/db/database";
+import { SettingsStore } from "../src/store/settings";
+import { SkillsService } from "../src/skills/service";
+
+const ENABLED = "realm-probe-enabled";
+const DISABLED = "realm-probe-disabled";
+const SPACE = "01ARZ3NDEKTSV4RRFFQ69G5FAV";
+/** Skills of the user's own that the isolation check looks for. Absence of ALL of them is the assertion. */
+const USER_SKILL_HINTS = ["caikins", "frontend-design", "quiet-saas", "refactoring-ui", "skill-creator"];
+
+let failures = 0;
+const ok = (label: string, cond: boolean, detail = "") => {
+  console.log(`  ${cond ? "PASS" : "FAIL"}  ${label}${detail ? ` — ${detail}` : ""}`);
+  if (!cond) failures += 1;
+};
+
+function library() {
+  const home = mkdtempSync(join(tmpdir(), "realm-skills-live-"));
+  const settings = new SettingsStore(openDatabase(join(home, "realm.db")));
+  const service = new SkillsService({ home, settings, bundledDir: null });
+  for (const id of [ENABLED, DISABLED]) {
+    mkdirSync(join(service.root, id), { recursive: true });
+    writeFileSync(join(service.root, id, "SKILL.md"), `---\nname: ${id}\ndescription: A Realm probe skill (${id}). Never invoke it.\n---\n\nprobe\n`);
+  }
+  // The disabled one is the control: it exists on disk and must NOT reach either agent.
+  service.setEnabled(SPACE, DISABLED, false);
+  const injection = service.injectionFor(SPACE, "claude");
+  if (!injection) throw new Error("SkillsService staged nothing — the check cannot prove anything");
+  return { home, injection };
+}
+
+/** Runs one query far enough to read its command list, then abandons it. No turn is ever sent. */
+async function claudeCommands(options: Record<string, unknown>, cwd: string): Promise<string[]> {
+  const input = (async function* () {
+    yield { type: "user" as const, message: { role: "user" as const, content: "probe" }, parent_tool_use_id: null, session_id: "" };
+  })();
+  const q = query({ prompt: input as never, options: { cwd, ...options } as never });
+  try {
+    return (await q.supportedCommands()).map((c: { name: string }) => c.name);
+  } finally {
+    await q.interrupt().catch(() => { /* the probe never started a turn; there may be nothing to interrupt */ });
+  }
+}
+
+async function checkClaude(pluginPath: string, cwd: string) {
+  console.log("\n=== claude ===");
+  const injected = await claudeCommands(
+    { settingSources: [], plugins: [{ type: "local", path: pluginPath, skipMcpDiscovery: true }] },
+    cwd,
+  );
+  const realm = injected.filter((n) => n.includes("realm-probe"));
+  ok("the enabled skill is loaded from the staged plugin", realm.includes(`realm:${ENABLED}`), realm.join(", ") || "(none)");
+  ok("the disabled skill is not", !realm.includes(`realm:${DISABLED}`), realm.join(", ") || "(none)");
+  const leaked = injected.filter((n) => USER_SKILL_HINTS.some((h) => n.includes(h)));
+  ok("settingSources: [] keeps the user's own skills out", leaked.length === 0, leaked.slice(0, 5).join(", ") || "(none)");
+
+  // The control: the same session without the two options is the behaviour Realm had before W1.
+  const bare = await claudeCommands({}, cwd);
+  ok("without the plugin, Realm's library is absent", !bare.some((n) => n.includes("realm-probe")));
+  ok("without settingSources: [], the user's own skills are present (so the isolation above is real)",
+    bare.some((n) => USER_SKILL_HINTS.some((h) => n.includes(h))), `${bare.length} commands vs ${injected.length} injected`);
+}
+
+async function checkCodex(root: string, cwd: string) {
+  console.log("\n=== codex ===");
+  const conn = await CodexConnection.open({ bin: process.env.REALM_CODEX_BIN ?? "codex", cwd });
+  try {
+    let supported = true;
+    try { await conn.request("skills/extraRoots/set", { extraRoots: [root] }, 15_000); }
+    catch (e) { supported = false; ok("skills/extraRoots/set is available on this codex build", false, e instanceof Error ? e.message : String(e)); }
+    if (!supported) return;
+    ok("skills/extraRoots/set is available on this codex build", true);
+    const listed = await conn.request<{ data: { skills: { name: string; path: string; scope: string }[] }[] }>(
+      "skills/list", { cwds: [cwd], forceReload: true }, 20_000);
+    const names = listed.data.flatMap((d) => d.skills.map((s) => s.name));
+    const probes = names.filter((n) => n.includes("realm-probe"));
+    ok("the enabled skill appears in skills/list", probes.includes(ENABLED), probes.join(", ") || "(none)");
+    ok("the disabled skill does not", !probes.includes(DISABLED), probes.join(", ") || "(none)");
+    // Codex resolves the symlink, which is what lets the staged root point back at the user's library
+    // instead of being a copy that goes stale the moment they edit a skill.
+    const path = listed.data.flatMap((d) => d.skills).find((s) => s.name === ENABLED)?.path ?? "";
+    ok("the staged symlink resolves back to the library", path.includes("skills/" + ENABLED), path || "(not listed)");
+  } finally {
+    await conn.dispose();
+  }
+}
+
+async function main() {
+  const { home, injection } = library();
+  const cwd = mkdtempSync(join(tmpdir(), "realm-skills-cwd-"));
+  console.log(`library: ${home}\nstaged:  ${injection.pluginPath}`);
+  try {
+    for (const [label, fn] of [["claude", () => checkClaude(injection.pluginPath, cwd)], ["codex", () => checkCodex(injection.root, cwd)]] as const) {
+      try { await fn(); }
+      catch (e) { console.log(`\n=== ${label} ===`); ok(`${label} reachable`, false, e instanceof Error ? e.message : String(e)); }
+    }
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+    rmSync(cwd, { recursive: true, force: true });
+  }
+  console.log(`\n${failures === 0 ? "ALL CHECKS PASSED" : `${failures} CHECK(S) FAILED`}`);
+  process.exit(failures === 0 ? 0 : 1);
+}
+
+main().catch((e) => { console.error("driver crashed:", e); process.exit(2); });

--- a/apps/server/scripts/live-workspace.ts
+++ b/apps/server/scripts/live-workspace.ts
@@ -1,0 +1,50 @@
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+/**
+ * The one directory every live check runs an agent in — **stable across runs, and deliberately not a
+ * `mkdtemp` scratch**.
+ *
+ * `codex app-server` records every `cwd` it is given as a trusted project in
+ * `$CODEX_HOME/config.toml`:
+ *
+ * ```toml
+ * [projects."/private/var/folders/…/T/realm-work-fOtXFa"]
+ * trust_level = "trusted"
+ * ```
+ *
+ * Verified against codex-cli 0.146.0 with a scratch `CODEX_HOME`: the write happens on `thread/start`,
+ * for **every** approval policy and sandbox mode including `untrusted`/`read-only`, is flushed
+ * asynchronously (a client that kills the process a second later never sees it), and is suppressed only
+ * when an entry for that path already exists — `untrusted` counts. `initialize` alone writes nothing.
+ * `ThreadStartParams` has no field that opts out. It is not a Realm bug and Realm cannot prevent it; it
+ * is how the app-server treats a host that has its own trust UI.
+ *
+ * What Realm *could* prevent, and did not, is pointing it at a directory that then stops existing. Four
+ * runs of `live-agent-check.ts` against `mkdtempSync(tmpdir(), "realm-work-")` left four permanent rows
+ * in the user's config naming four deleted temp directories. So the live checks use one fixed path and
+ * leave it on disk: at most one entry, always pointing somewhere real, and named so its origin is
+ * obvious in a config file the user reads.
+ *
+ * Realm proper is unaffected — its sessions run in space folders and worktrees under `~/Realm`, which
+ * are stable directories the user would expect to see trusted.
+ */
+export function liveWorkspace(): string {
+  const path = join(tmpdir(), "realm-live-workspace");
+  mkdirSync(path, { recursive: true });
+  const readme = join(path, "README.txt");
+  if (!existsSync(readme)) {
+    writeFileSync(readme, [
+      "Scratch working directory for Realm's live agent checks (apps/server/scripts/live-*-check.ts).",
+      "",
+      "It has a fixed name on purpose. `codex app-server` records every cwd it is asked to start a",
+      "thread in as a trusted project in ~/.codex/config.toml, and there is no way to ask it not to.",
+      "A fresh temp directory per run would leave one dead [projects.\"...\"] entry in that file per run.",
+      "",
+      "Safe to delete; it will be recreated on the next run.",
+      "",
+    ].join("\n"));
+  }
+  return path;
+}

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -11,6 +11,8 @@ import { SessionsStore, SessionEventsStore } from "./store/sessions";
 import { EnvironmentsStore } from "./store/environments";
 import { SessionService } from "./sessions/service";
 import { SkillsService } from "./skills/service";
+import { McpServersStore } from "./store/mcp";
+import { McpService } from "./mcp/service";
 import { ClaudeAdapter, CodexAdapter, AcpAdapter, FakeAdapter, type AdapterRegistry } from "@realm/adapters";
 import { GitInfoService } from "./workspace/git-info";
 import { GitDiffService } from "./workspace/git-diff";
@@ -86,11 +88,12 @@ export async function createApp(opts: { home: string; port: number; adapters?: A
   const skills = new SkillsService({ home: opts.home, settings });
   const installed = skills.installBundled();
   if (installed.length) console.error(`[skills] installed bundled skill(s): ${installed.join(", ")}`);
-  const sessions = new SessionService({ db, rpc, sessions: sessionsStore, events: new SessionEventsStore(db), items, spaces, projects, environments, worktrees, ports, terminals, adapters: opts.adapters ?? defaultAdapters(), skills, checkpoints });
+  const mcp = new McpService({ servers: new McpServersStore(db), settings });
+  const sessions = new SessionService({ db, rpc, sessions: sessionsStore, events: new SessionEventsStore(db), items, spaces, projects, environments, worktrees, ports, terminals, adapters: opts.adapters ?? defaultAdapters(), skills, mcp, checkpoints });
   sessionService = sessions;
   registerMethods({
     rpc, home: opts.home, version: SERVER_VERSION,
-    profiles, spaces, projects, environments, envService, items, settings, skills, terminals, sessions, gitInfo: new GitInfoService(), gitDiff: new GitDiffService(), gitWrite: new GitWriteService(), ports, checkpoints,
+    profiles, spaces, projects, environments, envService, items, settings, skills, mcp, terminals, sessions, gitInfo: new GitInfoService(), gitDiff: new GitDiffService(), gitWrite: new GitWriteService(), ports, checkpoints,
   });
   sessions.markStaleOnBoot();
   terminals.restoreAll();

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -10,6 +10,7 @@ import { TerminalService } from "./terminals/service";
 import { SessionsStore, SessionEventsStore } from "./store/sessions";
 import { EnvironmentsStore } from "./store/environments";
 import { SessionService } from "./sessions/service";
+import { SkillsService } from "./skills/service";
 import { ClaudeAdapter, CodexAdapter, AcpAdapter, FakeAdapter, type AdapterRegistry } from "@realm/adapters";
 import { GitInfoService } from "./workspace/git-info";
 import { GitDiffService } from "./workspace/git-diff";
@@ -80,11 +81,16 @@ export async function createApp(opts: { home: string; port: number; adapters?: A
   });
   const envService = new EnvironmentService({ environments, spaces, worktrees, ports, checkpoints });
   const terminals = new TerminalService({ db, rpc, spaces, items, terminals: new TerminalsStore(db), environments });
-  const sessions = new SessionService({ db, rpc, sessions: sessionsStore, events: new SessionEventsStore(db), items, spaces, projects, environments, worktrees, ports, terminals, adapters: opts.adapters ?? defaultAdapters(), checkpoints });
+  const settings = new SettingsStore(db);
+  // Repo-shipped skills reach the user's library here, once each, before any session can be started.
+  const skills = new SkillsService({ home: opts.home, settings });
+  const installed = skills.installBundled();
+  if (installed.length) console.error(`[skills] installed bundled skill(s): ${installed.join(", ")}`);
+  const sessions = new SessionService({ db, rpc, sessions: sessionsStore, events: new SessionEventsStore(db), items, spaces, projects, environments, worktrees, ports, terminals, adapters: opts.adapters ?? defaultAdapters(), skills, checkpoints });
   sessionService = sessions;
   registerMethods({
     rpc, home: opts.home, version: SERVER_VERSION,
-    profiles, spaces, projects, environments, envService, items, settings: new SettingsStore(db), terminals, sessions, gitInfo: new GitInfoService(), gitDiff: new GitDiffService(), gitWrite: new GitWriteService(), ports, checkpoints,
+    profiles, spaces, projects, environments, envService, items, settings, skills, terminals, sessions, gitInfo: new GitInfoService(), gitDiff: new GitDiffService(), gitWrite: new GitWriteService(), ports, checkpoints,
   });
   sessions.markStaleOnBoot();
   terminals.restoreAll();

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -13,6 +13,7 @@ import { SessionService } from "./sessions/service";
 import { SkillsService } from "./skills/service";
 import { McpServersStore } from "./store/mcp";
 import { McpService } from "./mcp/service";
+import { MemoryService } from "./memory/service";
 import { ClaudeAdapter, CodexAdapter, AcpAdapter, FakeAdapter, type AdapterRegistry } from "@realm/adapters";
 import { GitInfoService } from "./workspace/git-info";
 import { GitDiffService } from "./workspace/git-diff";
@@ -57,7 +58,9 @@ export function defaultAdapters(): AdapterRegistry {
   return reg;
 }
 
-export async function createApp(opts: { home: string; port: number; adapters?: AdapterRegistry }): Promise<App> {
+/** `claudeDir` overrides where MemoryService reads user-level Claude files (`~/.claude` otherwise) —
+ *  for tests and live checks, which must never depend on (or expose) the real user's memory files. */
+export async function createApp(opts: { home: string; port: number; adapters?: AdapterRegistry; claudeDir?: string }): Promise<App> {
   const db = openDatabase(dbPath(opts.home));
   const profiles = new ProfilesStore(db);
   // First boot: without a profile the New Space sheet is a dead end (spaces require one), so seed a
@@ -89,11 +92,12 @@ export async function createApp(opts: { home: string; port: number; adapters?: A
   const installed = skills.installBundled();
   if (installed.length) console.error(`[skills] installed bundled skill(s): ${installed.join(", ")}`);
   const mcp = new McpService({ servers: new McpServersStore(db), settings });
-  const sessions = new SessionService({ db, rpc, sessions: sessionsStore, events: new SessionEventsStore(db), items, spaces, projects, environments, worktrees, ports, terminals, adapters: opts.adapters ?? defaultAdapters(), skills, mcp, checkpoints });
+  const memory = new MemoryService({ home: opts.home, settings, environments, claudeDir: opts.claudeDir });
+  const sessions = new SessionService({ db, rpc, sessions: sessionsStore, events: new SessionEventsStore(db), items, spaces, projects, environments, worktrees, ports, terminals, adapters: opts.adapters ?? defaultAdapters(), skills, mcp, memory, checkpoints });
   sessionService = sessions;
   registerMethods({
     rpc, home: opts.home, version: SERVER_VERSION,
-    profiles, spaces, projects, environments, envService, items, settings, skills, mcp, terminals, sessions, gitInfo: new GitInfoService(), gitDiff: new GitDiffService(), gitWrite: new GitWriteService(), ports, checkpoints,
+    profiles, spaces, projects, environments, envService, items, settings, skills, mcp, memory, terminals, sessions, gitInfo: new GitInfoService(), gitDiff: new GitDiffService(), gitWrite: new GitWriteService(), ports, checkpoints,
   });
   sessions.markStaleOnBoot();
   terminals.restoreAll();

--- a/apps/server/src/db/migrations.ts
+++ b/apps/server/src/db/migrations.ts
@@ -127,4 +127,26 @@ export const migrations: string[] = [
   CREATE INDEX checkpoints_environment ON checkpoints(environment_id, created_at DESC);
   CREATE INDEX checkpoints_session ON checkpoints(session_id, created_at DESC);
   `,
+  // v8 — MCP server definitions (Plan 8 W2). Global rows; which spaces use them is per-space state in
+  // `settings` (`mcp.enabled:<spaceId>`), the same split W1 used for skills.
+  //
+  // `name` is UNIQUE because it is the key every agent addresses the server by — a record key for
+  // Claude, a `[mcp_servers.NAME]` table for Codex, a `name` field for ACP. Two rows sharing a name
+  // would be one server on the wire, with whichever Realm serialized last silently winning.
+  //
+  // `secrets_json` is named for exactly what it is: the stdio `env` map or the http/sse header map,
+  // **in plain text**. Realm has no secret store, and this column is the whole of the honesty about
+  // that — see MCP_SECRET_STORAGE_NOTE, which every surface that takes a key must show. It is one
+  // column rather than two because a server has one kind or the other, never both.
+  `
+  CREATE TABLE mcp_servers (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL UNIQUE,
+    transport TEXT NOT NULL,
+    command TEXT NOT NULL DEFAULT '',
+    args_json TEXT NOT NULL DEFAULT '[]',
+    url TEXT NOT NULL DEFAULT '',
+    secrets_json TEXT NOT NULL DEFAULT '{}',
+    created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL);
+  `,
 ];

--- a/apps/server/src/mcp/integration.test.ts
+++ b/apps/server/src/mcp/integration.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it, afterEach } from "vitest";
+import WebSocket from "ws";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { AsyncQueue, type AgentAdapter, type AgentHandle, type StartOptions } from "@realm/adapters";
+import { sessionEvent, type SessionEvent } from "@realm/contracts";
+import { createApp, type App } from "../app";
+import { waitFor } from "../test-utils";
+
+let app: App;
+afterEach(async () => { await app?.close(); });
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Any = any;
+
+/** Never a real key. Every assertion here is about where it does NOT appear. */
+const KEY = "pat-do-not-leak-me";
+
+/** Stands in for a real adapter under a real agent kind, and records the StartOptions it was handed. */
+class RecordingAdapter implements AgentAdapter {
+  readonly starts: StartOptions[] = [];
+  readonly logs: string[] = [];
+  constructor(readonly kind: "claude" | "codex") {}
+  async probe() { return { kind: this.kind, available: true, version: "0", loggedIn: true, reason: null }; }
+  start(opts: StartOptions): AgentHandle {
+    this.starts.push(opts);
+    const events = new AsyncQueue<SessionEvent>();
+    events.push(sessionEvent("init", { providerSessionId: "prov_1", model: "m", tools: [], cwd: opts.cwd }));
+    events.push(sessionEvent("status", { status: "idle" }));
+    return {
+      events,
+      send: async () => { events.push(sessionEvent("assistant_text", { messageId: "m1", text: "ok" })); events.push(sessionEvent("status", { status: "idle" })); },
+      respondPermission: () => {},
+      interrupt: async () => {},
+      setOptions: async () => {},
+      dispose: async () => { events.close(); },
+    };
+  }
+}
+
+async function client(port: number) {
+  const ws = await new Promise<WebSocket>((res, rej) => { const w = new WebSocket(`ws://127.0.0.1:${port}`); w.once("open", () => res(w)); w.once("error", rej); });
+  const pending = new Map<string, (v: Any) => void>(); const events: Any[] = [];
+  ws.on("message", (d) => { const m = JSON.parse(d.toString()); if ("id" in m) pending.get(m.id)?.(m); else events.push(m); });
+  let n = 0;
+  const call = (method: string, params: unknown) => new Promise<Any>((res, rej) => {
+    const id = String(++n);
+    const timer = setTimeout(() => { pending.delete(id); rej(new Error(`rpc ${method} timed out`)); }, 5000);
+    pending.set(id, (v) => { clearTimeout(timer); res(v); });
+    ws.send(JSON.stringify({ id, method, params }));
+  });
+  return { call, events, close: () => ws.close() };
+}
+
+async function boot() {
+  const home = mkdtempSync(join(tmpdir(), "realm-mcp-int-"));
+  const claude = new RecordingAdapter("claude");
+  app = await createApp({ home, port: 0, adapters: { claude } });
+  const c = await client(app.port);
+  const profile = (await c.call("profiles.create", { name: "P" })).result;
+  const work = (await c.call("spaces.create", { profileId: profile.id, name: "Work" })).result;
+  const school = (await c.call("spaces.create", { profileId: profile.id, name: "School" })).result;
+  return { c, claude, work, school };
+}
+
+/** Start a session in `spaceId` and return the StartOptions the adapter was handed. */
+async function startSession(c: Any, adapter: RecordingAdapter, spaceId: string): Promise<StartOptions> {
+  const before = adapter.starts.length;
+  const { session } = (await c.call("sessions.create", { spaceId, agentKind: "claude" })).result;
+  await c.call("sessions.send", { id: session.id, text: "go" });
+  await waitFor(() => adapter.starts.length > before);
+  return adapter.starts[before]!;
+}
+
+const addStdio = (c: Any, spaceId: string | null, name: string) =>
+  c.call("mcp.add", { spaceId, name, transport: "stdio", command: "/usr/bin/node", args: ["/abs/s.mjs"], env: { AIRTABLE_API_KEY: KEY } });
+
+describe("mcp reaches a session", () => {
+  it("hands the space's enabled servers to the adapter at start", async () => {
+    // The named mutant: restore `mcpServers: []` in SessionService.ensureLive and this fails.
+    const { c, claude, work } = await boot();
+    await addStdio(c, work.id, "airtable");
+    const opts = await startSession(c, claude, work.id);
+    expect(opts.mcpServers).toEqual([
+      { name: "airtable", transport: "stdio", command: "/usr/bin/node", args: ["/abs/s.mjs"], env: { AIRTABLE_API_KEY: KEY } },
+    ]);
+    c.close();
+  });
+
+  it("hands over an empty list when the space has enabled nothing", async () => {
+    const { c, claude, work } = await boot();
+    await addStdio(c, null, "airtable"); // defined, opted into nowhere
+    const opts = await startSession(c, claude, work.id);
+    expect(opts.mcpServers).toEqual([]);
+    c.close();
+  });
+
+  it("does not leak one space's servers into another's session", async () => {
+    const { c, claude, work, school } = await boot();
+    await addStdio(c, work.id, "work_only");
+    expect((await startSession(c, claude, school.id)).mcpServers).toEqual([]);
+    expect((await startSession(c, claude, work.id)).mcpServers.map((s) => s.name)).toEqual(["work_only"]);
+    c.close();
+  });
+
+  it("stops handing over a server that was disabled between sessions", async () => {
+    const { c, claude, work } = await boot();
+    const server = (await addStdio(c, work.id, "airtable")).result;
+    expect((await startSession(c, claude, work.id)).mcpServers).toHaveLength(1);
+    await c.call("mcp.setEnabled", { spaceId: work.id, id: server.id, enabled: false });
+    expect((await startSession(c, claude, work.id)).mcpServers).toEqual([]);
+    c.close();
+  });
+
+  it("carries an http server's url and headers through unchanged", async () => {
+    const { c, claude, work } = await boot();
+    await c.call("mcp.add", { spaceId: work.id, name: "vercel", transport: "http", url: "https://mcp.vercel.com", headers: { Authorization: `Bearer ${KEY}` } });
+    expect((await startSession(c, claude, work.id)).mcpServers).toEqual([
+      { name: "vercel", transport: "http", url: "https://mcp.vercel.com", headers: { Authorization: `Bearer ${KEY}` } },
+    ]);
+    c.close();
+  });
+});
+
+describe("mcp over rpc", () => {
+  it("never puts a secret value on the wire, in a result or in an event", async () => {
+    // The named mutant: secrets echoed into an event payload. `mcp.changed` carries no payload at all,
+    // and every result is the key-names projection.
+    const { c, claude, work } = await boot();
+    const added = await addStdio(c, work.id, "airtable");
+    const listed = await c.call("mcp.list", { spaceId: work.id });
+    const updated = await c.call("mcp.update", { spaceId: work.id, id: added.result.id, name: "airtable2" });
+    await startSession(c, claude, work.id);
+    await waitFor(() => c.events.some((e: Any) => e.event === "mcp.changed"));
+    const everything = JSON.stringify([added, listed, updated, c.events]);
+    expect(everything).not.toContain(KEY);
+    expect(listed.result.servers[0].envKeys).toEqual(["AIRTABLE_API_KEY"]);
+    c.close();
+  });
+
+  it("returns the storage note on every list, so a key-taking UI cannot forget it", async () => {
+    const { c, work } = await boot();
+    const listed = await c.call("mcp.list", { spaceId: work.id });
+    expect(listed.result.secretNote).toMatch(/plain text/);
+    c.close();
+  });
+
+  it("broadcasts mcp.changed on add, edit, toggle and remove", async () => {
+    const { c, work } = await boot();
+    const count = () => c.events.filter((e: Any) => e.event === "mcp.changed").length;
+    const added = await addStdio(c, work.id, "airtable");
+    await waitFor(() => count() === 1);
+    await c.call("mcp.update", { spaceId: work.id, id: added.result.id, name: "renamed" });
+    await waitFor(() => count() === 2);
+    await c.call("mcp.setEnabled", { spaceId: work.id, id: added.result.id, enabled: false });
+    await waitFor(() => count() === 3);
+    await c.call("mcp.remove", { id: added.result.id });
+    await waitFor(() => count() === 4);
+    expect((await c.call("mcp.list", { spaceId: work.id })).result.servers).toEqual([]);
+    c.close();
+  });
+
+  it("refuses a space that does not exist rather than writing preferences for it", async () => {
+    const { c } = await boot();
+    const ghost = "01ARZ3NDEKTSV4RRFFQ69G5FAZ";
+    for (const [method, params] of [
+      ["mcp.list", { spaceId: ghost }],
+      ["mcp.add", { spaceId: ghost, name: "x", transport: "stdio", command: "/bin/x" }],
+      ["mcp.setEnabled", { spaceId: ghost, id: "01ARZ3NDEKTSV4RRFFQ69G5FAY", enabled: true }],
+    ] as const) {
+      expect((await c.call(method, params)).error?.code).toBe("NOT_FOUND");
+    }
+    c.close();
+  });
+
+  it("reports a bad definition as an error code rather than storing it", async () => {
+    const { c, work } = await boot();
+    expect((await c.call("mcp.add", { spaceId: work.id, name: "empty", transport: "stdio" })).error?.code).toBe("MCP_INCOMPLETE");
+    await addStdio(c, work.id, "airtable");
+    expect((await addStdio(c, work.id, "airtable")).error?.code).toBe("MCP_NAME_TAKEN");
+    expect((await c.call("mcp.list", { spaceId: work.id })).result.servers).toHaveLength(1);
+    c.close();
+  });
+
+  it("removes a server from every space's enabled set, not just the one that asked", async () => {
+    const { c, claude, work, school } = await boot();
+    const server = (await addStdio(c, work.id, "airtable")).result;
+    await c.call("mcp.setEnabled", { spaceId: school.id, id: server.id, enabled: true });
+    await c.call("mcp.remove", { id: server.id });
+    expect((await startSession(c, claude, school.id)).mcpServers).toEqual([]);
+    c.close();
+  });
+});

--- a/apps/server/src/mcp/service.test.ts
+++ b/apps/server/src/mcp/service.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { openDatabase } from "../db/database";
+import { SettingsStore } from "../store/settings";
+import { McpServersStore } from "../store/mcp";
+import { McpService } from "./service";
+
+const WORK = "01ARZ3NDEKTSV4RRFFQ69G5FAV";
+const SCHOOL = "01ARZ3NDEKTSV4RRFFQ69G5FAW";
+/** Never a real key, and never printed: every assertion below is about it NOT being somewhere. */
+const KEY = "pat-do-not-leak-me";
+
+let mcp: McpService;
+beforeEach(() => {
+  const db = openDatabase(join(mkdtempSync(join(tmpdir(), "realm-mcp-")), "realm.db"));
+  mcp = new McpService({ servers: new McpServersStore(db), settings: new SettingsStore(db) });
+});
+
+const stdio = (name: string) => ({ name, transport: "stdio" as const, command: "/usr/bin/node", args: ["/abs/s.mjs"], env: { AIRTABLE_API_KEY: KEY } });
+const http = (name: string) => ({ name, transport: "http" as const, url: "https://mcp.vercel.com", headers: { Authorization: `Bearer ${KEY}` } });
+
+describe("per-space scoping", () => {
+  it("enables a new server ONLY in the space it was added from", () => {
+    // The deliberate inversion of W1's disabled-set: an MCP server is a process to spawn or a URL to
+    // send a key to, so it must not arm itself in a space the user never opened it in.
+    const s = mcp.add(stdio("airtable"), WORK);
+    expect(s.enabled).toBe(true);
+    expect(mcp.list(WORK).servers.map((x) => [x.name, x.enabled])).toEqual([["airtable", true]]);
+    expect(mcp.list(SCHOOL).servers.map((x) => [x.name, x.enabled])).toEqual([["airtable", false]]);
+  });
+
+  it("enables it nowhere when no space is named", () => {
+    mcp.add(stdio("airtable"), null);
+    expect(mcp.list(WORK).servers[0]!.enabled).toBe(false);
+    expect(mcp.configFor(WORK)).toEqual([]);
+  });
+
+  it("keeps one space's servers out of another's session config", () => {
+    // The named mutant: key the enable set on anything but the space id and this leaks.
+    const a = mcp.add(stdio("work_only"), WORK);
+    mcp.add(stdio("school_only"), SCHOOL);
+    expect(mcp.configFor(WORK).map((s) => s.name)).toEqual(["work_only"]);
+    expect(mcp.configFor(SCHOOL).map((s) => s.name)).toEqual(["school_only"]);
+    mcp.setEnabled(SCHOOL, a.id, true);
+    expect(mcp.configFor(SCHOOL).map((s) => s.name).sort()).toEqual(["school_only", "work_only"]);
+  });
+
+  it("stops passing a server the moment it is disabled", () => {
+    // The named mutant: a disabled server still passed.
+    const s = mcp.add(stdio("airtable"), WORK);
+    expect(mcp.configFor(WORK)).toHaveLength(1);
+    mcp.setEnabled(WORK, s.id, false);
+    expect(mcp.configFor(WORK)).toEqual([]);
+    expect(mcp.list(WORK).servers[0]!.enabled).toBe(false);
+  });
+
+  it("forgets every space's opt-in when the server is removed, so a re-add starts off", () => {
+    const s = mcp.add(stdio("airtable"), WORK);
+    mcp.setEnabled(SCHOOL, s.id, true);
+    mcp.remove(s.id, [WORK, SCHOOL]);
+    expect(mcp.list(WORK).servers).toEqual([]);
+    // Same id would be impossible, but the stale entry must not linger to poison an unrelated one.
+    expect(mcp.isEnabled(WORK, s.id)).toBe(false);
+    expect(mcp.isEnabled(SCHOOL, s.id)).toBe(false);
+  });
+});
+
+describe("secrets", () => {
+  it("never returns a secret value from list()", () => {
+    // The named mutant: put `env` on McpServerSchema (or stop projecting) and this fails.
+    mcp.add(stdio("airtable"), WORK);
+    mcp.add(http("vercel"), WORK);
+    const listed = mcp.list(WORK);
+    expect(JSON.stringify(listed)).not.toContain(KEY);
+    expect(listed.servers.map((s) => [s.envKeys, s.headerKeys])).toEqual([[["AIRTABLE_API_KEY"], []], [[], ["Authorization"]]]);
+  });
+
+  it("never returns one from add() or update() either", () => {
+    const s = mcp.add(stdio("airtable"), WORK);
+    expect(JSON.stringify(s)).not.toContain(KEY);
+    expect(JSON.stringify(mcp.update(s.id, { name: "renamed" }, WORK))).not.toContain(KEY);
+  });
+
+  it("does deliver the value to configFor — the one exit that exists", () => {
+    mcp.add(stdio("airtable"), WORK);
+    const [cfg] = mcp.configFor(WORK);
+    expect(cfg).toMatchObject({ transport: "stdio", env: { AIRTABLE_API_KEY: KEY } });
+  });
+
+  it("keeps a stored key when an edit omits env, because a client was never given it to send back", () => {
+    const s = mcp.add(stdio("airtable"), WORK);
+    mcp.update(s.id, { name: "airtable2", args: ["/abs/other.mjs"] }, WORK);
+    expect(mcp.configFor(WORK)[0]).toMatchObject({ name: "airtable2", args: ["/abs/other.mjs"], env: { AIRTABLE_API_KEY: KEY } });
+  });
+
+  it("replaces the whole map when env IS passed, which is how a key is removed", () => {
+    const s = mcp.add(stdio("airtable"), WORK);
+    mcp.update(s.id, { env: {} }, WORK);
+    expect(mcp.configFor(WORK)[0]).toMatchObject({ env: {} });
+    expect(mcp.list(WORK).servers[0]!.envKeys).toEqual([]);
+  });
+});
+
+describe("definitions", () => {
+  it("carries nothing across a transport switch", () => {
+    const s = mcp.add(stdio("airtable"), WORK);
+    const after = mcp.update(s.id, { transport: "http", url: "https://mcp.vercel.com" }, WORK);
+    expect(after).toMatchObject({ transport: "http", command: "", args: [], url: "https://mcp.vercel.com" });
+    // The old env keys would be meaningless as headers, and keeping them would silently ship an API key
+    // to a host in a header nobody chose.
+    expect(after.headerKeys).toEqual([]);
+    expect(JSON.stringify(mcp.configFor(WORK))).not.toContain(KEY);
+  });
+
+  it("refuses a definition that cannot connect to anything", () => {
+    expect(() => mcp.add({ name: "empty", transport: "stdio" }, WORK)).toThrow(/needs a command/);
+    expect(() => mcp.add({ name: "empty", transport: "http" }, WORK)).toThrow(/needs a url/);
+    expect(() => mcp.add({ name: "empty", transport: "sse" }, WORK)).toThrow(/needs a url/);
+    expect(mcp.list(WORK).servers).toEqual([]);
+  });
+
+  it("refuses to strand an existing server by editing its endpoint away", () => {
+    const s = mcp.add(stdio("airtable"), WORK);
+    expect(() => mcp.update(s.id, { command: "" }, WORK)).toThrow(/needs a command/);
+    expect(mcp.configFor(WORK)[0]).toMatchObject({ command: "/usr/bin/node" });
+  });
+
+  it("refuses a duplicate name, because a name is the key every agent addresses it by", () => {
+    mcp.add(stdio("airtable"), WORK);
+    expect(() => mcp.add(stdio("airtable"), WORK)).toThrow(/already exists/);
+    const other = mcp.add(stdio("other"), WORK);
+    expect(() => mcp.update(other.id, { name: "airtable" }, WORK)).toThrow(/already exists/);
+    // Renaming to its own name is not a clash.
+    expect(mcp.update(other.id, { name: "other" }, WORK).name).toBe("other");
+  });
+
+  it("reports an unknown id rather than creating one", () => {
+    expect(() => mcp.update("01ARZ3NDEKTSV4RRFFQ69G5FAZ", { name: "x" })).toThrow(/not found/);
+  });
+});

--- a/apps/server/src/mcp/service.ts
+++ b/apps/server/src/mcp/service.ts
@@ -1,0 +1,174 @@
+import { MCP_SECRET_STORAGE_NOTE, type McpServer, type McpTransport } from "@realm/contracts";
+import type { McpServerConfig } from "@realm/adapters";
+import { RpcError } from "../store/rows";
+import type { SettingsStore } from "../store/settings";
+import type { McpServerInput, McpServerRow, McpServersStore } from "../store/mcp";
+
+/**
+ * Per-space **enabled** ids — the opposite of W1's skills key, and deliberately so.
+ *
+ * Skills store the *disabled* set because a folder the user drops a `SKILL.md` into should work at
+ * once, and the cost of being wrong is a paragraph of text the agent might read. An MCP server is a
+ * process Realm spawns, or a URL Realm sends an API key to. A server added while configuring a Work
+ * space must not quietly arm itself in a School space where the user never agreed to run it. So the
+ * default is off, and a space's set names what it opted into.
+ */
+const enabledKey = (spaceId: string): string => `mcp.enabled:${spaceId}`;
+
+const readIds = (settings: SettingsStore, key: string): string[] => {
+  const v = settings.get(key);
+  return Array.isArray(v) ? v.filter((x): x is string => typeof x === "string") : [];
+};
+
+/** What `mcp.add` / `mcp.update` accept, before the transport decides which half of it is meaningful. */
+export type McpServerFields = {
+  name?: string; transport?: McpTransport;
+  command?: string; args?: string[]; env?: Record<string, string>;
+  url?: string; headers?: Record<string, string>;
+};
+
+/**
+ * Realm's MCP server definitions, and which spaces use them.
+ *
+ * The one rule that shapes this class: **secret values go out exactly one way** — through
+ * `configFor`, into a session's `StartOptions`, to the adapter that was configured to receive them.
+ * `list` returns key names. Nothing here logs, broadcasts, or returns a value.
+ */
+export class McpService {
+  constructor(private d: { servers: McpServersStore; settings: SettingsStore }) {}
+
+  /** Every server, carrying this space's enable flag, plus the storage note the UI must show. */
+  list(spaceId: string): { servers: McpServer[]; secretNote: string } {
+    const enabled = new Set(readIds(this.d.settings, enabledKey(spaceId)));
+    return { servers: this.d.servers.list().map((r) => toContract(r, enabled.has(r.id))), secretNote: MCP_SECRET_STORAGE_NOTE };
+  }
+
+  /**
+   * Define a server, and enable it in the space it was added from — and nowhere else.
+   *
+   * `spaceId: null` adds it enabled nowhere, which is what an import or a settings screen with no
+   * space in scope wants.
+   */
+  add(fields: McpServerFields & { name: string; transport: McpTransport }, spaceId: string | null): McpServer {
+    const input = { name: fields.name, ...normalize(fields, fields.transport, blank()) };
+    requireEndpoint(input);
+    const row = this.d.servers.create(input);
+    if (spaceId) this.setEnabled(spaceId, row.id, true);
+    return toContract(row, spaceId !== null);
+  }
+
+  /**
+   * Change a server in place. An omitted field keeps its stored value — including `env`/`headers`,
+   * which a client cannot round-trip because it was never given them.
+   *
+   * Changing the transport re-reads the fields for the NEW transport from `fields` alone: a stdio
+   * server turned into an HTTP one must not keep a `command` that would then be dead state, nor an
+   * `env` map whose keys mean nothing as headers. Nothing is carried across the switch.
+   */
+  update(id: string, fields: McpServerFields, spaceId: string | null = null): McpServer {
+    const existing = this.d.servers.get(id);
+    if (!existing) throw new RpcError("NOT_FOUND", `mcp server ${id} not found`);
+    const transport = fields.transport ?? existing.transport;
+    const base = transport === existing.transport ? existing : blank();
+    const input = { name: fields.name ?? existing.name, ...normalize(fields, transport, base) };
+    requireEndpoint(input);
+    const row = this.d.servers.update(id, input);
+    return toContract(row, spaceId !== null && this.isEnabled(spaceId, id));
+  }
+
+  /** Forget the server and every space's opt-in to it, so re-adding the same name starts clean. */
+  remove(id: string, spaceIds: readonly string[]): void {
+    this.d.servers.delete(id);
+    for (const spaceId of spaceIds) {
+      const key = enabledKey(spaceId);
+      const ids = readIds(this.d.settings, key);
+      if (ids.includes(id)) this.d.settings.set(key, ids.filter((x) => x !== id));
+    }
+  }
+
+  setEnabled(spaceId: string, id: string, enabled: boolean): void {
+    const key = enabledKey(spaceId);
+    const ids = new Set(readIds(this.d.settings, key));
+    if (enabled) ids.add(id); else ids.delete(id);
+    this.d.settings.set(key, [...ids].sort());
+  }
+
+  isEnabled(spaceId: string, id: string): boolean {
+    return readIds(this.d.settings, enabledKey(spaceId)).includes(id);
+  }
+
+  /**
+   * This space's enabled servers, secrets included, for one session's `StartOptions`.
+   *
+   * The **only** path a secret value takes out of the database. Deliberately not called anywhere that
+   * broadcasts, persists, or logs: `SessionService` passes the result straight to `adapter.start`.
+   *
+   * Transport filtering is NOT done here. Each adapter drops what its agent cannot reach and says which
+   * and why through `onLog` — one place that knows the wire, rather than two that can disagree.
+   *
+   * Never throws. An unreadable definition costs a session one tool server; it does not cost the user
+   * their session.
+   */
+  configFor(spaceId: string): McpServerConfig[] {
+    try {
+      const enabled = new Set(readIds(this.d.settings, enabledKey(spaceId)));
+      return this.d.servers.list().filter((r) => enabled.has(r.id)).flatMap(toAdapterConfig);
+    } catch (e) {
+      console.error(`[mcp] could not resolve servers for space ${spaceId}: ${e instanceof Error ? e.message : String(e)}`);
+      return [];
+    }
+  }
+}
+
+/**
+ * A server with no command (stdio) or no URL (http/sse) cannot connect to anything, so it is refused at
+ * the point of definition rather than stored and skipped at session start. "Saved, listed, and silently
+ * dead" is the exact failure this workstream exists to prevent — and `configFor` drops such a row, so
+ * without this the user would see it in the list and never in the agent.
+ */
+function requireEndpoint(input: McpServerInput): void {
+  if (input.transport === "stdio" ? !input.command : !input.url) {
+    throw new RpcError("MCP_INCOMPLETE", input.transport === "stdio"
+      ? "a stdio MCP server needs a command"
+      : `a ${input.transport} MCP server needs a url`);
+  }
+}
+
+/** The fields a server has when nothing has been said about it yet. A fresh object each call: the
+ *  caller writes into it, and a shared `args`/`secrets` would leak between two servers. */
+const blank = (): Omit<McpServerInput, "name" | "transport"> => ({ command: "", args: [], url: "", secrets: {} });
+
+/** `McpServerFields` → the store's shape, reading only the half that this transport uses. */
+function normalize(f: McpServerFields, transport: McpTransport, base: Omit<McpServerInput, "name" | "transport">): Omit<McpServerInput, "name"> {
+  return transport === "stdio"
+    ? { transport, command: f.command ?? base.command, args: f.args ?? base.args, url: "", secrets: f.env ?? base.secrets }
+    : { transport, command: "", args: [], url: f.url ?? base.url, secrets: f.headers ?? base.secrets };
+}
+
+/**
+ * Row → wire. **The projection that keeps secrets off every client surface**: `secrets` becomes
+ * `envKeys` or `headerKeys`, and the values are simply not carried.
+ */
+function toContract(r: McpServerRow, enabled: boolean): McpServer {
+  const keys = Object.keys(r.secrets).sort();
+  return {
+    id: r.id, name: r.name, transport: r.transport,
+    command: r.command, args: r.args, url: r.url,
+    envKeys: r.transport === "stdio" ? keys : [],
+    headerKeys: r.transport === "stdio" ? [] : keys,
+    enabled, createdAt: r.createdAt,
+  };
+}
+
+/**
+ * Row → adapter. Returns `[]` for a definition that cannot connect — a stdio row with no command, a
+ * remote row with no URL. Passing one on would spawn nothing and look configured.
+ */
+function toAdapterConfig(r: McpServerRow): McpServerConfig[] {
+  if (r.transport === "stdio") {
+    if (!r.command) return [];
+    return [{ name: r.name, transport: "stdio", command: r.command, args: r.args, env: r.secrets }];
+  }
+  if (!r.url) return [];
+  return [{ name: r.name, transport: r.transport, url: r.url, headers: r.secrets }];
+}

--- a/apps/server/src/memory/claude-files.test.ts
+++ b/apps/server/src/memory/claude-files.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { claudeMemoryFiles, parseImports } from "./claude-files";
+
+const scratch = () => mkdtempSync(join(tmpdir(), "realm-claude-files-"));
+const write = (dir: string, name: string, text: string) => {
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, name), text);
+  return join(dir, name);
+};
+
+describe("parseImports", () => {
+  it("finds @path tokens at line start and after whitespace", () => {
+    expect(parseImports("@docs/a.md then see @./b.md\nplain line\n @~/c.md")).toEqual(["docs/a.md", "./b.md", "~/c.md"]);
+  });
+
+  it("does not mistake an email or scoped package for an import", () => {
+    // No whitespace before the @: the CLI does not treat these as imports and neither may the model.
+    expect(parseImports("mail carlton@charmtechnologies.co about @anthropic-ai/sdk")).toEqual(["anthropic-ai/sdk"]);
+    expect(parseImports("carlton@charmtechnologies.co")).toEqual([]);
+  });
+
+  it("skips fenced code blocks, matching the CLI", () => {
+    const text = "@real.md\n```\n@fenced.md\n```\n@after.md\n~~~\n@tilde-fenced.md\n~~~\n";
+    expect(parseImports(text)).toEqual(["real.md", "after.md"]);
+  });
+});
+
+describe("claudeMemoryFiles", () => {
+  it("models the hierarchy in the CLI's order: user file, then ancestors root-first, then cwd", () => {
+    const root = scratch();
+    const userDir = join(root, "claude-home");
+    const repo = join(root, "repo");
+    const sub = join(repo, "sub");
+    write(userDir, "CLAUDE.md", "user memory");
+    write(repo, "CLAUDE.md", "repo memory");
+    write(sub, "CLAUDE.md", "sub memory");
+
+    const files = claudeMemoryFiles(sub, userDir);
+    // The walk legitimately passes through the scratch dir's own ancestors; only ours are asserted on.
+    const existing = files.filter((f) => f.exists && f.path.startsWith(root)).map((f) => [f.path, f.origin]);
+    expect(existing).toEqual([
+      [join(userDir, "CLAUDE.md"), "user"],
+      [join(repo, "CLAUDE.md"), "project"],
+      [join(sub, "CLAUDE.md"), "project"],
+    ]);
+  });
+
+  it("lists the two well-known locations even when absent, and no other absent candidates", () => {
+    const root = scratch();
+    const userDir = join(root, "claude-home");
+    const cwd = join(root, "empty");
+    mkdirSync(cwd, { recursive: true });
+    const files = claudeMemoryFiles(cwd, userDir).filter((f) => f.path.startsWith(root));
+    expect(files.map((f) => [f.path, f.exists])).toEqual([
+      [join(userDir, "CLAUDE.md"), false],
+      [join(cwd, "CLAUDE.md"), false],
+    ]);
+  });
+
+  it("reads .claude/CLAUDE.md and CLAUDE.local.md variants when they exist", () => {
+    const root = scratch();
+    const cwd = join(root, "repo");
+    write(join(cwd, ".claude"), "CLAUDE.md", "dot memory");
+    write(cwd, "CLAUDE.local.md", "local memory");
+    const files = claudeMemoryFiles(cwd, join(root, "claude-home"));
+    const existing = files.filter((f) => f.exists && f.path.startsWith(root)).map((f) => f.path);
+    expect(existing).toEqual([join(cwd, ".claude", "CLAUDE.md"), join(cwd, "CLAUDE.local.md")]);
+  });
+
+  it("follows @imports relative to the importing file, tagging them as imports", () => {
+    const root = scratch();
+    const cwd = join(root, "repo");
+    write(cwd, "CLAUDE.md", "see @docs/extra.md");
+    write(join(cwd, "docs"), "extra.md", "imported memory");
+    const files = claudeMemoryFiles(cwd, join(root, "claude-home"));
+    const imported = files.find((f) => f.origin === "import");
+    expect(imported).toMatchObject({ path: join(cwd, "docs", "extra.md"), exists: true, content: "imported memory" });
+    // Listed right after its importer, mirroring read order.
+    expect(files.findIndex((f) => f.path === join(cwd, "CLAUDE.md"))).toBeLessThan(files.indexOf(imported!));
+  });
+
+  it("drops import mentions that do not resolve to a file (prose @words)", () => {
+    const root = scratch();
+    const cwd = join(root, "repo");
+    write(cwd, "CLAUDE.md", "ping @alice about @missing/file.md");
+    const files = claudeMemoryFiles(cwd, join(root, "claude-home"));
+    expect(files.filter((f) => f.origin === "import")).toEqual([]);
+  });
+
+  it("stops at 4 hops and survives an import cycle", () => {
+    const root = scratch();
+    const cwd = join(root, "repo");
+    // CLAUDE.md -> a -> b -> c -> d -> e ; e is hop 5 and must not be read. b also re-imports a (cycle).
+    write(cwd, "CLAUDE.md", "@a.md");
+    write(cwd, "a.md", "@b.md");
+    write(cwd, "b.md", "@c.md and back @a.md");
+    write(cwd, "c.md", "@d.md");
+    write(cwd, "d.md", "@e.md");
+    write(cwd, "e.md", "too deep");
+    const paths = claudeMemoryFiles(cwd, join(root, "claude-home")).map((f) => f.path);
+    for (const name of ["a.md", "b.md", "c.md", "d.md"]) expect(paths).toContain(join(cwd, name));
+    expect(paths).not.toContain(join(cwd, "e.md"));
+    expect(paths.filter((p) => p === join(cwd, "a.md"))).toHaveLength(1);
+  });
+
+  it("resolves @~/ imports against the home directory shape (never listing a miss)", () => {
+    const root = scratch();
+    const cwd = join(root, "repo");
+    write(cwd, "CLAUDE.md", "@~/definitely-not-a-real-realm-test-file.md");
+    const files = claudeMemoryFiles(cwd, join(root, "claude-home"));
+    expect(files.filter((f) => f.origin === "import")).toEqual([]);
+  });
+});

--- a/apps/server/src/memory/claude-files.ts
+++ b/apps/server/src/memory/claude-files.ts
@@ -1,0 +1,101 @@
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, isAbsolute, join, resolve } from "node:path";
+
+/**
+ * The `CLAUDE.md` hierarchy, modeled by READING the same paths the CLI reads — never writing them.
+ *
+ * The CLI's own load order (spec §1.3): `~/.claude/CLAUDE.md`, then `CLAUDE.md` / `.claude/CLAUDE.md` /
+ * `CLAUDE.local.md` per ancestor directory of cwd, root-most first, with `@path` imports resolved from
+ * the file that names them (max 4 hops, skipped inside code fences). Claude reports nothing back about
+ * what it loaded — there is no `instructionSources` equivalent — so this model is as close to ground
+ * truth as the Claude side gets, and it is built from the identical paths rather than a guess.
+ */
+export type ClaudeMemoryFile = {
+  path: string;
+  origin: "user" | "project" | "import";
+  exists: boolean;
+  /** File text, capped at MAX_FILE_CHARS. Null when the file is absent or unreadable. */
+  content: string | null;
+};
+
+/** The CLI's own import limit: "max 4 hops". */
+const MAX_IMPORT_HOPS = 4;
+/** A memory file is prose measured in KB; anything bigger is truncated rather than allowed to swallow
+ *  a prompt. The pane still lists the file — `exists` is about the file, not the cap. */
+const MAX_FILE_CHARS = 256 * 1024;
+
+/** The directory the CLI itself reads user config from: `CLAUDE_CONFIG_DIR` when set, else `~/.claude`. */
+export function claudeUserDir(): string {
+  return process.env.CLAUDE_CONFIG_DIR || join(homedir(), ".claude");
+}
+
+function readCapped(path: string): string | null {
+  try {
+    const text = readFileSync(path, "utf8");
+    return text.length > MAX_FILE_CHARS ? text.slice(0, MAX_FILE_CHARS) : text;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * `@path` import references, the way the CLI finds them: preceded by start-of-line or whitespace
+ * (so `user@example.com` is not an import), running to the next whitespace, and ignored inside
+ * ``` / ~~~ fenced blocks. Prose that happens to start a word with `@` yields a path that does not
+ * exist, which the caller drops — same net behavior as the CLI trying and failing to read it.
+ */
+export function parseImports(text: string): string[] {
+  const out: string[] = [];
+  let fenced = false;
+  for (const line of text.split("\n")) {
+    const t = line.trimStart();
+    if (t.startsWith("```") || t.startsWith("~~~")) { fenced = !fenced; continue; }
+    if (fenced) continue;
+    for (const m of line.matchAll(/(?:^|\s)@([^\s@]+)/g)) out.push(m[1]!);
+  }
+  return out;
+}
+
+function resolveImport(spec: string, fromDir: string): string {
+  if (spec.startsWith("~/")) return join(homedir(), spec.slice(2));
+  if (isAbsolute(spec)) return spec;
+  return resolve(fromDir, spec);
+}
+
+/**
+ * Every memory file a Claude session at `cwd` loads (or would), in the CLI's own order.
+ *
+ * The two well-known locations — the user file and `<cwd>/CLAUDE.md` — are listed even when absent,
+ * because the pane's job includes showing where a file WOULD go. Ancestor, `.claude/` and `.local`
+ * variants plus imports appear only when they exist; listing every absent candidate up the tree would
+ * bury the real rows.
+ */
+export function claudeMemoryFiles(cwd: string, userDir = claudeUserDir()): ClaudeMemoryFile[] {
+  const out: ClaudeMemoryFile[] = [];
+  const seen = new Set<string>();
+  const push = (path: string, origin: ClaudeMemoryFile["origin"], listAbsent: boolean, hop: number): void => {
+    if (seen.has(path)) return; // also what makes an import cycle terminate
+    seen.add(path);
+    const content = readCapped(path);
+    if (content === null && !listAbsent) return;
+    out.push({ path, origin, exists: content !== null, content });
+    if (content === null || hop >= MAX_IMPORT_HOPS) return;
+    for (const spec of parseImports(content)) push(resolveImport(spec, dirname(path)), "import", false, hop + 1);
+  };
+
+  push(join(userDir, "CLAUDE.md"), "user", true, 0);
+
+  const top = resolve(cwd);
+  const dirs: string[] = [];
+  for (let dir = top; ; dir = dirname(dir)) {
+    dirs.unshift(dir);
+    if (dirname(dir) === dir) break;
+  }
+  for (const dir of dirs) {
+    push(join(dir, "CLAUDE.md"), "project", dir === top, 0);
+    push(join(dir, ".claude", "CLAUDE.md"), "project", false, 0);
+    push(join(dir, "CLAUDE.local.md"), "project", false, 0);
+  }
+  return out;
+}

--- a/apps/server/src/memory/integration.test.ts
+++ b/apps/server/src/memory/integration.test.ts
@@ -1,0 +1,212 @@
+import { describe, expect, it, afterEach, vi } from "vitest";
+import WebSocket from "ws";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { AsyncQueue, type AgentAdapter, type AgentHandle, type StartOptions } from "@realm/adapters";
+import { newId, sessionEvent, type AgentKind, type SessionEvent } from "@realm/contracts";
+import { createApp, type App } from "../app";
+import { waitFor } from "../test-utils";
+
+let app: App;
+afterEach(async () => { await app?.close(); vi.unstubAllEnvs(); });
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Any = any;
+
+/**
+ * Stands in for a real adapter under a real agent kind, records the StartOptions it was handed, and —
+ * for the codex kind — reports per-thread instructionSources on init the way the real adapter now does,
+ * derived from cwd so a cross-session mixup is visible as the wrong path.
+ */
+class RecordingAdapter implements AgentAdapter {
+  readonly starts: StartOptions[] = [];
+  constructor(readonly kind: AgentKind) {}
+  async probe() { return { kind: this.kind, available: true, version: "0", loggedIn: true, reason: null }; }
+  start(opts: StartOptions): AgentHandle {
+    this.starts.push(opts);
+    const events = new AsyncQueue<SessionEvent>();
+    events.push(sessionEvent("init", {
+      providerSessionId: `prov_${this.starts.length}`, model: "m", tools: [], cwd: opts.cwd,
+      ...(this.kind === "codex" ? { instructionSources: [join(opts.cwd, "AGENTS.md")] } : {}),
+    }));
+    events.push(sessionEvent("status", { status: "idle" }));
+    return {
+      events,
+      send: async () => { events.push(sessionEvent("assistant_text", { messageId: "m1", text: "ok" })); events.push(sessionEvent("status", { status: "idle" })); },
+      respondPermission: () => {},
+      interrupt: async () => {},
+      setOptions: async () => {},
+      dispose: async () => { events.close(); },
+    };
+  }
+}
+
+async function client(port: number) {
+  const ws = await new Promise<WebSocket>((res, rej) => { const w = new WebSocket(`ws://127.0.0.1:${port}`); w.once("open", () => res(w)); w.once("error", rej); });
+  const pending = new Map<string, (v: Any) => void>(); const events: Any[] = [];
+  ws.on("message", (d) => { const m = JSON.parse(d.toString()); if ("id" in m) pending.get(m.id)?.(m); else events.push(m); });
+  let n = 0;
+  const call = (method: string, params: unknown) => new Promise<Any>((res, rej) => {
+    const id = String(++n);
+    const timer = setTimeout(() => { pending.delete(id); rej(new Error(`rpc ${method} timed out`)); }, 5000);
+    pending.set(id, (v) => { clearTimeout(timer); res(v); });
+    ws.send(JSON.stringify({ id, method, params }));
+  });
+  return { call, events, close: () => ws.close() };
+}
+
+async function boot() {
+  const home = mkdtempSync(join(tmpdir(), "realm-memory-int-"));
+  vi.stubEnv("REALM_BUNDLED_SKILLS", join(home, "no-bundle"));
+  const claudeDir = join(home, "claude-home");
+  const claude = new RecordingAdapter("claude");
+  const codex = new RecordingAdapter("codex");
+  const cursor = new RecordingAdapter("acp:cursor");
+  app = await createApp({ home, port: 0, adapters: { claude, codex, "acp:cursor": cursor }, claudeDir });
+  const c = await client(app.port);
+  const p = (await c.call("profiles.create", { name: "W" })).result;
+  const spA = (await c.call("spaces.create", { profileId: p.id, name: "A" })).result;
+  const spB = (await c.call("spaces.create", { profileId: p.id, name: "B" })).result;
+  return { home, claudeDir, c, spA, spB, claude, codex, cursor };
+}
+
+/** Starts the session's adapter the way anything real does — on the first send. */
+async function startSession(c: Any, spaceId: string, agentKind: string) {
+  const { session } = (await c.call("sessions.create", { spaceId, agentKind })).result;
+  await c.call("sessions.send", { id: session.id, text: "go" });
+  return session;
+}
+
+describe("memory over rpc", () => {
+  it("round-trips the doc per space and broadcasts memory.changed", async () => {
+    const { c, spA, spB, home } = await boot();
+    const set = (await c.call("memory.set", { spaceId: spA.id, doc: "space A memory" })).result;
+    expect(set).toMatchObject({ doc: "space A memory", path: join(home, "memory", `${spA.id}.md`) });
+    await waitFor(() => c.events.some((e: Any) => e.event === "memory.changed" && e.payload.spaceId === spA.id));
+    expect((await c.call("memory.get", { spaceId: spA.id })).result.doc).toBe("space A memory");
+    expect((await c.call("memory.get", { spaceId: spB.id })).result.doc).toBe("");
+    c.close();
+  });
+
+  it("refuses a space that does not exist rather than reading memory for a typo", async () => {
+    const { c } = await boot();
+    const gone = newId();
+    expect((await c.call("memory.get", { spaceId: gone })).error.code).toBe("NOT_FOUND");
+    expect((await c.call("memory.set", { spaceId: gone, doc: "x" })).error.code).toBe("NOT_FOUND");
+    expect((await c.call("memory.setAgentsFile", { spaceId: gone, enabled: true })).error.code).toBe("NOT_FOUND");
+    c.close();
+  });
+
+  it("injects each space's own doc into its sessions — never another space's (Claude and Codex)", async () => {
+    const { c, spA, spB, claude, codex } = await boot();
+    await c.call("memory.set", { spaceId: spA.id, doc: "space A memory" });
+    await c.call("memory.set", { spaceId: spB.id, doc: "space B memory" });
+    await startSession(c, spA.id, "claude");
+    await startSession(c, spB.id, "claude");
+    await startSession(c, spB.id, "codex");
+    await waitFor(() => claude.starts.length === 2 && codex.starts.length === 1);
+    expect(claude.starts[0]!.systemContext).toContain("space A memory");
+    expect(claude.starts[0]!.systemContext).not.toContain("space B memory");
+    expect(claude.starts[1]!.systemContext).toContain("space B memory");
+    expect(claude.starts[1]!.systemContext).not.toContain("space A memory");
+    expect(codex.starts[0]!.systemContext).toContain("space B memory");
+    c.close();
+  });
+
+  it("hands Cursor no context at all — stated, not faked", async () => {
+    const { c, spA, cursor } = await boot();
+    await c.call("memory.set", { spaceId: spA.id, doc: "space A memory" });
+    await startSession(c, spA.id, "acp:cursor");
+    await waitFor(() => cursor.starts.length === 1);
+    expect(cursor.starts[0]!.systemContext).toBeUndefined();
+    c.close();
+  });
+
+  it("skills on + user CLAUDE.md present → the content still reaches the session (the W1 carry-forward)", async () => {
+    const { c, spA, home, claudeDir, claude } = await boot();
+    mkdirSync(claudeDir, { recursive: true });
+    writeFileSync(join(claudeDir, "CLAUDE.md"), "USER_MEMORY_MARKER_9317");
+    mkdirSync(join(home, "skills", "mac"), { recursive: true });
+    writeFileSync(join(home, "skills", "mac", "SKILL.md"), "---\nname: mac\ndescription: does mac.\n---\n");
+
+    await startSession(c, spA.id, "claude");
+    await waitFor(() => claude.starts.length === 1);
+    const start = claude.starts[0]!;
+    // The dangerous combination this exists for: the skills injection is active (so the CLI will load
+    // NO settings files) and the user's memory rides back in through systemContext.
+    expect(start.skills).toBeTruthy();
+    expect(start.systemContext).toContain("USER_MEMORY_MARKER_9317");
+    c.close();
+  });
+
+  it("with skills off the CLAUDE.md is NOT re-injected — the CLI loads it itself", async () => {
+    const { c, spA, claudeDir, claude } = await boot();
+    mkdirSync(claudeDir, { recursive: true });
+    writeFileSync(join(claudeDir, "CLAUDE.md"), "USER_MEMORY_MARKER_9317");
+    await startSession(c, spA.id, "claude");
+    await waitFor(() => claude.starts.length === 1);
+    expect(claude.starts[0]!.skills).toBeUndefined();
+    expect(claude.starts[0]!.systemContext).toBeUndefined();
+    c.close();
+  });
+
+  it("memory.sources reports per session: codex sessions carry their own thread's instructionSources", async () => {
+    const { c, spA, spB } = await boot();
+    const a = await startSession(c, spA.id, "codex");
+    const b = await startSession(c, spB.id, "codex");
+    const srcA = (await c.call("memory.sources", { sessionId: a.id })).result;
+    const srcB = (await c.call("memory.sources", { sessionId: b.id })).result;
+    expect(srcA).toMatchObject({ agent: "codex", basis: "reported" });
+    // Each session's report names its own cwd — one session's sources on another's pane is the mutant.
+    expect(srcA.sources.map((s: Any) => s.path)).toEqual([join(spA.folderPath, "AGENTS.md")]);
+    expect(srcB.sources.map((s: Any) => s.path)).toEqual([join(spB.folderPath, "AGENTS.md")]);
+    c.close();
+  });
+
+  it("memory.sources for an unstarted codex session says 'no report yet', not 'zero files'", async () => {
+    const { c, spA } = await boot();
+    const { session } = (await c.call("sessions.create", { spaceId: spA.id, agentKind: "codex" })).result;
+    expect((await c.call("memory.sources", { sessionId: session.id })).result).toMatchObject({ basis: "none", sources: [] });
+    c.close();
+  });
+
+  it("memory.sources for claude models the hierarchy; for cursor it is a stated nothing", async () => {
+    const { c, spA, claudeDir } = await boot();
+    mkdirSync(claudeDir, { recursive: true });
+    writeFileSync(join(claudeDir, "CLAUDE.md"), "user memory");
+    const cl = (await c.call("sessions.create", { spaceId: spA.id, agentKind: "claude" })).result.session;
+    const cu = (await c.call("sessions.create", { spaceId: spA.id, agentKind: "acp:cursor" })).result.session;
+    const srcCl = (await c.call("memory.sources", { sessionId: cl.id })).result;
+    expect(srcCl).toMatchObject({ agent: "claude", channel: "systemPrompt", basis: "modeled" });
+    expect(srcCl.sources.find((s: Any) => s.path === join(claudeDir, "CLAUDE.md"))).toMatchObject({ origin: "user", exists: true, via: "cli" });
+    const srcCu = (await c.call("memory.sources", { sessionId: cu.id })).result;
+    expect(srcCu).toMatchObject({ agent: "acp:cursor", channel: "none", basis: "none", sources: [] });
+    c.close();
+  });
+
+  it("the AGENTS.md toggle writes into the space's own Realm-created folder and follows doc edits", async () => {
+    const { c, spA } = await boot();
+    await c.call("memory.set", { spaceId: spA.id, doc: "the doc" });
+    const on = (await c.call("memory.setAgentsFile", { spaceId: spA.id, enabled: true })).result;
+    const path = join(spA.folderPath, "AGENTS.md");
+    expect(on.agentsFile).toMatchObject({ enabled: true, exists: true, managedByRealm: true, path });
+    expect(readFileSync(path, "utf8")).toContain("the doc");
+    await c.call("memory.set", { spaceId: spA.id, doc: "edited" });
+    expect(readFileSync(path, "utf8")).toContain("edited");
+    const off = (await c.call("memory.setAgentsFile", { spaceId: spA.id, enabled: false })).result;
+    expect(off.agentsFile.exists).toBe(false);
+    expect(existsSync(path)).toBe(false);
+    c.close();
+  });
+
+  it("never touches an AGENTS.md the user put there themselves", async () => {
+    const { c, spA } = await boot();
+    const path = join(spA.folderPath, "AGENTS.md");
+    writeFileSync(path, "the user's own agents file");
+    const r = await c.call("memory.setAgentsFile", { spaceId: spA.id, enabled: true });
+    expect(r.error.code).toBe("AGENTS_FILE_FOREIGN");
+    expect(readFileSync(path, "utf8")).toBe("the user's own agents file");
+    c.close();
+  });
+});

--- a/apps/server/src/memory/service.test.ts
+++ b/apps/server/src/memory/service.test.ts
@@ -1,0 +1,238 @@
+import { describe, expect, it } from "vitest";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Environment, EnvironmentKind } from "@realm/contracts";
+import { openDatabase } from "../db/database";
+import { SettingsStore } from "../store/settings";
+import { RpcError } from "../store/rows";
+import { AGENTS_FILE_MARKER, MemoryService } from "./service";
+
+const SPACE_A = "01ARZ3NDEKTSV4RRFFQ69G5FAA";
+const SPACE_B = "01ARZ3NDEKTSV4RRFFQ69G5FAB";
+
+/**
+ * A stand-in for EnvironmentsStore that can claim any `kind` for a space's primary row — which the real
+ * store never would, and which is exactly why the service's own kind guard has to hold: it is the last
+ * line between the AGENTS.md write and a directory the user made.
+ */
+const envs = (bySpace: Record<string, { path: string; kind: EnvironmentKind }>) => ({
+  ensurePrimary(spaceId: string): Environment {
+    const e = bySpace[spaceId];
+    if (!e) throw new Error(`no environment stubbed for ${spaceId}`);
+    return { id: `env-${spaceId}`, spaceId, path: e.path, branch: null, kind: e.kind, portBlockStart: null, createdAt: 0, updatedAt: 0 };
+  },
+});
+
+function harness(kinds: Partial<Record<string, EnvironmentKind>> = {}) {
+  const home = mkdtempSync(join(tmpdir(), "realm-memory-"));
+  const claudeDir = join(home, "claude-home");
+  const folders: Record<string, { path: string; kind: EnvironmentKind }> = {};
+  for (const [i, space] of [SPACE_A, SPACE_B].entries()) {
+    const path = join(home, `space-${i}`);
+    mkdirSync(path, { recursive: true });
+    folders[space] = { path, kind: kinds[space] ?? "primary" };
+  }
+  const settings = new SettingsStore(openDatabase(join(home, "realm.db")));
+  const memory = new MemoryService({ home, settings, environments: envs(folders), claudeDir });
+  return { home, claudeDir, memory, settings, folderOf: (s: string) => folders[s]!.path };
+}
+
+describe("MemoryService documents", () => {
+  it("round-trips the doc and reports its path under Realm's home", () => {
+    const { home, memory } = harness();
+    expect(memory.state(SPACE_A)).toMatchObject({ doc: "", path: join(home, "memory", `${SPACE_A}.md`) });
+    const state = memory.set(SPACE_A, "remember the deploy steps");
+    expect(state.doc).toBe("remember the deploy steps");
+    expect(readFileSync(join(home, "memory", `${SPACE_A}.md`), "utf8")).toBe("remember the deploy steps");
+  });
+
+  it("keeps spaces apart: writing one space's doc never shows up in another's", () => {
+    const { memory } = harness();
+    memory.set(SPACE_A, "space A memory");
+    memory.set(SPACE_B, "space B memory");
+    expect(memory.state(SPACE_A).doc).toBe("space A memory");
+    expect(memory.state(SPACE_B).doc).toBe("space B memory");
+  });
+
+  it("refuses a doc over the cap instead of writing an unbounded prompt", () => {
+    const { memory } = harness();
+    expect(() => memory.set(SPACE_A, "x".repeat(100_001))).toThrow(RpcError);
+    expect(memory.state(SPACE_A).doc).toBe("");
+  });
+});
+
+describe("MemoryService systemContextFor", () => {
+  it("injects THIS space's doc, not another's", () => {
+    const { memory } = harness();
+    memory.set(SPACE_A, "space A memory");
+    memory.set(SPACE_B, "space B memory");
+    const ctx = memory.systemContextFor({ spaceId: SPACE_A, kind: "codex", cwd: "/tmp", skillsInjected: false })!;
+    expect(ctx).toContain("space A memory");
+    expect(ctx).not.toContain("space B memory");
+  });
+
+  it("is undefined when there is nothing to inject", () => {
+    const { memory } = harness();
+    expect(memory.systemContextFor({ spaceId: SPACE_A, kind: "claude", cwd: "/tmp", skillsInjected: false })).toBeUndefined();
+    memory.set(SPACE_A, "   \n  "); // whitespace is nothing
+    expect(memory.systemContextFor({ spaceId: SPACE_A, kind: "claude", cwd: "/tmp", skillsInjected: false })).toBeUndefined();
+  });
+
+  it("is undefined for agents with no channel, whatever the doc says", () => {
+    const { memory } = harness();
+    memory.set(SPACE_A, "space A memory");
+    for (const kind of ["acp:cursor", "acp:gemini", "fake"] as const) {
+      expect(memory.systemContextFor({ spaceId: SPACE_A, kind, cwd: "/tmp", skillsInjected: false })).toBeUndefined();
+    }
+  });
+
+  it("re-injects the CLAUDE.md hierarchy for a Claude session running under settingSources: [] (the W1 carry-forward)", () => {
+    const { memory, claudeDir, folderOf } = harness();
+    mkdirSync(claudeDir, { recursive: true });
+    writeFileSync(join(claudeDir, "CLAUDE.md"), "USER_MEMORY_MARKER_9317 plus @extra.md");
+    writeFileSync(join(claudeDir, "extra.md"), "IMPORTED_MEMORY_MARKER_4482");
+    const cwd = folderOf(SPACE_A);
+    writeFileSync(join(cwd, "CLAUDE.md"), "PROJECT_MEMORY_MARKER_5561");
+
+    const ctx = memory.systemContextFor({ spaceId: SPACE_A, kind: "claude", cwd, skillsInjected: true })!;
+    // Losing any one of these silently is the failure this channel exists to prevent.
+    expect(ctx).toContain("USER_MEMORY_MARKER_9317");
+    expect(ctx).toContain("IMPORTED_MEMORY_MARKER_4482");
+    expect(ctx).toContain("PROJECT_MEMORY_MARKER_5561");
+    expect(ctx).toContain(join(claudeDir, "CLAUDE.md")); // each block names its file
+  });
+
+  it("does NOT re-inject when skills are off: the CLI loads those files itself and doubling them is the other bug", () => {
+    const { memory, claudeDir, folderOf } = harness();
+    mkdirSync(claudeDir, { recursive: true });
+    writeFileSync(join(claudeDir, "CLAUDE.md"), "USER_MEMORY_MARKER_9317");
+    memory.set(SPACE_A, "space A memory");
+    const ctx = memory.systemContextFor({ spaceId: SPACE_A, kind: "claude", cwd: folderOf(SPACE_A), skillsInjected: false })!;
+    expect(ctx).toContain("space A memory");
+    expect(ctx).not.toContain("USER_MEMORY_MARKER_9317");
+  });
+
+  it("never re-injects CLAUDE.md into Codex — Codex loses nothing to the skills path", () => {
+    const { memory, claudeDir, folderOf } = harness();
+    mkdirSync(claudeDir, { recursive: true });
+    writeFileSync(join(claudeDir, "CLAUDE.md"), "USER_MEMORY_MARKER_9317");
+    memory.set(SPACE_A, "space A memory");
+    const ctx = memory.systemContextFor({ spaceId: SPACE_A, kind: "codex", cwd: folderOf(SPACE_A), skillsInjected: true })!;
+    expect(ctx).toContain("space A memory");
+    expect(ctx).not.toContain("USER_MEMORY_MARKER_9317");
+  });
+});
+
+describe("MemoryService AGENTS.md", () => {
+  it("writes the marker-headed file into the Realm-created space folder on enable, and removes it on disable", () => {
+    const { memory, folderOf } = harness();
+    memory.set(SPACE_A, "the space doc");
+    const path = join(folderOf(SPACE_A), "AGENTS.md");
+    const on = memory.setAgentsFile(SPACE_A, true);
+    expect(on.agentsFile).toMatchObject({ enabled: true, exists: true, managedByRealm: true, path });
+    const written = readFileSync(path, "utf8");
+    expect(written.startsWith(AGENTS_FILE_MARKER)).toBe(true);
+    expect(written).toContain("the space doc");
+
+    const off = memory.setAgentsFile(SPACE_A, false);
+    expect(off.agentsFile).toMatchObject({ enabled: false, exists: false });
+    expect(existsSync(path)).toBe(false);
+  });
+
+  it("rewrites the managed file when the doc changes — and only while enabled", () => {
+    const { memory, folderOf } = harness();
+    const path = join(folderOf(SPACE_A), "AGENTS.md");
+    memory.setAgentsFile(SPACE_A, true);
+    memory.set(SPACE_A, "second version");
+    expect(readFileSync(path, "utf8")).toContain("second version");
+    memory.setAgentsFile(SPACE_A, false);
+    memory.set(SPACE_A, "third version");
+    expect(existsSync(path)).toBe(false);
+  });
+
+  it("REFUSES to write into a directory Realm did not create, whatever kind of row claims it", () => {
+    for (const kind of ["checkout", "worktree"] as const) {
+      const { memory, folderOf } = harness({ [SPACE_A]: kind });
+      expect(() => memory.setAgentsFile(SPACE_A, true)).toThrow(/did not create/);
+      expect(existsSync(join(folderOf(SPACE_A), "AGENTS.md"))).toBe(false);
+      // ...and the state says so, before anyone tries.
+      const state = memory.state(SPACE_A);
+      expect(state.agentsFile.writable).toBe(false);
+      expect(state.agentsFile.reason).toMatch(/did not create/);
+      // The flag was not persisted either: a doc edit later must not sneak the write in.
+      memory.set(SPACE_A, "later doc");
+      expect(existsSync(join(folderOf(SPACE_A), "AGENTS.md"))).toBe(false);
+    }
+  });
+
+  it("REFUSES to overwrite an AGENTS.md Realm did not write", () => {
+    const { memory, folderOf } = harness();
+    const path = join(folderOf(SPACE_A), "AGENTS.md");
+    writeFileSync(path, "the user's own agents file");
+    expect(() => memory.setAgentsFile(SPACE_A, true)).toThrow(/will not overwrite/);
+    expect(readFileSync(path, "utf8")).toBe("the user's own agents file");
+    expect(memory.state(SPACE_A).agentsFile).toMatchObject({ exists: true, managedByRealm: false, writable: false });
+  });
+
+  it("a user who deletes the marker takes the file over: no rewrite on doc change, no delete on disable", () => {
+    const { memory, folderOf } = harness();
+    const path = join(folderOf(SPACE_A), "AGENTS.md");
+    memory.setAgentsFile(SPACE_A, true);
+    writeFileSync(path, "mine now"); // marker gone
+    const after = memory.set(SPACE_A, "new doc"); // must not throw, must not rewrite
+    expect(readFileSync(path, "utf8")).toBe("mine now");
+    expect(after.agentsFile).toMatchObject({ managedByRealm: false, writable: false });
+    memory.setAgentsFile(SPACE_A, false);
+    expect(readFileSync(path, "utf8")).toBe("mine now");
+  });
+});
+
+describe("MemoryService sourcesFor", () => {
+  it("claude: models the hierarchy, marking how each file reaches the session", () => {
+    const { memory, claudeDir, folderOf } = harness();
+    mkdirSync(claudeDir, { recursive: true });
+    writeFileSync(join(claudeDir, "CLAUDE.md"), "user memory");
+    const cwd = folderOf(SPACE_A);
+
+    const viaCli = memory.sourcesFor({ kind: "claude", spaceId: SPACE_A, cwd, skillsInjected: false, reported: null });
+    expect(viaCli).toMatchObject({ agent: "claude", channel: "systemPrompt", basis: "modeled" });
+    expect(viaCli.sources.find((s) => s.path === join(claudeDir, "CLAUDE.md"))).toMatchObject({ origin: "user", exists: true, via: "cli" });
+    expect(viaCli.sources.find((s) => s.path === join(cwd, "CLAUDE.md"))).toMatchObject({ exists: false, via: "none" });
+
+    // Skills on: the CLI loads nothing; Realm carries it. The pane must say which is happening.
+    const viaRealm = memory.sourcesFor({ kind: "claude", spaceId: SPACE_A, cwd, skillsInjected: true, reported: null });
+    expect(viaRealm.sources.find((s) => s.path === join(claudeDir, "CLAUDE.md"))).toMatchObject({ via: "realm" });
+  });
+
+  it("codex: passes the session's own report through, and keeps 'no report yet' distinct from 'reported zero files'", () => {
+    const { memory, folderOf } = harness();
+    const real = join(folderOf(SPACE_A), "AGENTS.md");
+    writeFileSync(real, "agents");
+    const reported = memory.sourcesFor({ kind: "codex", spaceId: SPACE_A, cwd: "/tmp", skillsInjected: false, reported: [real, "/nowhere/AGENTS.md"] });
+    expect(reported).toMatchObject({ agent: "codex", channel: "developerInstructions", basis: "reported" });
+    expect(reported.sources).toEqual([
+      { path: real, origin: "reported", exists: true, via: "cli" },
+      { path: "/nowhere/AGENTS.md", origin: "reported", exists: false, via: "cli" },
+    ]);
+    const unstarted = memory.sourcesFor({ kind: "codex", spaceId: SPACE_A, cwd: "/tmp", skillsInjected: false, reported: null });
+    expect(unstarted).toMatchObject({ basis: "none", sources: [] });
+    const empty = memory.sourcesFor({ kind: "codex", spaceId: SPACE_A, cwd: "/tmp", skillsInjected: false, reported: [] });
+    expect(empty).toMatchObject({ basis: "reported", sources: [] });
+  });
+
+  it("cursor: a stated nothing — no channel, no sources, no realm memory, and a note naming the agent", () => {
+    const { memory } = harness();
+    memory.set(SPACE_A, "space A memory");
+    const r = memory.sourcesFor({ kind: "acp:cursor", spaceId: SPACE_A, cwd: "/tmp", skillsInjected: false, reported: null });
+    expect(r).toMatchObject({ agent: "acp:cursor", channel: "none", basis: "none", realmMemoryInjected: false, sources: [] });
+    expect(r.note).toContain("Cursor");
+  });
+
+  it("realmMemoryInjected tracks the doc of THE space asked about", () => {
+    const { memory } = harness();
+    memory.set(SPACE_A, "space A memory");
+    expect(memory.sourcesFor({ kind: "codex", spaceId: SPACE_A, cwd: "/tmp", skillsInjected: false, reported: null }).realmMemoryInjected).toBe(true);
+    expect(memory.sourcesFor({ kind: "codex", spaceId: SPACE_B, cwd: "/tmp", skillsInjected: false, reported: null }).realmMemoryInjected).toBe(false);
+  });
+});

--- a/apps/server/src/memory/service.ts
+++ b/apps/server/src/memory/service.ts
@@ -1,0 +1,191 @@
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  AGENT_MEMORY_CHANNEL, MEMORY_DOC_MAX, memorySupportNote,
+  type AgentKind, type AgentsFileState, type Environment, type MemorySource, type MemorySources, type MemoryState,
+} from "@realm/contracts";
+import { RpcError } from "../store/rows";
+import type { SettingsStore } from "../store/settings";
+import { claudeMemoryFiles, claudeUserDir } from "./claude-files";
+
+/** Per-space opt-in flag for the managed `AGENTS.md`. Off by default: it is a write into a folder. */
+const agentsKey = (spaceId: string): string => `memory.agentsFile:${spaceId}`;
+
+/**
+ * The first line of every `AGENTS.md` Realm writes, and the ONLY kind it will ever rewrite or remove.
+ * A user who deletes this line has taken the file over, and Realm treats it as theirs from then on.
+ */
+export const AGENTS_FILE_MARKER = "<!-- Managed by Realm.";
+const AGENTS_FILE_HEADER =
+  `${AGENTS_FILE_MARKER} Edit this space's memory in Realm instead — this file is rewritten whenever ` +
+  "that document changes, and removed when the toggle is turned off. Deleting this comment makes the file yours. -->";
+
+/** The one slice of EnvironmentsStore this service is allowed to see: where the space's own checkout
+ *  is and — decisive for the write — what `kind` of directory it is. */
+type PrimaryEnvironments = { ensurePrimary(spaceId: string): Environment };
+
+const tryRead = (path: string): string | null => {
+  try { return readFileSync(path, "utf8"); } catch { return null; }
+};
+
+/**
+ * W3's memory manager: a per-space document Realm owns, injected into sessions per invocation, plus a
+ * read-only model of what each agent actually loads.
+ *
+ * The document lives at `<realmHome>/memory/<spaceId>.md` — Realm's home, never any agent's config.
+ * `~/.claude`, `~/.codex`, `~/.cursor` and `~/.agents` are strictly read-only to this class; the one
+ * write it can make anywhere else is the marker-guarded `AGENTS.md` below, and only into a directory
+ * whose environment row says Realm created it.
+ */
+export class MemoryService {
+  /** Where user-level Claude files are read from. Overridable so tests and live checks never touch the
+   *  real `~/.claude`; the default is the exact directory the CLI itself reads. */
+  private readonly claudeDir: string;
+  constructor(private d: { home: string; settings: SettingsStore; environments: PrimaryEnvironments; claudeDir?: string }) {
+    this.claudeDir = d.claudeDir ?? claudeUserDir();
+  }
+
+  docPath(spaceId: string): string { return join(this.d.home, "memory", `${spaceId}.md`); }
+
+  readDoc(spaceId: string): string { return tryRead(this.docPath(spaceId)) ?? ""; }
+
+  state(spaceId: string): MemoryState {
+    return { path: this.docPath(spaceId), doc: this.readDoc(spaceId), agentsFile: this.agentsFileState(spaceId) };
+  }
+
+  set(spaceId: string, doc: string): MemoryState {
+    if (doc.length > MEMORY_DOC_MAX) throw new RpcError("MEMORY_DOC_TOO_LARGE", `the memory document is capped at ${MEMORY_DOC_MAX} characters`);
+    mkdirSync(join(this.d.home, "memory"), { recursive: true });
+    writeFileSync(this.docPath(spaceId), doc);
+    // Keep the managed AGENTS.md in step — but never let its refusal fail the edit that mattered. A
+    // file the user took over (marker deleted) stops being rewritten and says so in `agentsFile.reason`.
+    if (this.agentsFileEnabled(spaceId)) {
+      try { this.writeAgentsFile(this.d.environments.ensurePrimary(spaceId), doc); }
+      catch (e) { console.error(`[memory] AGENTS.md for space ${spaceId} not rewritten: ${e instanceof Error ? e.message : String(e)}`); }
+    }
+    return this.state(spaceId);
+  }
+
+  agentsFileEnabled(spaceId: string): boolean { return this.d.settings.get(agentsKey(spaceId)) === true; }
+
+  setAgentsFile(spaceId: string, enabled: boolean): MemoryState {
+    const env = this.d.environments.ensurePrimary(spaceId);
+    if (enabled) {
+      // Write first, record second: a toggle that cannot deliver its file must fail visibly rather
+      // than persist a preference the folder refuses.
+      this.writeAgentsFile(env, this.readDoc(spaceId));
+      this.d.settings.set(agentsKey(spaceId), true);
+    } else {
+      this.d.settings.set(agentsKey(spaceId), false);
+      this.removeAgentsFile(env);
+    }
+    return this.state(spaceId);
+  }
+
+  private agentsFilePath(env: Environment): string { return join(env.path, "AGENTS.md"); }
+
+  /** Why Realm will not write `AGENTS.md` here, or null when it may. Shared by the state report and the
+   *  write itself, so what the UI says and what the write does can never disagree. */
+  private agentsFileBlocker(env: Environment): { code: string; message: string } | null {
+    // The kind distinction is the whole guard: `primary` rows point at the folder SpacesStore.create
+    // made fresh under Realm's home. A `checkout` is the user's own directory and a `worktree` is a
+    // checkout of their repository — an AGENTS.md in either would pollute something Realm does not own.
+    if (env.kind !== "primary") {
+      return { code: "AGENTS_FILE_NOT_REALM_FOLDER", message: "Realm did not create this directory, so it will not write an AGENTS.md into it" };
+    }
+    const existing = tryRead(this.agentsFilePath(env));
+    if (existing !== null && !existing.startsWith(AGENTS_FILE_MARKER)) {
+      return { code: "AGENTS_FILE_FOREIGN", message: "an AGENTS.md Realm did not write is already in this folder; Realm will not overwrite it" };
+    }
+    return null;
+  }
+
+  /** The plan's ONE permitted write outside Realm's home. Marker-guarded and kind-guarded; throws rather
+   *  than degrade, because a memory write that silently lands nowhere is the failure W3 exists to end. */
+  private writeAgentsFile(env: Environment, doc: string): void {
+    const blocked = this.agentsFileBlocker(env);
+    if (blocked) throw new RpcError(blocked.code, blocked.message);
+    writeFileSync(this.agentsFilePath(env), `${AGENTS_FILE_HEADER}\n\n${doc}`);
+  }
+
+  /** Removes the managed file — and ONLY the managed file. A foreign or user-adopted AGENTS.md stays. */
+  private removeAgentsFile(env: Environment): void {
+    const path = this.agentsFilePath(env);
+    const existing = tryRead(path);
+    if (existing !== null && existing.startsWith(AGENTS_FILE_MARKER)) rmSync(path);
+  }
+
+  private agentsFileState(spaceId: string): AgentsFileState {
+    const env = this.d.environments.ensurePrimary(spaceId);
+    const path = this.agentsFilePath(env);
+    const existing = tryRead(path);
+    const blocked = this.agentsFileBlocker(env);
+    return {
+      enabled: this.agentsFileEnabled(spaceId),
+      path,
+      exists: existing !== null,
+      managedByRealm: existing !== null && existing.startsWith(AGENTS_FILE_MARKER),
+      writable: blocked === null,
+      reason: blocked?.message ?? null,
+    };
+  }
+
+  /**
+   * The per-session context for one agent start — `StartOptions.systemContext`, which the Claude
+   * adapter appends to its system prompt and the Codex adapter sends as `developerInstructions`.
+   *
+   * Two ingredients, in load order:
+   *
+   * 1. **The W1 carry-forward.** A Claude session whose skills library is active runs with
+   *    `settingSources: []`, which also stops the CLI loading `~/.claude/CLAUDE.md` and every project
+   *    `CLAUDE.md`. Enabling a skill must not silently cost the user their own memory files, so their
+   *    content rides back in here — the same files `claudeMemoryFiles` models for the pane, so what the
+   *    UI lists as re-injected and what the session receives are one computation. Only when
+   *    `skillsInjected` is true: otherwise the CLI loads these files itself and injecting them again
+   *    would double every one of them.
+   * 2. **This space's Realm memory document** — and only this space's; `spaceId` comes from the session
+   *    row the caller is starting.
+   *
+   * Undefined for agents with no channel (`AGENT_MEMORY_CHANNEL` = "none"): Cursor's ACP session/new
+   * takes `{cwd, mcpServers}` and nothing else, and handing an adapter context it can only drop would
+   * make the memory pane a lie.
+   */
+  systemContextFor(o: { spaceId: string; kind: AgentKind; cwd: string; skillsInjected: boolean }): string | undefined {
+    if (AGENT_MEMORY_CHANNEL[o.kind] === "none") return undefined;
+    const parts: string[] = [];
+    if (o.kind === "claude" && o.skillsInjected) {
+      for (const f of claudeMemoryFiles(o.cwd, this.claudeDir)) {
+        if (!f.content?.trim()) continue;
+        parts.push(`Contents of ${f.path} (re-injected by Realm; this session loads no settings files itself because its skills library isolates them):\n\n${f.content}`);
+      }
+    }
+    const doc = this.readDoc(o.spaceId).trim();
+    if (doc) parts.push(`# Space memory\n\nThe user keeps this context for every session in this workspace (managed in Realm):\n\n${doc}`);
+    return parts.length > 0 ? parts.join("\n\n") : undefined;
+  }
+
+  /**
+   * What durable context one session's agent loads, on the best authority available per agent:
+   * Claude modeled from the paths the CLI reads, Codex from the `instructionSources` ITS OWN
+   * `thread/start` reported (`reported` is null until it has), Cursor a stated nothing.
+   */
+  sourcesFor(o: { kind: AgentKind; spaceId: string; cwd: string; skillsInjected: boolean; reported: string[] | null }): MemorySources {
+    const channel = AGENT_MEMORY_CHANNEL[o.kind];
+    const note = memorySupportNote(o.kind);
+    const realmMemoryInjected = channel !== "none" && this.readDoc(o.spaceId).trim().length > 0;
+    if (o.kind === "claude") {
+      const sources: MemorySource[] = claudeMemoryFiles(o.cwd, this.claudeDir).map((f) => ({
+        path: f.path, origin: f.origin, exists: f.exists,
+        via: !f.exists ? "none" : o.skillsInjected ? "realm" : "cli",
+      }));
+      return { agent: o.kind, channel, basis: "modeled", note, realmMemoryInjected, sources };
+    }
+    if (o.kind === "codex") {
+      const sources: MemorySource[] = (o.reported ?? []).map((p) => ({ path: p, origin: "reported", exists: existsSync(p), via: "cli" }));
+      // basis "none" until the session has started: an empty REPORT ("codex loaded zero files") and no
+      // report yet are different facts, and the pane must not present the second as the first.
+      return { agent: o.kind, channel, basis: o.reported === null ? "none" : "reported", note, realmMemoryInjected, sources };
+    }
+    return { agent: o.kind, channel, basis: "none", note, realmMemoryInjected, sources: [] };
+  }
+}

--- a/apps/server/src/rpc/methods.ts
+++ b/apps/server/src/rpc/methods.ts
@@ -11,6 +11,7 @@ import type { ItemsStore } from "../store/items";
 import type { SettingsStore } from "../store/settings";
 import type { SkillsService } from "../skills/service";
 import type { McpService } from "../mcp/service";
+import type { MemoryService } from "../memory/service";
 import type { TerminalService } from "../terminals/service";
 import type { SessionService } from "../sessions/service";
 import type { GitInfoService } from "../workspace/git-info";
@@ -25,7 +26,7 @@ type Result<M extends MethodName> = MethodResult<M> | Promise<MethodResult<M>>;
 
 export type Deps = {
   rpc: RpcServer; home: string; version: string;
-  profiles: ProfilesStore; spaces: SpacesStore; projects: ProjectsStore; environments: EnvironmentsStore; envService: EnvironmentService; items: ItemsStore; settings: SettingsStore; skills: SkillsService; mcp: McpService; terminals: TerminalService; sessions: SessionService; gitInfo: GitInfoService; gitDiff: GitDiffService; gitWrite: GitWriteService; ports: PortAllocator; checkpoints: CheckpointService;
+  profiles: ProfilesStore; spaces: SpacesStore; projects: ProjectsStore; environments: EnvironmentsStore; envService: EnvironmentService; items: ItemsStore; settings: SettingsStore; skills: SkillsService; mcp: McpService; memory: MemoryService; terminals: TerminalService; sessions: SessionService; gitInfo: GitInfoService; gitDiff: GitDiffService; gitWrite: GitWriteService; ports: PortAllocator; checkpoints: CheckpointService;
 };
 
 export function registerMethods(d: Deps): void {
@@ -115,6 +116,29 @@ export function registerMethods(d: Deps): void {
     rpc.broadcast("mcp.changed", {});
     return { ok: true as const };
   });
+
+  // Space existence is checked for the same reason the skills and mcp handlers do it: the memory doc,
+  // its settings flag and the AGENTS.md target are all keyed by space id, so a typo would silently
+  // read and write another space's memory rather than saying so.
+  reg("memory.get", (p) => {
+    if (!d.spaces.get(p.spaceId)) throw new NotFoundError("space", p.spaceId);
+    return d.memory.state(p.spaceId);
+  });
+  reg("memory.set", (p) => {
+    if (!d.spaces.get(p.spaceId)) throw new NotFoundError("space", p.spaceId);
+    const r = d.memory.set(p.spaceId, p.doc);
+    rpc.broadcast("memory.changed", { spaceId: p.spaceId });
+    return r;
+  });
+  reg("memory.setAgentsFile", (p) => {
+    if (!d.spaces.get(p.spaceId)) throw new NotFoundError("space", p.spaceId);
+    const r = d.memory.setAgentsFile(p.spaceId, p.enabled);
+    rpc.broadcast("memory.changed", { spaceId: p.spaceId });
+    return r;
+  });
+  // Per-session on purpose: the SessionService joins the session row (agent kind, space, cwd) to the
+  // ground truth that belongs to that session and no other.
+  reg("memory.sources", (p) => d.sessions.memorySources(p.sessionId));
 
   reg("projects.list", (p) => d.projects.list(p.spaceId));
   reg("projects.create", (p) => { const r = d.projects.create(p); rpc.broadcast("items.changed", { spaceId: r.spaceId }); return r; });

--- a/apps/server/src/rpc/methods.ts
+++ b/apps/server/src/rpc/methods.ts
@@ -10,6 +10,7 @@ import type { CheckpointService } from "../checkpoints/service";
 import type { ItemsStore } from "../store/items";
 import type { SettingsStore } from "../store/settings";
 import type { SkillsService } from "../skills/service";
+import type { McpService } from "../mcp/service";
 import type { TerminalService } from "../terminals/service";
 import type { SessionService } from "../sessions/service";
 import type { GitInfoService } from "../workspace/git-info";
@@ -24,7 +25,7 @@ type Result<M extends MethodName> = MethodResult<M> | Promise<MethodResult<M>>;
 
 export type Deps = {
   rpc: RpcServer; home: string; version: string;
-  profiles: ProfilesStore; spaces: SpacesStore; projects: ProjectsStore; environments: EnvironmentsStore; envService: EnvironmentService; items: ItemsStore; settings: SettingsStore; skills: SkillsService; terminals: TerminalService; sessions: SessionService; gitInfo: GitInfoService; gitDiff: GitDiffService; gitWrite: GitWriteService; ports: PortAllocator; checkpoints: CheckpointService;
+  profiles: ProfilesStore; spaces: SpacesStore; projects: ProjectsStore; environments: EnvironmentsStore; envService: EnvironmentService; items: ItemsStore; settings: SettingsStore; skills: SkillsService; mcp: McpService; terminals: TerminalService; sessions: SessionService; gitInfo: GitInfoService; gitDiff: GitDiffService; gitWrite: GitWriteService; ports: PortAllocator; checkpoints: CheckpointService;
 };
 
 export function registerMethods(d: Deps): void {
@@ -81,6 +82,37 @@ export function registerMethods(d: Deps): void {
     if (!d.spaces.get(p.spaceId)) throw new NotFoundError("space", p.spaceId);
     d.skills.setEnabled(p.spaceId, p.id, p.enabled);
     rpc.broadcast("skills.changed", { spaceId: p.spaceId });
+    return { ok: true as const };
+  });
+
+  // Every one of these checks the space exists first, for the same reason the skills pair does: the
+  // enable set is keyed by space id, so a typo would silently read and write preferences for a space
+  // that is not there rather than saying so.
+  reg("mcp.list", (p) => {
+    if (!d.spaces.get(p.spaceId)) throw new NotFoundError("space", p.spaceId);
+    return d.mcp.list(p.spaceId);
+  });
+  reg("mcp.add", (p) => {
+    if (p.spaceId !== null && !d.spaces.get(p.spaceId)) throw new NotFoundError("space", p.spaceId);
+    const server = d.mcp.add(p, p.spaceId);
+    rpc.broadcast("mcp.changed", {});
+    return server;
+  });
+  reg("mcp.update", (p) => {
+    if (p.spaceId !== null && !d.spaces.get(p.spaceId)) throw new NotFoundError("space", p.spaceId);
+    const server = d.mcp.update(p.id, p, p.spaceId);
+    rpc.broadcast("mcp.changed", {});
+    return server;
+  });
+  reg("mcp.remove", (p) => {
+    d.mcp.remove(p.id, d.spaces.listAll().map((s) => s.id));
+    rpc.broadcast("mcp.changed", {});
+    return { ok: true as const };
+  });
+  reg("mcp.setEnabled", (p) => {
+    if (!d.spaces.get(p.spaceId)) throw new NotFoundError("space", p.spaceId);
+    d.mcp.setEnabled(p.spaceId, p.id, p.enabled);
+    rpc.broadcast("mcp.changed", {});
     return { ok: true as const };
   });
 

--- a/apps/server/src/rpc/methods.ts
+++ b/apps/server/src/rpc/methods.ts
@@ -9,6 +9,7 @@ import type { EnvironmentService } from "../environments/service";
 import type { CheckpointService } from "../checkpoints/service";
 import type { ItemsStore } from "../store/items";
 import type { SettingsStore } from "../store/settings";
+import type { SkillsService } from "../skills/service";
 import type { TerminalService } from "../terminals/service";
 import type { SessionService } from "../sessions/service";
 import type { GitInfoService } from "../workspace/git-info";
@@ -23,7 +24,7 @@ type Result<M extends MethodName> = MethodResult<M> | Promise<MethodResult<M>>;
 
 export type Deps = {
   rpc: RpcServer; home: string; version: string;
-  profiles: ProfilesStore; spaces: SpacesStore; projects: ProjectsStore; environments: EnvironmentsStore; envService: EnvironmentService; items: ItemsStore; settings: SettingsStore; terminals: TerminalService; sessions: SessionService; gitInfo: GitInfoService; gitDiff: GitDiffService; gitWrite: GitWriteService; ports: PortAllocator; checkpoints: CheckpointService;
+  profiles: ProfilesStore; spaces: SpacesStore; projects: ProjectsStore; environments: EnvironmentsStore; envService: EnvironmentService; items: ItemsStore; settings: SettingsStore; skills: SkillsService; terminals: TerminalService; sessions: SessionService; gitInfo: GitInfoService; gitDiff: GitDiffService; gitWrite: GitWriteService; ports: PortAllocator; checkpoints: CheckpointService;
 };
 
 export function registerMethods(d: Deps): void {
@@ -69,6 +70,19 @@ export function registerMethods(d: Deps): void {
 
   reg("settings.get", (p) => ({ value: d.settings.get(p.key) }));
   reg("settings.set", (p) => { d.settings.set(p.key, p.value); return { ok: true as const }; });
+
+  // Both check the space exists: the enabled set is keyed by space id, so a typo would silently read and
+  // write preferences for a space that is not there rather than saying so.
+  reg("skills.list", (p) => {
+    if (!d.spaces.get(p.spaceId)) throw new NotFoundError("space", p.spaceId);
+    return d.skills.list(p.spaceId);
+  });
+  reg("skills.setEnabled", (p) => {
+    if (!d.spaces.get(p.spaceId)) throw new NotFoundError("space", p.spaceId);
+    d.skills.setEnabled(p.spaceId, p.id, p.enabled);
+    rpc.broadcast("skills.changed", { spaceId: p.spaceId });
+    return { ok: true as const };
+  });
 
   reg("projects.list", (p) => d.projects.list(p.spaceId));
   reg("projects.create", (p) => { const r = d.projects.create(p); rpc.broadcast("items.changed", { spaceId: r.spaceId }); return r; });

--- a/apps/server/src/sessions/service.ts
+++ b/apps/server/src/sessions/service.ts
@@ -13,6 +13,7 @@ import { portEnv, type PortAllocator } from "../workspace/ports";
 import type { WorktreeService } from "../workspace/worktrees";
 import type { CheckpointService } from "../checkpoints/service";
 import { ProbeCache } from "./probe-cache";
+import type { SkillsService } from "../skills/service";
 
 const defaultTitle = (kind: AgentKind) => `${AGENT_META[kind].label} session`;
 export const TITLE_MAX = 40;
@@ -35,7 +36,7 @@ type Live = { handle: AgentHandle; pump: Promise<void> };
 export class SessionService {
   private live = new Map<string, Live>();
   private closing = false;
-  constructor(private d: { db: Db; rpc: RpcServer; sessions: SessionsStore; events: SessionEventsStore; items: ItemsStore; spaces: SpacesStore; projects: ProjectsStore; environments: EnvironmentsStore; worktrees: WorktreeService; ports: PortAllocator; terminals: TerminalService; adapters: AdapterRegistry; checkpoints?: CheckpointService }) {}
+  constructor(private d: { db: Db; rpc: RpcServer; sessions: SessionsStore; events: SessionEventsStore; items: ItemsStore; spaces: SpacesStore; projects: ProjectsStore; environments: EnvironmentsStore; worktrees: WorktreeService; ports: PortAllocator; terminals: TerminalService; adapters: AdapterRegistry; skills: SkillsService; checkpoints?: CheckpointService }) {}
 
   /** Cached probe (TTL + in-flight dedup): each `probeAll` spawns a child process per registered agent,
    *  and the renderer asks on every prompter mount. `force` bypasses it — see ProbeCache. */
@@ -273,7 +274,13 @@ export class SessionService {
     // The environment's port block, read back off the row that ensurePorts just settled: an agent
     // told to `pnpm dev` in a worktree starts on that worktree's ports, not on the space's.
     const env = this.d.environments.get(s.environmentId);
+    // Realm's skills library, staged for this space and handed over per-invocation (W1). Null for an
+    // agent that has no route for it and for a space with nothing enabled — and null must stay null
+    // rather than becoming an empty root, because on Claude the option's presence is also what isolates
+    // the session from the user's own settings.
+    const skills = this.d.skills.injectionFor(s.spaceId, s.agentKind) ?? undefined;
     const handle = adapter.start({ cwd: s.cwd, model: s.model, effort: s.effort, permissionMode: s.permissionMode, mcpServers: [], resume: s.providerSessionId,
+      skills,
       env: env ? portEnv(env) : {},
       onLog: (line) => console.error(`[session ${id.slice(-6)}] ${line}`) });
     const pump = (async () => {

--- a/apps/server/src/sessions/service.ts
+++ b/apps/server/src/sessions/service.ts
@@ -14,6 +14,7 @@ import type { WorktreeService } from "../workspace/worktrees";
 import type { CheckpointService } from "../checkpoints/service";
 import { ProbeCache } from "./probe-cache";
 import type { SkillsService } from "../skills/service";
+import type { McpService } from "../mcp/service";
 
 const defaultTitle = (kind: AgentKind) => `${AGENT_META[kind].label} session`;
 export const TITLE_MAX = 40;
@@ -36,7 +37,7 @@ type Live = { handle: AgentHandle; pump: Promise<void> };
 export class SessionService {
   private live = new Map<string, Live>();
   private closing = false;
-  constructor(private d: { db: Db; rpc: RpcServer; sessions: SessionsStore; events: SessionEventsStore; items: ItemsStore; spaces: SpacesStore; projects: ProjectsStore; environments: EnvironmentsStore; worktrees: WorktreeService; ports: PortAllocator; terminals: TerminalService; adapters: AdapterRegistry; skills: SkillsService; checkpoints?: CheckpointService }) {}
+  constructor(private d: { db: Db; rpc: RpcServer; sessions: SessionsStore; events: SessionEventsStore; items: ItemsStore; spaces: SpacesStore; projects: ProjectsStore; environments: EnvironmentsStore; worktrees: WorktreeService; ports: PortAllocator; terminals: TerminalService; adapters: AdapterRegistry; skills: SkillsService; mcp: McpService; checkpoints?: CheckpointService }) {}
 
   /** Cached probe (TTL + in-flight dedup): each `probeAll` spawns a child process per registered agent,
    *  and the renderer asks on every prompter mount. `force` bypasses it — see ProbeCache. */
@@ -279,7 +280,14 @@ export class SessionService {
     // rather than becoming an empty root, because on Claude the option's presence is also what isolates
     // the session from the user's own settings.
     const skills = this.d.skills.injectionFor(s.spaceId, s.agentKind) ?? undefined;
-    const handle = adapter.start({ cwd: s.cwd, model: s.model, effort: s.effort, permissionMode: s.permissionMode, mcpServers: [], resume: s.providerSessionId,
+    // This space's enabled MCP servers, resolved at start and handed over per-session (W2). Nothing is
+    // written to `~/.claude.json`, `~/.codex/config.toml` or `~/.cursor/mcp.json` to get them there.
+    //
+    // This is the ONLY place API keys leave the database, and they go straight into `adapter.start` —
+    // never onto an event, a broadcast or a log line. `onLog` below prints the SESSION id and the
+    // provider's own output; it never sees this array.
+    const mcpServers = this.d.mcp.configFor(s.spaceId);
+    const handle = adapter.start({ cwd: s.cwd, model: s.model, effort: s.effort, permissionMode: s.permissionMode, mcpServers, resume: s.providerSessionId,
       skills,
       env: env ? portEnv(env) : {},
       onLog: (line) => console.error(`[session ${id.slice(-6)}] ${line}`) });

--- a/apps/server/src/sessions/service.ts
+++ b/apps/server/src/sessions/service.ts
@@ -15,6 +15,8 @@ import type { CheckpointService } from "../checkpoints/service";
 import { ProbeCache } from "./probe-cache";
 import type { SkillsService } from "../skills/service";
 import type { McpService } from "../mcp/service";
+import type { MemoryService } from "../memory/service";
+import type { MemorySources } from "@realm/contracts";
 
 const defaultTitle = (kind: AgentKind) => `${AGENT_META[kind].label} session`;
 export const TITLE_MAX = 40;
@@ -37,7 +39,7 @@ type Live = { handle: AgentHandle; pump: Promise<void> };
 export class SessionService {
   private live = new Map<string, Live>();
   private closing = false;
-  constructor(private d: { db: Db; rpc: RpcServer; sessions: SessionsStore; events: SessionEventsStore; items: ItemsStore; spaces: SpacesStore; projects: ProjectsStore; environments: EnvironmentsStore; worktrees: WorktreeService; ports: PortAllocator; terminals: TerminalService; adapters: AdapterRegistry; skills: SkillsService; mcp: McpService; checkpoints?: CheckpointService }) {}
+  constructor(private d: { db: Db; rpc: RpcServer; sessions: SessionsStore; events: SessionEventsStore; items: ItemsStore; spaces: SpacesStore; projects: ProjectsStore; environments: EnvironmentsStore; worktrees: WorktreeService; ports: PortAllocator; terminals: TerminalService; adapters: AdapterRegistry; skills: SkillsService; mcp: McpService; memory: MemoryService; checkpoints?: CheckpointService }) {}
 
   /** Cached probe (TTL + in-flight dedup): each `probeAll` spawns a child process per registered agent,
    *  and the renderer asks on every prompter mount. `force` bypasses it — see ProbeCache. */
@@ -251,6 +253,22 @@ export class SessionService {
     if (taken) this.d.rpc.broadcast("checkpoints.changed", { environmentId: taken.environmentId });
   }
 
+  /**
+   * What durable context this session's agent loads (memory.sources). The Codex report comes from THIS
+   * session's own persisted `init` event and nowhere else — the store query is keyed by the session id,
+   * which is what keeps one session's `instructionSources` from ever dressing up another's pane.
+   */
+  memorySources(id: string): MemorySources {
+    const s = this.get(id);
+    const skillsInjected = this.d.skills.wouldInject(s.spaceId, s.agentKind);
+    let reported: string[] | null = null;
+    if (s.agentKind === "codex") {
+      const ev = this.d.events.lastOfType(id, "init");
+      reported = ev?.type === "init" ? ev.payload.instructionSources ?? null : null;
+    }
+    return this.d.memory.sourcesFor({ kind: s.agentKind, spaceId: s.spaceId, cwd: s.cwd, skillsInjected, reported });
+  }
+
   /** Whether any session in this environment holds a live adapter handle — what stops a restore
    *  rewriting a working tree under a running tool call. */
   isEnvironmentBusy(environmentId: string): boolean {
@@ -287,8 +305,14 @@ export class SessionService {
     // never onto an event, a broadcast or a log line. `onLog` below prints the SESSION id and the
     // provider's own output; it never sees this array.
     const mcpServers = this.d.mcp.configFor(s.spaceId);
+    // The session's durable context (W3): THIS space's Realm memory document, plus — when the skills
+    // injection above is active on a Claude session — the CLAUDE.md content that `settingSources: []`
+    // would otherwise silently drop. `skills !== undefined` is the same fact the adapter keys the
+    // isolation on, so the re-injection can never disagree with it.
+    const systemContext = this.d.memory.systemContextFor({ spaceId: s.spaceId, kind: s.agentKind, cwd: s.cwd, skillsInjected: skills !== undefined });
     const handle = adapter.start({ cwd: s.cwd, model: s.model, effort: s.effort, permissionMode: s.permissionMode, mcpServers, resume: s.providerSessionId,
       skills,
+      systemContext,
       env: env ? portEnv(env) : {},
       onLog: (line) => console.error(`[session ${id.slice(-6)}] ${line}`) });
     const pump = (async () => {

--- a/apps/server/src/skills/frontmatter.test.ts
+++ b/apps/server/src/skills/frontmatter.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { parseFrontmatter } from "./frontmatter";
+
+describe("parseFrontmatter", () => {
+  it("reads name and description out of a normal SKILL.md", () => {
+    expect(parseFrontmatter("---\nname: mac\ndescription: Drives native macOS apps.\n---\n\n# body\n"))
+      .toEqual({ name: "mac", description: "Drives native macOS apps." });
+  });
+
+  it("keeps colons inside a value", () => {
+    // Real descriptions are full sentences and routinely contain a colon; splitting on the last one, or on
+    // every one, silently truncates them.
+    expect(parseFrontmatter("---\ndescription: Use when: the task touches Calendar.\n---\n")!.description)
+      .toBe("Use when: the task touches Calendar.");
+  });
+
+  it("strips one layer of quotes", () => {
+    expect(parseFrontmatter("---\nname: \"mac\"\ndescription: 'x'\n---\n")).toEqual({ name: "mac", description: "x" });
+  });
+
+  it("returns null for a file with no frontmatter fence", () => {
+    expect(parseFrontmatter("# just a document\n")).toBeNull();
+    expect(parseFrontmatter("")).toBeNull();
+  });
+
+  it("returns null when the fence never closes", () => {
+    expect(parseFrontmatter("---\nname: mac\ndescription: x\n")).toBeNull();
+  });
+
+  it("reads a folded block scalar as one line", () => {
+    const fm = parseFrontmatter("---\nname: mac\ndescription: >-\n  Use when the task\n  touches Calendar.\n---\n");
+    expect(fm).toEqual({ name: "mac", description: "Use when the task touches Calendar." });
+  });
+
+  it("reads a literal block scalar keeping its line breaks", () => {
+    const fm = parseFrontmatter("---\nname: mac\ndescription: |\n  one\n  two\n---\n");
+    expect(fm!.description).toBe("one\ntwo");
+  });
+
+  it("ignores nested mappings and list items rather than flattening them into top-level keys", () => {
+    const fm = parseFrontmatter("---\nname: mac\nmetadata:\n  author: someone\nallowed-tools:\n  - Bash\ndescription: x\n---\n");
+    expect(fm).toEqual({ name: "mac", metadata: "", "allowed-tools": "", description: "x" });
+  });
+
+  it("survives an empty frontmatter block", () => {
+    expect(parseFrontmatter("---\n---\n# body")).toEqual({});
+  });
+
+  it("accepts a `...` terminator and a leading BOM", () => {
+    expect(parseFrontmatter("﻿---\nname: mac\n...\n")).toEqual({ name: "mac" });
+  });
+});

--- a/apps/server/src/skills/frontmatter.ts
+++ b/apps/server/src/skills/frontmatter.ts
@@ -1,0 +1,61 @@
+/**
+ * The smallest frontmatter reader that is correct for what every agent actually reads.
+ *
+ * All three CLIs key off exactly two fields — `name` and `description` — and ignore the rest
+ * (research §1.1). So this is not a YAML parser and must not grow into one: it reads top-level
+ * `key: value` pairs out of the leading `---` block and stops. Anything it cannot make sense of comes
+ * back as a missing field, which the caller turns into `valid: false` — never into a throw.
+ */
+
+export type Frontmatter = Record<string, string>;
+
+/** Strips one layer of matching quotes; YAML escapes inside them are not our problem at this depth. */
+function unquote(v: string): string {
+  const t = v.trim();
+  if (t.length >= 2 && ((t.startsWith('"') && t.endsWith('"')) || (t.startsWith("'") && t.endsWith("'")))) return t.slice(1, -1);
+  return t;
+}
+
+const indentOf = (line: string): number => line.length - line.trimStart().length;
+
+/**
+ * Parses the leading `---` block. Returns `null` when there isn't one — an unfenced file is a document,
+ * not a skill, and the two failures deserve different words.
+ *
+ * Block scalars (`description: >-` / `|`) are supported because real skills use them and treating one as
+ * an empty description would silently hide a perfectly good skill. Folded (`>`) joins with spaces,
+ * literal (`|`) with newlines; chomping indicators are accepted and the trailing newline is trimmed
+ * either way, which is all a one-line description cares about.
+ */
+export function parseFrontmatter(text: string): Frontmatter | null {
+  const lines = text.replace(/^﻿/, "").split(/\r?\n/);
+  if (lines[0]?.trim() !== "---") return null;
+  const out: Frontmatter = {};
+  let i = 1;
+  for (; i < lines.length; i++) {
+    const line = lines[i]!;
+    const trimmed = line.trim();
+    if (trimmed === "---" || trimmed === "...") return out; // closed: whatever we read is the answer
+    if (trimmed === "" || trimmed.startsWith("#")) continue;
+    if (indentOf(line) > 0) continue; // a nested mapping or list under some other key — not ours to read
+    const colon = line.indexOf(":");
+    if (colon <= 0) continue;
+    const key = line.slice(0, colon).trim();
+    const rest = line.slice(colon + 1).trim();
+    const block = /^([|>])[+-]?$/.exec(rest);
+    if (!block) { out[key] = unquote(rest); continue; }
+    const folded = block[1] === ">";
+    const body: string[] = [];
+    while (i + 1 < lines.length) {
+      const next = lines[i + 1]!;
+      if (next.trim() !== "" && indentOf(next) === 0) break; // back to column 0 ends the block, `---` included
+      body.push(next.trim());
+      i++;
+    }
+    while (body.length && body[body.length - 1] === "") body.pop();
+    out[key] = folded ? body.join(" ").trim() : body.join("\n").trim();
+  }
+  // Ran off the end without a closing fence. Treat it as unfenced rather than guessing: a file whose
+  // frontmatter never closes has no body either, and calling it valid would hand the agent a broken skill.
+  return null;
+}

--- a/apps/server/src/skills/integration.test.ts
+++ b/apps/server/src/skills/integration.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it, afterEach, vi } from "vitest";
+import WebSocket from "ws";
+import { mkdirSync, mkdtempSync, readdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { AsyncQueue, type AgentAdapter, type AgentHandle, type StartOptions } from "@realm/adapters";
+import { newId, sessionEvent, type SessionEvent } from "@realm/contracts";
+import { createApp, type App } from "../app";
+import { waitFor } from "../test-utils";
+
+let app: App;
+afterEach(async () => { await app?.close(); vi.unstubAllEnvs(); });
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Any = any;
+
+/** Stands in for a real adapter under a real agent kind, and records the StartOptions it was handed. */
+class RecordingAdapter implements AgentAdapter {
+  readonly starts: StartOptions[] = [];
+  constructor(readonly kind: "claude" | "acp:cursor") {}
+  async probe() { return { kind: this.kind, available: true, version: "0", loggedIn: true, reason: null }; }
+  start(opts: StartOptions): AgentHandle {
+    this.starts.push(opts);
+    const events = new AsyncQueue<SessionEvent>();
+    events.push(sessionEvent("init", { providerSessionId: "prov_1", model: "m", tools: [], cwd: opts.cwd }));
+    events.push(sessionEvent("status", { status: "idle" }));
+    return {
+      events,
+      send: async () => { events.push(sessionEvent("assistant_text", { messageId: "m1", text: "ok" })); events.push(sessionEvent("status", { status: "idle" })); },
+      respondPermission: () => {},
+      interrupt: async () => {},
+      setOptions: async () => {},
+      dispose: async () => { events.close(); },
+    };
+  }
+}
+
+async function client(port: number) {
+  const ws = await new Promise<WebSocket>((res, rej) => { const w = new WebSocket(`ws://127.0.0.1:${port}`); w.once("open", () => res(w)); w.once("error", rej); });
+  const pending = new Map<string, (v: Any) => void>(); const events: Any[] = [];
+  ws.on("message", (d) => { const m = JSON.parse(d.toString()); if ("id" in m) pending.get(m.id)?.(m); else events.push(m); });
+  let n = 0;
+  const call = (method: string, params: unknown) => new Promise<Any>((res, rej) => {
+    const id = String(++n);
+    const timer = setTimeout(() => { pending.delete(id); rej(new Error(`rpc ${method} timed out`)); }, 5000);
+    pending.set(id, (v) => { clearTimeout(timer); res(v); });
+    ws.send(JSON.stringify({ id, method, params }));
+  });
+  return { call, events, close: () => ws.close() };
+}
+
+const skill = (dir: string, id: string) => {
+  mkdirSync(join(dir, id), { recursive: true });
+  writeFileSync(join(dir, id, "SKILL.md"), `---\nname: ${id}\ndescription: does ${id}.\n---\n\n# ${id}\n`);
+};
+
+/** A home with no bundled install, so each test's library is exactly what it wrote. */
+async function boot(opts: { bundled?: string } = {}) {
+  const home = mkdtempSync(join(tmpdir(), "realm-skills-int-"));
+  vi.stubEnv("REALM_BUNDLED_SKILLS", opts.bundled ?? join(home, "no-bundle"));
+  const claude = new RecordingAdapter("claude");
+  const cursor = new RecordingAdapter("acp:cursor");
+  app = await createApp({ home, port: 0, adapters: { claude, "acp:cursor": cursor } });
+  const c = await client(app.port);
+  const p = (await c.call("profiles.create", { name: "W" })).result;
+  const sp = (await c.call("spaces.create", { profileId: p.id, name: "S" })).result;
+  return { home, c, sp, claude, cursor };
+}
+
+/** Starts the session's adapter the way anything real does — on the first send. */
+async function startSession(c: Any, spaceId: string, agentKind: string) {
+  const { session } = (await c.call("sessions.create", { spaceId, agentKind })).result;
+  await c.call("sessions.send", { id: session.id, text: "go" });
+  return session;
+}
+
+describe("skills over rpc", () => {
+  it("lists the library per space and toggles one skill, broadcasting the change", async () => {
+    const { c, sp, home } = await boot();
+    skill(join(home, "skills"), "mac");
+    skill(join(home, "skills"), "notes");
+    const listed = (await c.call("skills.list", { spaceId: sp.id })).result;
+    expect(listed.root).toBe(join(home, "skills"));
+    expect(listed.skills.map((s: Any) => [s.id, s.enabled])).toEqual([["mac", true], ["notes", true]]);
+
+    expect((await c.call("skills.setEnabled", { spaceId: sp.id, id: "notes", enabled: false })).result).toEqual({ ok: true });
+    await waitFor(() => c.events.some((e: Any) => e.event === "skills.changed" && e.payload.spaceId === sp.id));
+    expect((await c.call("skills.list", { spaceId: sp.id })).result.skills.map((s: Any) => [s.id, s.enabled]))
+      .toEqual([["mac", true], ["notes", false]]);
+    c.close();
+  });
+
+  it("refuses a space that does not exist rather than reading preferences for a typo", async () => {
+    const { c } = await boot();
+    const gone = newId(); // well-formed, just not a space: the preferences are keyed by this id
+    expect((await c.call("skills.list", { spaceId: gone })).error.code).toBe("NOT_FOUND");
+    expect((await c.call("skills.setEnabled", { spaceId: gone, id: "mac", enabled: false })).error.code).toBe("NOT_FOUND");
+    c.close();
+  });
+
+  it("hands the staged skills root to the adapter when the session starts", async () => {
+    const { c, sp, home, claude } = await boot();
+    skill(join(home, "skills"), "mac");
+    await startSession(c, sp.id, "claude");
+    await waitFor(() => claude.starts.length === 1);
+    const injected = claude.starts[0]!.skills!;
+    expect(injected).toBeTruthy();
+    expect(injected.root).toBe(join(injected.pluginPath, "skills"));
+    expect(readdirSync(injected.root)).toEqual(["mac"]);
+    c.close();
+  });
+
+  it("does not hand over a skill this space has disabled", async () => {
+    const { c, sp, home, claude } = await boot();
+    skill(join(home, "skills"), "mac");
+    skill(join(home, "skills"), "notes");
+    await c.call("skills.setEnabled", { spaceId: sp.id, id: "notes", enabled: false });
+    await startSession(c, sp.id, "claude");
+    await waitFor(() => claude.starts.length === 1);
+    expect(readdirSync(claude.starts[0]!.skills!.root)).toEqual(["mac"]);
+    c.close();
+  });
+
+  it("hands over nothing at all when the space has no skills", async () => {
+    const { c, sp, claude } = await boot();
+    await startSession(c, sp.id, "claude");
+    await waitFor(() => claude.starts.length === 1);
+    expect(claude.starts[0]!.skills).toBeUndefined();
+    c.close();
+  });
+
+  it("hands over nothing to an agent Realm cannot inject skills into", async () => {
+    const { c, sp, home, cursor } = await boot();
+    skill(join(home, "skills"), "mac");
+    await startSession(c, sp.id, "acp:cursor");
+    await waitFor(() => cursor.starts.length === 1);
+    expect(cursor.starts[0]!.skills).toBeUndefined();
+    c.close();
+  });
+
+  it("survives a malformed SKILL.md: the session starts and the good skills still go over", async () => {
+    const { c, sp, home, claude } = await boot();
+    skill(join(home, "skills"), "mac");
+    mkdirSync(join(home, "skills", "broken"), { recursive: true });
+    writeFileSync(join(home, "skills", "broken", "SKILL.md"), "no frontmatter here");
+    const session = await startSession(c, sp.id, "claude");
+    await waitFor(() => claude.starts.length === 1);
+    expect(readdirSync(claude.starts[0]!.skills!.root)).toEqual(["mac"]);
+    expect((await c.call("sessions.get", { id: session.id })).result.status).toBe("idle");
+    expect((await c.call("skills.list", { spaceId: sp.id })).result.skills.find((s: Any) => s.id === "broken"))
+      .toMatchObject({ valid: false });
+    c.close();
+  });
+
+  it("installs the bundled skills into the library once, on boot", async () => {
+    const bundled = mkdtempSync(join(tmpdir(), "realm-skills-bundle-"));
+    skill(bundled, "mac");
+    const { c, sp, home } = await boot({ bundled });
+    expect(readdirSync(join(home, "skills"))).toEqual(["mac"]);
+    expect((await c.call("skills.list", { spaceId: sp.id })).result.skills.map((s: Any) => s.id)).toEqual(["mac"]);
+    c.close();
+  });
+});

--- a/apps/server/src/skills/service.test.ts
+++ b/apps/server/src/skills/service.test.ts
@@ -1,0 +1,227 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
+import { mkdirSync, mkdtempSync, readFileSync, readdirSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { openDatabase } from "../db/database";
+import { SettingsStore } from "../store/settings";
+import { SkillsService, bundledSkillsDir, skillsRoot } from "./service";
+
+let home: string;
+let bundled: string;
+let service: SkillsService;
+let settings: SettingsStore;
+const SPACE = "spc_1";
+
+const skill = (dir: string, id: string, body = `---\nname: ${id}\ndescription: does ${id}.\n---\n\n# ${id}\n`) => {
+  mkdirSync(join(dir, id), { recursive: true });
+  writeFileSync(join(dir, id, "SKILL.md"), body);
+};
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "realm-skills-home-"));
+  bundled = mkdtempSync(join(tmpdir(), "realm-skills-bundle-"));
+  settings = new SettingsStore(openDatabase(join(home, "realm.db")));
+  service = new SkillsService({ home, settings, bundledDir: bundled });
+});
+afterEach(() => {
+  for (const d of [home, bundled]) rmSync(d, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+const ids = (spaceId = SPACE) => service.list(spaceId).skills.map((s) => s.id);
+const byId = (id: string, spaceId = SPACE) => service.list(spaceId).skills.find((s) => s.id === id)!;
+const staged = (inj: { root: string }) => readdirSync(inj.root).sort();
+
+describe("SkillsService.list", () => {
+  it("is empty, not an error, before the library directory exists", () => {
+    expect(service.list(SPACE)).toEqual({ root: skillsRoot(home), skills: [] });
+  });
+
+  it("reads name and description off each SKILL.md, enabled by default", () => {
+    skill(service.root, "mac");
+    expect(service.list(SPACE).skills).toEqual([
+      { id: "mac", name: "mac", description: "does mac.", path: join(service.root, "mac", "SKILL.md"), enabled: true, valid: true, reason: null },
+    ]);
+  });
+
+  it("lists a malformed skill as invalid rather than hiding it", () => {
+    // Silence is the failure mode here: a skill that vanished because of a typo has to be findable, or the
+    // user's only debugging tool is guessing.
+    skill(service.root, "no-fence", "# not a skill\n");
+    skill(service.root, "no-name", "---\ndescription: x\n---\n");
+    skill(service.root, "no-description", "---\nname: y\n---\n");
+    mkdirSync(join(service.root, "no-file"), { recursive: true });
+    skill(service.root, "good");
+    expect(ids()).toEqual(["good", "no-description", "no-fence", "no-file", "no-name"]);
+    expect(byId("no-fence").reason).toMatch(/frontmatter/);
+    expect(byId("no-name").reason).toMatch(/`name`/);
+    expect(byId("no-description").reason).toMatch(/`description`/);
+    expect(byId("no-file").reason).toMatch(/no SKILL.md/);
+    expect(service.list(SPACE).skills.filter((s) => s.valid).map((s) => s.id)).toEqual(["good"]);
+  });
+
+  it("skips dotfiles, loose files and names that are not addressable ids", () => {
+    skill(service.root, "good");
+    mkdirSync(join(service.root, ".git"), { recursive: true });
+    mkdirSync(join(service.root, "has space"), { recursive: true });
+    writeFileSync(join(service.root, "README.md"), "hi");
+    expect(ids()).toEqual(["good"]);
+  });
+});
+
+describe("SkillsService per-space enable/disable", () => {
+  it("disables a skill for one space and leaves every other space alone", () => {
+    skill(service.root, "mac");
+    skill(service.root, "notes");
+    service.setEnabled(SPACE, "mac", false);
+    expect(byId("mac").enabled).toBe(false);
+    expect(byId("notes").enabled).toBe(true);
+    expect(byId("mac", "spc_2").enabled).toBe(true);
+    service.setEnabled(SPACE, "mac", true);
+    expect(byId("mac").enabled).toBe(true);
+  });
+
+  it("remembers a preference for a skill that is not on disk right now", () => {
+    // Deleting a skill and putting it back must not silently re-enable it — the folder is the user's, and
+    // they move things around in it.
+    service.setEnabled(SPACE, "mac", false);
+    skill(service.root, "mac");
+    expect(byId("mac").enabled).toBe(false);
+  });
+});
+
+describe("SkillsService.injectionFor", () => {
+  it("stages a directory that is a Claude plugin and a Codex root at once", () => {
+    skill(service.root, "mac");
+    const inj = service.injectionFor(SPACE, "claude")!;
+    expect(inj.root).toBe(join(inj.pluginPath, "skills"));
+    const manifest = JSON.parse(readFileSync(join(inj.pluginPath, ".claude-plugin", "plugin.json"), "utf8")) as { name: string };
+    expect(manifest.name).toBe("realm");
+    expect(staged(inj)).toEqual(["mac"]);
+    // A symlink, not a copy: an edit the user makes mid-session is live, and both agents resolve it.
+    expect(realpathSync(join(inj.root, "mac"))).toBe(realpathSync(join(service.root, "mac")));
+  });
+
+  it("leaves a disabled skill out of the staged root", () => {
+    skill(service.root, "mac");
+    skill(service.root, "notes");
+    service.setEnabled(SPACE, "notes", false);
+    expect(staged(service.injectionFor(SPACE, "claude")!)).toEqual(["mac"]);
+  });
+
+  it("leaves an invalid skill out of the staged root however enabled it is", () => {
+    skill(service.root, "mac");
+    skill(service.root, "broken", "not frontmatter at all");
+    expect(byId("broken").enabled).toBe(true);
+    expect(staged(service.injectionFor(SPACE, "claude")!)).toEqual(["mac"]);
+  });
+
+  it("returns null when nothing is enabled, so Claude keeps the user's own settings", () => {
+    // Null rather than an empty root on purpose: on Claude the option's *presence* is what sets
+    // `settingSources: []`, so an empty library must not cost the user their CLAUDE.md.
+    expect(service.injectionFor(SPACE, "claude")).toBeNull();
+    skill(service.root, "mac");
+    service.setEnabled(SPACE, "mac", false);
+    expect(service.injectionFor(SPACE, "claude")).toBeNull();
+  });
+
+  it("returns null for the agents that have no route for a skills directory", () => {
+    skill(service.root, "mac");
+    expect(service.injectionFor(SPACE, "acp:cursor")).toBeNull();
+    expect(service.injectionFor(SPACE, "acp:gemini")).toBeNull();
+    expect(service.injectionFor(SPACE, "fake")).toBeNull();
+    expect(service.injectionFor(SPACE, "codex")).not.toBeNull();
+  });
+
+  it("stages each space separately", () => {
+    skill(service.root, "mac");
+    skill(service.root, "notes");
+    service.setEnabled("spc_a", "notes", false);
+    const a = service.injectionFor("spc_a", "codex")!;
+    const b = service.injectionFor("spc_b", "codex")!;
+    expect(a.root).not.toBe(b.root);
+    expect(staged(a)).toEqual(["mac"]);
+    expect(staged(b)).toEqual(["mac", "notes"]);
+  });
+
+  it("rebuilds the staged root rather than reconciling it", () => {
+    skill(service.root, "mac");
+    skill(service.root, "notes");
+    const first = service.injectionFor(SPACE, "codex")!;
+    expect(staged(first)).toEqual(["mac", "notes"]);
+    rmSync(join(service.root, "notes"), { recursive: true, force: true });
+    // A stale symlink to a skill that is gone is exactly what reconciliation would leave behind, and both
+    // agents would then log an unreadable root.
+    expect(staged(service.injectionFor(SPACE, "codex")!)).toEqual(["mac"]);
+  });
+
+  it("degrades to null instead of throwing when staging itself fails", () => {
+    skill(service.root, "mac");
+    // A session with no skills is a smaller failure than a session that will not start.
+    writeFileSync(join(home, ".cache"), "not a directory"); // nothing can be staged underneath a file
+    const err = vi.spyOn(console, "error").mockImplementation(() => {});
+    expect(service.injectionFor(SPACE, "claude")).toBeNull();
+    expect(err).toHaveBeenCalled();
+  });
+});
+
+describe("SkillsService.installBundled", () => {
+  it("copies a repo-shipped skill into the library on first boot", () => {
+    skill(bundled, "mac");
+    expect(service.installBundled()).toEqual(["mac"]);
+    expect(byId("mac").valid).toBe(true);
+    // Copied, not linked: `~/Realm/skills` is the user's folder, and a skill they cannot edit is not theirs.
+    expect(readFileSync(join(service.root, "mac", "SKILL.md"), "utf8")).toContain("name: mac");
+  });
+
+  it("installs once — a skill the user deletes stays deleted", () => {
+    skill(bundled, "mac");
+    expect(service.installBundled()).toEqual(["mac"]);
+    rmSync(join(service.root, "mac"), { recursive: true, force: true });
+    expect(service.installBundled()).toEqual([]);
+    expect(ids()).toEqual([]);
+  });
+
+  it("never overwrites a skill the user has edited", () => {
+    skill(bundled, "mac");
+    skill(service.root, "mac", "---\nname: mac\ndescription: mine now.\n---\n");
+    // Present already but not yet recorded: it must be adopted, not clobbered.
+    expect(service.installBundled()).toEqual([]);
+    expect(byId("mac").description).toBe("mine now.");
+    expect(service.installBundled()).toEqual([]);
+  });
+
+  it("copies the whole skill directory, not just SKILL.md", () => {
+    skill(bundled, "mac");
+    mkdirSync(join(bundled, "mac", "references"), { recursive: true });
+    writeFileSync(join(bundled, "mac", "references", "cli.md"), "reference");
+    service.installBundled();
+    expect(readFileSync(join(service.root, "mac", "references", "cli.md"), "utf8")).toBe("reference");
+  });
+
+  it("does nothing when there are no bundled skills", () => {
+    expect(new SkillsService({ home, settings, bundledDir: null }).installBundled()).toEqual([]);
+    expect(service.installBundled()).toEqual([]); // empty bundle dir
+  });
+
+  it("ignores a bundled directory with no SKILL.md", () => {
+    mkdirSync(join(bundled, "scripts"), { recursive: true });
+    expect(service.installBundled()).toEqual([]);
+  });
+});
+
+describe("bundledSkillsDir", () => {
+  it("finds the repo's own skills directory, which is where skills/mac lives", () => {
+    const dir = bundledSkillsDir();
+    expect(dir).not.toBeNull();
+    expect(readdirSync(dir!)).toContain("mac");
+  });
+
+  it("honours REALM_BUNDLED_SKILLS, and reports nothing when it points nowhere", () => {
+    vi.stubEnv("REALM_BUNDLED_SKILLS", bundled);
+    expect(bundledSkillsDir()).toBe(bundled);
+    vi.stubEnv("REALM_BUNDLED_SKILLS", join(bundled, "missing"));
+    expect(bundledSkillsDir()).toBeNull();
+    vi.unstubAllEnvs();
+  });
+});

--- a/apps/server/src/skills/service.ts
+++ b/apps/server/src/skills/service.ts
@@ -1,0 +1,166 @@
+import { cpSync, existsSync, mkdirSync, readFileSync, readdirSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { AGENT_SKILL_SUPPORT, SkillIdSchema, type AgentKind, type Skill } from "@realm/contracts";
+import type { SkillsInjection } from "@realm/adapters";
+import type { SettingsStore } from "../store/settings";
+import { parseFrontmatter } from "./frontmatter";
+
+/** Realm's library lives here and nowhere else. Nothing is ever written into `~/.claude`, `~/.codex`,
+ *  `~/.cursor` or `~/.agents` — see `SkillsInjection` for the two per-invocation routes that replace it. */
+export const skillsRoot = (home: string): string => join(home, "skills");
+/** Staged plugin/roots per space. Dot-prefixed and under Realm's own home: derived, disposable, and
+ *  deliberately not somewhere the user is invited to edit. */
+const stageRoot = (home: string): string => join(home, ".cache", "skills");
+
+/** Per-space disabled ids. Storing the *disabled* set rather than the enabled one is what makes a skill
+ *  the user drops into the folder work immediately instead of being invisible until they find a toggle. */
+const disabledKey = (spaceId: string): string => `skills.disabled:${spaceId}`;
+/** Bundled ids already installed once. Install-once, not sync: a bundled skill the user deletes stays
+ *  deleted, and a bundled skill the user edits is never overwritten from under them. */
+const INSTALLED_KEY = "skills.bundledInstalled";
+
+/**
+ * Where the repo-shipped skills (`<repo>/skills/<id>/SKILL.md`) are on this machine.
+ *
+ * `REALM_BUNDLED_SKILLS` wins, and is how tests point this at a fixture instead of the real repo. Then the
+ * workspace root, found by walking up from this module — which works identically for `src/` under vitest
+ * and for the single bundled `apps/server/dist/main.js`. Then the Electron resources directory, for a
+ * packaged build. Null when there are none, which is not an error.
+ */
+export function bundledSkillsDir(): string | null {
+  const override = process.env.REALM_BUNDLED_SKILLS;
+  if (override) return existsSync(override) ? override : null;
+  let dir = dirname(fileURLToPath(import.meta.url));
+  for (let i = 0; i < 8; i++) {
+    if (existsSync(join(dir, "pnpm-workspace.yaml")) && existsSync(join(dir, "skills"))) return join(dir, "skills");
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  const resources = (process as { resourcesPath?: string }).resourcesPath;
+  const packaged = resources ? join(resources, "skills") : null;
+  return packaged && existsSync(packaged) ? packaged : null;
+}
+
+const readIds = (settings: SettingsStore, key: string): string[] => {
+  const v = settings.get(key);
+  return Array.isArray(v) ? v.filter((x): x is string => typeof x === "string") : [];
+};
+
+/**
+ * Realm's skills library: what is on disk, which of it each space wants, and the staged directory that
+ * carries it to an agent.
+ *
+ * Everything here reads the filesystem on demand. The library is a folder the user is expected to open in
+ * Finder and edit, so a cache would only ever be a way to be wrong about it.
+ */
+export class SkillsService {
+  readonly root: string;
+  constructor(private d: { home: string; settings: SettingsStore; bundledDir?: string | null }) {
+    this.root = skillsRoot(d.home);
+  }
+
+  /**
+   * Copy repo-shipped skills into the library, once each, on boot.
+   *
+   * Copies rather than symlinks on purpose: `~/Realm/skills` is the user's folder, and a skill they can
+   * open but not edit — or that changes under them on the next `git pull` — is not theirs. Returns the ids
+   * it installed, which is only ever non-empty on the first boot after a skill ships.
+   */
+  installBundled(): string[] {
+    const src = this.d.bundledDir === undefined ? bundledSkillsDir() : this.d.bundledDir;
+    if (!src) return [];
+    const already = new Set(readIds(this.d.settings, INSTALLED_KEY));
+    const installed: string[] = [];
+    try { mkdirSync(this.root, { recursive: true }); } catch { return []; }
+    for (const id of this.dirNames(src)) {
+      if (already.has(id)) continue;
+      const from = join(src, id);
+      if (!existsSync(join(from, "SKILL.md"))) continue;
+      already.add(id); // recorded even if the copy fails, so a broken bundle is not retried every boot
+      const to = join(this.root, id);
+      if (existsSync(to)) continue;
+      try { cpSync(from, to, { recursive: true }); installed.push(id); }
+      catch (e) { console.error(`[skills] could not install bundled skill ${id}: ${e instanceof Error ? e.message : String(e)}`); }
+    }
+    this.d.settings.set(INSTALLED_KEY, [...already].sort());
+    return installed;
+  }
+
+  /** Every directory in the library, valid or not, with this space's enabled flag. Sorted by id. */
+  list(spaceId: string): { root: string; skills: Skill[] } {
+    const disabled = new Set(readIds(this.d.settings, disabledKey(spaceId)));
+    const skills = this.dirNames(this.root).map((id) => this.read(id, !disabled.has(id)));
+    return { root: this.root, skills };
+  }
+
+  setEnabled(spaceId: string, id: string, enabled: boolean): void {
+    const key = disabledKey(spaceId);
+    const disabled = new Set(readIds(this.d.settings, key));
+    if (enabled) disabled.delete(id); else disabled.add(id);
+    this.d.settings.set(key, [...disabled].sort());
+  }
+
+  /**
+   * Stage this space's enabled skills and return the two paths the adapters want, or null when there is
+   * nothing to hand over.
+   *
+   * Null is load-bearing on the Claude side: being given a library is also what makes that session
+   * isolate itself from the user's own `~/.claude` settings, so "no skills" has to mean "no option",
+   * not "an empty option".
+   *
+   * Never throws. A session that cannot be given skills is a session with fewer skills; it is not a
+   * session that fails to start, and no `SKILL.md` anyone can write may change that.
+   */
+  injectionFor(spaceId: string, kind: AgentKind): SkillsInjection | null {
+    if (AGENT_SKILL_SUPPORT[kind] !== "injected") return null;
+    try {
+      const enabled = this.list(spaceId).skills.filter((s) => s.valid && s.enabled);
+      if (enabled.length === 0) return null;
+      const pluginPath = join(stageRoot(this.d.home), spaceId);
+      const root = join(pluginPath, "skills");
+      // Rebuilt from scratch every start rather than reconciled: the staged tree is derived state, and a
+      // stale symlink to a skill the user renamed is exactly the bug reconciliation would leave behind.
+      rmSync(pluginPath, { recursive: true, force: true });
+      mkdirSync(join(pluginPath, ".claude-plugin"), { recursive: true });
+      writeFileSync(join(pluginPath, ".claude-plugin", "plugin.json"),
+        JSON.stringify({ name: "realm", version: "0.0.1", description: "Skills managed by Realm." }, null, 2));
+      mkdirSync(root, { recursive: true });
+      // Symlinks, not copies: both agents resolve them (proven in scripts/live-skills-check.ts), and an
+      // edit the user makes mid-session is then live rather than a snapshot taken at start.
+      for (const s of enabled) symlinkSync(dirname(s.path), join(root, s.id), "dir");
+      return { pluginPath, root };
+    } catch (e) {
+      console.error(`[skills] could not stage skills for space ${spaceId}: ${e instanceof Error ? e.message : String(e)}`);
+      return null;
+    }
+  }
+
+  /** Directory entries that could be a skill, cheapest-first: unreadable or absent root is an empty
+   *  library, and a name that is not a plain directory name is not addressable over RPC so it is skipped. */
+  private dirNames(dir: string): string[] {
+    let entries: string[];
+    try { entries = readdirSync(dir, { withFileTypes: true }).filter((e) => e.isDirectory() || e.isSymbolicLink()).map((e) => e.name); }
+    catch { return []; }
+    return entries.filter((n) => !n.startsWith(".") && SkillIdSchema.safeParse(n).success).sort();
+  }
+
+  /** One directory. Every failure below produces a listed-but-invalid skill, never an exception. */
+  private read(id: string, enabled: boolean): Skill {
+    const path = join(this.root, id, "SKILL.md");
+    const invalid = (reason: string): Skill => ({ id, name: id, description: "", path, enabled, valid: false, reason });
+    let text: string;
+    try { text = readFileSync(path, "utf8"); }
+    catch { return invalid("no SKILL.md in this directory"); }
+    const fm = parseFrontmatter(text);
+    if (!fm) return invalid("SKILL.md has no `---` frontmatter block");
+    const name = fm.name?.trim() ?? "";
+    const description = fm.description?.trim() ?? "";
+    if (!name) return invalid("frontmatter has no `name`");
+    // Every agent decides whether to invoke a skill from its description alone, so one without a
+    // description is not a skill that works badly — it is a skill that never runs.
+    if (!description) return invalid("frontmatter has no `description`");
+    return { id, name, description, path, enabled, valid: true, reason: null };
+  }
+}

--- a/apps/server/src/skills/service.ts
+++ b/apps/server/src/skills/service.ts
@@ -103,6 +103,17 @@ export class SkillsService {
   }
 
   /**
+   * Whether `injectionFor` would hand this session a library — without staging anything. This is what
+   * read paths (memory.sources) ask, because staging rebuilds a directory tree and a LIST call that
+   * rewrites disk state is a list call that races the session starts it is describing.
+   */
+  wouldInject(spaceId: string, kind: AgentKind): boolean {
+    if (AGENT_SKILL_SUPPORT[kind] !== "injected") return false;
+    try { return this.list(spaceId).skills.some((s) => s.valid && s.enabled); }
+    catch { return false; }
+  }
+
+  /**
    * Stage this space's enabled skills and return the two paths the adapters want, or null when there is
    * nothing to hand over.
    *

--- a/apps/server/src/store/mcp.ts
+++ b/apps/server/src/store/mcp.ts
@@ -1,0 +1,87 @@
+import type { Db } from "../db/database";
+import { newId, type McpTransport } from "@realm/contracts";
+import { NotFoundError, RpcError, now } from "./rows";
+
+/**
+ * A stored MCP server definition — **including its secret values**.
+ *
+ * This type never leaves the server. `McpService` projects it down to the `McpServer` contract (key
+ * names only) for anything a client can see, and hands the whole row to an adapter only as part of a
+ * session's `StartOptions`.
+ */
+export type McpServerRow = {
+  id: string;
+  name: string;
+  transport: McpTransport;
+  command: string;
+  args: string[];
+  url: string;
+  /** stdio `env` or http/sse `headers`, plaintext. See MCP_SECRET_STORAGE_NOTE. */
+  secrets: Record<string, string>;
+  createdAt: number;
+  updatedAt: number;
+};
+
+type Row = { id: string; name: string; transport: string; command: string; args_json: string; url: string; secrets_json: string; created_at: number; updated_at: number };
+
+/** Both JSON columns are Realm's own writes, so a parse failure is corruption, not input — degrade to
+ *  empty rather than making the whole list unreadable because one row went bad. */
+const parseArgs = (s: string): string[] => {
+  try { const v: unknown = JSON.parse(s); return Array.isArray(v) ? v.filter((x): x is string => typeof x === "string") : []; } catch { return []; }
+};
+const parseSecrets = (s: string): Record<string, string> => {
+  try {
+    const v: unknown = JSON.parse(s);
+    if (!v || typeof v !== "object" || Array.isArray(v)) return {};
+    return Object.fromEntries(Object.entries(v as Record<string, unknown>).filter(([, x]) => typeof x === "string")) as Record<string, string>;
+  } catch { return {}; }
+};
+
+const toServer = (r: Row): McpServerRow => ({
+  id: r.id, name: r.name, transport: r.transport as McpTransport, command: r.command,
+  args: parseArgs(r.args_json), url: r.url, secrets: parseSecrets(r.secrets_json),
+  createdAt: r.created_at, updatedAt: r.updated_at,
+});
+
+export type McpServerInput = { name: string; transport: McpTransport; command: string; args: string[]; url: string; secrets: Record<string, string> };
+
+export class McpServersStore {
+  constructor(private db: Db) {}
+
+  /** Every server, oldest first — the order a settings list shows them in and the order they reach an agent. */
+  list(): McpServerRow[] {
+    return (this.db.prepare("SELECT * FROM mcp_servers ORDER BY created_at, id").all() as Row[]).map(toServer);
+  }
+  get(id: string): McpServerRow | null {
+    const r = this.db.prepare("SELECT * FROM mcp_servers WHERE id = ?").get(id) as Row | undefined;
+    return r ? toServer(r) : null;
+  }
+
+  create(input: McpServerInput): McpServerRow {
+    const id = newId(); const t = now();
+    this.guardName(input.name, null);
+    this.db.prepare("INSERT INTO mcp_servers (id, name, transport, command, args_json, url, secrets_json, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)")
+      .run(id, input.name, input.transport, input.command, JSON.stringify(input.args), input.url, JSON.stringify(input.secrets), t, t);
+    return this.get(id)!;
+  }
+
+  update(id: string, patch: Partial<McpServerInput>): McpServerRow {
+    const existing = this.get(id); if (!existing) throw new NotFoundError("mcp server", id);
+    if (patch.name !== undefined) this.guardName(patch.name, id);
+    const next = { ...existing, ...patch };
+    this.db.prepare("UPDATE mcp_servers SET name = ?, transport = ?, command = ?, args_json = ?, url = ?, secrets_json = ?, updated_at = ? WHERE id = ?")
+      .run(next.name, next.transport, next.command, JSON.stringify(next.args), next.url, JSON.stringify(next.secrets), now(), id);
+    return this.get(id)!;
+  }
+
+  delete(id: string): void {
+    if (!this.get(id)) throw new NotFoundError("mcp server", id);
+    this.db.prepare("DELETE FROM mcp_servers WHERE id = ?").run(id);
+  }
+
+  /** The UNIQUE index would catch this too, as a SQLite error with no `code` a client could act on. */
+  private guardName(name: string, exceptId: string | null): void {
+    const clash = this.db.prepare("SELECT id FROM mcp_servers WHERE name = ?").get(name) as { id: string } | undefined;
+    if (clash && clash.id !== exceptId) throw new RpcError("MCP_NAME_TAKEN", `an MCP server named "${name}" already exists`);
+  }
+}

--- a/apps/server/src/store/mcp.ts
+++ b/apps/server/src/store/mcp.ts
@@ -48,9 +48,13 @@ export type McpServerInput = { name: string; transport: McpTransport; command: s
 export class McpServersStore {
   constructor(private db: Db) {}
 
-  /** Every server, oldest first — the order a settings list shows them in and the order they reach an agent. */
+  /**
+   * Every server, oldest first — the order a settings list shows them in and the order they reach an
+   * agent. `name` breaks ties rather than `id`: two servers added in the same millisecond have ULIDs
+   * whose random suffixes order arbitrarily, so an id tiebreak makes the list flicker between calls.
+   */
   list(): McpServerRow[] {
-    return (this.db.prepare("SELECT * FROM mcp_servers ORDER BY created_at, id").all() as Row[]).map(toServer);
+    return (this.db.prepare("SELECT * FROM mcp_servers ORDER BY created_at, name").all() as Row[]).map(toServer);
   }
   get(id: string): McpServerRow | null {
     const r = this.db.prepare("SELECT * FROM mcp_servers WHERE id = ?").get(id) as Row | undefined;

--- a/apps/server/src/store/sessions.ts
+++ b/apps/server/src/store/sessions.ts
@@ -101,6 +101,16 @@ export class SessionEventsStore {
     }
     return [...open];
   }
+  /** The newest persisted event of one type, or null. Skips rows that fail schema validation. */
+  lastOfType(sessionId: string, type: SessionEvent["type"]): SessionEvent | null {
+    const r = this.db.prepare("SELECT * FROM session_events WHERE session_id = ? AND type = ? ORDER BY seq DESC LIMIT 1")
+      .get(sessionId, type) as EventRow | undefined;
+    if (!r) return null;
+    let payload: unknown; try { payload = JSON.parse(r.payload_json); } catch { return null; }
+    const p = SessionEventSchema.safeParse({ type: r.type, ts: r.ts, payload });
+    return p.success ? p.data : null;
+  }
+
   /** Events with seq > afterSeq, ascending. Rows that fail schema validation (e.g. from an older build) are skipped. */
   listAfter(sessionId: string, afterSeq: number, limit: number): StoredSessionEvent[] {
     const rows = this.db.prepare("SELECT * FROM session_events WHERE session_id = ? AND seq > ? ORDER BY seq LIMIT ?").all(sessionId, afterSeq, limit) as EventRow[];

--- a/docs/superpowers/specs/2026-08-29-agent-config-surfaces.md
+++ b/docs/superpowers/specs/2026-08-29-agent-config-surfaces.md
@@ -340,7 +340,29 @@ merge protocol.
 ```
 
 Realm did not write those — **Codex did, on Realm's behalf**, when Realm spawned it in
-temporary worktrees the user then trusted. All four point at directories that no longer exist.
+temporary directories. All four point at directories that no longer exist.
+
+**Mechanism, isolated during Plan 8 W2 (codex-cli 0.146.0, scratch `CODEX_HOME`, six probe
+configurations):** `thread/start` records its `cwd` as
+`[projects."<canonicalized cwd>"] trust_level = "trusted"` whenever `$CODEX_HOME/config.toml`
+has no entry for that path. Verified properties:
+
+- It happens for **every** approval policy and sandbox mode, `untrusted`/`read-only` included —
+  it is not a consequence of `bypassPermissions`, and the original guess that "the user then
+  trusted" them is wrong; no user action is involved.
+- `initialize` alone writes nothing. `ephemeral: true` does not suppress it. `ThreadStartParams`
+  (fields recovered from the binary's TS bindings) has no opt-out.
+- The write is **flushed asynchronously**: a client that kills the process ~800ms after
+  `thread/start` never sees it, which is why a first probe found nothing.
+- An existing entry for that path suppresses it, `trust_level = "untrusted"` included.
+
+So Realm cannot prevent it, and should not want to for a real space folder or worktree — those
+are stable directories under `~/Realm` that a user would expect to see trusted. What Realm
+*could* prevent is pointing Codex at a directory that then stops existing. The four entries came
+from `apps/server/scripts/live-agent-check.ts` calling `mkdtempSync(tmpdir(), "realm-work-")`,
+once per run. Fixed in W2: the live checks share one fixed path
+(`$TMPDIR/realm-live-workspace`, see `apps/server/scripts/live-workspace.ts`) and leave it on
+disk, so at most one entry exists and it always points somewhere real.
 That is the failure mode in miniature: an agent CLI treats its config as a mutable state store,
 and a host app driving it accumulates garbage in the user's file. Small and harmless today; the
 same mechanism becomes a data-loss vector once the writes get larger.

--- a/packages/adapters/src/acp/acp-adapter.test.ts
+++ b/packages/adapters/src/acp/acp-adapter.test.ts
@@ -5,7 +5,7 @@ import { mkdir, mkdtemp, readFile, realpath, symlink, truncate, writeFile } from
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { SessionEvent, SessionEventOf, SessionEventType } from "@realm/contracts";
-import { AcpAdapter, acpBootFailureMessage, MAX_FS_READ_BYTES, pickAcpOption, sliceLines, type AcpAgentSpec } from "./acp-adapter";
+import { AcpAdapter, acpBootFailureMessage, acpMcpServers, MAX_FS_READ_BYTES, pickAcpOption, sliceLines, type AcpAgentSpec } from "./acp-adapter";
 import { JsonRpcCallError } from "../jsonrpc/stdio";
 import type { AgentHandle, StartOptions } from "../types";
 
@@ -788,5 +788,46 @@ describe("AcpAdapter", () => {
     expect(types(evs)).not.toContain("permission_request");
     expect(statuses(evs)).not.toContain("waiting_permission");
     await handle.dispose();
+  });
+});
+
+describe("acpMcpServers", () => {
+  const stdio = { name: "airtable", transport: "stdio" as const, command: "/usr/bin/node", args: ["/abs/s.mjs"], env: { A: "1", B: "2" } };
+  const http = { name: "vercel", transport: "http" as const, url: "https://mcp.vercel.com", headers: { Authorization: "Bearer t" } };
+  const sse = { name: "legacy", transport: "sse" as const, url: "https://sse.example/mcp", headers: {} };
+
+  it("sends stdio env as an ARRAY of name/value pairs, not a record", () => {
+    // The named mutant. Cursor validates with zod before its own lenient normalizer runs, so a record
+    // here is rejected `invalid_union` and session/new fails outright — proven live in
+    // scripts/live-mcp-check.ts, which watches the fixture server's env verdict.
+    const [out] = acpMcpServers("acp:cursor", [stdio]) as [Record<string, unknown>];
+    expect(out.env).toEqual([{ name: "A", value: "1" }, { name: "B", value: "2" }]);
+    expect(Array.isArray(out.env)).toBe(true);
+  });
+
+  it("keeps args and env present even when empty — both are required, not optional", () => {
+    const [out] = acpMcpServers("acp:cursor", [{ name: "bare", transport: "stdio", command: "/bin/x", args: [], env: {} }]) as [Record<string, unknown>];
+    expect(out).toEqual({ name: "bare", command: "/bin/x", args: [], env: [] });
+  });
+
+  it("gives the stdio variant no `type` discriminant, and the remote ones one", () => {
+    expect(acpMcpServers("acp:cursor", [stdio])[0]).not.toHaveProperty("type");
+    expect(acpMcpServers("acp:cursor", [http])).toEqual([
+      { type: "http", name: "vercel", url: "https://mcp.vercel.com", headers: [{ name: "Authorization", value: "Bearer t" }] },
+    ]);
+    expect(acpMcpServers("acp:cursor", [sse])).toEqual([{ type: "sse", name: "legacy", url: "https://sse.example/mcp", headers: [] }]);
+  });
+
+  it("believes the handshake over the static table when a build advertises less", () => {
+    const lines: string[] = [];
+    // An agent that omits mcpCapabilities is saying stdio only. Sending it an http server would fail
+    // session/new for the whole session, not just that server.
+    expect(acpMcpServers("acp:cursor", [stdio, http, sse], {}, (l) => lines.push(l)).map((s) => s.name)).toEqual(["airtable"]);
+    expect(lines.join("\n")).toContain("mcpCapabilities.http");
+    expect(acpMcpServers("acp:cursor", [http, sse], { http: true }).map((s) => s.name)).toEqual(["vercel"]);
+  });
+
+  it("assumes both when nothing is passed, which is what both installed agents advertise", () => {
+    expect(acpMcpServers("acp:cursor", [stdio, http, sse])).toHaveLength(3);
   });
 });

--- a/packages/adapters/src/acp/acp-adapter.test.ts
+++ b/packages/adapters/src/acp/acp-adapter.test.ts
@@ -543,7 +543,7 @@ describe("AcpAdapter", () => {
   });
 
   it("sends mcp servers with env as name/value pairs, not a record", async () => {
-    const { handle, evs } = await booted({ mcpServers: [{ name: "realm", command: "/usr/bin/node", args: ["/abs/realm-mcp.mjs"], env: { A: "1", B: "2" } }] });
+    const { handle, evs } = await booted({ mcpServers: [{ name: "realm", transport: "stdio" as const, command: "/usr/bin/node", args: ["/abs/realm-mcp.mjs"], env: { A: "1", B: "2" } }] });
     await turn(handle, evs, "REVEAL");
     const journal = JSON.parse(texts(evs)[0]!) as { newParams: { cwd: string; mcpServers: unknown[] } };
     expect(journal.newParams.mcpServers).toEqual([

--- a/packages/adapters/src/acp/acp-adapter.ts
+++ b/packages/adapters/src/acp/acp-adapter.ts
@@ -63,6 +63,17 @@ export function pickAcpOption(decision: PermissionDecision, options: readonly un
   return null;
 }
 
+/**
+ * `StartOptions.skills` is deliberately unread here, and there is no TODO attached to it.
+ *
+ * ACP `session/new` is `{cwd, mcpServers}` and nothing else, `cursor-agent acp` accepts no flags of its
+ * own, and no `CURSOR_SKILLS*` env var exists. Cursor's one filesystem route — picking up other agents'
+ * skill directories — is gated behind a server-side predicate Realm can neither read nor set, and it
+ * returned different answers on different runs of the same binary (research §1.1.3). A skills path built
+ * on that would work for some users and silently not for others, which is worse than not having one.
+ * `AGENT_SKILL_SUPPORT` says `unsupported` for both ACP kinds so the UI can say so out loud.
+ */
+
 /** `McpServer[]` for `session/new`/`session/load`. Stdio `env` is an array of pairs, NOT a record (§2.3). */
 export function acpMcpServers(servers: McpStdioConfig[]): Bag[] {
   return servers.map((s) => ({

--- a/packages/adapters/src/acp/acp-adapter.ts
+++ b/packages/adapters/src/acp/acp-adapter.ts
@@ -5,7 +5,8 @@ import { AsyncQueue } from "../event-queue";
 import { JsonRpcCallError, StdioJsonRpc, withTimeout, type JsonRpcId } from "../jsonrpc/stdio";
 import { createAcpMapper } from "./map-acp";
 import { probeAcp } from "./probe";
-import type { AgentAdapter, AgentHandle, McpStdioConfig, PermissionDecision, ProbeResult, StartOptions, UserMessage } from "../types";
+import { selectMcpServers } from "../mcp-transport";
+import type { AgentAdapter, AgentHandle, McpServerConfig, PermissionDecision, ProbeResult, StartOptions, UserMessage } from "../types";
 
 type Bag = Record<string, unknown>;
 const obj = (v: unknown): Bag => (v && typeof v === "object" ? (v as Bag) : {});
@@ -74,14 +75,39 @@ export function pickAcpOption(decision: PermissionDecision, options: readonly un
  * `AGENT_SKILL_SUPPORT` says `unsupported` for both ACP kinds so the UI can say so out loud.
  */
 
-/** `McpServer[]` for `session/new`/`session/load`. Stdio `env` is an array of pairs, NOT a record (§2.3). */
-export function acpMcpServers(servers: McpStdioConfig[]): Bag[] {
-  return servers.map((s) => ({
-    name: s.name,
-    command: s.command,
-    args: s.args ?? [],
-    env: Object.entries(s.env ?? {}).map(([name, value]) => ({ name, value })),
-  }));
+/**
+ * `McpServer[]` for `session/new` / `session/load` (§2.3).
+ *
+ * Two shapes, and the difference between them is not cosmetic:
+ *
+ *   - stdio — `{name, command, args, env}` with **`env` an ARRAY of `{name,value}` pairs, not a record**,
+ *     and both `args` and `env` required. Cursor validates with zod *before* its own more lenient
+ *     normalizer runs, so a record here is rejected `invalid_union` and `session/new` fails outright.
+ *   - http / sse — `{type, name, url, headers}`, with `headers` the same array-of-pairs shape.
+ *
+ * The stdio variant carries no `type` discriminant; the remote ones do. Sending `type: "stdio"` is not
+ * part of 0.4.5's union.
+ */
+export function acpMcpServers(
+  kind: AgentKind,
+  servers: readonly McpServerConfig[],
+  /** `initialize`'s `agentCapabilities.mcpCapabilities`, verbatim. Both installed agents advertise
+   *  `{http:true,sse:true}`, but the field is optional in 0.4.5 and an agent that omits it is telling
+   *  Realm it takes stdio only — believing the static table over the handshake is how a session ends up
+   *  rejected at `session/new` for a server the agent never claimed to support. */
+  advertised: { http?: unknown; sse?: unknown } = { http: true, sse: true },
+  onLog?: (line: string) => void,
+): Bag[] {
+  const pairs = (m: Record<string, string>): Bag[] => Object.entries(m).map(([name, value]) => ({ name, value }));
+  const usable = selectMcpServers(kind, servers, onLog).filter((s) => {
+    if (s.transport === "stdio" || advertised[s.transport] === true) return true;
+    onLog?.(`[mcp] skipping "${s.name}": this build did not advertise mcpCapabilities.${s.transport}`);
+    return false;
+  });
+  return usable.map((s) =>
+    s.transport === "stdio"
+      ? { name: s.name, command: s.command, args: s.args, env: pairs(s.env) }
+      : { type: s.transport, name: s.name, url: s.url, headers: pairs(s.headers) });
 }
 
 /** User-visible copy for the stop reasons that are outcomes rather than plain completions (§3). */
@@ -343,7 +369,7 @@ export class AcpAdapter implements AgentAdapter {
         authMethods = Array.isArray(init.authMethods) ? init.authMethods : [];
         if (disposed) return;
 
-        const mcpServers = acpMcpServers(opts.mcpServers);
+        const mcpServers = acpMcpServers(spec.kind, opts.mcpServers, obj(caps.mcpCapabilities), log);
         let id: string | null = null;
         let session: Bag = {};
         if (opts.resume && caps.loadSession === true) {

--- a/packages/adapters/src/claude/claude-adapter.test.ts
+++ b/packages/adapters/src/claude/claude-adapter.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { ClaudeAdapter } from "./claude-adapter";
+import { ClaudeAdapter, claudeMcpServers } from "./claude-adapter";
 import type { SessionEvent } from "@realm/contracts";
 import type { StartOptions } from "../types";
 import { readFileSync } from "node:fs"; import { join, dirname } from "node:path"; import { fileURLToPath } from "node:url";
@@ -232,5 +232,33 @@ describe("ClaudeAdapter skills", () => {
     // what every Realm session did before skills existed and what a space with none must keep doing.
     expect("settingSources" in o).toBe(false);
     await handle.dispose();
+  });
+});
+
+describe("claudeMcpServers", () => {
+  const stdio = { name: "airtable", transport: "stdio" as const, command: "/usr/bin/node", args: ["/abs/s.mjs"], env: { K: "v" } };
+  const http = { name: "vercel", transport: "http" as const, url: "https://mcp.vercel.com", headers: { Authorization: "Bearer t" } };
+  const sse = { name: "legacy", transport: "sse" as const, url: "https://sse.example/mcp", headers: {} };
+
+  it("is a RECORD keyed by name, not an array (sdk.d.ts:1734 — some docs say otherwise)", () => {
+    const out = claudeMcpServers([stdio, http]);
+    expect(Array.isArray(out)).toBe(false);
+    expect(Object.keys(out)).toEqual(["airtable", "vercel"]);
+  });
+
+  it("tags each entry with its transport and carries only that transport's fields", () => {
+    expect(claudeMcpServers([stdio])).toEqual({ airtable: { type: "stdio", command: "/usr/bin/node", args: ["/abs/s.mjs"], env: { K: "v" } } });
+    expect(claudeMcpServers([http])).toEqual({ vercel: { type: "http", url: "https://mcp.vercel.com", headers: { Authorization: "Bearer t" } } });
+    expect(claudeMcpServers([sse])).toEqual({ legacy: { type: "sse", url: "https://sse.example/mcp", headers: {} } });
+  });
+
+  it("drops nothing, because Claude is the one agent that takes all three", () => {
+    const lines: string[] = [];
+    expect(Object.keys(claudeMcpServers([stdio, http, sse], (l) => lines.push(l)))).toHaveLength(3);
+    expect(lines).toEqual([]);
+  });
+
+  it("is empty — not absent — when there is nothing configured", () => {
+    expect(claudeMcpServers([])).toEqual({});
   });
 });

--- a/packages/adapters/src/claude/claude-adapter.test.ts
+++ b/packages/adapters/src/claude/claude-adapter.test.ts
@@ -223,6 +223,24 @@ describe("ClaudeAdapter skills", () => {
     await handle.dispose();
   });
 
+  it("appends systemContext to the claude_code preset prompt — W3's memory channel, and the only route the user's CLAUDE.md has back into a settingSources: [] session", async () => {
+    const { handle, options } = capture({
+      systemContext: "REALM CONTEXT 4417",
+      skills: { pluginPath: "/tmp/realm-plugin", root: "/tmp/realm-plugin/skills" },
+    });
+    await handle.send({ text: "hi", attachments: [] });
+    // The preset base prompt must survive: replacing it instead of appending would cost far more than memory.
+    expect(options()!.systemPrompt).toEqual({ type: "preset", preset: "claude_code", append: "REALM CONTEXT 4417" });
+    await handle.dispose();
+  });
+
+  it("leaves systemPrompt untouched when there is no context", async () => {
+    const { handle, options } = capture({});
+    await handle.send({ text: "hi", attachments: [] });
+    expect(options()!.systemPrompt).toBeUndefined();
+    await handle.dispose();
+  });
+
   it("touches neither option when Realm is not managing this session's skills", async () => {
     const { handle, options } = capture({});
     await handle.send({ text: "hi", attachments: [] });

--- a/packages/adapters/src/claude/claude-adapter.test.ts
+++ b/packages/adapters/src/claude/claude-adapter.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { ClaudeAdapter } from "./claude-adapter";
 import type { SessionEvent } from "@realm/contracts";
+import type { StartOptions } from "../types";
 import { readFileSync } from "node:fs"; import { join, dirname } from "node:path"; import { fileURLToPath } from "node:url";
 const fixture = JSON.parse(readFileSync(join(dirname(fileURLToPath(import.meta.url)), "fixtures", "turn.json"), "utf8")) as unknown[];
 
@@ -188,5 +189,48 @@ describe("ClaudeAdapter", () => {
     await new Promise<void>((res) => { const t = setInterval(() => { if (types(seen).includes("usage")) { clearInterval(t); res(); } }, 5); });
     expect(statuses(seen).filter((s) => s === "idle")).toHaveLength(1);
     await h.dispose(); await c;
+  });
+});
+
+/**
+ * The two halves of Claude's skills channel, proven live in `apps/server/scripts/live-skills-check.ts`:
+ * `plugins` is what adds Realm's library, and `settingSources: []` is what stops the user's own 29 skills
+ * (and their `~/.claude/CLAUDE.md`) loading alongside it. Either one alone is a different product.
+ */
+describe("ClaudeAdapter skills", () => {
+  /** Captures the options object the SDK was called with, without running a turn. */
+  function capture(opts: Partial<StartOptions>) {
+    let seen: Record<string, unknown> | null = null;
+    const adapter = new ClaudeAdapter({
+      query: ((args: { options: Record<string, unknown> }) => {
+        seen = args.options;
+        const gen = (async function* () { /* no messages: nothing here needs a turn */ })();
+        return Object.assign(gen, { interrupt: async () => {}, setPermissionMode: async () => {}, setModel: async () => {} });
+      }) as never,
+    });
+    const handle = adapter.start({ cwd: "/tmp", mcpServers: [], ...opts });
+    return { handle, options: () => seen as unknown as Record<string, unknown> | null };
+  }
+
+  it("passes the staged plugin and isolates the session from the user's own settings", async () => {
+    const { handle, options } = capture({ skills: { pluginPath: "/tmp/realm-plugin", root: "/tmp/realm-plugin/skills" } });
+    await handle.send({ text: "hi", attachments: [] });
+    const o = options()!;
+    expect(o.plugins).toEqual([{ type: "local", path: "/tmp/realm-plugin", skipMcpDiscovery: true }]);
+    // Dropping this is the silent mutation: the session still works, and quietly loads every skill the
+    // user has installed on top of the library Realm's UI is listing.
+    expect(o.settingSources).toEqual([]);
+    await handle.dispose();
+  });
+
+  it("touches neither option when Realm is not managing this session's skills", async () => {
+    const { handle, options } = capture({});
+    await handle.send({ text: "hi", attachments: [] });
+    const o = options()!;
+    expect(o.plugins).toBeUndefined();
+    // Undefined, NOT []: the SDK reads an omitted settingSources as "all sources, like the CLI", which is
+    // what every Realm session did before skills existed and what a space with none must keep doing.
+    expect("settingSources" in o).toBe(false);
+    await handle.dispose();
   });
 });

--- a/packages/adapters/src/claude/claude-adapter.ts
+++ b/packages/adapters/src/claude/claude-adapter.ts
@@ -4,9 +4,27 @@ import { MAX_ATTACHMENT_BYTES, newId, sessionEvent, type SessionEvent } from "@r
 import { AsyncQueue } from "../event-queue";
 import { createSdkMapper } from "./map-sdk-message";
 import { probeClaude } from "./probe";
-import type { AgentAdapter, AgentHandle, PermissionDecision, ProbeResult, StartOptions, UserMessage } from "../types";
+import { selectMcpServers } from "../mcp-transport";
+import type { AgentAdapter, AgentHandle, McpServerConfig, PermissionDecision, ProbeResult, StartOptions, UserMessage } from "../types";
 
 type QueryFn = typeof sdkQuery;
+
+/**
+ * `Options.mcpServers` for the SDK: a record keyed by name (`sdk.d.ts:1734`), whose members are the
+ * three process transports — `{type:'stdio',command,args,env}` and `{type:'http'|'sse',url,headers}`.
+ *
+ * Claude is the one agent that takes all three, so nothing is ever dropped here in practice; the filter
+ * stays because `AGENT_MCP_TRANSPORTS` is the single source of truth for which agent takes what, and an
+ * adapter that decides for itself is one that can disagree with the UI.
+ */
+export function claudeMcpServers(servers: readonly McpServerConfig[], onLog?: (line: string) => void): Record<string, unknown> {
+  return Object.fromEntries(selectMcpServers("claude", servers, onLog).map((s) => [
+    s.name,
+    s.transport === "stdio"
+      ? { type: "stdio" as const, command: s.command, args: s.args, env: s.env }
+      : { type: s.transport, url: s.url, headers: s.headers },
+  ]));
+}
 
 const STDERR_TAIL_LINES = 50;
 const DISPOSE_TIMEOUT_MS = 3000;
@@ -80,7 +98,9 @@ export class ClaudeAdapter implements AgentAdapter {
       abortController: abort,
       resume: opts.resume ?? undefined,
       systemPrompt: opts.systemContext ? { type: "preset", preset: "claude_code", append: opts.systemContext } : undefined,
-      mcpServers: Object.fromEntries(opts.mcpServers.map((s) => [s.name, { type: "stdio" as const, command: s.command, args: s.args, env: s.env }])),
+      // A RECORD keyed by name, not an array: `sdk.d.ts` `mcpServers?: Record<string, McpServerConfig>`.
+      // Some documentation shows an array; disk wins.
+      mcpServers: claudeMcpServers(opts.mcpServers, opts.onLog) as Options["mcpServers"],
       // Realm's skills library as a local plugin, and `settingSources: []` so it is the ONLY library
       // this session has. The two go together and neither works alone for what Realm wants:
       //

--- a/packages/adapters/src/claude/claude-adapter.ts
+++ b/packages/adapters/src/claude/claude-adapter.ts
@@ -81,6 +81,20 @@ export class ClaudeAdapter implements AgentAdapter {
       resume: opts.resume ?? undefined,
       systemPrompt: opts.systemContext ? { type: "preset", preset: "claude_code", append: opts.systemContext } : undefined,
       mcpServers: Object.fromEntries(opts.mcpServers.map((s) => [s.name, { type: "stdio" as const, command: s.command, args: s.args, env: s.env }])),
+      // Realm's skills library as a local plugin, and `settingSources: []` so it is the ONLY library
+      // this session has. The two go together and neither works alone for what Realm wants:
+      //
+      //   - without `plugins`, there is no way to add a skills directory at all;
+      //   - without `settingSources: []`, the user's own `~/.claude/skills` (29 of them here) load
+      //     alongside Realm's, so the library the UI lists is not the library the agent has.
+      //
+      // Proven live in scripts/live-skills-check.ts: this shape surfaces `realm:<id>` and leaks nothing;
+      // dropping `settingSources` takes the command count from 53 to 147.
+      //
+      // The cost is real and deliberate: `settingSources: []` also drops the user's `~/.claude/CLAUDE.md`
+      // and the repo's `.claude/` settings. That is why the option is only present when the space
+      // actually has enabled skills — a space that manages none is left exactly as it was.
+      ...(opts.skills ? { settingSources: [], plugins: [{ type: "local" as const, path: opts.skills.pluginPath, skipMcpDiscovery: true }] } : {}),
       env: { ...process.env, ...opts.env },
       stderr: onStderr,
       pathToClaudeCodeExecutable: process.env.REALM_CLAUDE_BIN,

--- a/packages/adapters/src/codex/codex-adapter.test.ts
+++ b/packages/adapters/src/codex/codex-adapter.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, afterEach, vi } from "vitest";
 import { fileURLToPath } from "node:url";
 import type { SessionEvent, SessionEventOf, SessionEventType } from "@realm/contracts";
-import { CodexAdapter, codexPolicyFor, pickCodexDecision } from "./codex-adapter";
+import { CodexAdapter, codexMcpConfig, codexPolicyFor, pickCodexDecision } from "./codex-adapter";
 import type { AgentHandle, StartOptions } from "../types";
 
 /**
@@ -765,5 +765,37 @@ describe("CodexAdapter skills", () => {
     expect(adapter.skillsSupported).toBe(true);
     await handle.send({ text: "hello", attachments: [] });
     await waitFor(() => expect(texts(evs).join("")).toContain("hello"));
+  });
+});
+
+describe("codexMcpConfig", () => {
+  const stdio = { name: "airtable", transport: "stdio" as const, command: "/usr/bin/node", args: ["/abs/s.mjs"], env: { K: "v" } };
+  const http = { name: "vercel", transport: "http" as const, url: "https://mcp.vercel.com", headers: { Authorization: "Bearer t" } };
+  const sse = { name: "legacy", transport: "sse" as const, url: "https://sse.example/mcp", headers: { A: "b" } };
+
+  it("writes a stdio server as command/args/env under its name", () => {
+    expect(codexMcpConfig([stdio])).toEqual({ mcp_servers: { airtable: { command: "/usr/bin/node", args: ["/abs/s.mjs"], env: { K: "v" } } } });
+  });
+
+  it("writes an http server as url/http_headers — Codex's own key, not `headers`", () => {
+    expect(codexMcpConfig([http])).toEqual({ mcp_servers: { vercel: { url: "https://mcp.vercel.com", http_headers: { Authorization: "Bearer t" } } } });
+  });
+
+  it("drops an sse server entirely and says so, because Codex has no SSE transport", () => {
+    const lines: string[] = [];
+    expect(codexMcpConfig([sse], (l) => lines.push(l))).toBeUndefined();
+    expect(lines.join("")).toContain('"legacy"');
+    // `thread/start` does not validate `config` keys, so a wrong shape here would be accepted in
+    // silence — which is why it must never be produced.
+    expect(JSON.stringify(codexMcpConfig([stdio, sse]))).not.toContain("legacy");
+  });
+
+  it("omits empty args and env rather than sending empty collections", () => {
+    const bare = { name: "bare", transport: "stdio" as const, command: "/bin/x", args: [], env: {} };
+    expect(codexMcpConfig([bare])).toEqual({ mcp_servers: { bare: { command: "/bin/x" } } });
+  });
+
+  it("is undefined when nothing survives, so `config` is omitted from thread/start", () => {
+    expect(codexMcpConfig([])).toBeUndefined();
   });
 });

--- a/packages/adapters/src/codex/codex-adapter.test.ts
+++ b/packages/adapters/src/codex/codex-adapter.test.ts
@@ -1,4 +1,7 @@
 import { describe, it, expect, afterEach, vi } from "vitest";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { SessionEvent, SessionEventOf, SessionEventType } from "@realm/contracts";
 import { CodexAdapter, codexMcpConfig, codexPolicyFor, pickCodexDecision } from "./codex-adapter";
@@ -797,5 +800,55 @@ describe("codexMcpConfig", () => {
 
   it("is undefined when nothing survives, so `config` is omitted from thread/start", () => {
     expect(codexMcpConfig([])).toBeUndefined();
+  });
+});
+
+/**
+ * W3's memory channel on Codex: the same `StartOptions.systemContext` the Claude adapter appends to its
+ * system prompt goes to Codex as `thread/start` `developerInstructions` — and the start response's
+ * `instructionSources` (the exact files Codex loaded) comes back on this session's init event.
+ * `model: "reflect"` makes the fixture echo the whole thread/start params as the model string, which is
+ * how the tests see exactly what went on the wire.
+ */
+describe("CodexAdapter memory", () => {
+  const reflected = (evs: SessionEvent[]) => JSON.parse(of(evs, "init")[0]!.payload.model) as Record<string, unknown>;
+
+  it("sends systemContext as developerInstructions on thread/start", async () => {
+    const { evs } = await booted({ model: "reflect", systemContext: "REALM CONTEXT 4417" });
+    expect(reflected(evs).developerInstructions).toBe("REALM CONTEXT 4417");
+  });
+
+  it("omits the field entirely when there is no context, rather than sending an empty string", async () => {
+    const { evs } = await booted({ model: "reflect" });
+    expect("developerInstructions" in reflected(evs)).toBe(false);
+  });
+
+  it("does not send it on thread/resume — a resumed thread keeps what it was started with", async () => {
+    const { evs } = await booted({ model: "reflect", resume: "th_prior", systemContext: "REALM CONTEXT 4417" });
+    const params = reflected(evs);
+    expect(params.threadId).toBe("th_prior");
+    expect("developerInstructions" in params).toBe(false);
+  });
+
+  it("surfaces the thread's own instructionSources on init — each session gets its own thread's list", async () => {
+    // Two sessions on ONE adapter: the shared-process design is exactly where a cross-thread mixup would live.
+    // The spawn needs a real cwd (the first session's); the second thread's cwd is only a thread/start param.
+    const adapter = newAdapter();
+    const cwdA = mkdtempSync(join(tmpdir(), "realm-mem-a-"));
+    const cwdB = mkdtempSync(join(tmpdir(), "realm-mem-b-"));
+    const a = adapter.start(startOpts({ cwd: cwdA }));
+    const evsA = drain(a).evs;
+    const b = adapter.start(startOpts({ cwd: cwdB }));
+    const evsB = drain(b).evs;
+    await waitFor(() => expect(types(evsA)).toContain("init"));
+    await waitFor(() => expect(types(evsB)).toContain("init"));
+    // The fixture derives the list from cwd, so a cross-thread mixup would show as the wrong path here.
+    expect(of(evsA, "init")[0]!.payload.instructionSources).toEqual([`${cwdA}/AGENTS.md`]);
+    expect(of(evsB, "init")[0]!.payload.instructionSources).toEqual([`${cwdB}/AGENTS.md`]);
+  });
+
+  it("leaves instructionSources absent when the server does not report it (older build), not []", async () => {
+    const { evs } = await booted({ env: { FAKE_CODEX_NO_INSTRUCTION_SOURCES: "1" } });
+    expect("instructionSources" in of(evs, "init")[0]!.payload).toBe(false);
   });
 });

--- a/packages/adapters/src/codex/codex-adapter.test.ts
+++ b/packages/adapters/src/codex/codex-adapter.test.ts
@@ -668,3 +668,102 @@ describe("CodexAdapter", () => {
     expect(types(evs)).not.toContain("assistant_text");
   });
 });
+
+/**
+ * `skills/extraRoots/set` is per-CONNECTION, not per-thread, and CodexAdapter shares one connection across
+ * every session — so these tests are as much about the union and the refcount as about the call itself.
+ * The live counterpart (against the real 0.146.0 binary) is `apps/server/scripts/live-skills-check.ts`.
+ */
+describe("CodexAdapter skills", () => {
+  const roots = async (adapter: CodexAdapter) =>
+    (await (await adapter.connection!).request<{ extraRoots: string[] | null; calls: number }>("$test/extraRoots"));
+
+  it("sets the session's skills root on the connection once the thread exists", async () => {
+    const adapter = newAdapter();
+    const handle = adapter.start(startOpts({ skills: { pluginPath: "/tmp/realm-plugin", root: "/tmp/realm-plugin/skills" } }));
+    const { evs } = drain(handle);
+    await waitFor(() => expect(types(evs)).toContain("init"));
+    await waitFor(async () => expect((await roots(adapter)).extraRoots).toEqual(["/tmp/realm-plugin/skills"]));
+  });
+
+  it("never calls it at all for a session with no skills", async () => {
+    const { adapter, evs } = await booted();
+    expect(types(evs)).toContain("init");
+    expect((await roots(adapter)).calls).toBe(0);
+    expect(adapter.extraRootCount).toBe(0);
+  });
+
+  it("unions the roots of every live session and drops each one as its session ends", async () => {
+    const adapter = newAdapter();
+    const a = adapter.start(startOpts({ skills: { pluginPath: "/tmp/a", root: "/tmp/a/skills" } }));
+    const evsA = drain(a).evs;
+    await waitFor(() => expect(types(evsA)).toContain("init"));
+    const b = adapter.start(startOpts({ skills: { pluginPath: "/tmp/b", root: "/tmp/b/skills" } }));
+    const evsB = drain(b).evs;
+    await waitFor(() => expect(types(evsB)).toContain("init"));
+    await waitFor(async () => expect((await roots(adapter)).extraRoots).toEqual(["/tmp/a/skills", "/tmp/b/skills"]));
+    // One session ending must not take the other's skills away with it.
+    await b.dispose();
+    await waitFor(async () => expect((await roots(adapter)).extraRoots).toEqual(["/tmp/a/skills"]));
+    expect(adapter.extraRootCount).toBe(1);
+  });
+
+  it("counts two sessions sharing one root and only drops it when the last of them goes", async () => {
+    const adapter = newAdapter();
+    const skills = { pluginPath: "/tmp/same", root: "/tmp/same/skills" };
+    const a = adapter.start(startOpts({ skills }));
+    const evsA = drain(a).evs;
+    await waitFor(() => expect(types(evsA)).toContain("init"));
+    const b = adapter.start(startOpts({ skills }));
+    const evsB = drain(b).evs;
+    await waitFor(() => expect(types(evsB)).toContain("init"));
+    expect(adapter.extraRootCount).toBe(1);
+    await b.dispose();
+    await waitFor(async () => expect((await roots(adapter)).extraRoots).toEqual(["/tmp/same/skills"]));
+  });
+
+  it("starts the session anyway on a codex build that has no skills/extraRoots/set", async () => {
+    // The whole point of the feature detection: this machine runs a preview build ahead of the public
+    // release, so -32601 is the expected answer from an older binary and must cost the user nothing but skills.
+    const adapter = newAdapter();
+    const logs: string[] = [];
+    const handle = adapter.start(startOpts({
+      env: { FAKE_CODEX_NO_EXTRA_ROOTS: "1" },
+      skills: { pluginPath: "/tmp/realm-plugin", root: "/tmp/realm-plugin/skills" },
+      onLog: (l) => logs.push(l),
+    }));
+    const { evs } = drain(handle);
+    await waitFor(() => expect(types(evs)).toContain("init"));
+    expect(statuses(evs)).toContain("idle");
+    expect(types(evs)).not.toContain("error");
+    await waitFor(() => expect(logs.join("\n")).toContain("no skills/extraRoots/set"));
+    expect(adapter.skillsSupported).toBe(false);
+    // Sticky: a second session must not pay for the same round trip to learn the same thing.
+    const before = logs.length;
+    const b = adapter.start(startOpts({ env: { FAKE_CODEX_NO_EXTRA_ROOTS: "1" }, skills: { pluginPath: "/tmp/b", root: "/tmp/b/skills" }, onLog: (l) => logs.push(l) }));
+    const evsB = drain(b).evs;
+    await waitFor(() => expect(types(evsB)).toContain("init"));
+    expect(logs.slice(before).join("\n")).not.toContain("no skills/extraRoots/set");
+    // And the turn still runs.
+    await b.send({ text: "hello", attachments: [] });
+    await waitFor(() => expect(texts(evsB).join("")).toContain("hello"));
+  });
+
+  it("starts the session anyway when the method exists but fails", async () => {
+    const adapter = newAdapter();
+    const logs: string[] = [];
+    const handle = adapter.start(startOpts({
+      env: { FAKE_CODEX_EXTRA_ROOTS_FAIL: "1" },
+      skills: { pluginPath: "/tmp/realm-plugin", root: "/tmp/realm-plugin/skills" },
+      onLog: (l) => logs.push(l),
+    }));
+    const { evs } = drain(handle);
+    await waitFor(() => expect(types(evs)).toContain("init"));
+    expect(types(evs)).not.toContain("error");
+    await waitFor(() => expect(logs.join("\n")).toContain("skills/extraRoots/set failed"));
+    // A transient failure is not a missing method: the next session must try again.
+    expect(adapter.skillsSupported).toBe(true);
+    await handle.send({ text: "hello", attachments: [] });
+    await waitFor(() => expect(texts(evs).join("")).toContain("hello"));
+  });
+});

--- a/packages/adapters/src/codex/codex-adapter.test.ts
+++ b/packages/adapters/src/codex/codex-adapter.test.ts
@@ -188,7 +188,7 @@ describe("CodexAdapter", () => {
   it("passes mcp servers through config.mcp_servers", async () => {
     const { handle, evs } = await booted({
       model: "reflect",
-      mcpServers: [{ name: "realm", command: "/usr/bin/node", args: ["/abs/realm-mcp.mjs"], env: { A: "1" } }],
+      mcpServers: [{ name: "realm", transport: "stdio" as const, command: "/usr/bin/node", args: ["/abs/realm-mcp.mjs"], env: { A: "1" } }],
     });
     const params = JSON.parse(of(evs, "init")[0]!.payload.model) as { config: { mcp_servers: Record<string, unknown> } };
     expect(params.config.mcp_servers).toEqual({ realm: { command: "/usr/bin/node", args: ["/abs/realm-mcp.mjs"], env: { A: "1" } } });

--- a/packages/adapters/src/codex/codex-adapter.ts
+++ b/packages/adapters/src/codex/codex-adapter.ts
@@ -4,7 +4,8 @@ import { JsonRpcCallError, type JsonRpcId } from "../jsonrpc/stdio";
 import { CodexConnection, type ThreadListener } from "./connection";
 import { createCodexMapper } from "./map-codex";
 import { probeCodex } from "./probe";
-import type { AgentAdapter, AgentHandle, McpStdioConfig, PermissionDecision, ProbeResult, StartOptions, UserMessage } from "../types";
+import { selectMcpServers } from "../mcp-transport";
+import type { AgentAdapter, AgentHandle, McpServerConfig, PermissionDecision, ProbeResult, StartOptions, UserMessage } from "../types";
 
 type Bag = Record<string, unknown>;
 const obj = (v: unknown): Bag => (v && typeof v === "object" ? (v as Bag) : {});
@@ -59,9 +60,27 @@ export function codexPolicyFor(permissionMode: string | undefined): { approvalPo
   return { approvalPolicy: "on-request", sandbox: "workspace-write" };
 }
 
-function mcpConfig(servers: McpStdioConfig[]): Bag | undefined {
-  if (servers.length === 0) return undefined;
-  const entries = servers.map((s) => [s.name, { command: s.command, ...(s.args ? { args: s.args } : {}), ...(s.env ? { env: s.env } : {}) }] as const);
+/**
+ * `thread/start` `config.mcp_servers` — a `[mcp_servers.NAME]` table per server, for this thread only.
+ *
+ * Codex's `RawMcpServerConfig` is one struct covering both shapes: `command`/`args`/`env` for a stdio
+ * server, `url`/`http_headers` for a streamable-HTTP one. **There is no SSE variant**, which is why the
+ * transport filter is not decoration — an SSE server sent as `{url}` would be dialled as HTTP and fail
+ * at connect time, long after Realm told the user it was configured.
+ *
+ * `undefined` when nothing survives, so `config` is omitted entirely rather than sent as an empty map:
+ * `thread/start` does not validate `config` keys (research §1.2), so an empty one is accepted in
+ * silence and there is no reason to send it.
+ */
+export function codexMcpConfig(servers: readonly McpServerConfig[], onLog?: (line: string) => void): Bag | undefined {
+  const usable = selectMcpServers("codex", servers, onLog);
+  if (usable.length === 0) return undefined;
+  const entries = usable.map((s) => [
+    s.name,
+    s.transport === "stdio"
+      ? { command: s.command, ...(s.args.length ? { args: s.args } : {}), ...(Object.keys(s.env).length ? { env: s.env } : {}) }
+      : { url: s.url, ...(Object.keys(s.headers).length ? { http_headers: s.headers } : {}) },
+  ] as const);
   return { mcp_servers: Object.fromEntries(entries) };
 }
 
@@ -307,7 +326,7 @@ export class CodexAdapter implements AgentAdapter {
         if (disposed) { await releaseOnce(); return; }
         conn = c;
         const { approvalPolicy, sandbox } = codexPolicyFor(opts.permissionMode);
-        const config = mcpConfig(opts.mcpServers);
+        const config = codexMcpConfig(opts.mcpServers, opts.onLog);
         // `opts.effort` is deliberately dropped: Codex takes reasoning effort per turn, not per thread, and
         // Realm has no per-turn effort control yet. Claude passes it through; this asymmetry is intentional.
         const common = {

--- a/packages/adapters/src/codex/codex-adapter.ts
+++ b/packages/adapters/src/codex/codex-adapter.ts
@@ -15,6 +15,11 @@ const message = (e: unknown): string => (e instanceof Error ? e.message : String
 const DISPOSE_TIMEOUT_MS = 3000;
 /** thread/start loads config, resolves the model and checks auth — slower than initialize, never unbounded. */
 const BOOT_TIMEOUT_MS = 30_000;
+/** `skills/extraRoots/set` only rescans a couple of directories, and nothing about the session depends on
+ *  its answer — so it gets a short leash rather than the boot budget. */
+const EXTRA_ROOTS_TIMEOUT_MS = 10_000;
+/** JSON-RPC "method not found": the signal that this codex build predates `skills/extraRoots/set`. */
+const METHOD_NOT_FOUND = -32601;
 
 const APPROVAL_METHODS: Record<string, { toolName: string; title: string }> = {
   "item/commandExecution/requestApproval": { toolName: "exec_command", title: "Run this command?" },
@@ -83,6 +88,22 @@ export class CodexAdapter implements AgentAdapter {
   private readonly bootTimeoutMs?: number;
   private conn: Promise<CodexConnection> | null = null;
   private refs = 0;
+  /**
+   * Skills roots contributed by live sessions, refcounted by root.
+   *
+   * `skills/extraRoots/set` takes `{ extraRoots }` and **no `threadId`** — it is per-connection, and
+   * CodexAdapter deliberately shares one `codex app-server` across every Realm session. So the roots of
+   * every live session are unioned and the whole set is re-sent on each change; a Work space and a School
+   * space with different skills enabled will each see both sets in Codex. That is the documented trade
+   * (research §2) — the alternative is a process per space, which loses the refcount this class exists for.
+   */
+  private readonly extraRoots = new Map<string, number>();
+  /**
+   * Feature detection, sticky per adapter. This machine runs a codex preview ahead of the public release;
+   * an older binary answers `skills/extraRoots/set` with -32601 and must degrade to "Codex sees no Realm
+   * skills", never throw and never fail a session.
+   */
+  private extraRootsSupported = true;
 
   constructor(deps: { bin?: string; args?: string[]; bootTimeoutMs?: number } = {}) {
     this.bin = deps.bin;
@@ -131,11 +152,50 @@ export class CodexAdapter implements AgentAdapter {
     }
   }
 
+  /** Visible for tests: the roots currently unioned onto the shared connection. */
+  get extraRootCount(): number { return this.extraRoots.size; }
+  /** Visible for tests: false once a codex build has answered -32601 to `skills/extraRoots/set`. */
+  get skillsSupported(): boolean { return this.extraRootsSupported; }
+
+  /**
+   * Re-sends the union to the shared connection. Never throws and never rejects: a skills root that does
+   * not land is a session with fewer skills, not a session that failed to start — and this is awaited on
+   * the boot path, where a throw would be reported to the user as a dead agent.
+   */
+  private async syncExtraRoots(conn: CodexConnection, onLog?: (line: string) => void): Promise<void> {
+    if (!this.extraRootsSupported) return;
+    try {
+      await conn.request("skills/extraRoots/set", { extraRoots: [...this.extraRoots.keys()] }, EXTRA_ROOTS_TIMEOUT_MS);
+    } catch (e) {
+      if (e instanceof JsonRpcCallError && e.code === METHOD_NOT_FOUND) {
+        this.extraRootsSupported = false;
+        onLog?.("[codex] this codex build has no skills/extraRoots/set; Realm skills will not be visible to Codex");
+        return;
+      }
+      onLog?.(`[codex] skills/extraRoots/set failed: ${message(e)}`);
+    }
+  }
+
+  private async addExtraRoot(conn: CodexConnection, root: string, onLog?: (line: string) => void): Promise<void> {
+    this.extraRoots.set(root, (this.extraRoots.get(root) ?? 0) + 1);
+    await this.syncExtraRoots(conn, onLog);
+  }
+
+  private async dropExtraRoot(conn: CodexConnection, root: string, onLog?: (line: string) => void): Promise<void> {
+    const next = (this.extraRoots.get(root) ?? 0) - 1;
+    if (next > 0) this.extraRoots.set(root, next);
+    else this.extraRoots.delete(root);
+    await this.syncExtraRoots(conn, onLog);
+  }
+
   private async release(): Promise<void> {
     this.refs -= 1;
     if (this.refs > 0) return;
     const pending = this.conn;
     this.conn = null;
+    // The roots live on the connection, not on the adapter: a later session gets a fresh process that has
+    // never been told anything, so a leftover entry here would make syncExtraRoots think it already had.
+    this.extraRoots.clear();
     if (!pending) return;
     try { await (await pending).dispose(); } catch { /* open() already tore down its own child */ }
   }
@@ -150,6 +210,8 @@ export class CodexAdapter implements AgentAdapter {
     let acquired = false;
     let released = false;
     let disposed = false;
+    /** Set only once this session's root is counted into the union, so shutdown drops exactly what boot added. */
+    let ownedRoot: string | null = null;
 
     const fail = (text: string) => {
       events.push(sessionEvent("error", { message: text }));
@@ -188,6 +250,9 @@ export class CodexAdapter implements AgentAdapter {
       disposed = true;
       denyAllPending();
       if (conn && threadId) conn.detach(threadId);
+      // Before releasing: the process may be about to go, but while other sessions still hold it their
+      // union must stop including a root this session is no longer entitled to.
+      if (conn && ownedRoot) { const r = ownedRoot; ownedRoot = null; await this.dropExtraRoot(conn, r, opts.onLog); }
       for (const e of mapper.closeOpenTools("session closed")) events.push(e);
       events.push(sessionEvent("status", { status: "ended" }));
       events.close();
@@ -269,6 +334,9 @@ export class CodexAdapter implements AgentAdapter {
         events.push(sessionEvent("init", { providerSessionId: id, model: str(res.model) || str(opts.model), tools: [], cwd: str(res.cwd) || opts.cwd }));
         events.push(sessionEvent("status", { status: "idle" }));
         c.attach(id, listener);
+        // After the thread exists, per the protocol's own ordering, and awaited inside boot so that the
+        // first send() — which awaits boot — cannot start a turn before Codex knows about the skills.
+        if (opts.skills) { ownedRoot = opts.skills.root; await this.addExtraRoot(c, opts.skills.root, opts.onLog); }
       } catch (e) {
         if (disposed) return;
         fail(bootFailureMessage(e));

--- a/packages/adapters/src/codex/codex-adapter.ts
+++ b/packages/adapters/src/codex/codex-adapter.ts
@@ -340,17 +340,36 @@ export class CodexAdapter implements AgentAdapter {
         // nothing would otherwise leave `boot` — and every send()/setOptions()/dispose() behind it — pending
         // for the life of the process.
         const bootMs = this.bootTimeoutMs ?? BOOT_TIMEOUT_MS;
+        // `developerInstructions` is W3's memory channel: the same text the Claude adapter appends to its
+        // system prompt, as a thread/start parameter. thread/start ONLY — a resumed thread keeps the
+        // instructions it was started with, and what a fresh value on thread/resume would mean is not
+        // something the protocol says (the field is listed unverified there; proven for thread/start in
+        // scripts/live-memory-check.ts).
         const res = obj(opts.resume
           ? await c.request("thread/resume", { threadId: opts.resume, ...common }, bootMs)
-          : await c.request("thread/start", { ...common, sessionStartSource: "startup" }, bootMs));
+          : await c.request("thread/start", {
+            ...common,
+            ...(opts.systemContext ? { developerInstructions: opts.systemContext } : {}),
+            sessionStartSource: "startup",
+          }, bootMs));
         if (disposed) return;
         const id = str(obj(res.thread).id) || str(opts.resume);
         if (!id) throw new Error("codex did not return a thread id");
         threadId = id;
+        // Codex names the exact instruction files it loaded (AGENTS.md hierarchy) in the start response —
+        // ground truth the memory pane shows instead of a guess. Absent (older build / resume without the
+        // field) stays absent rather than becoming [], so "reported nothing" and "reported zero files"
+        // remain distinguishable downstream.
+        const instructionSources = Array.isArray(res.instructionSources)
+          ? res.instructionSources.filter((s): s is string => typeof s === "string")
+          : undefined;
         // Both before attach(): attach flushes the thread's buffer synchronously, and notifications that beat
         // the thread/start response would otherwise be mapped into the stream ahead of init. Nothing is lost by
         // waiting — the connection buffers by threadId until someone attaches.
-        events.push(sessionEvent("init", { providerSessionId: id, model: str(res.model) || str(opts.model), tools: [], cwd: str(res.cwd) || opts.cwd }));
+        events.push(sessionEvent("init", {
+          providerSessionId: id, model: str(res.model) || str(opts.model), tools: [], cwd: str(res.cwd) || opts.cwd,
+          ...(instructionSources ? { instructionSources } : {}),
+        }));
         events.push(sessionEvent("status", { status: "idle" }));
         c.attach(id, listener);
         // After the thread exists, per the protocol's own ordering, and awaited inside boot so that the

--- a/packages/adapters/src/codex/fixtures/fake-codex-server.mjs
+++ b/packages/adapters/src/codex/fixtures/fake-codex-server.mjs
@@ -29,7 +29,9 @@
  * `text_elements` is validated on text input exactly as the real server does — omitting it is a deserialize
  * error there, and silently accepting it here would let that regression through.
  *
- * Test-only hooks: the `$test/exit` request kills the process (so tests can tell an unexpected death from
+ * Test-only hooks: the `$test/extraRoots` request reports the last `skills/extraRoots/set` payload and how
+ * many times it was called, FAKE_CODEX_NO_EXTRA_ROOTS=1 answers that method -32601 (a build from before it
+ * existed) and FAKE_CODEX_EXTRA_ROOTS_FAIL=1 fails it -32603; the `$test/exit` request kills the process (so tests can tell an unexpected death from
  * an intentional dispose), `model: "explode"` fails `thread/start` with the revoked-login error shape,
  * `model: "reflect"` echoes the whole `thread/start`/`thread/resume` params object back as the model string
  * (the only field of the start response the adapter surfaces), a resumed thread id containing "busy" rejoins a
@@ -46,6 +48,9 @@ const threads = new Map(); // threadId -> { cwd }
 const activeTurns = new Map(); // threadId -> turnId, the precondition turn/steer checks
 const pendingRequests = new Map(); // server request id -> (clientReply) => void
 let stdinBuf = "";
+// Last `skills/extraRoots/set` payload plus a call count, readable via the `$test/extraRoots` request.
+let lastExtraRoots = null;
+let extraRootsCalls = 0;
 
 const send = (frame) => process.stdout.write(JSON.stringify(frame) + "\n");
 const ok = (id, result) => send({ id, result });
@@ -304,6 +309,20 @@ function handleRequest(id, method, params) {
       agentMessage(params.threadId, active, `steered:${inputText(params.input)}`);
       return;
     }
+    case "skills/extraRoots/set": {
+      // FAKE_CODEX_NO_EXTRA_ROOTS=1 is a codex build from before the method existed: -32601, which the
+      // adapter must feature-detect rather than surface as a dead session.
+      if (process.env.FAKE_CODEX_NO_EXTRA_ROOTS) { fail(id, -32601, "Method not found: skills/extraRoots/set"); return; }
+      // ...and this is the method existing but failing, which must degrade the same way.
+      if (process.env.FAKE_CODEX_EXTRA_ROOTS_FAIL) { fail(id, -32603, "could not read one of those roots"); return; }
+      extraRootsCalls++;
+      lastExtraRoots = Array.isArray(params.extraRoots) ? params.extraRoots : null;
+      ok(id, {});
+      return;
+    }
+    case "$test/extraRoots":
+      ok(id, { extraRoots: lastExtraRoots, calls: extraRootsCalls });
+      return;
     case "turn/interrupt":
       ok(id, {});
       void streamInterrupt(params.threadId, params.turnId);

--- a/packages/adapters/src/codex/fixtures/fake-codex-server.mjs
+++ b/packages/adapters/src/codex/fixtures/fake-codex-server.mjs
@@ -238,6 +238,10 @@ function startThread(id, params, threadId) {
     thread: { id: threadId, status: { type: "idle" }, cwd: params.cwd, turns: [] },
     model: params.model === "reflect" ? JSON.stringify(params) : (params.model ?? "gpt-5.2"),
     cwd: params.cwd,
+    // The real server reports the instruction files it loaded, per-thread, derived from cwd — a fabricated
+    // one per thread lets tests prove the adapter surfaces THIS thread's list and not another's.
+    // FAKE_CODEX_NO_INSTRUCTION_SOURCES=1 is a build from before the field existed.
+    ...(process.env.FAKE_CODEX_NO_INSTRUCTION_SOURCES ? {} : { instructionSources: [`${params.cwd}/AGENTS.md`] }),
   });
 }
 

--- a/packages/adapters/src/mcp-transport.test.ts
+++ b/packages/adapters/src/mcp-transport.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { selectMcpServers } from "./mcp-transport";
+import type { McpServerConfig } from "./types";
+
+const stdio = (name: string): McpServerConfig => ({ name, transport: "stdio", command: "/usr/bin/node", args: [], env: { K: "sk-live-do-not-log" } });
+const http = (name: string): McpServerConfig => ({ name, transport: "http", url: "https://mcp.vercel.com", headers: { Authorization: "Bearer sk-live-do-not-log" } });
+const sse = (name: string): McpServerConfig => ({ name, transport: "sse", url: "https://sse.example/mcp?token=sk-live-do-not-log", headers: {} });
+
+describe("selectMcpServers", () => {
+  it("keeps everything for an agent that takes everything", () => {
+    const all = [stdio("a"), http("b"), sse("c")];
+    const lines: string[] = [];
+    expect(selectMcpServers("claude", all, (l) => lines.push(l)).map((s) => s.name)).toEqual(["a", "b", "c"]);
+    expect(lines).toEqual([]);
+  });
+
+  it("drops sse for codex and keeps stdio and http", () => {
+    // The named mutant: give codex "sse" in AGENT_MCP_TRANSPORTS and this passes an SSE URL to a client
+    // that will dial it as HTTP. Configured, listed, connects to nothing.
+    expect(selectMcpServers("codex", [stdio("a"), http("b"), sse("c")]).map((s) => s.name)).toEqual(["a", "b"]);
+  });
+
+  it("says which server it dropped and why, because a silent skip is the failure being prevented", () => {
+    const lines: string[] = [];
+    selectMcpServers("codex", [sse("vercel")], (l) => lines.push(l));
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toContain('"vercel"');
+    expect(lines[0]).toContain("sse");
+    expect(lines[0]).toContain("codex");
+  });
+
+  it("never puts a secret or a URL in that log line", () => {
+    const lines: string[] = [];
+    selectMcpServers("codex", [sse("vercel")], (l) => lines.push(l));
+    selectMcpServers("fake", [stdio("a"), http("b")], (l) => lines.push(l));
+    const all = lines.join("\n");
+    expect(all).not.toContain("sk-live-do-not-log");
+    expect(all).not.toContain("https://");
+  });
+
+  it("drops everything for the fake agent, which reads mcpServers not at all", () => {
+    const lines: string[] = [];
+    expect(selectMcpServers("fake", [stdio("a"), http("b"), sse("c")], (l) => lines.push(l))).toEqual([]);
+    expect(lines).toHaveLength(3);
+  });
+
+  it("tolerates having no logger at all", () => {
+    expect(() => selectMcpServers("codex", [sse("c")])).not.toThrow();
+  });
+});

--- a/packages/adapters/src/mcp-transport.ts
+++ b/packages/adapters/src/mcp-transport.ts
@@ -1,0 +1,26 @@
+import { AGENT_MCP_TRANSPORTS, agentSupportsTransport, type AgentKind } from "@realm/contracts";
+import type { McpServerConfig } from "./types";
+
+/**
+ * The servers this agent can actually reach, with every skipped one announced.
+ *
+ * Every adapter runs its `mcpServers` through this before translating. Two things make it worth a
+ * shared function rather than a filter inline in each adapter:
+ *
+ *   - **Codex has no SSE.** Passing an SSE server to Codex as though it were HTTP produces a server
+ *     that is configured, listed, and connects to nothing. Dropping it is the correct behaviour; doing
+ *     it quietly is not.
+ *   - The log line is the only thing standing between "my server is not working" and an afternoon.
+ *
+ * Only the name and the transport are logged. A URL can carry a token in its query string and `env`
+ * and `headers` are secrets by definition — none of them belong in a log Realm prints to the console.
+ */
+export function selectMcpServers(kind: AgentKind, servers: readonly McpServerConfig[], onLog?: (line: string) => void): McpServerConfig[] {
+  const kept: McpServerConfig[] = [];
+  for (const s of servers) {
+    if (agentSupportsTransport(kind, s.transport)) { kept.push(s); continue; }
+    const takes = AGENT_MCP_TRANSPORTS[kind];
+    onLog?.(`[mcp] skipping "${s.name}": ${kind} has no ${s.transport} transport (it takes ${takes.length ? takes.join(", ") : "none"})`);
+  }
+  return kept;
+}

--- a/packages/adapters/src/types.ts
+++ b/packages/adapters/src/types.ts
@@ -2,6 +2,29 @@ import type { AgentKind, SessionEvent } from "@realm/contracts";
 
 export type McpStdioConfig = { name: string; command: string; args?: string[]; env?: Record<string, string> };
 
+/**
+ * Realm's skills library, handed to an agent **per invocation**. Nothing is ever written into
+ * `~/.claude`, `~/.codex`, `~/.cursor` or `~/.agents` — the two routes below are the whole mechanism.
+ *
+ * The server stages one directory per space that is simultaneously both shapes, because the two agents
+ * want the same tree from different heights:
+ *
+ *   <staged>/                      ← `pluginPath`: a Claude local plugin
+ *     .claude-plugin/plugin.json
+ *     skills/                      ← `root`: a Codex extra skills root
+ *       <id>/SKILL.md              (a symlink to <realmHome>/skills/<id>; both agents follow it)
+ *
+ * Absent (`undefined`) means "Realm is not managing skills for this session" — every adapter must then
+ * behave exactly as it did before this option existed. That is not the same as an empty library: see
+ * ClaudeAdapter, where being handed a library also isolates the session from the user's own settings.
+ */
+export type SkillsInjection = {
+  /** Claude Code: `plugins: [{ type: "local", path: pluginPath }]`. */
+  pluginPath: string;
+  /** Codex: `skills/extraRoots/set { extraRoots: [root] }`. Contains `<id>/SKILL.md` directly. */
+  root: string;
+};
+
 export type StartOptions = {
   cwd: string;
   model?: string | null;
@@ -9,6 +32,9 @@ export type StartOptions = {
   permissionMode?: string;
   systemContext?: string;
   mcpServers: McpStdioConfig[];
+  /** Omitted for agents Realm cannot inject skills into (see AGENT_SKILL_SUPPORT), and for a space
+   *  whose enabled skill set is empty. */
+  skills?: SkillsInjection;
   resume?: string | null;
   env?: Record<string, string>;
   /** Diagnostic sink for provider stderr / log lines. */

--- a/packages/adapters/src/types.ts
+++ b/packages/adapters/src/types.ts
@@ -1,6 +1,18 @@
 import type { AgentKind, SessionEvent } from "@realm/contracts";
 
-export type McpStdioConfig = { name: string; command: string; args?: string[]; env?: Record<string, string> };
+/**
+ * One MCP server on its way to an agent, secrets and all.
+ *
+ * This is the ONLY shape a secret value travels in. It is built per session by `McpService.configFor`
+ * and handed straight to an adapter; nothing persists it, logs it, or puts it on an event.
+ *
+ * Every adapter must filter by `transport` against `AGENT_MCP_TRANSPORTS` before translating — Codex
+ * has no SSE, and an SSE server passed to it as though it were HTTP would connect to nothing while
+ * looking configured.
+ */
+export type McpServerConfig =
+  | { name: string; transport: "stdio"; command: string; args: string[]; env: Record<string, string> }
+  | { name: string; transport: "http" | "sse"; url: string; headers: Record<string, string> };
 
 /**
  * Realm's skills library, handed to an agent **per invocation**. Nothing is ever written into
@@ -31,7 +43,9 @@ export type StartOptions = {
   effort?: string | null;
   permissionMode?: string;
   systemContext?: string;
-  mcpServers: McpStdioConfig[];
+  /** This space's enabled servers. Each adapter drops the transports its agent cannot reach and says so
+   *  through `onLog`; a server that is silently absent is the failure this option exists to prevent. */
+  mcpServers: McpServerConfig[];
   /** Omitted for agents Realm cannot inject skills into (see AGENT_SKILL_SUPPORT), and for a space
    *  whose enabled skill set is empty. */
   skills?: SkillsInjection;

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -7,4 +7,5 @@ export * from "./presets";
 export * from "./attachments";
 export * from "./skills";
 export * from "./mcp";
+export * from "./memory";
 export * from "./session-events";

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -5,4 +5,5 @@ export * from "./layout";
 export * from "./rpc";
 export * from "./presets";
 export * from "./attachments";
+export * from "./skills";
 export * from "./session-events";

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -6,4 +6,5 @@ export * from "./rpc";
 export * from "./presets";
 export * from "./attachments";
 export * from "./skills";
+export * from "./mcp";
 export * from "./session-events";

--- a/packages/contracts/src/mcp.test.ts
+++ b/packages/contracts/src/mcp.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vitest";
+import {
+  AGENT_MCP_TRANSPORTS, MCP_SECRET_STORAGE_NOTE, McpServerNameSchema, McpServerSchema,
+  McpTransportSchema, agentSupportsTransport, mcpSupportNote,
+} from "./mcp";
+import { AGENT_META } from "./presets";
+import { Methods, Events } from "./rpc";
+import type { AgentKind } from "./entities";
+
+const kinds = Object.keys(AGENT_META) as AgentKind[];
+const SPACE = "01ARZ3NDEKTSV4RRFFQ69G5FAV";
+const SERVER = "01ARZ3NDEKTSV4RRFFQ69G5FAW";
+
+describe("AGENT_MCP_TRANSPORTS", () => {
+  it("has a row for every agent kind", () => {
+    expect(Object.keys(AGENT_MCP_TRANSPORTS).sort()).toEqual(kinds.sort());
+  });
+
+  it("gives Codex stdio and http but NOT sse", () => {
+    // The one asymmetry that bites. `codex`'s RawMcpServerConfig has `url`/`http_headers` and no SSE
+    // variant, so an sse row here would produce a server that is configured, listed, and dials nothing.
+    expect([...AGENT_MCP_TRANSPORTS.codex]).toEqual(["stdio", "http"]);
+    expect(agentSupportsTransport("codex", "sse")).toBe(false);
+    expect(agentSupportsTransport("codex", "http")).toBe(true);
+  });
+
+  it("gives every other real agent all three, and the fake none", () => {
+    for (const kind of ["claude", "acp:cursor", "acp:gemini"] as const) {
+      expect([...AGENT_MCP_TRANSPORTS[kind]].sort()).toEqual(["http", "sse", "stdio"]);
+    }
+    expect([...AGENT_MCP_TRANSPORTS.fake]).toEqual([]);
+    for (const t of McpTransportSchema.options) expect(agentSupportsTransport("fake", t)).toBe(false);
+  });
+});
+
+describe("mcpSupportNote", () => {
+  it("names the agent, so a note rendered for the wrong session is visibly wrong", () => {
+    for (const kind of kinds) expect(mcpSupportNote(kind)).toContain(AGENT_META[kind].label);
+  });
+
+  it("says out loud that Codex will skip an sse server", () => {
+    expect(mcpSupportNote("codex")).toMatch(/no sse support/);
+    expect(mcpSupportNote("codex")).toMatch(/skipped/);
+  });
+
+  it("promises nothing extra for the agents that take everything", () => {
+    expect(mcpSupportNote("claude")).not.toMatch(/skipped/);
+    expect(mcpSupportNote("acp:cursor")).not.toMatch(/skipped/);
+  });
+
+  it("says the fake agent ignores them entirely", () => {
+    expect(mcpSupportNote("fake")).toMatch(/does not connect to MCP servers/);
+  });
+});
+
+describe("McpServerNameSchema", () => {
+  it("accepts what every agent can key a server by, and rejects what one of them cannot", () => {
+    for (const ok of ["realm", "realm-mcp", "realm_mcp", "v2", "A1_b-c"]) expect(McpServerNameSchema.safeParse(ok).success).toBe(true);
+    // A dot would open a nested TOML table under Codex's `[mcp_servers.NAME]`; a space or quote breaks
+    // the key outright; the rest are not addressable.
+    for (const bad of ["", "has space", "dot.ted", "-leading", 'quo"te', "sla/sh", "x".repeat(65)]) {
+      expect(McpServerNameSchema.safeParse(bad).success).toBe(false);
+    }
+  });
+});
+
+describe("McpServerSchema", () => {
+  const listed = {
+    id: SERVER, name: "airtable", transport: "stdio" as const,
+    command: "/usr/bin/node", args: ["/abs/server.mjs"], url: "",
+    envKeys: ["AIRTABLE_API_KEY"], headerKeys: [], enabled: true, createdAt: 1,
+  };
+
+  it("round-trips a listed server", () => {
+    expect(McpServerSchema.parse(listed)).toEqual(listed);
+  });
+
+  it("carries no field a secret VALUE could travel in", () => {
+    // The guarantee is structural, not a convention someone has to remember: strip() drops anything the
+    // schema does not name, so a caller that hands it `env` gets a result without one.
+    const parsed = McpServerSchema.parse({ ...listed, env: { AIRTABLE_API_KEY: "pat-real-secret" }, headers: { Authorization: "Bearer x" } });
+    expect(JSON.stringify(parsed)).not.toContain("pat-real-secret");
+    expect(JSON.stringify(parsed)).not.toContain("Bearer x");
+    expect(Object.keys(McpServerSchema.shape).filter((k) => k === "env" || k === "headers" || k === "secrets")).toEqual([]);
+  });
+});
+
+describe("MCP_SECRET_STORAGE_NOTE", () => {
+  it("says plainly that keys are unencrypted, and where they are", () => {
+    // A vaguer sentence would be worse than none: the point is that a user typing an API key knows
+    // exactly what they are agreeing to.
+    expect(MCP_SECRET_STORAGE_NOTE).toMatch(/plain text/);
+    expect(MCP_SECRET_STORAGE_NOTE).toMatch(/not encrypted/);
+    expect(MCP_SECRET_STORAGE_NOTE).toMatch(/realm\.db/);
+  });
+});
+
+describe("mcp methods", () => {
+  it("are registered with zod params like their neighbours", () => {
+    expect(Methods["mcp.list"].params.safeParse({ spaceId: "not-a-ulid" }).success).toBe(false);
+    expect(Methods["mcp.list"].params.safeParse({ spaceId: SPACE }).success).toBe(true);
+    expect(Methods["mcp.add"].params.safeParse({ spaceId: SPACE, name: "bad name", transport: "stdio" }).success).toBe(false);
+    expect(Methods["mcp.add"].params.safeParse({ spaceId: SPACE, name: "ok", transport: "smtp" }).success).toBe(false);
+    expect(Methods["mcp.setEnabled"].params.safeParse({ spaceId: SPACE, id: SERVER, enabled: true }).success).toBe(true);
+    expect(Methods["mcp.remove"].params.safeParse({ id: "nope" }).success).toBe(false);
+  });
+
+  it("default `mcp.add` to enabled in no space at all, rather than in one it was not told about", () => {
+    const p = Methods["mcp.add"].params.parse({ name: "ok", transport: "http", url: "https://mcp.vercel.com" });
+    expect(p.spaceId).toBeNull();
+    expect(p.env).toEqual({});
+    expect(p.headers).toEqual({});
+  });
+
+  it("let `mcp.update` omit env/headers, because a client is never given them to send back", () => {
+    const p = Methods["mcp.update"].params.parse({ id: SERVER, name: "renamed" });
+    expect(p.env).toBeUndefined();
+    expect(p.headers).toBeUndefined();
+  });
+
+  it("broadcast a payload-free mcp.changed, since add/edit/remove change what EVERY space lists", () => {
+    expect(Events["mcp.changed"].safeParse({}).success).toBe(true);
+  });
+});

--- a/packages/contracts/src/mcp.ts
+++ b/packages/contracts/src/mcp.ts
@@ -1,0 +1,105 @@
+import { z } from "zod";
+import { AGENT_META } from "./presets";
+import { IdSchema } from "./ids";
+import type { AgentKind } from "./entities";
+
+/**
+ * A server's **name** is what every agent keys it by on the wire — a record key for Claude, a
+ * `[mcp_servers.NAME]` TOML table for Codex, a `name` field for ACP. So it has to survive being a TOML
+ * bare key, which is the narrowest of the three: letters, digits, `_` and `-`, nothing else.
+ *
+ * It is separate from the row's `id` because the user can rename a server, and a rename must not look
+ * like a delete-plus-add to the per-space enable sets that point at it.
+ */
+export const McpServerNameSchema = z.string().min(1).max(64).regex(/^[A-Za-z0-9_][A-Za-z0-9_-]*$/,
+  "server name must be letters, digits, underscore or hyphen");
+
+/**
+ * How Realm reaches the server. All three are real; none of them reaches every agent (see
+ * `AGENT_MCP_TRANSPORTS`), which is why the transport is stored rather than inferred from the URL.
+ */
+export const McpTransportSchema = z.enum(["stdio", "http", "sse"]);
+export type McpTransport = z.infer<typeof McpTransportSchema>;
+
+/**
+ * Where Realm keeps the API keys an MCP server needs, stated plainly because the alternative is a
+ * false sense of security.
+ *
+ * This string is UI copy, not decoration: any surface that takes a secret has to show it. Realm has no
+ * Keychain integration and no encryption — the value is in `realm.db` in the clear. That is the same
+ * posture as the CLIs Realm drives (`~/.codex/config.toml` and `~/.claude.json` both hold MCP env
+ * blocks in plaintext), so it is not *worse* than the status quo; it is simply not a secret store.
+ */
+export const MCP_SECRET_STORAGE_NOTE =
+  "Keys and headers are stored in plain text in Realm's database (~/Realm/realm.db) — not encrypted, not in the Keychain. Anyone who can read that file, or any process running as you, can read them. Realm's CLIs keep their own MCP credentials the same way.";
+
+/**
+ * One configured MCP server, as `mcp.list` reports it.
+ *
+ * **No secret values appear here, ever.** `envKeys` and `headerKeys` name what is set; the values stay
+ * in the database and travel only to the agent that was configured to receive them. A settings UI can
+ * therefore show "AIRTABLE_API_KEY is set" and offer to replace it, and nothing that is logged,
+ * broadcast, or screenshotted can leak the key — including this object.
+ */
+export const McpServerSchema = z.object({
+  id: IdSchema,
+  name: McpServerNameSchema,
+  transport: McpTransportSchema,
+  /** stdio only; `""` for a remote server. */
+  command: z.string(),
+  /** stdio only; `[]` for a remote server. */
+  args: z.array(z.string()),
+  /** http/sse only; `""` for stdio. */
+  url: z.string(),
+  /** Names of the stdio `env` entries. Values are deliberately absent — see the type doc. */
+  envKeys: z.array(z.string()),
+  /** Names of the http/sse headers. Values are deliberately absent — see the type doc. */
+  headerKeys: z.array(z.string()),
+  /** Whether the space this was listed for passes it to its agents. Per-space, persisted, default OFF. */
+  enabled: z.boolean(),
+  createdAt: z.number().int(),
+});
+export type McpServer = z.infer<typeof McpServerSchema>;
+
+/** stdio `env` / remote `headers` on the way IN. The only shape any secret value is ever carried by. */
+export const McpSecretsSchema = z.record(z.string().min(1), z.string());
+
+/**
+ * What each agent will actually connect to, proven against the installed CLIs
+ * (`docs/superpowers/specs/2026-08-29-agent-config-surfaces.md` §1.2).
+ *
+ * **Codex has no SSE at all.** That is the one asymmetry that bites: an SSE server configured in Realm
+ * reaches Claude and Cursor and is silently missing on Codex unless somebody says so out loud, which is
+ * what `mcpSupportNote` and the adapters' drop-logging are for.
+ *
+ * `fake` takes none: the scripted adapter never spawns anything, and claiming otherwise would make an
+ * offline dev session look like it had tools it does not have.
+ */
+export const AGENT_MCP_TRANSPORTS = {
+  // claude-adapter.ts → SDK `mcpServers`; sdk.d.ts has McpStdioServerConfig / McpSSEServerConfig / McpHttpServerConfig.
+  claude: ["stdio", "http", "sse"],
+  // codex-adapter.ts → `thread/start` `config.mcp_servers`. RawMcpServerConfig carries `url` + `http_headers`; no SSE variant exists.
+  codex: ["stdio", "http"],
+  // acp-adapter.ts → `session/new` `mcpServers`. Cursor advertises `mcpCapabilities:{http:true,sse:true}` (verified live).
+  "acp:cursor": ["stdio", "http", "sse"],
+  // Same shape; Gemini advertises the same capabilities (research §7).
+  "acp:gemini": ["stdio", "http", "sse"],
+  // fake-adapter.ts never reads `mcpServers`.
+  fake: [],
+} as const satisfies Record<AgentKind, readonly McpTransport[]>;
+
+export const agentSupportsTransport = (kind: AgentKind, transport: McpTransport): boolean =>
+  (AGENT_MCP_TRANSPORTS[kind] as readonly McpTransport[]).includes(transport);
+
+/**
+ * One sentence naming the agent and the transports it will take. Always names the agent, so a note
+ * rendered against the wrong session is visibly wrong rather than quietly misleading.
+ */
+export function mcpSupportNote(kind: AgentKind): string {
+  const label = AGENT_META[kind].label;
+  const supported = AGENT_MCP_TRANSPORTS[kind] as readonly McpTransport[];
+  if (supported.length === 0) return `${label} does not connect to MCP servers, so this space's servers are ignored there.`;
+  const missing = (McpTransportSchema.options as readonly McpTransport[]).filter((t) => !supported.includes(t));
+  const takes = `${label} connects to this space's enabled ${supported.join(" and ")} servers`;
+  return missing.length === 0 ? `${takes}.` : `${takes}; it has no ${missing.join(" or ")} support, so those are skipped.`;
+}

--- a/packages/contracts/src/memory.test.ts
+++ b/packages/contracts/src/memory.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { AGENT_MEMORY_CHANNEL, MemorySourcesSchema, memorySupportNote } from "./memory";
+import { AgentKindSchema } from "./entities";
+
+describe("AGENT_MEMORY_CHANNEL", () => {
+  it("covers every agent kind", () => {
+    for (const kind of AgentKindSchema.options) expect(AGENT_MEMORY_CHANNEL[kind]).toBeDefined();
+  });
+
+  it("matches what was proven live: Claude and Codex have a channel, ACP agents and the fake do not", () => {
+    expect(AGENT_MEMORY_CHANNEL.claude).toBe("systemPrompt");
+    expect(AGENT_MEMORY_CHANNEL.codex).toBe("developerInstructions");
+    expect(AGENT_MEMORY_CHANNEL["acp:cursor"]).toBe("none");
+    expect(AGENT_MEMORY_CHANNEL["acp:gemini"]).toBe("none");
+    expect(AGENT_MEMORY_CHANNEL.fake).toBe("none");
+  });
+});
+
+describe("memorySupportNote", () => {
+  it("always names the agent, so a note rendered for the wrong session is visibly wrong", () => {
+    expect(memorySupportNote("claude")).toContain("Claude");
+    expect(memorySupportNote("codex")).toContain("Codex");
+    expect(memorySupportNote("acp:cursor")).toContain("Cursor");
+  });
+
+  it("states the Cursor reality outright rather than hedging", () => {
+    expect(memorySupportNote("acp:cursor")).toMatch(/no per-session context/);
+  });
+});
+
+describe("MemorySourcesSchema", () => {
+  it("accepts the three honest shapes", () => {
+    for (const r of [
+      { agent: "claude", channel: "systemPrompt", basis: "modeled", note: "n", realmMemoryInjected: true, sources: [{ path: "/a", origin: "user", exists: true, via: "realm" }] },
+      { agent: "codex", channel: "developerInstructions", basis: "reported", note: "n", realmMemoryInjected: false, sources: [{ path: "/b", origin: "reported", exists: false, via: "cli" }] },
+      { agent: "acp:cursor", channel: "none", basis: "none", note: "n", realmMemoryInjected: false, sources: [] },
+    ]) {
+      expect(MemorySourcesSchema.safeParse(r).success).toBe(true);
+    }
+  });
+
+  it("rejects a source that does not say how it reaches the session", () => {
+    const r = MemorySourcesSchema.safeParse({ agent: "claude", channel: "systemPrompt", basis: "modeled", note: "n", realmMemoryInjected: false, sources: [{ path: "/a", origin: "user", exists: true }] });
+    expect(r.success).toBe(false);
+  });
+});

--- a/packages/contracts/src/memory.ts
+++ b/packages/contracts/src/memory.ts
@@ -1,0 +1,113 @@
+import { z } from "zod";
+import { AGENT_META } from "./presets";
+import { AgentKindSchema, type AgentKind } from "./entities";
+
+/**
+ * W3's ground rule: Realm READS the files each agent loads and never writes them. The one permitted
+ * write is the opt-in `AGENTS.md` in a space folder Realm itself created (`AgentsFileState`), and even
+ * that is refused anywhere else. Everything else reaches a session through a per-session parameter —
+ * `systemPrompt.append` for Claude, `thread/start` `developerInstructions` for Codex — or not at all.
+ */
+
+/** Hard cap on the Realm memory document. It travels inside every session's system context, so an
+ *  unbounded doc is a prompt that quietly swallows the context window. */
+export const MEMORY_DOC_MAX = 100_000;
+
+/**
+ * One file of durable context, as `memory.sources` reports it for a session.
+ *
+ * `via` is the honest part: `cli` means the agent loads the file itself, `realm` means Realm carries
+ * its content into the session (a Claude session whose skills library sets `settingSources: []` loads
+ * NO settings files on its own — Realm re-injects them), and `none` means the file is a known location
+ * that is currently empty or absent.
+ */
+export const MemorySourceSchema = z.object({
+  /** Absolute path. */
+  path: z.string(),
+  /** `user` = the agent's home-dir file, `project` = a checkout-level file, `import` = pulled in by an
+   *  `@path` reference, `reported` = named by the agent itself (Codex `instructionSources`). */
+  origin: z.enum(["user", "project", "import", "reported"]),
+  exists: z.boolean(),
+  /** How the content reaches the session: loaded by the CLI itself, re-injected by Realm, or not at all. */
+  via: z.enum(["cli", "realm", "none"]),
+});
+export type MemorySource = z.infer<typeof MemorySourceSchema>;
+
+/**
+ * The opt-in `AGENTS.md` at the root of a Realm-created space folder — the plan's one permitted write.
+ *
+ * `writable: false` (with `reason`) covers the two refusals: the space's primary checkout is a
+ * directory Realm did not create, or an `AGENTS.md` Realm did not write already sits there.
+ */
+export const AgentsFileStateSchema = z.object({
+  enabled: z.boolean(),
+  /** Where the file goes (or is): `<space folder>/AGENTS.md`. */
+  path: z.string(),
+  exists: z.boolean(),
+  /** True when the file on disk carries Realm's marker header — the only kind Realm will rewrite or remove. */
+  managedByRealm: z.boolean(),
+  writable: z.boolean(),
+  reason: z.string().nullable(),
+});
+export type AgentsFileState = z.infer<typeof AgentsFileStateSchema>;
+
+/** A space's Realm-owned memory document, stored under Realm's home — never in any agent's config. */
+export const MemoryStateSchema = z.object({
+  /** Where the document lives: `<realmHome>/memory/<spaceId>.md`. */
+  path: z.string(),
+  doc: z.string(),
+  agentsFile: AgentsFileStateSchema,
+});
+export type MemoryState = z.infer<typeof MemoryStateSchema>;
+
+/**
+ * The per-session channel Realm can hand durable context through, per agent — proven live, not assumed
+ * (see `docs/superpowers/specs/2026-08-29-agent-config-surfaces.md` §1.3).
+ *
+ * - `systemPrompt` — Claude: `systemPrompt: { type: "preset", preset: "claude_code", append }`.
+ * - `developerInstructions` — Codex: a `thread/start` parameter.
+ * - `none` — ACP `session/new` is `{cwd, mcpServers}`: there is no parameter to put context in, so
+ *   nothing Realm manages reaches these agents. Stated, not faked: no adapter fallback pretends otherwise.
+ */
+export type MemoryChannel = "systemPrompt" | "developerInstructions" | "none";
+export const AGENT_MEMORY_CHANNEL = {
+  claude: "systemPrompt",
+  codex: "developerInstructions",
+  "acp:cursor": "none",
+  "acp:gemini": "none",
+  fake: "none",
+} as const satisfies Record<AgentKind, MemoryChannel>;
+
+/**
+ * What `memory.sources` answers for one session: which durable-context files reach its agent, and on
+ * what authority.
+ *
+ * `basis` names the authority so the UI can say it: `modeled` — Realm read the same paths the CLI
+ * reads (Claude); `reported` — the agent itself named the files it loaded (Codex `instructionSources`);
+ * `none` — either the agent takes no durable context at all (Cursor) or it has not started yet and so
+ * has reported nothing (a Codex session before its first message).
+ */
+export const MemorySourcesSchema = z.object({
+  agent: AgentKindSchema,
+  channel: z.enum(["systemPrompt", "developerInstructions", "none"]),
+  basis: z.enum(["modeled", "reported", "none"]),
+  /** One sentence naming the agent and its reality, so a note rendered for the wrong session is visibly wrong. */
+  note: z.string(),
+  /** Whether this space's Realm memory document is non-empty and travels to this agent's sessions. */
+  realmMemoryInjected: z.boolean(),
+  sources: z.array(MemorySourceSchema),
+});
+export type MemorySources = z.infer<typeof MemorySourcesSchema>;
+
+/** The per-agent honesty line for the memory pane. Always names the agent. */
+export function memorySupportNote(kind: AgentKind): string {
+  const label = AGENT_META[kind].label;
+  switch (AGENT_MEMORY_CHANNEL[kind]) {
+    case "systemPrompt":
+      return `${label} sessions receive this space's Realm memory per session; the files below are the ones the CLI reads, modeled by Realm from the same paths.`;
+    case "developerInstructions":
+      return `${label} sessions receive this space's Realm memory per session, and ${label} itself reports the exact instruction files it loaded once the session starts.`;
+    default:
+      return `${label} takes no per-session context parameter, so neither Realm's memory nor any managed file reaches it.`;
+  }
+}

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -3,6 +3,7 @@ import { ProfileSchema, SpaceSchema, ProjectSchema, ItemSchema, ItemKindSchema, 
 
 import { LayoutSchema } from "./layout";
 import { StoredSessionEventSchema } from "./session-events";
+import { SkillSchema, SkillIdSchema } from "./skills";
 
 export const RpcRequestSchema = z.object({ id: z.string(), method: z.string(), params: z.unknown() });
 export const RpcErrorSchema = z.object({ code: z.string(), message: z.string() });
@@ -302,6 +303,19 @@ export const Methods = {
   "settings.get": { params: z.object({ key: z.string() }), result: z.object({ value: z.unknown() }) },
   "settings.set": { params: z.object({ key: z.string(), value: z.unknown() }), result: z.object({ ok: z.literal(true) }) },
 
+  /**
+   * Realm's skills library as this space sees it: every directory under `<realmHome>/skills`, each
+   * carrying that space's own enabled flag. Read off disk every call — the library is a folder the
+   * user is expected to edit, so there is nothing to invalidate.
+   *
+   * Malformed skills are listed with `valid: false` rather than dropped. They are never given to an
+   * agent, but a skill that vanished because of a typo in its frontmatter has to be findable.
+   */
+  "skills.list": { params: z.object({ spaceId: IdSchema }), result: z.object({ root: z.string(), skills: z.array(SkillSchema) }) },
+  /** Turn one skill on or off for one space. Unknown ids are accepted: a skill can be removed from
+   *  disk and put back, and the preference should survive that. */
+  "skills.setEnabled": { params: z.object({ spaceId: IdSchema, id: SkillIdSchema, enabled: z.boolean() }), result: z.object({ ok: z.literal(true) }) },
+
   "system.info": { params: z.object({}), result: z.object({ realmHome: z.string(), version: z.string() }) },
 
   "workspace.gitInfo": { params: z.object({ cwd: z.string() }), result: GitInfoSchema.nullable() },
@@ -370,6 +384,9 @@ export const Events = {
   /** A checkpoint was taken, restored or pruned in this environment (W4). Broadcast on every turn, so
    *  clients holding a checkpoint list re-fetch and everyone else ignores it. */
   "checkpoints.changed": z.object({ environmentId: IdSchema }),
+  /** A space's skill set changed — either the library on disk or that space's enabled flags. Clients
+   *  holding a skills list re-fetch; a session already running keeps the set it started with. */
+  "skills.changed":   z.object({ spaceId: IdSchema }),
   /** Realm itself changed a working tree (stage, unstage, commit, push). Carries the cwd the write
    *  went through; clients refresh every diff they hold, because two panes on the same repository may
    *  have asked from two different subdirectories and only the server knows they are the same tree. */

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -4,6 +4,7 @@ import { ProfileSchema, SpaceSchema, ProjectSchema, ItemSchema, ItemKindSchema, 
 import { LayoutSchema } from "./layout";
 import { StoredSessionEventSchema } from "./session-events";
 import { SkillSchema, SkillIdSchema } from "./skills";
+import { McpSecretsSchema, McpServerNameSchema, McpServerSchema, McpTransportSchema } from "./mcp";
 
 export const RpcRequestSchema = z.object({ id: z.string(), method: z.string(), params: z.unknown() });
 export const RpcErrorSchema = z.object({ code: z.string(), message: z.string() });
@@ -316,6 +317,58 @@ export const Methods = {
    *  disk and put back, and the preference should survive that. */
   "skills.setEnabled": { params: z.object({ spaceId: IdSchema, id: SkillIdSchema, enabled: z.boolean() }), result: z.object({ ok: z.literal(true) }) },
 
+  /**
+   * Every MCP server Realm knows about, each carrying this space's own enabled flag.
+   *
+   * The server list is global; only the enable flag is per-space. `secretNote` is `MCP_SECRET_STORAGE_NOTE`
+   * and is returned on every call rather than left for the UI to remember, because a surface that takes an
+   * API key has to say where the key is going.
+   *
+   * Secret VALUES never appear in the result — see `McpServerSchema`.
+   */
+  "mcp.list": { params: z.object({ spaceId: IdSchema }), result: z.object({ servers: z.array(McpServerSchema), secretNote: z.string() }) },
+  /**
+   * Define a server. `spaceId` is the space it was added from and the ONLY space it is enabled in:
+   * a server is a process to spawn or a URL to send credentials to, so it is opt-in per space rather
+   * than live everywhere the moment it exists. Pass `null` to add it enabled nowhere.
+   *
+   * `env` (stdio) and `headers` (http/sse) carry secret values in the clear, both on this wire and at
+   * rest. `MCP_SECRET_STORAGE_NOTE` says so; do not build a UI for this method that does not.
+   */
+  "mcp.add": {
+    params: z.object({
+      spaceId: IdSchema.nullable().default(null),
+      name: McpServerNameSchema,
+      transport: McpTransportSchema,
+      command: z.string().default(""), args: z.array(z.string()).default([]), env: McpSecretsSchema.default({}),
+      url: z.string().default(""), headers: McpSecretsSchema.default({}),
+    }),
+    result: McpServerSchema,
+  },
+  /**
+   * Change a server in place. Every field is optional and an omitted one is left alone — including
+   * `env` and `headers`, so a UI that never received the secret values (it cannot: `mcp.list` does not
+   * return them) can save a rename without wiping the API key it was not shown.
+   *
+   * Passing `env`/`headers` REPLACES the whole map, which is how a key is removed.
+   */
+  "mcp.update": {
+    params: z.object({
+      id: IdSchema,
+      /** Only so the result can report `enabled` truthfully for the space the editor is open in.
+       *  Editing a server never changes which spaces use it. */
+      spaceId: IdSchema.nullable().default(null),
+      name: McpServerNameSchema.optional(), transport: McpTransportSchema.optional(),
+      command: z.string().optional(), args: z.array(z.string()).optional(), env: McpSecretsSchema.optional(),
+      url: z.string().optional(), headers: McpSecretsSchema.optional(),
+    }),
+    result: McpServerSchema,
+  },
+  /** Forget a server everywhere, secrets included. Its per-space enable flags go with it. */
+  "mcp.remove": { params: z.object({ id: IdSchema }), result: z.object({ ok: z.literal(true) }) },
+  /** Turn one server on or off for one space. Sessions already running keep the set they started with. */
+  "mcp.setEnabled": { params: z.object({ spaceId: IdSchema, id: IdSchema, enabled: z.boolean() }), result: z.object({ ok: z.literal(true) }) },
+
   "system.info": { params: z.object({}), result: z.object({ realmHome: z.string(), version: z.string() }) },
 
   "workspace.gitInfo": { params: z.object({ cwd: z.string() }), result: GitInfoSchema.nullable() },
@@ -387,6 +440,10 @@ export const Events = {
   /** A space's skill set changed — either the library on disk or that space's enabled flags. Clients
    *  holding a skills list re-fetch; a session already running keeps the set it started with. */
   "skills.changed":   z.object({ spaceId: IdSchema }),
+  /** An MCP server was added, edited, removed, or toggled for a space. Carries no payload because the
+   *  server list is global: add/edit/remove change what EVERY space lists, and a per-space event would
+   *  leave the other spaces' open settings panes stale. Clients holding a list re-fetch. */
+  "mcp.changed":      z.object({}),
   /** Realm itself changed a working tree (stage, unstage, commit, push). Carries the cwd the write
    *  went through; clients refresh every diff they hold, because two panes on the same repository may
    *  have asked from two different subdirectories and only the server knows they are the same tree. */

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -5,6 +5,7 @@ import { LayoutSchema } from "./layout";
 import { StoredSessionEventSchema } from "./session-events";
 import { SkillSchema, SkillIdSchema } from "./skills";
 import { McpSecretsSchema, McpServerNameSchema, McpServerSchema, McpTransportSchema } from "./mcp";
+import { MEMORY_DOC_MAX, MemorySourcesSchema, MemoryStateSchema } from "./memory";
 
 export const RpcRequestSchema = z.object({ id: z.string(), method: z.string(), params: z.unknown() });
 export const RpcErrorSchema = z.object({ code: z.string(), message: z.string() });
@@ -369,6 +370,30 @@ export const Methods = {
   /** Turn one server on or off for one space. Sessions already running keep the set they started with. */
   "mcp.setEnabled": { params: z.object({ spaceId: IdSchema, id: IdSchema, enabled: z.boolean() }), result: z.object({ ok: z.literal(true) }) },
 
+  /**
+   * This space's Realm memory document plus the state of its opt-in `AGENTS.md`. The document lives at
+   * `<realmHome>/memory/<spaceId>.md` — Realm's home, never any agent's config — and is injected per
+   * session (Claude `systemPrompt.append`, Codex `developerInstructions`; Cursor has no channel).
+   */
+  "memory.get": { params: z.object({ spaceId: IdSchema }), result: MemoryStateSchema },
+  /** Replace the document. Sessions already running keep the context they started with; the next start
+   *  carries the new text. Also rewrites the space's managed `AGENTS.md` when that toggle is on. */
+  "memory.set": { params: z.object({ spaceId: IdSchema, doc: z.string().max(MEMORY_DOC_MAX) }), result: MemoryStateSchema },
+  /**
+   * The plan's one permitted write: turn the managed `AGENTS.md` in this space's own folder on or off.
+   * Refused (AGENTS_FILE_NOT_REALM_FOLDER) when the space's primary checkout is a directory Realm did
+   * not create, and (AGENTS_FILE_FOREIGN) when an `AGENTS.md` Realm did not write already sits there.
+   * Turning it off removes the file only when it still carries Realm's marker.
+   */
+  "memory.setAgentsFile": { params: z.object({ spaceId: IdSchema, enabled: z.boolean() }), result: MemoryStateSchema },
+  /**
+   * Ground truth (or the honest absence of it) about the durable context one session's agent loads:
+   * Codex sessions report the exact files (`instructionSources`, captured from THIS session's own
+   * `thread/start`), Claude's hierarchy is modeled by reading the same paths the CLI reads, and Cursor
+   * is a stated "nothing reaches this agent" row.
+   */
+  "memory.sources": { params: z.object({ sessionId: IdSchema }), result: MemorySourcesSchema },
+
   "system.info": { params: z.object({}), result: z.object({ realmHome: z.string(), version: z.string() }) },
 
   "workspace.gitInfo": { params: z.object({ cwd: z.string() }), result: GitInfoSchema.nullable() },
@@ -444,6 +469,9 @@ export const Events = {
    *  server list is global: add/edit/remove change what EVERY space lists, and a per-space event would
    *  leave the other spaces' open settings panes stale. Clients holding a list re-fetch. */
   "mcp.changed":      z.object({}),
+  /** A space's Realm memory document or its managed `AGENTS.md` changed. Clients holding the memory
+   *  pane re-fetch; sessions already running keep the context they started with. */
+  "memory.changed":   z.object({ spaceId: IdSchema }),
   /** Realm itself changed a working tree (stage, unstage, commit, push). Carries the cwd the write
    *  went through; clients refresh every diff they hold, because two panes on the same repository may
    *  have asked from two different subdirectories and only the server knows they are the same tree. */

--- a/packages/contracts/src/session-events.ts
+++ b/packages/contracts/src/session-events.ts
@@ -12,7 +12,12 @@ const P = {
   status: z.object({ status: z.enum(["idle", "running", "waiting_permission", "error", "ended"]) }),
   error: z.object({ message: z.string() }),
   usage: z.object({ costUsd: z.number(), inputTokens: z.number(), outputTokens: z.number(), numTurns: z.number() }),
-  init: z.object({ providerSessionId: z.string(), model: z.string(), tools: z.array(z.string()), cwd: z.string() }),
+  init: z.object({
+    providerSessionId: z.string(), model: z.string(), tools: z.array(z.string()), cwd: z.string(),
+    /** The instruction files the agent says it loaded — Codex `thread/start` `instructionSources`, W3's
+     *  ground truth for the memory pane. Absent for agents that report nothing (all the others today). */
+    instructionSources: z.array(z.string()).optional(),
+  }),
 } as const;
 
 export type SessionEventType = keyof typeof P;

--- a/packages/contracts/src/skills.test.ts
+++ b/packages/contracts/src/skills.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { AGENT_SKILL_SUPPORT, SkillIdSchema, SkillSchema, skillSupportNote } from "./skills";
+import { AGENT_META } from "./presets";
+import { Methods } from "./rpc";
+import type { AgentKind } from "./entities";
+
+const kinds = Object.keys(AGENT_META) as AgentKind[];
+
+describe("AGENT_SKILL_SUPPORT", () => {
+  it("has a row for every agent kind", () => {
+    expect(Object.keys(AGENT_SKILL_SUPPORT).sort()).toEqual(kinds.sort());
+  });
+
+  it("says injected only for the two agents with a proven per-invocation route", () => {
+    // Cursor is the one that matters: it ships skills, so the tempting answer is `injected`. Its
+    // cross-directory discovery is gated by a predicate Realm can neither read nor set, and it differed
+    // between runs of the same binary — see the research §1.1.3 and the note in acp-adapter.ts.
+    expect(Object.entries(AGENT_SKILL_SUPPORT).filter(([, v]) => v === "injected").map(([k]) => k).sort())
+      .toEqual(["claude", "codex"]);
+  });
+});
+
+describe("skillSupportNote", () => {
+  it("names the agent, so a note rendered for the wrong session is visibly wrong", () => {
+    for (const kind of kinds) expect(skillSupportNote(kind)).toContain(AGENT_META[kind].label);
+  });
+
+  it("says out loud that an unsupported agent will not see the library", () => {
+    expect(skillSupportNote("acp:cursor")).toMatch(/will not see this library/);
+    expect(skillSupportNote("claude")).toMatch(/your own installed skills are left out/);
+  });
+});
+
+describe("SkillIdSchema", () => {
+  it("accepts plain directory names and rejects anything that is not one", () => {
+    for (const ok of ["mac", "mac-cli", "mac_cli", "v1.2", "A1"]) expect(SkillIdSchema.safeParse(ok).success).toBe(true);
+    // A path separator here would let a caller address anything on disk through `skills.setEnabled`.
+    for (const bad of ["", ".hidden", "-leading", "has space", "a/b", "../escape", "a\\b"]) {
+      expect(SkillIdSchema.safeParse(bad).success).toBe(false);
+    }
+  });
+});
+
+describe("SkillSchema", () => {
+  it("round-trips a listed skill and requires a reason slot even when valid", () => {
+    const s = { id: "mac", name: "mac", description: "d", path: "/x/mac/SKILL.md", enabled: true, valid: true, reason: null };
+    expect(SkillSchema.parse(s)).toEqual(s);
+    expect(SkillSchema.safeParse({ ...s, reason: undefined }).success).toBe(false);
+  });
+});
+
+describe("skills methods", () => {
+  it("are registered with zod params like their neighbours", () => {
+    expect(Methods["skills.list"].params.safeParse({ spaceId: "not-a-ulid" }).success).toBe(false);
+    expect(Methods["skills.setEnabled"].params.safeParse({ spaceId: "01ARZ3NDEKTSV4RRFFQ69G5FAV", id: "../x", enabled: true }).success).toBe(false);
+    expect(Methods["skills.setEnabled"].params.safeParse({ spaceId: "01ARZ3NDEKTSV4RRFFQ69G5FAV", id: "mac", enabled: false }).success).toBe(true);
+  });
+});

--- a/packages/contracts/src/skills.ts
+++ b/packages/contracts/src/skills.ts
@@ -1,0 +1,70 @@
+import { z } from "zod";
+import { AGENT_META } from "./presets";
+import type { AgentKind } from "./entities";
+
+/**
+ * A skill's identity is its **directory name** under `~/Realm/skills`, not its frontmatter `name`.
+ *
+ * The directory is the only thing that is unique by construction and the only thing that survives a
+ * `SKILL.md` Realm cannot parse — and an unparseable skill still has to be listable, or the user has no
+ * way to find out why it is missing. Frontmatter `name` is carried alongside for display, and a skill is
+ * only handed to an agent when it has one.
+ */
+export const SkillIdSchema = z.string().regex(/^[A-Za-z0-9][A-Za-z0-9._-]*$/, "skill id must be a plain directory name");
+
+/**
+ * One entry of Realm's skills library, as `skills.list` reports it for a given space.
+ *
+ * `valid: false` entries are listed on purpose: they are what the user sees instead of silence when a
+ * `SKILL.md` is malformed. They are never staged for an agent, whatever `enabled` says.
+ */
+export const SkillSchema = z.object({
+  id: SkillIdSchema,
+  /** Frontmatter `name`; falls back to the directory name when the file could not be parsed. */
+  name: z.string(),
+  /** Frontmatter `description` — the whole basis on which every agent decides to invoke a skill. */
+  description: z.string(),
+  /** Absolute path of the skill's `SKILL.md`. */
+  path: z.string(),
+  /** Whether this space passes it to its agents. Defaults to true; per-space, persisted. */
+  enabled: z.boolean(),
+  /** False when `SKILL.md` is missing, unreadable, or has no `name`/`description` frontmatter. */
+  valid: z.boolean(),
+  /** Why it is invalid, in one sentence. Null when valid. */
+  reason: z.string().nullable(),
+});
+export type Skill = z.infer<typeof SkillSchema>;
+
+/**
+ * What actually happens to Realm's skills library on each agent, proven live (see
+ * `docs/superpowers/specs/2026-08-29-agent-config-surfaces.md` §1.1 and
+ * `apps/server/scripts/live-skills-check.ts`).
+ *
+ * - `injected` — the library reaches the agent per-invocation with no writes to user-owned files.
+ * - `unsupported` — there is no route. Cursor's cross-directory skill discovery is gated by a
+ *   server-side predicate Realm can neither read nor set, and it differed between runs of the same
+ *   binary; a skills path built on it would work for some users and silently not for others.
+ */
+export type SkillSupport = "injected" | "unsupported";
+
+export const AGENT_SKILL_SUPPORT = {
+  // claude-adapter.ts: `plugins: [{ type: "local", path }]` + `settingSources: []`.
+  claude: "injected",
+  // codex-adapter.ts: `skills/extraRoots/set` on the app-server connection, after the thread exists.
+  codex: "injected",
+  // acp-adapter.ts: ACP `session/new` is `{cwd, mcpServers}` and `cursor-agent acp` takes no flags.
+  "acp:cursor": "unsupported",
+  // Same ACP session shape; Gemini has no skills concept to inject into either.
+  "acp:gemini": "unsupported",
+  // fake-adapter.ts never looks at `skills`.
+  fake: "unsupported",
+} as const satisfies Record<AgentKind, SkillSupport>;
+
+/** One sentence naming the agent and what it will do with the library. Always names the agent, so a
+ *  note rendered for the wrong session is visibly wrong. */
+export function skillSupportNote(kind: AgentKind): string {
+  const label = AGENT_META[kind].label;
+  return AGENT_SKILL_SUPPORT[kind] === "injected"
+    ? `${label} gets this space's enabled skills, and only those — your own installed skills are left out.`
+    : `${label} cannot be given a skills directory, so it will not see this library.`;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,6 +106,9 @@ importers:
       tsup:
         specifier: ^8.3.0
         version: 8.5.1(postcss@8.5.26)(tsx@4.23.12)(typescript@5.9.3)
+      tsx:
+        specifier: ^4.19.0
+        version: 4.23.12
 
   packages/adapters:
     dependencies:


### PR DESCRIPTION
The backend trio of Plan 8, proven live against the installed CLIs at every step. **1371 tests** (from 1203 on main), typecheck and build clean. W4 (@-mention) and W5 (settings UI) follow separately — they live in renderer files currently being restyled.

## W1 — SkillSync (per-invocation, no sync)

Realm owns `~/Realm/skills/`; nothing is ever copied or symlinked into `~/.claude`, `~/.codex`, `~/.cursor`, or `~/.agents`. Claude gets the library as a local plugin with `settingSources: []`; Codex via `skills/extraRoots/set` (feature-detected — no config key or flag exists). Proven with a control leg: 52 commands with isolation vs 149 without, the 149 containing the user's own skills. Cursor gets no skills path — its discovery is gated server-side and returned different results between runs of the same binary; the UI says so instead of faking it. Bundled `skills/mac` installs once into the user's library and stops being latent.

## W2 — MCP connections

Fills the `mcpServers: []` hardcode. Servers stored by Realm (migration v8), scoped per space as an *enabled* set — a server added in Work must not arm itself in School. Delivery proven end-to-end: a marker-file server reached Claude in 205ms, Codex in 245ms, Cursor in 863ms, with per-space scoping holding and ACP's env-as-array quirk surviving. Secrets are plaintext in Realm's DB and every `mcp.list` says so out loud — same posture as the CLIs' own configs, no pretend security; values leave the DB through exactly one method and no client-facing schema has a field they fit in.

Also closed: the Codex trust-entry pollution. `thread/start` marks its cwd trusted on every call with no opt-out; our live-check scripts were minting one dead entry per run via `mkdtemp`. They now reuse one fixed path.

## W3 — Memory manager

`StartOptions.systemContext` now reaches Codex as `developerInstructions` (verified live — the model echoed the marker back), and `instructionSources` from every Codex thread is captured per session, so the memory pane reports what a session *actually* loaded. Per-space Realm memory doc, injected on Claude and Codex; Cursor is an honest "nothing reaches this agent" row.

The critical interaction: with skills enabled, `settingSources: []` also drops the user's `CLAUDE.md` hierarchy. Re-injection now keys off the *same computation* as the isolation, so they can never disagree — proven with a control session that received neither token without the injection. The one permitted write, an opt-in marker-headed `AGENTS.md`, refuses any directory Realm did not create (Plan 7's environment `kind` is the guard), and a user who strips the marker takes the file over permanently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)