### PR TITLE
Real model catalogs for Codex and Cursor

### DIFF
--- a/apps/desktop/src/renderer/src/panes/session/ModelPicker.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/ModelPicker.tsx
@@ -1,6 +1,6 @@
 import { AGENT_META, DEFAULT_MODEL_LABEL, type AgentKind } from "@realm/contracts";
 import { Icon } from "@realm/ui";
-import { useCallback, useMemo, useRef, useState, type KeyboardEvent } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type KeyboardEvent } from "react";
 import { createPortal } from "react-dom";
 import { useAnchoredPopover } from "../../components/use-anchored-popover";
 import type { AgentProbe } from "../../state/store";
@@ -87,6 +87,13 @@ function ModelPopover({ rows, anchorRef, onClose, onPick, effortItems, overflow 
   // and a highlight pointing past the end would make Enter do nothing with no visible reason why.
   const cur = Math.min(active, shown.length - 1);
   const activeRow = shown[cur];
+
+  // With live catalogs the list runs to 40+ rows inside `.mp-list`'s max-height, so arrowing past the
+  // fold must bring the highlight along. `nearest` keeps this a no-op for rows already visible, which
+  // also makes the mouseEnter -> setActive path scroll-free.
+  useEffect(() => {
+    if (activeRow) document.getElementById(`mp-${activeRow.key}`)?.scrollIntoView({ block: "nearest" });
+  }, [activeRow]);
 
   const pick = (row: ModelRow | undefined) => {
     if (!row || row.blockedReason) return; // blocked rows are readable, never actionable

--- a/apps/desktop/src/renderer/src/panes/session/ModelPicker.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/ModelPicker.tsx
@@ -92,7 +92,7 @@ function ModelPopover({ rows, anchorRef, onClose, onPick, effortItems, overflow 
   // fold must bring the highlight along. `nearest` keeps this a no-op for rows already visible, which
   // also makes the mouseEnter -> setActive path scroll-free.
   useEffect(() => {
-    if (activeRow) document.getElementById(`mp-${activeRow.key}`)?.scrollIntoView({ block: "nearest" });
+    if (activeRow) document.getElementById(`mp-${activeRow.key}`)?.scrollIntoView?.({ block: "nearest" });
   }, [activeRow]);
 
   const pick = (row: ModelRow | undefined) => {

--- a/apps/desktop/src/renderer/src/panes/session/model-rows.test.ts
+++ b/apps/desktop/src/renderer/src/panes/session/model-rows.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import { DEFAULT_MODEL_LABEL } from "@realm/contracts";
+import { filterRows, modelRows, railKinds } from "./model-rows";
+import type { AgentProbe } from "../../state/store";
+
+const probe = (kind: AgentProbe["kind"], models: AgentProbe["models"]): AgentProbe =>
+  ({ kind, available: true, version: "1", loggedIn: true, reason: null, models });
+
+/** The catalog cursor-agent actually reported live: parameterized ids, `default[]` for Auto. */
+const cursorCatalog = [
+  { id: "default[]", label: "Auto" },
+  { id: "composer-2.5[fast=true]", label: "composer-2.5" },
+  { id: "gpt-5.3-codex[reasoning=medium,fast=false]", label: "gpt-5.3-codex" },
+];
+
+describe("modelRows with a probe catalog", () => {
+  it("renders the probe's models for that kind, led by an explicit adapter-default row", () => {
+    const rows = modelRows({ kind: "acp:cursor", model: null, agentProbe: [probe("acp:cursor", cursorCatalog)], canSwitchAgent: true });
+    const cursor = rows.filter((r) => r.kind === "acp:cursor");
+    // The default row leads because a live catalog's order promises nothing about what an un-pinned
+    // session runs (Cursor's leads with Auto while the adapter default is Composer — verified live).
+    expect(cursor[0]).toMatchObject({ modelId: null, label: DEFAULT_MODEL_LABEL["acp:cursor"], selected: true });
+    expect(cursor.slice(1).map((r) => ({ id: r.modelId, label: r.label }))).toEqual(cursorCatalog.map((m) => ({ id: m.id, label: m.label })));
+    // model === null selects ONLY the default row — never the catalog's first entry.
+    expect(cursor.filter((r) => r.selected)).toHaveLength(1);
+  });
+
+  it("transmits catalog ids verbatim — Auto keeps its real id, and nothing produces a literal \"auto\"", () => {
+    const rows = modelRows({ kind: "acp:cursor", model: null, agentProbe: [probe("acp:cursor", cursorCatalog)], canSwitchAgent: true });
+    expect(rows.find((r) => r.label === "Auto")?.modelId).toBe("default[]"); // the id set_model accepts
+    expect(rows.some((r) => r.modelId === "auto")).toBe(false);              // the id it rejects
+  });
+
+  it("selects the catalog row whose id the session pins", () => {
+    const rows = modelRows({ kind: "acp:cursor", model: "gpt-5.3-codex[reasoning=medium,fast=false]", agentProbe: [probe("acp:cursor", cursorCatalog)], canSwitchAgent: true });
+    expect(rows.filter((r) => r.selected).map((r) => r.modelId)).toEqual(["gpt-5.3-codex[reasoning=medium,fast=false]"]);
+  });
+
+  it("never renders one kind's catalog under another kind", () => {
+    // Codex's probe answered without models; only Cursor's carries a catalog. A find() keyed on the
+    // wrong entry would offer Cursor's parameterized ids to Codex, which rejects them on the wire.
+    const probes = [probe("codex", null), probe("acp:cursor", cursorCatalog)];
+    const rows = modelRows({ kind: "codex", model: null, agentProbe: probes, canSwitchAgent: true });
+    const codex = rows.filter((r) => r.kind === "codex");
+    expect(codex).toHaveLength(1); // static AGENT_MODELS.codex is empty -> the single default row
+    expect(codex[0]).toMatchObject({ modelId: null, label: DEFAULT_MODEL_LABEL.codex });
+    expect(rows.filter((r) => r.kind === "acp:cursor").map((r) => r.modelId)).toContain("default[]");
+  });
+
+  it("keeps the curated static list (and its first-row-selected rule) when the probe has no models", () => {
+    for (const models of [null, undefined, []] as const) {
+      const rows = modelRows({ kind: "claude", model: null, agentProbe: [probe("claude", models as AgentProbe["models"])], canSwitchAgent: true });
+      const claude = rows.filter((r) => r.kind === "claude");
+      expect(claude.map((r) => r.modelId)).toEqual(["claude-fable-5", "claude-opus-5", "claude-sonnet-5", "claude-haiku-4-5"]);
+      expect(claude[0]!.selected).toBe(true); // static lists pin first row = adapter default (presets.test.ts)
+    }
+  });
+
+  it("a probe catalog for the session's own kind still yields exactly one selected row", () => {
+    const codexCatalog = [{ id: "gpt-5.6-sol", label: "GPT-5.6-Sol" }, { id: "gpt-5.6-terra", label: "GPT-5.6-Terra" }];
+    const rows = modelRows({ kind: "codex", model: "gpt-5.6-terra", agentProbe: [probe("codex", codexCatalog)], canSwitchAgent: false });
+    expect(rows.filter((r) => r.selected).map((r) => r.modelId)).toEqual(["gpt-5.6-terra"]);
+    // And the blocked reason still lands on the OTHER kinds only.
+    expect(rows.filter((r) => r.kind === "codex").every((r) => r.blockedReason === null)).toBe(true);
+    expect(rows.filter((r) => r.kind !== "codex").every((r) => r.blockedReason !== null)).toBe(true);
+  });
+});
+
+describe("filterRows at catalog scale", () => {
+  const bigCatalog = Array.from({ length: 40 }, (_, i) => ({ id: `m-${i}[x=1]`, label: `Model ${i}` }));
+  const rows = modelRows({ kind: "acp:cursor", model: null, agentProbe: [probe("acp:cursor", bigCatalog)], canSwitchAgent: true });
+
+  it("carries all 40 catalog rows plus the default row", () => {
+    expect(rows.filter((r) => r.kind === "acp:cursor")).toHaveLength(41);
+  });
+
+  it("search still narrows by model name across the whole catalog", () => {
+    expect(filterRows(rows, { query: "model 39", provider: null }).map((r) => r.label)).toEqual(["Model 39"]);
+    expect(filterRows(rows, { query: "model 3", provider: null }).length).toBe(11); // 3, 30..39
+  });
+
+  it("the provider rail still narrows a large mixed list to one kind", () => {
+    const cursorOnly = filterRows(rows, { query: "", provider: "acp:cursor" });
+    expect(cursorOnly).toHaveLength(41);
+    expect(new Set(cursorOnly.map((r) => r.kind))).toEqual(new Set(["acp:cursor"]));
+    expect(railKinds(rows)).toContain("acp:cursor");
+  });
+});

--- a/apps/desktop/src/renderer/src/panes/session/model-rows.ts
+++ b/apps/desktop/src/renderer/src/panes/session/model-rows.ts
@@ -38,6 +38,19 @@ export type ModelRow = {
  * Availability (`agentProbe`) is reported but never blocking — picking a missing CLI lands on the
  * install card with the exact command, which is somewhere to go; disabling the row hides the fix.
  *
+ * Model lists come from THREE sources, most honest first:
+ *
+ * 1. **The probe's live catalog** (`agentProbe[kind].models`) — ids the provider itself handed over
+ *    (Codex `model/list`, Cursor's ACP `availableModels`). A probe-sourced list additionally gets a
+ *    leading DEFAULT row (`modelId: null`, the adapter's own default): unlike the curated static
+ *    lists, a live catalog's ordering carries no promise that its first entry IS the default the
+ *    adapter runs un-pinned (Cursor's catalog leads with "Auto" while an un-pinned session runs
+ *    Composer — verified live), so `model === null` selects the explicit default row instead of
+ *    guessing at index 0. Stale-by-TTL is fine; a probe list is never mixed across kinds.
+ * 2. **The static curated list** (`AGENT_MODELS[kind]`) — Claude, whose CLI has no enumeration
+ *    channel, plus any kind whose probe has not answered (or answered without models).
+ * 3. **The single DEFAULT_MODEL_LABEL row** — a kind with no list at all.
+ *
  * `model === null` means the user has pinned nothing and the adapter is running its own default. That
  * still marks a row: the frontier model, which is the first of the kind's list and the one the chip
  * already names via `DEFAULT_MODEL_LABEL` (presets.test.ts pins the two to each other). A picker that
@@ -56,13 +69,23 @@ export function modelRows({ kind, model, agentProbe, canSwitchAgent }: {
       ? `${meta.label} can’t be picked — this session has already run, and a session's agent can only change before its first message.`
       : null;
     const base = { kind: k, agentLabel: meta.label, icon: meta.icon, note: availabilityNote(agentAvailability(k, agentProbe)), blockedReason };
-    const models = AGENT_MODELS[k] as ReadonlyArray<{ id: string; label: string }>;
     const onThisAgent = k === kind;
+    // Strictly this kind's own probe entry: rendering kind A's catalog under kind B would offer ids
+    // agent B rejects on the wire.
+    const probed = agentProbe.find((p) => p.kind === k)?.models ?? null;
+    const live = probed !== null && probed.length > 0;
+    const models: ReadonlyArray<{ id: string; label: string }> = live ? probed : AGENT_MODELS[k];
+    const selectedOnDefault = onThisAgent && model === null;
     if (models.length === 0) return [{ ...base, key: `${k}:default`, modelId: null, label: DEFAULT_MODEL_LABEL[k], selected: onThisAgent }];
-    return models.map((m, i) => ({
+    const defaultRow: ModelRow[] = live
+      ? [{ ...base, key: `${k}:default`, modelId: null, label: DEFAULT_MODEL_LABEL[k], selected: selectedOnDefault }]
+      : [];
+    return [...defaultRow, ...models.map((m, i) => ({
       ...base, key: `${k}:${m.id}`, modelId: m.id, label: m.label,
-      selected: onThisAgent && (model === null ? i === 0 : m.id === model),
-    }));
+      // Static curated lists pin their first entry as the adapter default (presets.test.ts holds the
+      // two together), so `model === null` selects it; a live catalog got the explicit row above.
+      selected: onThisAgent && (model === null ? !live && i === 0 : m.id === model),
+    }))];
   });
 }
 

--- a/apps/desktop/src/renderer/src/panes/session/session-pane.test.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/session-pane.test.tsx
@@ -1015,6 +1015,55 @@ describe("prompter model picker", () => {
       await waitFor(() => expect(store.getState().sessions.se1?.model).toBe("claude-opus-5")); // row 2 of Claude's list
     });
   });
+
+  describe("with a live probe catalog", () => {
+    // The shape cursor-agent reported live: parameterized ids, `default[]` for Auto.
+    const catalog = [
+      { id: "default[]", label: "Auto" },
+      { id: "composer-2.5[fast=true]", label: "composer-2.5" },
+      { id: "gpt-5.3-codex[reasoning=medium,fast=false]", label: "gpt-5.3-codex" },
+    ];
+    const cursorProbe = (models: AgentProbe["models"]): AgentProbe[] =>
+      [{ kind: "acp:cursor", available: true, version: "2026.09", loggedIn: null, reason: null, models }];
+
+    it("renders the catalog under its own kind, default row leading and selected", async () => {
+      const { store } = await mountFresh({ agentKind: "acp:cursor" }, 0, cursorProbe(catalog));
+      await waitFor(() => expect(store.getState().agentProbe).toHaveLength(1));
+      openPicker();
+      // Cursor first (session's own kind): default row, then the catalog verbatim; Claude's static
+      // list and Codex's default row are untouched by Cursor's probe models.
+      expect(rowNames()).toEqual(["Composer", "Auto", "composer-2.5", "gpt-5.3-codex",
+        "Claude Fable 5", "Claude Opus 5", "Claude Sonnet 5", "Claude Haiku 4.5", "GPT-5.6"]);
+      expect(screen.getByRole("option", { name: /Composer/ })).toHaveAttribute("aria-selected", "true");
+      expect(screen.getByRole("option", { name: /Auto/ })).toHaveAttribute("aria-selected", "false");
+    });
+
+    it("picking a catalog row transmits its id verbatim — Auto's real id included", async () => {
+      const { store } = await mountFresh({ agentKind: "acp:cursor" }, 0, cursorProbe(catalog));
+      await waitFor(() => expect(store.getState().agentProbe).toHaveLength(1));
+      openPicker();
+      fireEvent.click(screen.getByRole("option", { name: /gpt-5.3-codex/ }));
+      await waitFor(() => expect(store.getState().sessions.se1?.model).toBe("gpt-5.3-codex[reasoning=medium,fast=false]"));
+      openPicker();
+      // "Auto" is a REAL id in Cursor's catalog (set_model accepts `default[]`, rejects `auto`):
+      // picking it transmits that id — it is never rewritten to null or to a literal "auto".
+      fireEvent.click(screen.getAllByRole("option", { name: /Auto/ })[0]!);
+      await waitFor(() => expect(store.getState().sessions.se1?.model).toBe("default[]"));
+    });
+
+    it("search and keyboard still work across a 40-row catalog", async () => {
+      const big = Array.from({ length: 40 }, (_, i) => ({ id: `m-${i}[x=1]`, label: `Model ${i}` }));
+      const { store } = await mountFresh({ agentKind: "acp:cursor" }, 0, cursorProbe(big));
+      await waitFor(() => expect(store.getState().agentProbe).toHaveLength(1));
+      openPicker();
+      expect(screen.getAllByRole("option").length).toBeGreaterThan(40);
+      const search = screen.getByRole("combobox", { name: "Search models" });
+      fireEvent.change(search, { target: { value: "model 39" } });
+      expect(rowNames()).toEqual(["Model 39"]);
+      fireEvent.keyDown(search, { key: "Enter" });
+      await waitFor(() => expect(store.getState().sessions.se1?.model).toBe("m-39[x=1]"));
+    });
+  });
 });
 
 

--- a/apps/server/scripts/live-models-check.ts
+++ b/apps/server/scripts/live-models-check.ts
@@ -1,0 +1,127 @@
+/**
+ * Live check of the model-catalog pipeline against the REAL agent CLIs.
+ *
+ *   pnpm --filter @realm/server exec tsx scripts/live-models-check.ts
+ *
+ * Proves, against the real binaries, the three claims the unit fixtures can only mimic:
+ *
+ *   1. Codex answers app-server `model/list` and the probe surfaces that catalog (or, on a build
+ *      without the method, degrades to `models: null` — either verdict is printed).
+ *   2. Cursor's ACP `session/new` reports `availableModels` and the probe surfaces it — including
+ *      `default[]`, the id "Auto" actually travels as (the literal `auto` is rejected on this wire).
+ *   3. A session started with a PICKED non-default model transmits it: `session/set_model` is
+ *      accepted at boot, the init event reports the pinned id, and a one-word identity prompt comes
+ *      back from the pinned vendor's model, not the default Composer.
+ *
+ * Exits non-zero if any check fails. Requires `codex` and `cursor-agent` installed and logged in.
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { SessionEvent } from "@realm/contracts";
+import { AcpAdapter, CodexAdapter } from "@realm/adapters";
+
+const TURN_TIMEOUT_MS = 120_000; // cursor-agent can sit ~60s before its first chunk (see live-agent-check)
+
+let failures = 0;
+const ok = (label: string, cond: boolean, detail = "") => {
+  console.log(`  ${cond ? "PASS" : "FAIL"}  ${label}${detail ? ` — ${detail}` : ""}`);
+  if (!cond) failures += 1;
+};
+
+async function main() {
+  console.log("== codex model/list ==");
+  const codex = new CodexAdapter();
+  const codexProbe = await codex.probe();
+  ok("codex probes available", codexProbe.available, codexProbe.reason ?? "");
+  if (codexProbe.models === null || codexProbe.models === undefined) {
+    ok("codex model/list degraded to null (build without the method?)", !codex.modelListEnumerable,
+      "models: null with modelListEnumerable still true means enumeration failed for another reason");
+  } else {
+    ok("codex catalog is non-empty", codexProbe.models.length > 0);
+    for (const m of codexProbe.models) console.log(`    ${m.id}  (${m.label})`);
+  }
+
+  console.log("== cursor availableModels ==");
+  const cursor = new AcpAdapter({
+    kind: "acp:cursor", bin: process.env.REALM_CURSOR_BIN ?? "cursor-agent", args: ["acp"],
+    label: "Cursor", loginHint: "Run `cursor-agent login`.", modelCatalog: true,
+  });
+  const cursorProbe = await cursor.probe();
+  ok("cursor probes available", cursorProbe.available, cursorProbe.reason ?? "");
+  const models = cursorProbe.models ?? [];
+  ok("cursor catalog is non-empty", models.length > 0);
+  ok("Auto travels as its real id, default[]", models.some((m) => m.id === "default[]" && m.label === "Auto"));
+  ok("no literal \"auto\" id is ever offered", !models.some((m) => m.id === "auto"));
+  console.log(`    ${models.length} models; first five: ${models.slice(0, 5).map((m) => m.id).join(", ")}`);
+
+  // A model that is not Cursor's default AND whose vendor a one-word identity answer can separate
+  // from Composer. Cheapest family first: premium ids can bounce off plan limits ("Upgrade your plan"),
+  // which proves routing but fails the turn.
+  const families: [prefix: string, vendor: RegExp][] = [
+    ["gemini-", /google|gemini/i], ["gpt-", /openai|gpt/i], ["claude-", /anthropic|claude/i],
+  ];
+  const family = families.find(([prefix]) => models.some((m) => m.id.startsWith(prefix)));
+  const picked = family ? models.find((m) => m.id.startsWith(family[0])) : undefined;
+  const vendor = family?.[1] ?? /anthropic|openai|google/i;
+  console.log(`== cursor session with picked model ${picked?.id ?? "(none found)"} ==`);
+  ok("catalog offers a non-Composer vendor id to pin", picked !== undefined);
+  /** One session, one prompt, drained to idle. */
+  const runTurn = async (model: string | null) => {
+    const cwd = mkdtempSync(join(tmpdir(), "realm-live-models-"));
+    const logs: string[] = [];
+    const handle = cursor.start({ cwd, mcpServers: [], model, onLog: (l) => logs.push(l) });
+    const evs: SessionEvent[] = [];
+    const drained = (async () => { for await (const e of handle.events) evs.push(e); })();
+    try {
+      await handle.send({ text: "In one word, which company created the model answering this? Answer with only that word.", attachments: [] });
+      const deadline = Date.now() + TURN_TIMEOUT_MS;
+      while (Date.now() < deadline) {
+        const last = evs.filter((e) => e.type === "status").at(-1)?.payload.status;
+        if ((last === "idle" && evs.some((e) => e.type === "assistant_text")) || last === "error" || last === "ended") break;
+        await new Promise((r) => setTimeout(r, 250));
+      }
+      const init = evs.find((e) => e.type === "init");
+      return {
+        initModel: init?.type === "init" ? init.payload.model : null,
+        setModelRefused: logs.some((l) => l.includes("session/set_model") && l.includes("failed")),
+        errors: evs.filter((e) => e.type === "error").map((e) => e.payload.message),
+        text: evs.filter((e) => e.type === "assistant_text").map((e) => e.payload.text).join(""),
+      };
+    } finally {
+      await handle.dispose();
+      await drained.catch(() => {});
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  };
+
+  if (picked) {
+    // Control first: the SAME prompt on the adapter default (Composer). If the pinned leg then either
+    // names the pinned vendor or bounces off the per-model plan gate that the control sailed past,
+    // the pin demonstrably changed the routing.
+    const control = await runTurn(null);
+    ok("control (unpinned) turn answers", control.errors.length === 0 && control.text.trim() !== "", control.text.trim().slice(0, 80));
+    const pinned = await runTurn(picked.id);
+    ok("init reports the pinned model", pinned.initModel === picked.id, String(pinned.initModel));
+    ok("boot-time session/set_model was not refused", !pinned.setModelRefused);
+    ok("pinned turn produced no errors", pinned.errors.length === 0, pinned.errors.join(" | "));
+    if (/upgrade your plan/i.test(control.text)) {
+      // The ACCOUNT is out of quota: even Composer is refused, so no answer can name a vendor and the
+      // plan gate proves nothing about routing. The wire-level acceptance above (set_model took a
+      // catalog id; the probe path shows it rejects non-catalog ids with Invalid params) is the proof
+      // this leg still carries. SKIP, honestly, rather than a fake PASS or a misleading FAIL.
+      console.log("  SKIP  vendor-identity check — the account is plan-gated for every model (control also refused)");
+    } else {
+      const gated = /upgrade your plan/i.test(pinned.text);
+      ok("the pinned model (not Composer) handled the request",
+        vendor.test(pinned.text) || gated,
+        gated ? `plan-gated at the pinned model while the control answered — answer: ${pinned.text.trim().slice(0, 80)}`
+              : `answer: ${pinned.text.trim().slice(0, 120)}`);
+    }
+  }
+
+  console.log(failures === 0 ? "ALL CHECKS PASSED" : `${failures} CHECK(S) FAILED`);
+  process.exit(failures === 0 ? 0 : 1);
+}
+
+void main();

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -58,6 +58,8 @@ export function defaultAdapters(): AdapterRegistry {
       args: ["acp"],
       label: "Cursor",
       loginHint: "Run `cursor-agent login`.",
+      // Cursor's session/new reports availableModels (verified live); Gemini's does not get asked.
+      modelCatalog: true,
     }),
     "acp:gemini": new AcpAdapter({
       kind: "acp:gemini",

--- a/packages/adapters/src/acp/acp-adapter.test.ts
+++ b/packages/adapters/src/acp/acp-adapter.test.ts
@@ -834,3 +834,49 @@ describe("acpMcpServers", () => {
     expect(acpMcpServers([stdio, http, sse])).toHaveLength(3);
   });
 });
+
+describe("AcpAdapter model catalog and boot-time model", () => {
+  it("probe() with modelCatalog enumerates via a throwaway session; without it, models is null", async () => {
+    const withCatalog = await newAdapter({ modelCatalog: true }).probe();
+    expect(withCatalog.available).toBe(true);
+    expect(withCatalog.models).toEqual([{ id: "fake-model-1", label: "Fake 1" }, { id: "fake-model-2", label: "Fake 2" }]);
+    // Gemini-shaped spec: no catalog claim, so no probe-time session spawn and nothing to show.
+    const without = await newAdapter().probe();
+    expect(without.models).toBeNull();
+  });
+
+  it("probe() reports models:null when the binary is missing, catalog claim or not", async () => {
+    const r = await newAdapter({ modelCatalog: true, bin: "/nonexistent/acp-bin" }).probe();
+    expect(r.available).toBe(false);
+    expect(r.models).toBeNull();
+  });
+
+  it("transmits a pinned model at boot via session/set_model and reports it on init", async () => {
+    const { handle, evs } = await booted({ model: "fake-model-2" }, { env: { FAKE_ACP_SET_MODEL_OK: "1" } });
+    expect(of(evs, "init")[0]!.payload.model).toBe("fake-model-2");
+    await turn(handle, evs, "REVEAL");
+    const journal = JSON.parse(texts(evs)[0]!) as { calls: { method: string; params: Record<string, unknown> }[] };
+    const call = journal.calls.find((c) => c.method === "session/set_model");
+    expect(call?.params).toEqual({ sessionId: "sess_0", modelId: "fake-model-2" });
+    await handle.dispose();
+  });
+
+  it("degrades a refused boot-time set_model to a log line and the agent's own default", async () => {
+    const logs: string[] = [];
+    const { handle, evs } = await booted({ model: "fake-model-2", onLog: (l) => logs.push(l) });
+    // The fixture's default set_model answers -32601 (ACP 0.4.5 marks it unstable): no error event,
+    // and init reports the model the agent says it is on, not the one that failed to pin.
+    expect(errors(evs)).toEqual([]);
+    expect(of(evs, "init")[0]!.payload.model).toBe("fake-model-1");
+    expect(logs.join("\n")).toContain("session/set_model");
+    await handle.dispose();
+  });
+
+  it("does not call session/set_model at boot when no model is pinned", async () => {
+    const { handle, evs } = await booted({}, { env: { FAKE_ACP_SET_MODEL_OK: "1" } });
+    await turn(handle, evs, "REVEAL");
+    const journal = JSON.parse(texts(evs)[0]!) as { calls: { method: string }[] };
+    expect(journal.calls.some((c) => c.method === "session/set_model")).toBe(false);
+    await handle.dispose();
+  });
+});

--- a/packages/adapters/src/acp/acp-adapter.ts
+++ b/packages/adapters/src/acp/acp-adapter.ts
@@ -1,10 +1,11 @@
 import { basename, dirname, join, resolve, sep } from "node:path";
+import { tmpdir } from "node:os";
 import { readFile, realpath, stat, writeFile } from "node:fs/promises";
 import { sessionEvent, type AgentKind, type SessionEvent } from "@realm/contracts";
 import { AsyncQueue } from "../event-queue";
 import { JsonRpcCallError, StdioJsonRpc, withTimeout, type JsonRpcId } from "../jsonrpc/stdio";
 import { createAcpMapper } from "./map-acp";
-import { probeAcp } from "./probe";
+import { fetchAcpModels, probeAcp } from "./probe";
 import type { AgentAdapter, AgentHandle, McpServerConfig, PermissionDecision, ProbeResult, StartOptions, UserMessage } from "../types";
 
 type Bag = Record<string, unknown>;
@@ -25,6 +26,13 @@ export type AcpAgentSpec = {
   env?: Record<string, string>;
   /** Overridable for tests. Bounds every boot call: initialize, session/new and session/load. */
   bootTimeoutMs?: number;
+  /**
+   * True for agents whose `session/new` answer carries a usable `models.availableModels` catalog
+   * (Cursor does). The probe then enumerates it — by opening a throwaway session, ACP's only channel —
+   * and the picker offers the real list. Absent/false skips the attempt entirely: an agent that
+   * reports nothing would cost a probe-time session spawn to learn nothing.
+   */
+  modelCatalog?: boolean;
 };
 
 /** Copies ClaudeAdapter: app quit awaits every dispose(), so no dispose may depend on a healthy child. */
@@ -212,7 +220,12 @@ export class AcpAdapter implements AgentAdapter {
   }
 
   async probe(): Promise<ProbeResult> {
-    return { kind: this.kind, ...(await probeAcp(this.spec.bin)) };
+    const base = await probeAcp(this.spec.bin);
+    // tmpdir because the throwaway catalog session needs SOME real cwd and must not imply a project.
+    const models = base.available && this.spec.modelCatalog === true
+      ? await fetchAcpModels({ bin: this.spec.bin, args: this.spec.args, cwd: tmpdir(), env: this.spec.env })
+      : null;
+    return { kind: this.kind, ...base, models };
   }
 
   start(opts: StartOptions): AgentHandle {
@@ -396,9 +409,23 @@ export class AcpAdapter implements AgentAdapter {
         }
         if (disposed) return;
         sessionId = id;
+        // The session's pinned model is transmitted HERE, not merely displayed: ACP's `session/new`
+        // takes `{cwd, mcpServers}` and nothing else, so a model picked in an earlier run (or before
+        // the first message) only reaches the agent through a follow-up `session/set_model`. Failure
+        // is a log line, not a dead session — the agent then runs its own default, and the init event
+        // below reports the model the agent says it is on rather than the one we failed to set.
+        let pinned = false;
+        if (opts.model) {
+          try {
+            await ask("session/set_model", { sessionId: id, modelId: opts.model }, SESSION_TIMEOUT_MS);
+            pinned = true;
+          } catch (e) {
+            log(`session/set_model ${opts.model} failed (${message(e)}); staying on the agent's default`);
+          }
+        }
         events.push(sessionEvent("init", {
           providerSessionId: id,
-          model: str(obj(session.models).currentModelId) || str(opts.model),
+          model: pinned ? str(opts.model) : str(obj(session.models).currentModelId) || str(opts.model),
           tools: [],
           cwd: opts.cwd,
         }));

--- a/packages/adapters/src/acp/fixtures/fake-acp-agent.mjs
+++ b/packages/adapters/src/acp/fixtures/fake-acp-agent.mjs
@@ -32,6 +32,8 @@
  * the loadSession capability, FAKE_ACP_NOIMAGE=1 drops the image prompt capability, FAKE_ACP_ALLOWONLY=1 offers no reject option, and FAKE_ACP_LOAD_ASKS=1
  * makes session/load call fs/read_text_file and session/request_permission back on us mid-replay.
  * FAKE_ACP_MUTE_INITIALIZE=1, FAKE_ACP_MUTE_SESSION_NEW=1 and FAKE_ACP_MUTE_SESSION_LOAD=1 leave that request unanswered forever.
+ * FAKE_ACP_SET_MODEL_OK=1 makes session/set_model succeed (it fails -32601 by default), and
+ * FAKE_ACP_MODEL_GARBAGE=1 pollutes session/new's availableModels with malformed rows.
  * FAKE_ACP_IGNORE_EOF=1 keeps the child alive after its stdin closes, FAKE_ACP_NOSESSIONID=1 answers session/new without a sessionId, FAKE_ACP_BADAUTH=1 sends a non-array
  * `authMethods`, and FAKE_ACP_EXIT_MARKER=<path> writes that file when our stdin closes.
  */
@@ -190,7 +192,11 @@ function handleRequest(id, method, params) {
       if (process.env.FAKE_ACP_STARTFAIL) { fail(id, -32603, "Internal error", { message: "Failed to initialize session services", details: "[unauthenticated] Error" }); return; }
       journal.newParams = params;
       if (process.env.FAKE_ACP_NOSESSIONID) { ok(id, {}); return; }
-      ok(id, { sessionId: `sess_${nextSessionN++}`, models: { currentModelId: "fake-model-1", availableModels: [{ modelId: "fake-model-1", name: "Fake 1" }] } });
+      ok(id, { sessionId: `sess_${nextSessionN++}`, models: { currentModelId: "fake-model-1", availableModels: process.env.FAKE_ACP_MODEL_GARBAGE
+        // Rows a real preview build could plausibly emit around the good ones: no modelId, wrong types,
+        // blank ids, plus one nameless-but-valid id. Only the well-formed survive parseAcpModels.
+        ? [null, 42, "composer", { name: "No id" }, { modelId: "", name: "Blank id" }, { modelId: "fake-model-1", name: "Fake 1" }, { modelId: 7, name: "Numeric id" }, { modelId: "fake-model-2" }]
+        : [{ modelId: "fake-model-1", name: "Fake 1" }, { modelId: "fake-model-2", name: "Fake 2" }] } });
       return;
     case "session/load":
       if (process.env.FAKE_ACP_MUTE_SESSION_LOAD) return; // never replies: the resume has to time out and fall back
@@ -207,6 +213,9 @@ function handleRequest(id, method, params) {
       return;
     case "session/set_model":
       journal.calls.push({ method, params });
+      // Default mirrors ACP 0.4.5's "unstable" reality; FAKE_ACP_SET_MODEL_OK=1 is a Cursor-like build
+      // that accepts it (verified live: cursor-agent answers `{}` for a catalog id).
+      if (process.env.FAKE_ACP_SET_MODEL_OK) { ok(id, {}); return; }
       fail(id, -32601, "session/set_model is unstable and not implemented");
       return;
     default:

--- a/packages/adapters/src/acp/probe.test.ts
+++ b/packages/adapters/src/acp/probe.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { probeAcp } from "./probe";
+import { fileURLToPath } from "node:url";
+import { fetchAcpModels, parseAcpModels, probeAcp } from "./probe";
 
 describe("probeAcp", () => {
   it("reports unavailable with a reason when the binary is missing", async () => {
@@ -28,5 +29,60 @@ describe("probeAcp", () => {
   it("never reports loggedIn as anything but null, even when the binary is available", async () => {
     const r = await probeAcp(process.execPath, ["-e", "console.log('v1')"]);
     expect(r.loggedIn).toBeNull();
+  });
+});
+
+describe("parseAcpModels", () => {
+  // Shape captured live from cursor-agent's session/new answer: parameterized ids, `default[]` for Auto.
+  const live = { currentModelId: "composer-2.5[fast=true]", availableModels: [
+    { modelId: "default[]", name: "Auto" },
+    { modelId: "composer-2.5[fast=true]", name: "composer-2.5" },
+  ] };
+
+  it("maps modelId and name verbatim from the live response shape", () => {
+    expect(parseAcpModels(live)).toEqual([
+      { id: "default[]", label: "Auto" },
+      { id: "composer-2.5[fast=true]", label: "composer-2.5" },
+    ]);
+  });
+
+  it("passes Auto's real id through untouched — nothing ever rewrites it to a literal \"auto\"", () => {
+    // Pinned live: session/set_model accepts "default[]" and rejects "auto" with Invalid params.
+    const rows = parseAcpModels(live);
+    expect(rows[0]!.id).toBe("default[]");
+    expect(rows.some((r) => r.id === "auto")).toBe(false);
+  });
+
+  it("skips malformed rows rather than inventing models from them", () => {
+    const rows = parseAcpModels({ availableModels: [null, 7, "composer", { name: "No id" }, { modelId: "" }, { modelId: "  ", name: "Blank" }, { modelId: "ok[x=1]", name: "OK" }, { modelId: "nameless[]" }, { modelId: 3, name: "Numeric" }] });
+    expect(rows).toEqual([{ id: "ok[x=1]", label: "OK" }, { id: "nameless[]", label: "nameless[]" }]);
+  });
+
+  it("yields nothing (never a throw) when models is not the expected shape", () => {
+    for (const junk of [null, undefined, "x", 3, [], {}, { availableModels: "nope" }]) {
+      expect(parseAcpModels(junk)).toEqual([]);
+    }
+  });
+});
+
+describe("fetchAcpModels", () => {
+  const FAKE = fileURLToPath(new URL("./fixtures/fake-acp-agent.mjs", import.meta.url));
+  const opts = (env: Record<string, string> = {}) => ({ bin: process.execPath, args: [FAKE], cwd: process.cwd(), env }); // StdioJsonRpc merges over process.env
+
+  it("opens a throwaway session and reads the catalog off session/new", async () => {
+    expect(await fetchAcpModels(opts())).toEqual([{ id: "fake-model-1", label: "Fake 1" }, { id: "fake-model-2", label: "Fake 2" }]);
+  });
+
+  it("keeps only the well-formed rows of a polluted catalog", async () => {
+    expect(await fetchAcpModels(opts({ FAKE_ACP_MODEL_GARBAGE: "1" }))).toEqual([{ id: "fake-model-1", label: "Fake 1" }, { id: "fake-model-2", label: "fake-model-2" }]);
+  });
+
+  it("answers null when session/new fails, and when the binary is missing", async () => {
+    expect(await fetchAcpModels(opts({ FAKE_ACP_STARTFAIL: "1" }))).toBeNull();
+    expect(await fetchAcpModels({ bin: "/definitely/not/a/binary", args: [], cwd: process.cwd() })).toBeNull();
+  });
+
+  it("answers null (within the bound) when the agent handshakes and then goes mute", async () => {
+    expect(await fetchAcpModels({ ...opts({ FAKE_ACP_MUTE_SESSION_NEW: "1" }), timeoutMs: 500 })).toBeNull();
   });
 });

--- a/packages/adapters/src/acp/probe.ts
+++ b/packages/adapters/src/acp/probe.ts
@@ -1,5 +1,6 @@
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
+import { StdioJsonRpc, withTimeout } from "../jsonrpc/stdio";
 
 const run = promisify(execFile);
 
@@ -21,5 +22,75 @@ export async function probeAcp(
     return { available: true, version, loggedIn: null, reason: "unknown until a session starts" };
   } catch (e) {
     return { available: false, version: null, loggedIn: null, reason: (e as Error).message };
+  }
+}
+
+/**
+ * Extracts picker rows from the `models` object an ACP `session/new` answers with.
+ *
+ * This — not `cursor-agent --list-models` — is the catalog Realm can honestly offer, because it is the
+ * id vocabulary `session/set_model` actually accepts (verified live against cursor-agent 2026.09:
+ * parameterized ids like `composer-2.5[fast=true]` and `default[]` are accepted; the bare
+ * `--list-models` ids like `gpt-5.3-codex-high`, and the literal `auto`, are rejected with
+ * "Invalid params"). Listing ids from one channel and transmitting them on another would make every
+ * pick fail.
+ *
+ * Defensive on purpose: entries missing a string `modelId` are skipped, never invented. A missing
+ * `name` falls back to the id — an ugly true label over a pretty guess.
+ */
+export function parseAcpModels(models: unknown): { id: string; label: string }[] {
+  const list = (models as { availableModels?: unknown } | null)?.availableModels;
+  const rows = Array.isArray(list) ? list : [];
+  const out: { id: string; label: string }[] = [];
+  for (const row of rows) {
+    const m = row as { modelId?: unknown; name?: unknown } | null;
+    if (!m || typeof m.modelId !== "string" || m.modelId.trim() === "") continue;
+    const label = typeof m.name === "string" && m.name.trim() !== "" ? m.name.trim() : m.modelId;
+    out.push({ id: m.modelId, label });
+  }
+  return out;
+}
+
+/** `session/new` reaches the network (Cursor signs in and spins up session services); shorter than the
+ *  adapter's 30s session budget because a probe is advisory — `null` is always an acceptable answer. */
+const LIST_MODELS_TIMEOUT_MS = 20_000;
+
+/**
+ * Fetches the live model catalog by doing the one thing ACP offers: opening a real (throwaway) session
+ * and reading `models.availableModels` off the answer. There is no lighter call — `initialize` carries
+ * no catalog, and there is no `model/list` in the protocol. `null` on any failure: the picker falls
+ * back to its static rows and the probe still reports availability.
+ */
+export async function fetchAcpModels(
+  opts: { bin: string; args: string[]; cwd: string; env?: Record<string, string>; timeoutMs?: number },
+): Promise<{ id: string; label: string }[] | null> {
+  const ms = opts.timeoutMs ?? LIST_MODELS_TIMEOUT_MS;
+  let rpc: StdioJsonRpc | null = null;
+  try {
+    const transport = new StdioJsonRpc({
+      command: opts.bin,
+      args: opts.args,
+      cwd: opts.cwd,
+      env: opts.env,
+      onNotification: () => {},
+      // The probe declares no capabilities and prompts nothing, so any server request is one it cannot
+      // honour; answering (rather than ignoring) keeps the child from wedging on an unanswered frame.
+      onServerRequest: (r) => transport.respondError(r.id, -32601, "not supported by the model probe"),
+      onStderr: () => {},
+      onExit: () => {},
+    });
+    rpc = transport;
+    await withTimeout(rpc.request("initialize", {
+      protocolVersion: 1,
+      clientCapabilities: { fs: { readTextFile: true, writeTextFile: true }, terminal: false },
+    }), ms, `${opts.bin} did not answer initialize within ${ms}ms`);
+    const session = await withTimeout(rpc.request("session/new", { cwd: opts.cwd, mcpServers: [] }), ms,
+      `${opts.bin} did not answer session/new within ${ms}ms`);
+    const models = parseAcpModels((session as { models?: unknown } | null)?.models);
+    return models.length > 0 ? models : null;
+  } catch {
+    return null;
+  } finally {
+    await rpc?.dispose().catch(() => {});
   }
 }

--- a/packages/adapters/src/codex/codex-adapter.test.ts
+++ b/packages/adapters/src/codex/codex-adapter.test.ts
@@ -860,3 +860,71 @@ describe("CodexAdapter memory", () => {
     expect("instructionSources" in of(evs, "init")[0]!.payload).toBe(false);
   });
 });
+
+describe("CodexAdapter model catalog", () => {
+  // The probe's transient app-server child inherits process.env (probe() has no env channel of its
+  // own), so the fixture's hooks are toggled here and always cleaned up.
+  const HOOKS = ["FAKE_CODEX_NO_MODEL_LIST", "FAKE_CODEX_MODEL_GARBAGE", "FAKE_CODEX_MODEL_PAGES"] as const;
+  afterEach(() => { for (const k of HOOKS) delete process.env[k]; });
+
+  it("probe() enumerates model/list over a transient connection and takes it down again", async () => {
+    const adapter = newAdapter();
+    const r = await adapter.probe();
+    expect(r.kind).toBe("codex");
+    expect(r.available).toBe(true);
+    // The hidden preview model is exactly what `hidden` means — it must not reach the picker.
+    expect(r.models).toEqual([{ id: "gpt-5.6-sol", label: "GPT-5.6-Sol" }, { id: "gpt-5.6-terra", label: "GPT-5.6-Terra" }]);
+    // A probe must not leave an app-server child behind: the shared-connection refcount never saw it.
+    expect(adapter.processCount).toBe(0);
+    expect(adapter.sessionCount).toBe(0);
+  });
+
+  it("follows nextCursor across pages", async () => {
+    process.env.FAKE_CODEX_MODEL_PAGES = "1";
+    const r = await newAdapter().probe();
+    expect(r.models).toEqual([{ id: "gpt-5.6-sol", label: "GPT-5.6-Sol" }, { id: "gpt-5.4-mini", label: "GPT-5.4-Mini" }]);
+  });
+
+  it("keeps only the well-formed rows of a polluted catalog", async () => {
+    process.env.FAKE_CODEX_MODEL_GARBAGE = "1";
+    const r = await newAdapter().probe();
+    expect(r.models).toEqual([{ id: "gpt-5.6-sol", label: "GPT-5.6-Sol" }, { id: "gpt-nameless", label: "gpt-nameless" }]);
+  });
+
+  it("degrades -32601 to models:null (a build from before model/list) without failing the probe, sticky", async () => {
+    process.env.FAKE_CODEX_NO_MODEL_LIST = "1";
+    const adapter = newAdapter();
+    const r = await adapter.probe();
+    expect(r.available).toBe(true); // the CLI is fine; only enumeration is missing
+    expect(r.models).toBeNull();
+    expect(adapter.modelListEnumerable).toBe(false);
+    // Sticky: the verdict is about the binary, so the next probe must not ask again.
+    delete process.env.FAKE_CODEX_NO_MODEL_LIST;
+    const again = await adapter.probe();
+    expect(again.models).toBeNull();
+  });
+
+  it("reports models:null when the CLI itself is unavailable", async () => {
+    const r = await new CodexAdapter({ bin: "/definitely/not/a/codex/binary" }).probe();
+    expect(r.available).toBe(false);
+    expect(r.models).toBeNull();
+  });
+
+  it("rides the shared connection when a session already holds one", async () => {
+    const adapter = newAdapter();
+    const handle = adapter.start(startOpts());
+    const { evs } = drain(handle);
+    await waitFor(() => expect(types(evs)).toContain("init"));
+    expect(adapter.processCount).toBe(1);
+    const r = await adapter.probe();
+    expect(r.models).not.toBeNull();
+    expect(r.models!.length).toBeGreaterThan(0);
+    // Still exactly the session's process: the probe neither spawned a second one nor tore this one down.
+    expect(adapter.processCount).toBe(1);
+    const conn = await adapter.connection!;
+    const counted = await conn.request<{ calls: number }>("$test/modelList");
+    expect(counted.calls).toBeGreaterThan(0); // the enumeration really went over THIS connection
+    await handle.dispose();
+    expect(adapter.processCount).toBe(0);
+  });
+});

--- a/packages/adapters/src/codex/codex-adapter.ts
+++ b/packages/adapters/src/codex/codex-adapter.ts
@@ -230,6 +230,8 @@ export class CodexAdapter implements AgentAdapter {
   get extraRootCount(): number { return this.extraRoots.size; }
   /** Visible for tests: false once a codex build has answered -32601 to `skills/extraRoots/set`. */
   get skillsSupported(): boolean { return this.extraRootsSupported; }
+  /** Visible for tests: false once a codex build has answered -32601 to `model/list`. */
+  get modelListEnumerable(): boolean { return this.modelListSupported; }
 
   /**
    * Re-sends the union to the shared connection. Never throws and never rejects: a skills root that does

--- a/packages/adapters/src/codex/codex-adapter.ts
+++ b/packages/adapters/src/codex/codex-adapter.ts
@@ -3,7 +3,7 @@ import { AsyncQueue } from "../event-queue";
 import { JsonRpcCallError, type JsonRpcId } from "../jsonrpc/stdio";
 import { CodexConnection, type ThreadListener } from "./connection";
 import { createCodexMapper } from "./map-codex";
-import { probeCodex } from "./probe";
+import { parseCodexModelPage, probeCodex } from "./probe";
 import type { AgentAdapter, AgentHandle, McpServerConfig, PermissionDecision, ProbeResult, StartOptions, UserMessage } from "../types";
 
 type Bag = Record<string, unknown>;
@@ -18,8 +18,12 @@ const BOOT_TIMEOUT_MS = 30_000;
 /** `skills/extraRoots/set` only rescans a couple of directories, and nothing about the session depends on
  *  its answer — so it gets a short leash rather than the boot budget. */
 const EXTRA_ROOTS_TIMEOUT_MS = 10_000;
-/** JSON-RPC "method not found": the signal that this codex build predates `skills/extraRoots/set`. */
+/** JSON-RPC "method not found": the signal that this codex build predates the method just asked for. */
 const METHOD_NOT_FOUND = -32601;
+/** `model/list` reads a local catalog; a slow answer means something is wrong, not that it needs longer. */
+const MODEL_LIST_TIMEOUT_MS = 10_000;
+/** Pagination guard for `model/list`: the live catalog is one page of 6; a cursor loop past this is a bug. */
+const MODEL_LIST_MAX_PAGES = 5;
 
 /**
  * W4 double-prompt verdict for Codex: NOTHING to wire, on purpose. Claude's SDK prompts per MCP tool
@@ -131,6 +135,9 @@ export class CodexAdapter implements AgentAdapter {
    * skills", never throw and never fail a session.
    */
   private extraRootsSupported = true;
+  /** Same feature-detect discipline for `model/list`: a build without it degrades to the static picker
+   *  fallback (`models: null`), never a failed probe. Sticky, because -32601 is a fact about the binary. */
+  private modelListSupported = true;
 
   constructor(deps: { bin?: string; args?: string[]; bootTimeoutMs?: number } = {}) {
     this.bin = deps.bin;
@@ -151,7 +158,47 @@ export class CodexAdapter implements AgentAdapter {
 
   async probe(): Promise<ProbeResult> {
     const p = await probeCodex(this.bin);
-    return { kind: this.kind, ...p };
+    const models = p.available ? await this.listModels() : null;
+    return { kind: this.kind, ...p, models };
+  }
+
+  /**
+   * The live model catalog over app-server `model/list` (response shape verified against codex-cli
+   * 0.146.0: `{ data, nextCursor }` — see `parseCodexModelPage`). Rides the shared connection when a
+   * session already holds one; otherwise spins up a probe-lifetime process the way the CLI probe spawns
+   * its own children, and takes it down again. `null` on ANY failure — a -32601 build (sticky, like
+   * `skills/extraRoots/set`), a dead spawn, a timeout — because the picker has a static fallback and a
+   * failed enumeration must never fail the probe that carries availability.
+   */
+  private async listModels(): Promise<{ id: string; label: string }[] | null> {
+    if (!this.modelListSupported) return null;
+    let owned: CodexConnection | null = null;
+    try {
+      // A rejected shared open is a boot problem for the session that caused it, not for this probe:
+      // fall through to a transient process rather than inheriting the rejection.
+      const shared = this.conn ? await this.conn.catch(() => null) : null;
+      const conn = shared ?? (owned = await CodexConnection.open({
+        bin: this.bin ?? process.env.REALM_CODEX_BIN ?? "codex",
+        args: this.args,
+        cwd: process.cwd(),
+        initializeTimeoutMs: this.bootTimeoutMs,
+      }));
+      const models: { id: string; label: string }[] = [];
+      let cursor: string | null = null;
+      for (let page = 0; page < MODEL_LIST_MAX_PAGES; page += 1) {
+        const res = await conn.request("model/list", cursor === null ? {} : { cursor }, MODEL_LIST_TIMEOUT_MS);
+        const parsed = parseCodexModelPage(res);
+        models.push(...parsed.models);
+        cursor = parsed.nextCursor;
+        if (cursor === null) break;
+      }
+      return models;
+    } catch (e) {
+      if (e instanceof JsonRpcCallError && e.code === METHOD_NOT_FOUND) this.modelListSupported = false;
+      return null;
+    } finally {
+      if (owned) await owned.dispose().catch(() => {});
+    }
   }
 
   /**

--- a/packages/adapters/src/codex/fixtures/fake-codex-server.mjs
+++ b/packages/adapters/src/codex/fixtures/fake-codex-server.mjs
@@ -51,6 +51,7 @@ let stdinBuf = "";
 // Last `skills/extraRoots/set` payload plus a call count, readable via the `$test/extraRoots` request.
 let lastExtraRoots = null;
 let extraRootsCalls = 0;
+let modelListCalls = 0;
 
 const send = (frame) => process.stdout.write(JSON.stringify(frame) + "\n");
 const ok = (id, result) => send({ id, result });
@@ -326,6 +327,33 @@ function handleRequest(id, method, params) {
     }
     case "$test/extraRoots":
       ok(id, { extraRoots: lastExtraRoots, calls: extraRootsCalls });
+      return;
+    case "model/list": {
+      // FAKE_CODEX_NO_MODEL_LIST=1 is a codex build from before the method existed: -32601, which the
+      // probe must feature-detect into `models: null`, never a failed probe.
+      if (process.env.FAKE_CODEX_NO_MODEL_LIST) { fail(id, -32601, "Method not found: model/list"); return; }
+      modelListCalls++;
+      // Rows a preview build could plausibly emit around the good ones; only the well-formed survive
+      // parseCodexModelPage. `hidden: true` is the flag's documented meaning and must not reach the picker.
+      if (process.env.FAKE_CODEX_MODEL_GARBAGE) {
+        ok(id, { data: [null, "gpt", { displayName: "No id" }, { id: "", displayName: "Blank id" }, { id: "gpt-5.6-sol", displayName: "GPT-5.6-Sol", hidden: false }, { id: "gpt-secret", displayName: "Hidden", hidden: true }, { id: "gpt-nameless" }], nextCursor: null });
+        return;
+      }
+      // Two pages, so the cursor loop is exercised; shape copied from the live 0.146.0 response.
+      if (process.env.FAKE_CODEX_MODEL_PAGES) {
+        if (params.cursor === "page2") { ok(id, { data: [{ id: "gpt-5.4-mini", displayName: "GPT-5.4-Mini", hidden: false }], nextCursor: null }); return; }
+        ok(id, { data: [{ id: "gpt-5.6-sol", displayName: "GPT-5.6-Sol", hidden: false }], nextCursor: "page2" });
+        return;
+      }
+      ok(id, { data: [
+        { id: "gpt-5.6-sol", displayName: "GPT-5.6-Sol", hidden: false, isDefault: true },
+        { id: "gpt-5.6-terra", displayName: "GPT-5.6-Terra", hidden: false, isDefault: false },
+        { id: "gpt-secret", displayName: "Hidden preview", hidden: true, isDefault: false },
+      ], nextCursor: null });
+      return;
+    }
+    case "$test/modelList":
+      ok(id, { calls: modelListCalls });
       return;
     case "turn/interrupt":
       ok(id, {});

--- a/packages/adapters/src/codex/probe.test.ts
+++ b/packages/adapters/src/codex/probe.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { fileURLToPath } from "node:url";
-import { probeCodex } from "./probe";
+import { parseCodexModelPage, probeCodex } from "./probe";
 
 const FAKE_CODEX = fileURLToPath(new URL("./fixtures/fake-codex.mjs", import.meta.url));
 
@@ -77,5 +77,37 @@ describe("probeCodex", () => {
       if (prev === undefined) delete process.env.FAKE_CODEX_LOGIN;
       else process.env.FAKE_CODEX_LOGIN = prev;
     }
+  });
+});
+
+describe("parseCodexModelPage", () => {
+  // Shape captured live from codex-cli 0.146.0's `model/list` answer.
+  const live = { data: [{ id: "gpt-5.6-sol", model: "gpt-5.6-sol", displayName: "GPT-5.6-Sol", hidden: false, isDefault: true }], nextCursor: null };
+
+  it("maps id and displayName from the live response shape", () => {
+    expect(parseCodexModelPage(live)).toEqual({ models: [{ id: "gpt-5.6-sol", label: "GPT-5.6-Sol" }], nextCursor: null });
+  });
+
+  it("skips malformed rows rather than inventing models from them", () => {
+    const page = { data: [null, 42, "gpt", { displayName: "No id" }, { id: "", displayName: "Blank id" }, { id: "  ", displayName: "Whitespace id" }, { id: "ok-model", displayName: "OK" }, { id: 7, displayName: "Numeric id" }] };
+    expect(parseCodexModelPage(page).models).toEqual([{ id: "ok-model", label: "OK" }]);
+  });
+
+  it("drops only an explicit hidden:true, and falls back to the id when displayName is unusable", () => {
+    const page = { data: [{ id: "shown" }, { id: "shown-2", displayName: "  " }, { id: "secret", displayName: "Secret", hidden: true }, { id: "odd", displayName: "Odd", hidden: "yes" }] };
+    expect(parseCodexModelPage(page).models).toEqual([{ id: "shown", label: "shown" }, { id: "shown-2", label: "shown-2" }, { id: "odd", label: "Odd" }]);
+  });
+
+  it("yields nothing (never a throw) for a page that is not a page at all", () => {
+    for (const junk of [null, undefined, "x", 3, [], { data: "nope" }]) {
+      expect(parseCodexModelPage(junk)).toEqual({ models: [], nextCursor: null });
+    }
+  });
+
+  it("surfaces a real nextCursor and normalizes absent or blank ones to null", () => {
+    expect(parseCodexModelPage({ data: [], nextCursor: "abc" }).nextCursor).toBe("abc");
+    expect(parseCodexModelPage({ data: [], nextCursor: "" }).nextCursor).toBeNull();
+    expect(parseCodexModelPage({ data: [] }).nextCursor).toBeNull();
+    expect(parseCodexModelPage({ data: [], nextCursor: 9 }).nextCursor).toBeNull();
   });
 });

--- a/packages/adapters/src/codex/probe.ts
+++ b/packages/adapters/src/codex/probe.ts
@@ -48,3 +48,27 @@ export async function probeCodex(
     return { available: true, version: version || null, loggedIn: null, reason: `could not determine login status: ${detail}` };
   }
 }
+
+/**
+ * Extracts the picker rows from one `model/list` response page (shape verified live against
+ * codex-cli 0.146.0: `{ data: Model[], nextCursor: string | null }`, Model carrying `id`,
+ * `displayName`, `hidden`, ...).
+ *
+ * Defensive on purpose — the shape is a preview build's and may drift. A malformed page yields the
+ * rows that ARE well-formed, never a throw and never a row with an invented or blank id. `hidden`
+ * models are skipped because that is what the flag means ("hidden from the default picker list");
+ * only an explicit `hidden: true` hides — an absent flag is not treated as hiding.
+ */
+export function parseCodexModelPage(page: unknown): { models: { id: string; label: string }[]; nextCursor: string | null } {
+  const data = (page as { data?: unknown } | null)?.data;
+  const rows = Array.isArray(data) ? data : [];
+  const models: { id: string; label: string }[] = [];
+  for (const row of rows) {
+    const m = row as { id?: unknown; displayName?: unknown; hidden?: unknown } | null;
+    if (!m || typeof m.id !== "string" || m.id.trim() === "" || m.hidden === true) continue;
+    const label = typeof m.displayName === "string" && m.displayName.trim() !== "" ? m.displayName.trim() : m.id;
+    models.push({ id: m.id, label });
+  }
+  const cursor = (page as { nextCursor?: unknown } | null)?.nextCursor;
+  return { models, nextCursor: typeof cursor === "string" && cursor !== "" ? cursor : null };
+}

--- a/packages/adapters/src/types.ts
+++ b/packages/adapters/src/types.ts
@@ -1,4 +1,4 @@
-import type { AgentKind, SessionEvent } from "@realm/contracts";
+import type { AgentKind, AgentModel, SessionEvent } from "@realm/contracts";
 
 /**
  * One MCP server on its way to an agent.
@@ -85,7 +85,14 @@ export interface AgentHandle {
   dispose(): Promise<void>;
 }
 
-export type ProbeResult = { kind: AgentKind; available: boolean; version: string | null; loggedIn: boolean | null; reason: string | null };
+/**
+ * `models` is the provider's live catalog, when the adapter has a channel to ask on: Codex answers
+ * app-server `model/list`, Cursor reports `availableModels` on ACP `session/new`. `null`/absent means
+ * "cannot enumerate" — Claude has no such channel (the curated static list in contracts stands in),
+ * and an unavailable CLI obviously can't be asked. Never an invented list: ids here are ids the
+ * provider itself handed over, verbatim.
+ */
+export type ProbeResult = { kind: AgentKind; available: boolean; version: string | null; loggedIn: boolean | null; reason: string | null; models?: AgentModel[] | null };
 
 export interface AgentAdapter {
   readonly kind: AgentKind;

--- a/packages/contracts/src/presets.ts
+++ b/packages/contracts/src/presets.ts
@@ -2,10 +2,28 @@ export const SPACE_COLORS = ["#7c6cff", "#3ddc97", "#ffb454", "#ff6b8b", "#4cc9f
 export const SPACE_ICONS = ["briefcase", "cap", "home", "folder", "terminal", "browser", "session", "artifact", "context", "layout"] as const;
 export const pickSpaceColor = (i: number): string => SPACE_COLORS[i % SPACE_COLORS.length]!;
 
+/** One pickable model: the id the wire transmits and the name the row shows. */
+export type AgentModel = { id: string; label: string };
+
+/**
+ * STATIC fallback model lists — what the picker shows for a kind when no probe has answered yet
+ * (`agents.probe` results carry `models`, the live catalog, which wins whenever present).
+ *
+ * The asymmetry is deliberate, not an accident of neglect:
+ *
+ *  - **claude** is a curated list that stays hardcoded because no enumeration channel exists — the
+ *    Claude Code CLI has no `--list-models`, and the Agent SDK takes a model id on faith. Curation is
+ *    the honest option left; keep it in step with the CLI's own picker.
+ *  - **codex** and **acp:cursor** are empty ON PURPOSE: their real catalogs are enumerated live by the
+ *    probe (Codex over app-server `model/list`, Cursor from ACP `session/new`'s `availableModels`), so
+ *    a hardcoded list here would only ever be a stale copy that shadows the truth. Empty means the
+ *    picker falls back to the single DEFAULT_MODEL_LABEL row until a probe has answered.
+ *  - **acp:gemini** is empty because the kind is no longer offered (see SELECTABLE_AGENT_KINDS).
+ */
 export const AGENT_MODELS = {
   claude: [{ id: "claude-fable-5", label: "Claude Fable 5" }, { id: "claude-opus-5", label: "Claude Opus 5" }, { id: "claude-sonnet-5", label: "Claude Sonnet 5" }, { id: "claude-haiku-4-5", label: "Claude Haiku 4.5" }],
   codex: [], "acp:gemini": [], "acp:cursor": [], fake: [{ id: "fake", label: "Fake" }],
-} as const;
+} as const satisfies Record<import("./entities").AgentKind, readonly AgentModel[]>;
 export const EFFORT_LEVELS = ["low", "medium", "high", "xhigh", "max"] as const;
 /**
  * Agent kinds a user can pick — the palette's one-shot entries and the prompter's agent chip.

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -552,7 +552,7 @@ export const Methods = {
   },
   /** `force` skips the server's TTL cache — what the install card's "Check again" and its window-focus
    *  refresh send, because a cached "not installed" is exactly what the user just fixed. */
-  "agents.probe": { params: z.object({ force: z.boolean().default(false) }), result: z.array(z.object({ kind: AgentKindSchema, available: z.boolean(), version: z.string().nullable(), loggedIn: z.boolean().nullable(), reason: z.string().nullable() })) },
+  "agents.probe": { params: z.object({ force: z.boolean().default(false) }), result: z.array(z.object({ kind: AgentKindSchema, available: z.boolean(), version: z.string().nullable(), loggedIn: z.boolean().nullable(), reason: z.string().nullable(), models: z.array(z.object({ id: z.string(), label: z.string() })).nullable().optional() })) },
   "sessions.list":   { params: z.object({ spaceId: IdSchema }), result: z.array(SessionSchema) },
   /** Every session across every space — the client's sessionId→spaceId map for cross-space badges. */
   "sessions.listAll": { params: z.object({}), result: z.array(SessionSchema) },


### PR DESCRIPTION
The picker showed only hardcoded rows — `codex: []`, `cursor: []`. Both providers can enumerate; now they do. **2183 tests**, live-proven against both real CLIs.

- **Codex**: `model/list` on the app-server protocol (6 models live, `gpt-5.6-sol` default), feature-detected — an older binary degrades to the static fallback stickily, never throws.
- **Cursor**: enumerated over ACP `session/new`'s `models.availableModels` — NOT `--list-models`, whose 208 bare ids the wire rejects (verified: `session/set_model` refuses them and accepts exactly the 35 parameterized catalog ids). "Auto" is a real catalog row transmitting `default[]` verbatim; the adapter-default row is separate and honestly labeled, because an un-pinned session runs Composer, not Auto.
- **Bug found in passing, fixed**: the ACP adapter dropped `opts.model` at boot — a pinned model never survived restart/resume. Boot now transmits it and init reports the agent's actual model.
- Claude stays curated (no enumeration command exists — stated in a comment, not hidden). Catalogs ride the existing probe cache/TTL. Picker handles 40-row catalogs (search past the fold, keyboard scroll-into-view).

Known limitation: picking the default row can't clear an existing pin (`setOptions` has no `model: null` channel) — pre-existing, noted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)