### PR TITLE
Plan 14 — dogfood polish convoy

### DIFF
--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -116,6 +116,12 @@ export function App() {
       const st = store.getState();
       st.run(() => st.refreshAllDiffs());
     });
+    // A ship-log row was written (Plan 14 W1). Held-only, like skills/memory: the History tab is the
+    // one holder, and a space whose log nobody is looking at has nothing to go stale.
+    const offSh = rpc().on("ships.changed", ({ spaceId }) => {
+      const st = store.getState();
+      if (st.ships[spaceId]) st.run(() => st.refreshShips(spaceId));
+    });
     // A checkpoint was taken, restored or pruned. Only re-listed when the sheet is actually showing
     // that environment: this fires on every turn, and a store holding a list nobody is looking at is
     // work for nothing.
@@ -189,7 +195,7 @@ export function App() {
     window.addEventListener("dragover", swallowDrop);
     window.addEventListener("drop", swallowDrop);
     return () => {
-      offS(); offI(); offV(); offW(); offP(); offK(); offMem(); offB(); offSA(); offBA(); offBD(); offE(); offT(); offN(); offM(); offMS(); offMC(); offC();
+      offS(); offI(); offV(); offW(); offSh(); offP(); offK(); offMem(); offB(); offSA(); offBA(); offBD(); offE(); offT(); offN(); offM(); offMS(); offMC(); offC();
       window.removeEventListener("pagehide", onPageHide);
       window.removeEventListener("dragover", swallowDrop);
       window.removeEventListener("drop", swallowDrop);

--- a/apps/desktop/src/renderer/src/components/CommandPalette.tsx
+++ b/apps/desktop/src/renderer/src/components/CommandPalette.tsx
@@ -100,6 +100,7 @@ function PaletteBody() {
   const openSheet = useApp((s) => s.openSheet);
   const openSpacePage = useApp((s) => s.openSpacePage);
   const openDestinationPage = useApp((s) => s.openDestinationPage);
+  const openProfilePage = useApp((s) => s.openProfilePage);
   const openActivity = useApp((s) => s.openActivity);
   const setPaletteOpen = useApp((s) => s.setPaletteOpen);
   const refreshAllItems = useApp((s) => s.refreshAllItems);
@@ -165,6 +166,8 @@ function PaletteBody() {
       act("new-space", "New space…", "add", () => openSheet({ kind: "new-space" })),
       // A space is a PAGE (Plan 12 W3): this routes to the space-page pane, not a sheet.
       ...(activeSpaceId ? [act("open-space", "Open space", "settings", () => run(() => openSpacePage(activeSpaceId)))] : []),
+      // The active space's PROFILE page (Plan 14 W2) — same gate: the page needs a layout to live in.
+      ...(activeSpaceId ? [act("open-profile", "Open profile", "profile-page", () => run(() => openProfilePage()))] : []),
       // The sidebar destinations (W4) — gated like "Open space": the page needs a layout to live in.
       ...(activeSpaceId ? [
         act("open-library", "Open library", "library-page", () => run(() => openDestinationPage("library-page"))),
@@ -192,7 +195,7 @@ function PaletteBody() {
     return [...open, ...activeRest, ...others, ...actions, ...themes];
   }, [spaces, activeSpaceId, items, allItems, layout, focusedLeafId, sessions, sessionStatus, themePref,
       selectSpace, openItem, newTerminal, newBrowser, newSession, newSessionInstant, newSessionInWorktree, splitFocused, closeFromLayout, requestRename,
-      interruptSession, jumpToPermission, applyPreset, setThemePref, openSheet, openSpacePage, openDestinationPage, openActivity, run]);
+      interruptSession, jumpToPermission, applyPreset, setThemePref, openSheet, openSpacePage, openDestinationPage, openProfilePage, openActivity, run]);
 
   // Empty query: everything, grouped under faint section headers. With a query: a flat list ranked
   // by match score (ties keep the sectioned order, so recency still breaks ties).

--- a/apps/desktop/src/renderer/src/components/command-palette.test.tsx
+++ b/apps/desktop/src/renderer/src/components/command-palette.test.tsx
@@ -260,6 +260,14 @@ describe("Open library / Open connections (Plan 12 W4)", () => {
     await waitFor(() => expect(store.getState().items.some((i) => i.kind === "connections-page")).toBe(true));
   });
 
+  it("Open profile opens the profile-page item (Plan 14 W2) — the PROFILE page, not the space page", async () => {
+    const { store } = await mount();
+    fireEvent.change(input(), { target: { value: "open profile" } });
+    fireEvent.click(screen.getByRole("option", { name: /Open profile/ }));
+    await waitFor(() => expect(store.getState().items.some((i) => i.kind === "profile-page")).toBe(true));
+    expect(store.getState().items.some((i) => i.kind === "space-page")).toBe(false);
+  });
+
   it("Open settings opens the settings-page item (W6) — the SETTINGS page, not the space page", async () => {
     const { store } = await mount();
     fireEvent.change(input(), { target: { value: "open settings" } });

--- a/apps/desktop/src/renderer/src/components/scoped/ScopeGroups.tsx
+++ b/apps/desktop/src/renderer/src/components/scoped/ScopeGroups.tsx
@@ -80,13 +80,18 @@ export function ScopeGroups({ entries, listClassName = "settings-list" }: {
  * fires the actual RPC in `onConfirm`, with the VANTAGE space id — never a profile id, which is
  * resolved server-side from the space.
  */
-export function MoveScopeConfirm({ direction, name, profileName, onCancel, onConfirm }: {
+export function MoveScopeConfirm({ direction, name, profileName, spaceName, onCancel, onConfirm }: {
   direction: "promote" | "demote"; name: string; profileName: string;
+  /** Names the destination space where "this space" would be ambiguous — the profile page (Plan 14
+   *  W2), whose demote pins the item to the VANTAGE space the page was opened from. Space-page
+   *  surfaces omit it: there, "this space" is exact. */
+  spaceName?: string;
   onCancel: () => void; onConfirm: () => void;
 }) {
+  const here = spaceName ?? "this space";
   const copy = direction === "promote"
     ? `Move “${name}” to ${profileName}? Other spaces in ${profileName} will see it; spaces that had it stay as they are.`
-    : `Keep “${name}” in this space only? Other spaces in ${profileName} will stop seeing it; this space keeps it as it is.`;
+    : `Keep “${name}” in ${here} only? Other spaces in ${profileName} will stop seeing it; ${here} keeps it as it is.`;
   return (
     <div className="scope-confirm">
       <span className="scope-confirm-copy">{copy}</span>

--- a/apps/desktop/src/renderer/src/components/sidebar/BrowserOrigins.tsx
+++ b/apps/desktop/src/renderer/src/components/sidebar/BrowserOrigins.tsx
@@ -1,0 +1,93 @@
+import { useEffect, useState, type FormEvent } from "react";
+import { useApp } from "../../state/store";
+import { ALLOWLIST_GUARDRAIL_NOTE, parseOriginInput } from "../../panes/browser/browser-client";
+
+/**
+ * The per-space browser origin allowlist's editor (Plan 14 W4) — the Connections tab's "Browser
+ * origins" section, next to the MCP servers the same tab already owns.
+ *
+ * The posture is a real choice, surfaced as one: **All origins** is `null` in settings (W1's default,
+ * no list configured) and **Only listed** is an array — including the honest-but-blocking empty one,
+ * which the hint calls out rather than papering over. Entries are validated as ORIGINS, not URLs
+ * (`parseOriginInput`), because that is exactly what the enforcement compares. Writes go through
+ * `setBrowserAllowlist`, which persists the setting AND re-fences every live browser view of the
+ * space in place — the guarantee this section's copy leans on.
+ */
+export function BrowserOrigins({ spaceId }: { spaceId: string }) {
+  const list = useApp((s) => s.browserAllowlists[spaceId]);
+  const refreshBrowserAllowlist = useApp((s) => s.refreshBrowserAllowlist);
+  const setBrowserAllowlist = useApp((s) => s.setBrowserAllowlist);
+  const run = useApp((s) => s.run);
+  const [draft, setDraft] = useState("");
+  const [rejected, setRejected] = useState<string | null>(null);
+
+  useEffect(() => { run(() => refreshBrowserAllowlist(spaceId)); }, [spaceId, refreshBrowserAllowlist, run]);
+
+  const fetched = list !== undefined;
+  const listed = list ?? [];
+  const allOrigins = list === null;
+
+  const add = (e: FormEvent) => {
+    e.preventDefault();
+    const origin = parseOriginInput(draft);
+    // Origins, not URLs: a stored path would silently widen to the whole origin, so it is refused
+    // here with the normalized form the field expects — never quietly rewritten.
+    if (origin === null) { setRejected(draft.trim() || "an empty entry"); return; }
+    setRejected(null);
+    setDraft("");
+    run(() => setBrowserAllowlist(spaceId, [...new Set([...listed, origin])].sort()));
+  };
+  const remove = (origin: string) => run(() => setBrowserAllowlist(spaceId, listed.filter((o) => o !== origin)));
+
+  return (
+    <div className="field">
+      <span>Browser origins</span>
+      <p className="settings-hint">Where this space's browser panes may navigate. Changes apply to open panes immediately.</p>
+      {!fetched ? <p className="env-empty">Loading…</p> : (
+        <>
+          <fieldset className="settings-tabs" aria-label="Browser origin posture">
+            <label className="settings-tab" data-selected={allOrigins || undefined}>
+              <input type="radio" name={`browser-origins-${spaceId}`} value="all" checked={allOrigins}
+                onChange={() => run(() => setBrowserAllowlist(spaceId, null))} />
+              All origins
+            </label>
+            <label className="settings-tab" data-selected={!allOrigins || undefined}>
+              <input type="radio" name={`browser-origins-${spaceId}`} value="listed" checked={!allOrigins}
+                onChange={() => run(() => setBrowserAllowlist(spaceId, listed))} />
+              Only listed
+            </label>
+          </fieldset>
+          {allOrigins
+            ? <p className="settings-hint">All origins — no list is configured, and browser panes can go anywhere.</p>
+            : (
+              <>
+                {listed.length === 0
+                  ? <p className="settings-hint">No origins listed — browser panes can't go anywhere until one is added (or the posture goes back to All origins).</p>
+                  : (
+                    <ul className="env-list">
+                      {listed.map((o) => (
+                        <li key={o} className="env-row">
+                          <div className="env-main"><span className="env-name">{o}</span></div>
+                          <div className="env-actions">
+                            <button type="button" className="btn-quiet" onClick={() => remove(o)}>Remove</button>
+                          </div>
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                <form className="origin-add" onSubmit={add}>
+                  <input aria-label="Origin to allow" value={draft} placeholder="https://example.com"
+                    onChange={(e) => { setDraft(e.target.value); setRejected(null); }} />
+                  <button type="submit" className="btn-quiet">Add origin</button>
+                </form>
+                {rejected !== null && (
+                  <p className="settings-hint" role="alert">Not an origin: {rejected}. Enter scheme and host only — like https://example.com or http://localhost:3000 — with no path.</p>
+                )}
+              </>
+            )}
+        </>
+      )}
+      <p className="settings-note">{ALLOWLIST_GUARDRAIL_NOTE}</p>
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/src/components/sidebar/Destinations.tsx
+++ b/apps/desktop/src/renderer/src/components/sidebar/Destinations.tsx
@@ -30,6 +30,10 @@ export function Destinations() {
         <Icon name="notifications-page" size={16} /><span>Notifications</span>
         {unread > 0 && <span className="status-pill dest-count" data-tone="warning" aria-label={`${unread} unread`}>{unread}</span>}
       </button>
+      {/* Seam (Plan 14 W5, deliberately unbuilt): when Plan 13's Tasks lens lands, its row goes here
+          with a running-tasks count pill on the Notifications pattern above — server-derived count,
+          rendered only when non-zero. Not stubbed now: a row for a page that does not exist yet is
+          exactly the dead chrome this nav bans. */}
     </nav>
   );
 }

--- a/apps/desktop/src/renderer/src/components/sidebar/McpSection.tsx
+++ b/apps/desktop/src/renderer/src/components/sidebar/McpSection.tsx
@@ -138,6 +138,7 @@ function McpServerRow({ spaceId, server }: { spaceId: string; server: McpServer 
   const testMcpServer = useApp((s) => s.testMcpServer);
   const promoteMcpServer = useApp((s) => s.promoteMcpServer);
   const demoteMcpServer = useApp((s) => s.demoteMcpServer);
+  const openProfilePage = useApp((s) => s.openProfilePage);
   const profiles = useApp((s) => s.profiles);
   const space = useApp((s) => s.spaces.find((x) => x.id === spaceId));
   const [editing, setEditing] = useState(false);
@@ -196,10 +197,15 @@ function McpServerRow({ spaceId, server }: { spaceId: string; server: McpServer 
           Enabled
         </label>
         <button type="button" className="btn-quiet" onClick={runTest}>Test</button>
-        {/* Never a bare "Edit" on an inherited row — in-place editing is the mutant §2 forbids. The
-            affordance jumps to the defining scope's editor: the same form, opened AS the profile's. */}
+        {/* Never a bare "Edit" on an inherited row — in-place editing is the mutant §2 forbids. Since
+            Plan 14 W2 the defining scope has a real page, so "Edit in profile" JUMPS there (primary);
+            the banner-wearing inline form survives as the fallback behind "Edit here…" — the same
+            form, opened AS the profile's, for when leaving the tab mid-thought isn't worth it. */}
+        {inherited && !editing && (
+          <button type="button" className="btn-quiet" onClick={() => run(() => openProfilePage("connections"))}>Edit in profile</button>
+        )}
         <button type="button" className="btn-quiet" onClick={() => setEditing((v) => !v)}>
-          {editing ? "Close" : inherited ? "Edit in profile" : "Edit"}
+          {editing ? "Close" : inherited ? "Edit here…" : "Edit"}
         </button>
         {!confirmMove && (
           <button type="button" className="btn-quiet" onClick={() => setConfirmMove(true)}>
@@ -285,7 +291,7 @@ const emptyRows: SecretRow[] = [];
 /** Add/edit form: the W2 fields (name, transport, endpoint, secrets) plus auth. `server` present = edit;
  *  absent = a fresh add. Self-contained on purpose — everything the form needs to reason about (dirty
  *  URL, oauth vs key, existing key names) lives in this one component. */
-function McpServerForm({ spaceId, server, onDone, scopeNote }: { spaceId: string; server?: McpServer; onDone: () => void;
+export function McpServerForm({ spaceId, server, onDone, scopeNote }: { spaceId: string; server?: McpServer; onDone: () => void;
   /** Set when this form is the DEFINING scope's editor opened from an inheriting space ("Edit in
    *  profile"): one sentence naming the scope and the reach of a save. Rendered first — the user must
    *  read it before any field. */

--- a/apps/desktop/src/renderer/src/components/sidebar/SpaceHeader.tsx
+++ b/apps/desktop/src/renderer/src/components/sidebar/SpaceHeader.tsx
@@ -14,6 +14,7 @@ export function SpaceHeader({ space }: { space: Space }) {
   const swipeInvert = useApp((s) => s.swipeInvert);
   const setSwipeInvert = useApp((s) => s.setSwipeInvert);
   const openSpacePage = useApp((s) => s.openSpacePage);
+  const openProfilePage = useApp((s) => s.openProfilePage);
   const newTerminal = useApp((s) => s.newTerminal);
   const newSessionInWorktree = useApp((s) => s.newSessionInWorktree);
   const run = useApp((s) => s.run);
@@ -28,7 +29,9 @@ export function SpaceHeader({ space }: { space: Space }) {
         <Icon name={space.icon} size={16} /><span className="space-name">{space.name}</span>
       </button></h2>
       <div className="space-header-actions">
-        {profile && <button className="pill" title="Open space" onClick={openPage}>{profile.name}</button>}
+        {/* The pill NAMES the profile, so it opens the profile page (Plan 14 W2) — it used to be a
+            second door to the space page, which the title button beside it already is. */}
+        {profile && <button className="pill" title="Open profile" onClick={() => run(() => openProfilePage())}>{profile.name}</button>}
         <button ref={btnRef} className="icon-btn" aria-label="Space menu" aria-haspopup="menu" aria-expanded={menu}
           title="More" onClick={() => setMenu((o) => !o)}><Icon name="more" size={15} /></button>
         {menu && (

--- a/apps/desktop/src/renderer/src/components/sidebar/browser-origins.test.tsx
+++ b/apps/desktop/src/renderer/src/components/sidebar/browser-origins.test.tsx
@@ -1,0 +1,133 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { BrowserOrigins } from "./BrowserOrigins";
+import { ALLOWLIST_GUARDRAIL_NOTE, allowlistKey, parseOriginInput, setBrowserBridgesForTests, type BrowserBridges } from "../../panes/browser/browser-client";
+import { StoreContext, createAppStore } from "../../state/store";
+import { fakeApi, item } from "../../state/store.test-fakes";
+
+/* ——— parseOriginInput: the validator the editor stands on (Plan 14 W4) ——— */
+
+describe("parseOriginInput", () => {
+  it("accepts origins and normalizes bare hosts onto https", () => {
+    expect(parseOriginInput("https://example.com")).toBe("https://example.com");
+    expect(parseOriginInput("  example.com  ")).toBe("https://example.com");
+    expect(parseOriginInput("https://example.com:8443")).toBe("https://example.com:8443");
+    // The origin form as browsers print it — a single trailing slash is still just the origin.
+    expect(parseOriginInput("https://example.com/")).toBe("https://example.com");
+  });
+  it("defaults loopback hosts to http, like main's normalizeAddress (dev servers speak no TLS)", () => {
+    expect(parseOriginInput("localhost:3000")).toBe("http://localhost:3000");
+    expect(parseOriginInput("127.0.0.1:8787")).toBe("http://127.0.0.1:8787");
+    expect(parseOriginInput("https://localhost:8443")).toBe("https://localhost:8443"); // explicit scheme wins
+  });
+  it("REJECTS full URLs — a stored path would silently widen to the whole origin", () => {
+    // The named mutant: validation that accepts URLs stores entries that fence more than they say.
+    expect(parseOriginInput("https://example.com/admin")).toBeNull();
+    expect(parseOriginInput("example.com/admin")).toBeNull();
+    expect(parseOriginInput("https://example.com?q=1")).toBeNull();
+    expect(parseOriginInput("https://example.com/#top")).toBeNull();
+    expect(parseOriginInput("https://user:pw@example.com")).toBeNull();
+  });
+  it("rejects non-http schemes, garbage and emptiness", () => {
+    expect(parseOriginInput("file:///etc/passwd")).toBeNull();
+    expect(parseOriginInput("data:text/html,x")).toBeNull();
+    expect(parseOriginInput("not a url")).toBeNull();
+    expect(parseOriginInput("")).toBeNull();
+    expect(parseOriginInput("   ")).toBeNull();
+  });
+});
+
+/* ——— The editor + the live re-fence ——— */
+
+function fakeHost() {
+  const setCalls: { id: string; list: string[] | null }[] = [];
+  const bridges: BrowserBridges = {
+    host: {
+      create: async () => {}, destroy: async () => {}, navigate: async () => null, nav: async () => {},
+      setAllowlist: async (id, list) => { setCalls.push({ id, list }); },
+      setBounds: () => {}, onState: () => () => {},
+    },
+    server: { get: async () => { throw new Error("unused"); }, update: async () => {}, allowlist: async () => null },
+  };
+  return { bridges, setCalls };
+}
+
+async function mount(settings: Record<string, unknown> = {}) {
+  const { bridges, setCalls } = fakeHost();
+  setBrowserBridgesForTests(bridges);
+  // The active space s1 has one OPEN browser pane (item b1) plus the default terminal — the live view
+  // the write must re-fence — and s2 exists so cross-space leakage would have somewhere to go.
+  const api = fakeApi({
+    settings,
+    items: { s1: [item("i1", "s1", { title: "Terminal" }), item("ib", "s1", { kind: "browser", refId: "b1", title: "Browser" })] },
+  });
+  const store = createAppStore(api);
+  await store.getState().boot();
+  const r = render(<StoreContext.Provider value={store}><BrowserOrigins spaceId="s1" /></StoreContext.Provider>);
+  await waitFor(() => expect(screen.queryByText("Loading…")).toBeNull());
+  return { api, store, setCalls, ...r };
+}
+
+afterEach(() => setBrowserBridgesForTests(null));
+
+describe("BrowserOrigins", () => {
+  it("surfaces the default posture honestly and carries the guardrail doctrine verbatim", async () => {
+    await mount();
+    expect(screen.getByRole("radio", { name: "All origins" })).toBeChecked();
+    expect(screen.getByText(/no list is configured, and browser panes can go anywhere/)).toBeInTheDocument();
+    expect(screen.getByText(ALLOWLIST_GUARDRAIL_NOTE)).toBeInTheDocument();
+    // Allow-all shows no add form: there is no list to add to until the posture says so.
+    expect(screen.queryByRole("textbox", { name: "Origin to allow" })).toBeNull();
+  });
+
+  it("renders a configured list with the Only listed posture", async () => {
+    await mount({ [allowlistKey("s1")]: ["https://example.com"] });
+    expect(screen.getByRole("radio", { name: "Only listed" })).toBeChecked();
+    expect(screen.getByText("https://example.com")).toBeInTheDocument();
+  });
+
+  it("adds a valid origin: persisted under the space's key AND pushed into the live pane", async () => {
+    const { api, setCalls } = await mount({ [allowlistKey("s1")]: [] });
+    fireEvent.change(screen.getByRole("textbox", { name: "Origin to allow" }), { target: { value: "example.com" } });
+    fireEvent.click(screen.getByRole("button", { name: "Add origin" }));
+    await waitFor(() => expect(screen.getByText("https://example.com")).toBeInTheDocument());
+    expect(api.calls).toContain(`setSetting:${allowlistKey("s1")}=https://example.com`);
+    // The live re-fence (the named mutant): the OPEN browser view is re-pointed without a reopen —
+    // and only the browser item, never the terminal sharing the space.
+    expect(setCalls).toEqual([{ id: "b1", list: ["https://example.com"] }]);
+  });
+
+  it("refuses a URL where an origin belongs, and persists NOTHING", async () => {
+    const { api, setCalls } = await mount({ [allowlistKey("s1")]: [] });
+    fireEvent.change(screen.getByRole("textbox", { name: "Origin to allow" }), { target: { value: "https://example.com/admin" } });
+    fireEvent.click(screen.getByRole("button", { name: "Add origin" }));
+    expect(await screen.findByRole("alert")).toHaveTextContent("Not an origin: https://example.com/admin");
+    expect(api.calls.filter((c) => c.startsWith(`setSetting:${allowlistKey("s1")}`))).toEqual([]);
+    expect(setCalls).toEqual([]);
+  });
+
+  it("removing an origin and returning to All origins both re-fence the live pane", async () => {
+    const { setCalls } = await mount({ [allowlistKey("s1")]: ["https://a.com", "https://b.com"] });
+    const row = screen.getByText("https://a.com").closest("li")!;
+    fireEvent.click(row.querySelector("button")!);
+    await waitFor(() => expect(setCalls).toEqual([{ id: "b1", list: ["https://b.com"] }]));
+    // Removing the last entry keeps the honest "nothing allowed" posture, said out loud…
+    fireEvent.click(screen.getByText("https://b.com").closest("li")!.querySelector("button")!);
+    await waitFor(() => expect(screen.getByText(/No origins listed — browser panes can't go anywhere/)).toBeInTheDocument());
+    expect(setCalls[1]).toEqual({ id: "b1", list: [] });
+    // …and All origins is the deliberate way out: null reaches the pane, not [].
+    fireEvent.click(screen.getByRole("radio", { name: "All origins" }));
+    await waitFor(() => expect(setCalls[2]).toEqual({ id: "b1", list: null }));
+  });
+
+  it("does not touch another space's panes: an inactive space's write re-fences nothing", async () => {
+    const { bridges, setCalls } = fakeHost();
+    setBrowserBridgesForTests(bridges);
+    const api = fakeApi({ items: { s1: [item("ib", "s1", { kind: "browser", refId: "b1", title: "Browser" })] } });
+    const store = createAppStore(api);
+    await store.getState().boot(); // active space is s1; the write below is for s2
+    await store.getState().setBrowserAllowlist("s2", ["https://x.com"]);
+    expect(api.calls).toContain(`setSetting:${allowlistKey("s2")}=https://x.com`);
+    expect(setCalls).toEqual([]); // s1's open pane keeps s1's fence
+  });
+});

--- a/apps/desktop/src/renderer/src/components/sidebar/mcp-section.test.tsx
+++ b/apps/desktop/src/renderer/src/components/sidebar/mcp-section.test.tsx
@@ -229,11 +229,11 @@ describe("scoped server groups (W4)", () => {
     expect(within(screen.getByRole("region", { name: "Everywhere" })).getByText("legacy")).toBeInTheDocument();
   });
 
-  it("an inherited server is NEVER editable in place: no bare Edit — 'Edit in profile' opens the same form wearing the defining-scope banner (named mutant)", async () => {
+  it("an inherited server is NEVER editable in place: no bare Edit — the banner form survives behind 'Edit here…' (named mutant)", async () => {
     await mount({ mcpServers: scopedServers() });
     const row = (await screen.findByText("shared")).closest(".mcp-row") as HTMLElement;
     expect(within(row).queryByRole("button", { name: "Edit" })).toBeNull();
-    fireEvent.click(within(row).getByRole("button", { name: "Edit in profile" }));
+    fireEvent.click(within(row).getByRole("button", { name: "Edit here…" }));
     expect(within(row).getByText("Defined in Work. Changes here apply to every space of Work.")).toBeInTheDocument();
     // Still the one shared form — same fields, same component.
     expect(within(row).getByRole("textbox", { name: "Server name" })).toBeInTheDocument();
@@ -241,6 +241,19 @@ describe("scoped server groups (W4)", () => {
     const mine = screen.getByText("mine").closest(".mcp-row") as HTMLElement;
     fireEvent.click(within(mine).getByRole("button", { name: "Edit" }));
     expect(within(mine).queryByText(/Changes here apply to every space/)).toBeNull();
+  });
+
+  it("'Edit in profile' is the PRIMARY affordance and jumps to the profile page's Connections tab (Plan 14 W2)", async () => {
+    const { store } = await mount({ mcpServers: scopedServers() });
+    const row = (await screen.findByText("shared")).closest(".mcp-row") as HTMLElement;
+    fireEvent.click(within(row).getByRole("button", { name: "Edit in profile" }));
+    await waitFor(() => expect(store.getState().items.some((i) => i.kind === "profile-page")).toBe(true));
+    expect(store.getState().profilePageTab.p1).toBe("connections");
+    // A jump, not the inline editor: no form opened in the row.
+    expect(within(row).queryByRole("textbox", { name: "Server name" })).toBeNull();
+    // A this-space row offers no jump — it is already at its defining scope.
+    const mine = screen.getByText("mine").closest(".mcp-row") as HTMLElement;
+    expect(within(mine).queryByRole("button", { name: "Edit in profile" })).toBeNull();
   });
 
   it("the inherited row's Enabled toggle rides the per-space wire with the vantage space id (named mutant: writing the defining scope)", async () => {

--- a/apps/desktop/src/renderer/src/components/sidebar/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/components/sidebar/sidebar.test.tsx
@@ -212,10 +212,13 @@ describe("Arc sidebar", () => {
     expect(pages[0]!.hasAttribute("inert")).toBe(true);
   });
 
-  it("the profile pill opens the space PAGE and + opens the new-space sheet", async () => {
+  it("the profile pill opens the PROFILE page (Plan 14 W2) and + opens the new-space sheet", async () => {
     const { store } = await mount();
     fireEvent.click(screen.getByRole("button", { name: "Work" }));
-    await waitFor(() => expect(store.getState().items.some((i) => i.kind === "space-page" && i.refId === "s1")).toBe(true));
+    // The pill names the profile, so it opens the profile page — the space page keeps its own two
+    // doors (the title row and the menu's Open space, tested below).
+    await waitFor(() => expect(store.getState().items.some((i) => i.kind === "profile-page")).toBe(true));
+    expect(store.getState().items.some((i) => i.kind === "space-page")).toBe(false);
     expect(store.getState().sheet).toBeNull();
     fireEvent.click(screen.getByRole("button", { name: "New space" }));
     expect(store.getState().sheet).toEqual({ kind: "new-space" });

--- a/apps/desktop/src/renderer/src/panes/browser/browser-client.ts
+++ b/apps/desktop/src/renderer/src/panes/browser/browser-client.ts
@@ -12,6 +12,39 @@ export function parseAllowlist(v: unknown): string[] | null {
   return v.filter((x): x is string => typeof x === "string");
 }
 
+/** The editor's posture sentence, verbatim from the enforcement's own doctrine (`originAllowed` in
+ *  Electron main / Plan 11 W1): the list is a guardrail, and pretending otherwise would be the lie. */
+export const ALLOWLIST_GUARDRAIL_NOTE =
+  "This is a guardrail against agent and user mistakes, explicitly not a security boundary — DNS rebinding, redirect chains and subresource loads can get past an origin check. Treat it as a fence, not a wall.";
+
+/**
+ * One typed allowlist entry → the ORIGIN it names, or null when it does not name one (Plan 14 W4).
+ *
+ * Origins, not URLs, deliberately: `originAllowed` compares `new URL(entry).origin`, so a stored
+ * `https://example.com/admin` would silently mean all of `https://example.com` — the editor refusing
+ * the path is what keeps the list honest about what it fences. Scheme defaults mirror main's
+ * `normalizeAddress`: bare loopback hosts get `http://` (dev servers do not speak TLS), everything
+ * else `https://`. What is stored is `URL.origin` itself — scheme-explicit, so the enforcement's
+ * default-scheme guess never has to be right about it later.
+ */
+export function parseOriginInput(input: string): string | null {
+  const raw = input.trim();
+  if (raw === "") return null;
+  let candidate = raw;
+  if (!/^[a-z][a-z0-9+.-]*:\/\//i.test(raw)) {
+    const bare = (raw.replace(/^\/*/, "").split(/[/?#]/)[0] ?? "").split(":")[0]?.toLowerCase() ?? "";
+    candidate = `${bare === "localhost" || bare === "127.0.0.1" || bare === "[::1]" ? "http" : "https"}://${raw}`;
+  }
+  let u: URL;
+  try { u = new URL(candidate); } catch { return null; }
+  if (u.protocol !== "http:" && u.protocol !== "https:") return null;
+  // A path, query, hash or credentials means the user pasted a URL, not an origin. A single "/" is
+  // the origin form as browsers print it, so it alone passes.
+  if ((u.pathname !== "/" && u.pathname !== "") || u.search !== "" || u.hash !== "" || u.username !== "" || u.password !== "") return null;
+  if (u.hostname === "") return null;
+  return u.origin;
+}
+
 /** The native side (Electron main's BrowserPaneHost, over the preload). Structural mirror of
  *  `window.realm.browser` so tests can fake it without a preload. */
 export type BrowserHostBridge = {

--- a/apps/desktop/src/renderer/src/panes/diff/DiffPane.tsx
+++ b/apps/desktop/src/renderer/src/panes/diff/DiffPane.tsx
@@ -101,7 +101,7 @@ function FileRow({ cwd, file }: { cwd: string; file: DiffFile }) {
 
 /** The ship outcome as three sentences and, where there is one, a next action. Every state named in
  *  the contract is handled here; a state with no words would be the silence W3 exists to remove. */
-function ShipReport({ cwd, result }: { cwd: string; result: ShipResult }) {
+function ShipReport({ cwd, environmentId, result }: { cwd: string; environmentId: string; result: ShipResult }) {
   const ship = useApp((s) => s.ship);
   const message = useApp((s) => s.commitMessages[cwd] ?? "");
   const run = useApp((s) => s.run);
@@ -119,7 +119,7 @@ function ShipReport({ cwd, result }: { cwd: string; result: ShipResult }) {
       {push.state === "no-upstream" && (
         <p className="ship-bad">
           {push.reason}{" "}
-          <button type="button" className="btn-quiet" onClick={() => run(() => ship({ cwd, commit: false, message, push: true, setUpstream: true, openPr: true }))}>
+          <button type="button" className="btn-quiet" onClick={() => run(() => ship({ cwd, environmentId, commit: false, message, push: true, setUpstream: true, openPr: true }))}>
             Push and set upstream
           </button>
         </p>
@@ -181,7 +181,7 @@ export function DiffPane({ item }: PaneProps) {
   const canCommit = unstageable.length > 0 && message.trim() !== "";
   const doShip = (openPr: boolean) => {
     if (!canCommit || shipping) return;
-    run(() => ship({ cwd, commit: true, message, push: openPr, setUpstream: false, openPr }));
+    run(() => ship({ cwd, environmentId, commit: true, message, push: openPr, setUpstream: false, openPr }));
   };
   const onKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) { e.preventDefault(); doShip(true); }
@@ -213,7 +213,7 @@ export function DiffPane({ item }: PaneProps) {
       </div>
 
       <div className="diff-commit">
-        {result && <ShipReport cwd={cwd} result={result} />}
+        {result && <ShipReport cwd={cwd} environmentId={environmentId} result={result} />}
         <textarea className="commit-message" aria-label="Commit message" rows={2} placeholder="Describe the change…"
           value={message} onChange={(e) => setCommitMessage(cwd, e.target.value)} onKeyDown={onKeyDown} />
         <div className="diff-commit-bar">

--- a/apps/desktop/src/renderer/src/panes/diff/diff-pane.test.tsx
+++ b/apps/desktop/src/renderer/src/panes/diff/diff-pane.test.tsx
@@ -122,7 +122,7 @@ describe("DiffPane", () => {
     fireEvent.click(button);
     await waitFor(() => expect(api.calls.some((c) => c.startsWith("ship:"))).toBe(true));
     expect(api.calls.find((c) => c.startsWith("ship:")))
-      .toBe(`ship:${CWD}|commit=true|msg=Fix the login flow|push=true|upstream=false|pr=true`);
+      .toBe(`ship:${CWD}|commit=true|msg=Fix the login flow|push=true|upstream=false|pr=true|env=env1`);
   });
 
   it("cannot ship with nothing staged", async () => {
@@ -148,6 +148,9 @@ describe("DiffPane", () => {
     // The retry must not commit again — the commit already landed.
     expect(api.calls.filter((c) => c.startsWith("ship:"))[1]).toContain("commit=false");
     expect(api.calls.filter((c) => c.startsWith("ship:"))[1]).toContain("upstream=true");
+    // The retry names the same environment: the durable log must file the pushed commit under the
+    // pane's checkout, not an unattributed cwd (Plan 14 W1).
+    expect(api.calls.filter((c) => c.startsWith("ship:"))[1]).toContain("env=env1");
   });
 
   it("gives a rejected push no fix button, only the explanation", async () => {

--- a/apps/desktop/src/renderer/src/panes/index.ts
+++ b/apps/desktop/src/renderer/src/panes/index.ts
@@ -18,3 +18,5 @@ import { NotificationsPage } from "./notifications/NotificationsPage";
 registerPane("notifications-page", NotificationsPage);
 import { SettingsPage } from "./settings/SettingsPage";
 registerPane("settings-page", SettingsPage);
+import { ProfilePage } from "./profile/ProfilePage";
+registerPane("profile-page", ProfilePage);

--- a/apps/desktop/src/renderer/src/panes/library/LibraryPage.tsx
+++ b/apps/desktop/src/renderer/src/panes/library/LibraryPage.tsx
@@ -97,6 +97,7 @@ function ProfileMemoryRow({ spaceId, profile }: { spaceId: string; profile: Prof
   const refreshProfileMemory = useApp((s) => s.refreshProfileMemory);
   const saveProfileMemoryDoc = useApp((s) => s.saveProfileMemoryDoc);
   const setProfileDocEnabled = useApp((s) => s.setProfileDocEnabled);
+  const openProfilePage = useApp((s) => s.openProfilePage);
   const run = useApp((s) => s.run);
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState<string | null>(null);
@@ -124,7 +125,12 @@ function ProfileMemoryRow({ spaceId, profile }: { spaceId: string; profile: Prof
             : `${fmt(profile.doc.length)} characters, injected before this space's own memory.`}
         </span>
       </div>
-      <button type="button" className="btn-quiet scope-move" onClick={toggleEditor}>{editing ? "Close" : "Edit in profile…"}</button>
+      {/* Plan 14 W2: the defining scope has a real page now, so "Edit in profile" JUMPS there
+          (primary); the banner-wearing inline editor below stays as the fallback behind "Edit here…". */}
+      {!editing && (
+        <button type="button" className="btn-quiet scope-move" onClick={() => run(() => openProfilePage("memory"))}>Edit in profile…</button>
+      )}
+      <button type="button" className="btn-quiet scope-move" onClick={toggleEditor}>{editing ? "Close" : "Edit here…"}</button>
       <input type="checkbox" role="switch" className="switch" aria-label={`${name} memory in this space`}
         title={`Defined in ${name} — this switch is this space's override.`}
         checked={profile.enabledHere} onChange={(e) => run(() => setProfileDocEnabled(spaceId, e.target.checked))} />

--- a/apps/desktop/src/renderer/src/panes/library/library-page.test.tsx
+++ b/apps/desktop/src/renderer/src/panes/library/library-page.test.tsx
@@ -65,10 +65,20 @@ describe("the Library page (Plan 12 W4)", () => {
     expect(api.data.profileMemoryDocs.p1).toBe("Work-wide standing instruction.");
   });
 
-  it("Edit in profile: the editor names its reach, and saving writes the PROFILE doc via memory.setProfile — the space doc untouched", async () => {
-    const { api } = await mount();
+  it("'Edit in profile…' is the PRIMARY affordance and jumps to the profile page's Memory tab (Plan 14 W2)", async () => {
+    const { store } = await mount();
     fireEvent.click(screen.getByRole("radio", { name: "Memory" }));
     fireEvent.click(await screen.findByRole("button", { name: "Edit in profile…" }));
+    await waitFor(() => expect(store.getState().items.some((i) => i.kind === "profile-page")).toBe(true));
+    expect(store.getState().profilePageTab.p1).toBe("memory");
+    // A jump, not the inline editor.
+    expect(screen.queryByRole("textbox", { name: "Work memory document" })).toBeNull();
+  });
+
+  it("Edit here: the inline fallback editor names its reach, and saving writes the PROFILE doc via memory.setProfile — the space doc untouched", async () => {
+    const { api } = await mount();
+    fireEvent.click(screen.getByRole("radio", { name: "Memory" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Edit here…" }));
     expect(screen.getByText("Defined in Work. Changes here apply to every space of Work.")).toBeInTheDocument();
     const editor = await screen.findByRole("textbox", { name: "Work memory document" });
     await waitFor(() => expect(api.calls).toContain("getProfileMemory:p1"));

--- a/apps/desktop/src/renderer/src/panes/profile/ProfilePage.tsx
+++ b/apps/desktop/src/renderer/src/panes/profile/ProfilePage.tsx
@@ -1,0 +1,297 @@
+import { MCP_SECRET_STORAGE_NOTE, MEMORY_DOC_MAX, type McpServer, type Skill } from "@realm/contracts";
+import { Icon } from "@realm/ui";
+import { useEffect, useState } from "react";
+import { useApp, type ProfilePageTab } from "../../state/store";
+import { MoveScopeConfirm } from "../../components/scoped/ScopeGroups";
+import { McpServerForm } from "../../components/sidebar/McpSection";
+import type { PaneProps } from "../registry";
+
+const PROFILE_TABS: { id: ProfilePageTab; label: string }[] = [
+  { id: "skills", label: "Skills" },
+  { id: "connections", label: "Connections" },
+  { id: "memory", label: "Memory" },
+];
+
+/** The one sentence every pre-scoping row carries here: these rows are governed per space, so the
+ *  page points at where they are actually used instead of pretending to own them. */
+const EVERYWHERE_NOTE = "Available in every space until someone moves it — manage it from a space page.";
+
+/**
+ * The profile PAGE (Plan 14 W2) — the defining-scope home W4-p12's "Edit in profile" affordances
+ * pointed at, on W3's `.page` pattern. A `profile-page` destination item (sentinel refId,
+ * `PAGE_REF_IDS`); the profile is derived LIVE from `item.spaceId`'s space — never stored — so a
+ * space moved between profiles moves its page's subject with it, and the page can never keep editing
+ * a profile its space has left (the named W2 mutant is the inverse: showing another profile's items).
+ *
+ * Each tab lists the profile's OWN items — defining scope = THIS profile — with the full editors and
+ * no banner, because this page IS the defining scope the banners named. Pre-scoping ("Everywhere")
+ * rows are listed read-only with a note pointing at their space of use; another profile's rows are
+ * not listed at all. Demote ("Keep in one space…") pins an item to the VANTAGE space, per the W2-p12
+ * semantics the shared confirm states.
+ */
+export function ProfilePage({ item }: PaneProps) {
+  const spaceId = item.spaceId;
+  const space = useApp((s) => s.spaces.find((x) => x.id === spaceId));
+  const profile = useApp((s) => s.profiles.find((p) => p.id === space?.profileId));
+  const spaces = useApp((s) => s.spaces);
+  const selectSpace = useApp((s) => s.selectSpace);
+  const tab = useApp((s) => (profile ? s.profilePageTab[profile.id] : undefined) ?? "skills");
+  const setProfilePageTab = useApp((s) => s.setProfilePageTab);
+  const run = useApp((s) => s.run);
+
+  if (!space) return <div className="pane-placeholder muted">This page's space no longer exists.</div>;
+  if (!profile) return <div className="pane-placeholder muted">This space's profile no longer exists.</div>;
+  const profileSpaces = spaces.filter((sp) => sp.profileId === profile.id);
+
+  return (
+    <div className="page profile-page-pane">
+      <header className="page-head">
+        <span className="page-glyph"><Icon name={profile.icon} size={20} /></span>
+        <div className="page-title">
+          <h1>{profile.name}</h1>
+          <span className="page-sub">Skills, connections and memory defined here reach every space of this profile.</span>
+        </div>
+      </header>
+      {/* The profile's spaces as jump chips: the page's subject is a group of spaces, and each chip
+          goes to one of them (the space switcher's own path — never a second navigation scheme). */}
+      <div className="profile-spaces" aria-label={`Spaces of ${profile.name}`}>
+        {profileSpaces.map((sp) => (
+          <button key={sp.id} type="button" className="profile-chip" title={`Switch to ${sp.name}`}
+            onClick={() => run(() => selectSpace(sp.id))}>
+            <Icon name={sp.icon} size={13} /> {sp.name}
+          </button>
+        ))}
+      </div>
+      <div className="page-body">
+        <fieldset className="page-rail">
+          <legend className="visually-hidden">Profile page section</legend>
+          {PROFILE_TABS.map((t) => (
+            <label key={t.id} className="settings-tab page-rail-tab" data-selected={tab === t.id || undefined}>
+              <input type="radio" name={`profile-page-tab-${item.id}`} value={t.id} checked={tab === t.id} onChange={() => setProfilePageTab(profile.id, t.id)} />
+              {t.label}
+            </label>
+          ))}
+        </fieldset>
+        <div className="page-content">
+          {tab === "skills" && <ProfileSkillsTab spaceId={spaceId} profileId={profile.id} profileName={profile.name} spaceName={space.name} />}
+          {tab === "connections" && <ProfileConnectionsTab spaceId={spaceId} profileId={profile.id} profileName={profile.name} spaceName={space.name} />}
+          {tab === "memory" && <ProfileMemoryTab profileId={profile.id} profileName={profile.name} />}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/** Is this row the page's OWN? Strictly the page's profile — a row scoped to any OTHER profile is
+ *  not shown here at all: rendering (or worse, editing) it would be the named W2 mutant. */
+const ownedBy = (scope: Skill["scope"] | McpServer["scope"], profileId: string) =>
+  scope.kind === "profile" && scope.profileId === profileId;
+const isEverywhere = (scope: Skill["scope"] | McpServer["scope"]) =>
+  scope.kind === "space" && scope.spaceId === null;
+
+/**
+ * The Skills tab: the profile's own skills, plus pre-scoping rows read-only. Skills have no editor at
+ * any scope (a skill IS its directory — SkillsPanel's rule), so "full editor" here means the full
+ * defining-scope affordance set: the row, and the demote move. Enablement stays per space — each
+ * space's own Skills tab holds that switch — so no toggle pretends otherwise here.
+ */
+function ProfileSkillsTab({ spaceId, profileId, profileName, spaceName }: { spaceId: string; profileId: string; profileName: string; spaceName: string }) {
+  const skills = useApp((s) => s.spaceSkills[spaceId]);
+  const refreshSkills = useApp((s) => s.refreshSkills);
+  const run = useApp((s) => s.run);
+  useEffect(() => { run(() => refreshSkills(spaceId)); }, [spaceId, refreshSkills, run]);
+
+  if (!skills) return <div className="form settings-panel"><p className="env-empty">Loading…</p></div>;
+  const own = skills.filter((sk) => ownedBy(sk.scope, profileId));
+  const everywhere = skills.filter((sk) => isEverywhere(sk.scope));
+
+  return (
+    <div className="form settings-panel">
+      <p className="settings-note">Skills here are seen by every space of {profileName}. Each space keeps its own on/off switch, on its Skills tab.</p>
+      <div className="field">
+        <span>{profileName}'s skills</span>
+        {own.length === 0
+          ? <p className="env-empty">No skills are defined at this profile yet — move one here with "Move to profile…" on a space's Skills tab.</p>
+          : <ul className="settings-list">{own.map((sk) => <ProfileSkillRow key={sk.id} spaceId={spaceId} skill={sk} profileName={profileName} spaceName={spaceName} />)}</ul>}
+      </div>
+      {everywhere.length > 0 && (
+        <div className="field">
+          <span>Everywhere</span>
+          <p className="settings-hint">{EVERYWHERE_NOTE}</p>
+          <ul className="settings-list">
+            {everywhere.map((sk) => (
+              <li key={sk.id} className="settings-row">
+                <div className="settings-row-main">
+                  <span className="settings-row-name">{sk.name}</span>
+                  <span className="settings-row-desc">{sk.valid ? sk.description : sk.reason}</span>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** One of the profile's own skills: the row plus its demote move behind the shared confirm. */
+function ProfileSkillRow({ spaceId, skill: sk, profileName, spaceName }: { spaceId: string; skill: Skill; profileName: string; spaceName: string }) {
+  const demoteSkill = useApp((s) => s.demoteSkill);
+  const run = useApp((s) => s.run);
+  const [confirming, setConfirming] = useState(false);
+  return (
+    <li className="settings-row" data-invalid={!sk.valid || undefined}>
+      <div className="settings-row-main">
+        <span className="settings-row-name">{sk.name}</span>
+        {sk.valid
+          ? <span className="settings-row-desc">{sk.description}</span>
+          : <span className="settings-row-problem"><Icon name="alert" size={12} /> {sk.reason}</span>}
+      </div>
+      {sk.valid && !confirming && (
+        <button type="button" className="btn-quiet scope-move" onClick={() => setConfirming(true)}>Keep in one space…</button>
+      )}
+      {confirming && (
+        <MoveScopeConfirm direction="demote" name={sk.name} profileName={profileName} spaceName={spaceName}
+          onCancel={() => setConfirming(false)}
+          onConfirm={() => { setConfirming(false); run(() => demoteSkill(spaceId, sk.id)); }} />
+      )}
+    </li>
+  );
+}
+
+/**
+ * The Connections tab: the profile's own MCP servers with the FULL editor — the same McpServerForm,
+ * worn without a banner, because this page is the defining scope the banner used to name — plus
+ * pre-scoping rows read-only. Fetches through the same store slot McpSection uses (clear first, so a
+ * stale space's rows never flash; the cleanup un-records the mounted panel).
+ */
+function ProfileConnectionsTab({ spaceId, profileId, profileName, spaceName }: { spaceId: string; profileId: string; profileName: string; spaceName: string }) {
+  const servers = useApp((s) => s.mcpServers);
+  const refreshMcpServers = useApp((s) => s.refreshMcpServers);
+  const clearMcpServers = useApp((s) => s.clearMcpServers);
+  const run = useApp((s) => s.run);
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- run/refreshMcpServers/clearMcpServers are stable store actions
+  useEffect(() => {
+    clearMcpServers(spaceId); run(() => refreshMcpServers(spaceId));
+    return () => clearMcpServers(null);
+  }, [spaceId]);
+
+  const own = servers.filter((sv) => ownedBy(sv.scope, profileId));
+  const everywhere = servers.filter((sv) => isEverywhere(sv.scope));
+
+  return (
+    <div className="form settings-panel">
+      <div className="field">
+        <span>{profileName}'s MCP servers</span>
+        {own.length === 0
+          ? <p className="env-empty">No servers are defined at this profile yet — move one here with "Move to profile…" on a space's Connections tab.</p>
+          : <ul className="env-list">{own.map((sv) => <ProfileServerRow key={sv.id} spaceId={spaceId} server={sv} profileName={profileName} spaceName={spaceName} />)}</ul>}
+      </div>
+      {everywhere.length > 0 && (
+        <div className="field">
+          <span>Everywhere</span>
+          <p className="settings-hint">{EVERYWHERE_NOTE}</p>
+          <ul className="env-list">
+            {everywhere.map((sv) => (
+              <li key={sv.id} className="env-row mcp-row">
+                <div className="env-main">
+                  <span className="env-name">{sv.name}</span>
+                  <span className="env-kind">{sv.transport}</span>
+                </div>
+                <div className="env-meta">
+                  <code className="env-path">{(sv.transport === "stdio" ? [sv.command, ...sv.args].filter(Boolean).join(" ") : sv.url) || "(no endpoint set)"}</code>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+      <p className="settings-note">{MCP_SECRET_STORAGE_NOTE}</p>
+    </div>
+  );
+}
+
+/** One of the profile's own servers: full edit (no banner — this IS the defining scope), removal with
+ *  its reach named, and the demote move. Enablement is per space and lives on space pages. */
+function ProfileServerRow({ spaceId, server, profileName, spaceName }: { spaceId: string; server: McpServer; profileName: string; spaceName: string }) {
+  const demoteMcpServer = useApp((s) => s.demoteMcpServer);
+  const removeMcpServer = useApp((s) => s.removeMcpServer);
+  const run = useApp((s) => s.run);
+  const [editing, setEditing] = useState(false);
+  const [confirmDelete, setConfirmDelete] = useState(false);
+  const [confirmMove, setConfirmMove] = useState(false);
+  const endpoint = server.transport === "stdio" ? [server.command, ...server.args].filter(Boolean).join(" ") : server.url;
+  return (
+    <li className="env-row mcp-row">
+      <div className="env-main">
+        <span className="env-name">{server.name}</span>
+        <span className="env-kind">{server.transport}</span>
+      </div>
+      <div className="env-meta">
+        <code className="env-path">{endpoint || "(no endpoint set)"}</code>
+      </div>
+      <div className="env-actions">
+        <button type="button" className="btn-quiet" onClick={() => setEditing((v) => !v)}>{editing ? "Close" : "Edit"}</button>
+        {!confirmMove && (
+          <button type="button" className="btn-quiet" onClick={() => setConfirmMove(true)}>Keep in one space…</button>
+        )}
+        {confirmDelete
+          ? <>
+              <span className="muted">Removes it for every space of {profileName}.</span>
+              <button type="button" className="btn-quiet" onClick={() => setConfirmDelete(false)}>Cancel</button>
+              <button type="button" className="btn-quiet danger" onClick={() => run(() => removeMcpServer(server.id))}>Remove</button>
+            </>
+          : <button type="button" className="btn-quiet" onClick={() => setConfirmDelete(true)}>Remove…</button>}
+      </div>
+      {confirmMove && (
+        <MoveScopeConfirm direction="demote" name={server.name} profileName={profileName} spaceName={spaceName}
+          onCancel={() => setConfirmMove(false)}
+          onConfirm={() => { setConfirmMove(false); run(() => demoteMcpServer(spaceId, server.id)); }} />
+      )}
+      {editing && <McpServerForm spaceId={spaceId} server={server} onDone={() => setEditing(false)} />}
+    </li>
+  );
+}
+
+const fmt = (n: number): string => n.toLocaleString("en-US");
+
+/**
+ * The Memory tab: the profile document at its defining scope, edited in full — no banner, because
+ * this page IS the scope the Library's banner editor named. The reach is still SAID (a save lands in
+ * every space of the profile), just as page copy rather than a warning about being somewhere else.
+ * Cap posture is MemoryPanel's: over MEMORY_DOC_MAX the save is refused with the overage named.
+ */
+function ProfileMemoryTab({ profileId, profileName }: { profileId: string; profileName: string }) {
+  const stored = useApp((s) => s.profileMemory[profileId]);
+  const refreshProfileMemory = useApp((s) => s.refreshProfileMemory);
+  const saveProfileMemoryDoc = useApp((s) => s.saveProfileMemoryDoc);
+  const run = useApp((s) => s.run);
+  const [draft, setDraft] = useState<string | null>(null);
+  useEffect(() => { run(() => refreshProfileMemory(profileId)); }, [profileId, refreshProfileMemory, run]);
+  useEffect(() => { setDraft(null); }, [profileId]);
+
+  if (!stored) return <div className="form settings-panel"><p className="env-empty">Loading…</p></div>;
+  const text = draft ?? stored.doc;
+  const over = text.length - MEMORY_DOC_MAX;
+  const dirty = draft !== null && draft !== stored.doc;
+
+  return (
+    <div className="form settings-panel">
+      <div className="field">
+        <span>{profileName} memory</span>
+        <p className="settings-hint">Travels into every new session in every space of {profileName}, injected before each space's own memory. Stored at <code className="env-path">{stored.path}</code>.</p>
+        <textarea className="memory-doc" aria-label={`${profileName} memory document`} value={text} rows={10} spellCheck={false}
+          onChange={(e) => setDraft(e.target.value)}
+          placeholder={`Durable context for every ${profileName} space — conventions, links, standing instructions…`} />
+        <div className="memory-meta">
+          <span className="settings-hint" data-tone={over > 0 ? "danger" : undefined}>
+            {fmt(text.length)} / {fmt(MEMORY_DOC_MAX)}
+            {over > 0 && ` — over the cap by ${fmt(over)} characters. Trim it down; Realm will not truncate it.`}
+          </span>
+          <button type="button" className="btn primary" disabled={!dirty || over > 0}
+            onClick={() => run(async () => { await saveProfileMemoryDoc(profileId, text); setDraft(null); })}>Save memory</button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/src/panes/profile/profile-page.test.tsx
+++ b/apps/desktop/src/renderer/src/panes/profile/profile-page.test.tsx
@@ -1,0 +1,160 @@
+import { describe, expect, it } from "vitest";
+import { render, screen, act, fireEvent, waitFor, within } from "@testing-library/react";
+import { PAGE_REF_IDS } from "@realm/contracts";
+import { ProfilePage } from "./ProfilePage";
+import { StoreContext, createAppStore } from "../../state/store";
+import { fakeApi, item, mcpServer, skillRow, space, type FakeData } from "../../state/store.test-fakes";
+
+/** The page pane as PaneHost mounts it: a destination item whose refId is the kind's sentinel
+ *  (Plan 14 W2) — the PROFILE is derived live from the item's space, never stored. */
+const pageItem = (spaceId: string) =>
+  item(`pg-profile-${spaceId}`, spaceId, { kind: "profile-page", title: "Profile", refId: PAGE_REF_IDS["profile-page"] });
+
+/* Defaults (fakeApi): profiles p1 "Work" / p2 "School"; spaces s1 "Versed" (p1) / s2 "Homework" (p2). */
+async function mount(overrides: FakeData = {}, spaceId = "s1") {
+  const api = fakeApi(overrides); const store = createAppStore(api); await store.getState().boot();
+  const r = render(<StoreContext.Provider value={store}><ProfilePage item={pageItem(spaceId)} visible /></StoreContext.Provider>);
+  return { store, api, ...r };
+}
+
+describe("ProfilePage · header", () => {
+  it("names the vantage space's profile and lists THAT profile's spaces as jump chips", async () => {
+    const { store } = await mount({
+      spaces: [space("s1", "p1", "Versed"), space("s3", "p1", "Side project"), space("s2", "p2", "Homework")],
+    });
+    expect(screen.getByRole("heading", { name: "Work" })).toBeInTheDocument();
+    const chips = within(screen.getByLabelText("Spaces of Work"));
+    expect(chips.getByRole("button", { name: /Versed/ })).toBeInTheDocument();
+    expect(chips.getByRole("button", { name: /Side project/ })).toBeInTheDocument();
+    // Another profile's space is not this profile's — no chip.
+    expect(chips.queryByRole("button", { name: /Homework/ })).toBeNull();
+    fireEvent.click(chips.getByRole("button", { name: /Side project/ }));
+    await waitFor(() => expect(store.getState().activeSpaceId).toBe("s3"));
+  });
+
+  it("derives the profile LIVE from the item's space — a space moved between profiles moves the page's subject", async () => {
+    const { store } = await mount();
+    expect(screen.getByRole("heading", { name: "Work" })).toBeInTheDocument();
+    // The space changes profile under the open page: the page must follow, or it would keep showing
+    // (and editing) a profile its space has left — the named W2 mutant's sibling.
+    act(() => store.setState({ spaces: store.getState().spaces.map((sp) => (sp.id === "s1" ? { ...sp, profileId: "p2" } : sp)) }));
+    expect(screen.getByRole("heading", { name: "School" })).toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "Work" })).toBeNull();
+  });
+
+  it("the rail moves between Skills, Connections and Memory", async () => {
+    await mount({ profileMemoryDocs: { p1: "profile-wide context" } });
+    expect(await screen.findByText(/Skills here are seen by every space of Work/)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("radio", { name: "Connections" }));
+    expect(await screen.findByText(/stored in plain text in Realm's database/)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("radio", { name: "Memory" }));
+    expect(await screen.findByRole("textbox", { name: "Work memory document" })).toHaveValue("profile-wide context");
+  });
+});
+
+describe("ProfilePage · Skills", () => {
+  const rows = [
+    skillRow("mine", { scope: { kind: "profile", profileId: "p1" } }),
+    skillRow("foreign", { scope: { kind: "profile", profileId: "p2" } }),
+    skillRow("legacy", { scope: { kind: "space", spaceId: null } }),
+    skillRow("space-only", { scope: { kind: "space", spaceId: "s1" } }),
+  ] as const;
+
+  it("lists the profile's OWN skills and the pre-scoping rows — never another profile's, never a space's", async () => {
+    await mount({ skills: { s1: [...rows] } });
+    const own = within(await screen.findByText("Work's skills").then((el) => el.closest(".field") as HTMLElement));
+    expect(own.getByText("mine")).toBeInTheDocument();
+    // The named W2 mutant: another profile's item surfacing (editable or at all) on this page.
+    expect(screen.queryByText("foreign")).toBeNull();
+    // A space's own row belongs to that space's page, not here.
+    expect(screen.queryByText("space-only")).toBeNull();
+    const everywhere = within(screen.getByText("Everywhere").closest(".field") as HTMLElement);
+    expect(everywhere.getByText("legacy")).toBeInTheDocument();
+    // Read-only: no move, no switch — just the note pointing at its space of use.
+    expect(everywhere.queryByRole("button")).toBeNull();
+    expect(everywhere.getByText(/manage it from a space page/)).toBeInTheDocument();
+  });
+
+  it("demote ('Keep in one space…') confirms, names the vantage space, and fires DEMOTE — never promote", async () => {
+    const { api } = await mount({ skills: { s1: [...rows] } });
+    fireEvent.click(await screen.findByRole("button", { name: "Keep in one space…" }));
+    // Nothing moved yet — the confirm is the gate.
+    expect(api.calls.some((c) => c.startsWith("demoteSkill"))).toBe(false);
+    expect(screen.getByText(/Keep “mine” in Versed only\?/)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Move to this space" }));
+    await waitFor(() => expect(api.calls).toContain("demoteSkill:s1:mine"));
+    // The named mutant: the demote confirm firing promote.
+    expect(api.calls.some((c) => c.startsWith("promoteSkill"))).toBe(false);
+  });
+});
+
+describe("ProfilePage · Connections", () => {
+  // A factory, not a shared constant: the fake mutates its rows in place, and one test's rename
+  // must not leak into the next.
+  const servers = () => [
+    mcpServer("m-own", { name: "ours", scope: { kind: "profile", profileId: "p1" } }),
+    mcpServer("m-foreign", { name: "theirs", scope: { kind: "profile", profileId: "p2" } }),
+    mcpServer("m-legacy", { name: "old-timer", scope: { kind: "space", spaceId: null } }),
+  ];
+
+  it("lists the profile's own servers with a FULL bannerless editor; pre-scoping rows are read-only", async () => {
+    await mount({ mcpServers: servers() });
+    fireEvent.click(screen.getByRole("radio", { name: "Connections" }));
+    const ownRow = (await screen.findByText("ours")).closest(".mcp-row") as HTMLElement;
+    fireEvent.click(within(ownRow).getByRole("button", { name: "Edit" }));
+    // The full editor, worn WITHOUT the defining-scope banner: this page IS the defining scope.
+    expect(within(ownRow).getByRole("textbox", { name: "Server name" })).toHaveValue("ours");
+    expect(ownRow.querySelector(".scope-note")).toBeNull();
+    // The named W2 mutant: another profile's server showing up (with or without an editor).
+    expect(screen.queryByText("theirs")).toBeNull();
+    // Pre-scoping: listed, note, no actions.
+    const legacyRow = screen.getByText("old-timer").closest(".mcp-row") as HTMLElement;
+    expect(within(legacyRow).queryByRole("button")).toBeNull();
+  });
+
+  it("saving the editor updates the one shared row", async () => {
+    const { api } = await mount({ mcpServers: servers() });
+    fireEvent.click(screen.getByRole("radio", { name: "Connections" }));
+    const ownRow = (await screen.findByText("ours")).closest(".mcp-row") as HTMLElement;
+    fireEvent.click(within(ownRow).getByRole("button", { name: "Edit" }));
+    fireEvent.change(within(ownRow).getByRole("textbox", { name: "Server name" }), { target: { value: "renamed" } });
+    fireEvent.click(within(ownRow).getByRole("button", { name: "Save" }));
+    await waitFor(() => expect(api.mcpWrites.some((w) => "id" in w && w.id === "m-own" && w.name === "renamed")).toBe(true));
+  });
+
+  it("removal names its whole-profile reach and demote fires DEMOTE — never promote", async () => {
+    const { api } = await mount({ mcpServers: servers() });
+    fireEvent.click(screen.getByRole("radio", { name: "Connections" }));
+    const ownRow = (await screen.findByText("ours")).closest(".mcp-row") as HTMLElement;
+    fireEvent.click(within(ownRow).getByRole("button", { name: "Remove…" }));
+    expect(within(ownRow).getByText("Removes it for every space of Work.")).toBeInTheDocument();
+    fireEvent.click(within(ownRow).getByRole("button", { name: "Cancel" }));
+    fireEvent.click(within(ownRow).getByRole("button", { name: "Keep in one space…" }));
+    fireEvent.click(within(ownRow).getByRole("button", { name: "Move to this space" }));
+    await waitFor(() => expect(api.calls).toContain("demoteMcpServer:s1:m-own"));
+    expect(api.calls.some((c) => c.startsWith("promoteMcpServer"))).toBe(false);
+    expect(api.calls.some((c) => c.startsWith("removeMcpServer"))).toBe(false);
+  });
+});
+
+describe("ProfilePage · Memory", () => {
+  it("edits the PROFILE doc in full — the save lands on this page's profile, no other", async () => {
+    const { api } = await mount({ profileMemoryDocs: { p1: "old", p2: "other profile's doc" } });
+    fireEvent.click(screen.getByRole("radio", { name: "Memory" }));
+    const doc = await screen.findByRole("textbox", { name: "Work memory document" });
+    expect(doc).toHaveValue("old");
+    // The reach is page copy, not a banner: this page IS the defining scope.
+    expect(screen.getByText(/every new session in every space of Work/)).toBeInTheDocument();
+    fireEvent.change(doc, { target: { value: "new profile-wide rule" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save memory" }));
+    await waitFor(() => expect(api.data.profileMemoryDocs.p1).toBe("new profile-wide rule"));
+    expect(api.data.profileMemoryDocs.p2).toBe("other profile's doc");
+  });
+});
+
+describe("ProfilePage · gone states", () => {
+  it("says so when the space (and with it the profile vantage) no longer exists", async () => {
+    await mount({}, "s-gone");
+    expect(screen.getByText("This page's space no longer exists.")).toBeInTheDocument();
+  });
+});

--- a/apps/desktop/src/renderer/src/panes/session/Composer.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/Composer.tsx
@@ -401,7 +401,12 @@ export function Composer({ session, status, gitInfo, onOpenDiff, draft, onDraftC
     { label: "New worktree…", onSelect: () => onNewWorktree?.() },
   ];
 
-  const send = () => { const t = draft.trim(); if (!t) return; onSend(t); onDraftChange(""); };
+  // Attachment-only messages (Plan 14 W5): a send needs text OR at least one attachment this agent
+  // will actually receive. Attachments whose disposition is `ignored` (non-images on Claude, anything
+  // on the fake agent) can't carry a message by themselves — the adapter would deliver literally
+  // nothing — so they don't unlock the button, and its tooltip says why.
+  const deliverable = attachments.some((a) => attachmentDisposition(kind, a.mime) !== "ignored");
+  const send = () => { const t = draft.trim(); if (!t && !deliverable) return; onSend(t); onDraftChange(""); };
   const onKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
     // ⌘/Ctrl+Enter sends even while the picker is open — the send gesture never changes meaning.
     if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) { e.preventDefault(); send(); return; }
@@ -530,12 +535,15 @@ export function Composer({ session, status, gitInfo, onOpenDiff, draft, onDraftC
               agentProbe={agentProbe} onPick={onPickModel} effortItems={effortItems} overflow={overflow} />
             {/* Send↔stop morph (§6): both icons stay in the DOM; data-state cross-fades them (160ms,
                 opacity + scale .25→1 + 4px blur). ⌘↵ still sends while running — only the button morphs. */}
-            {/* `sessions.send` requires non-empty text (rpc.ts), so attachments alone cannot be sent.
-                Rather than let the button look broken, it says why. */}
+            {/* Attachments the agent will receive can go alone (Plan 14 W5 relaxed sessions.send's
+                text.min(1) for exactly this); ones it would IGNORE cannot — rather than let the
+                button look broken there, it says why. */}
             <button className="composer-send" data-state={running ? "stop" : "send"}
               aria-label={running ? "Stop" : "Send"}
-              title={running ? "Stop (interrupt)" : (!draft.trim() && attachments.length > 0 ? "Add a message to send with these files" : "Send (⌘↵)")}
-              disabled={!running && !draft.trim()}
+              title={running ? "Stop (interrupt)"
+                : !draft.trim() && attachments.length > 0 && !deliverable ? `${AGENT_META[kind].label} ignores these attachments — add a message to send`
+                : "Send (⌘↵)"}
+              disabled={!running && !draft.trim() && !deliverable}
               onClick={() => (running ? onStop() : send())}>
               <Icon name="arrowUp" size={16} className="send-icon" />
               <Icon name="stop" size={13} className="stop-icon" />

--- a/apps/desktop/src/renderer/src/panes/session/Composer.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/Composer.tsx
@@ -1,4 +1,4 @@
-import { AGENT_META, AGENT_SUPPORTS_PERMISSION_MODES, AGENT_SUPPORTS_PLAN_MODE, EFFORT_LEVELS, PERMISSION_MODES, PLAN_PERMISSION_MODE, SESSION_MODES, attachmentDisposition, attachmentNote, attachmentSummary, formatAttachmentSize, isImageMime, type AgentKind, type Environment, type GitInfo, type McpServer, type Session, type SessionMode, type SessionStatus, type Skill } from "@realm/contracts";
+import { AGENT_META, AGENT_SUPPORTS_PERMISSION_MODES, AGENT_SUPPORTS_PLAN_MODE, EFFORT_LEVELS, PERMISSION_MODES, PLAN_PERMISSION_MODE, SESSION_MODES, acpPlanMode, attachmentDisposition, attachmentNote, attachmentSummary, formatAttachmentSize, isImageMime, type AcpSessionMode, type AgentKind, type Environment, type GitInfo, type McpServer, type Session, type SessionMode, type SessionStatus, type Skill } from "@realm/contracts";
 import { Icon } from "@realm/ui";
 import { useEffect, useLayoutEffect, useMemo, useRef, useState, type ClipboardEvent, type DragEvent, type KeyboardEvent, type ReactNode } from "react";
 import { Menu, type MenuItem } from "../../components/Menu";
@@ -207,7 +207,21 @@ function PlusMenu({ onAttachPick, onAddFolder, onSkills, canSkills, connectors, 
  *  ⌘/Ctrl+Enter sends; Enter inserts a newline. The draft text is owned by the store (keyed by
  *  session id, A-M9) so a suggestion chip can fill it without sending — and layout reshapes never
  *  lose it. */
-export function Composer({ session, status, gitInfo, onOpenDiff, draft, onDraftChange, attachments, onAttachPick, onAttachFiles, onRemoveAttachment, onSend, onStop, onOptions, onPickModel, onMode, planReturn, canSwitchAgent, agentProbe, hero, spaceName, onSuggestion, mentionSkills = [], staleMentions = [], machineName = "", environments = [], onSelectEnvironment, onNewWorktree, connectors = null, onConnectorsOpened, onAddFolder, onManageConnections }: {
+/**
+ * What Plan MEANS for this agent — the chip title's honesty clause (Plan 14 W3). Claude and Codex have
+ * Realm-transmitted plan semantics; an ACP agent's Plan is its OWN mode, described in its own words
+ * where it offered any.
+ */
+function planMeaning(kind: AgentKind, acpPlan: AcpSessionMode | null): string {
+  if (acpPlan) {
+    const label = AGENT_META[kind].label;
+    return acpPlan.description ? `Plan is ${label}'s own ${acpPlan.name} mode: ${acpPlan.description}` : `Plan is ${label}'s own ${acpPlan.name} mode`;
+  }
+  if (kind === "codex") return "Plan runs the turn read-only under an untrusted approval policy — the agent proposes, but does not edit";
+  return "Plan means the agent researches and proposes, but does not edit";
+}
+
+export function Composer({ session, status, gitInfo, onOpenDiff, draft, onDraftChange, attachments, onAttachPick, onAttachFiles, onRemoveAttachment, onSend, onStop, onOptions, onPickModel, onMode, planReturn, canSwitchAgent, agentProbe, hero, spaceName, onSuggestion, mentionSkills = [], staleMentions = [], machineName = "", environments = [], onSelectEnvironment, onNewWorktree, connectors = null, onConnectorsOpened, onAddFolder, onManageConnections, acpModes = null }: {
   session: Session; status: SessionStatus; gitInfo: GitInfo | null;
   /** Open the diff pane for the session's checkout (W3) — what the branch/diff chips do. */
   onOpenDiff: () => void;
@@ -224,6 +238,10 @@ export function Composer({ session, status, gitInfo, onOpenDiff, draft, onDraftC
   onPickModel: (kind: AgentKind, modelId: string | null) => void;
   /** Build ⇄ Plan. The store parks and restores the permission mode around the trip. */
   onMode: (mode: SessionMode) => void;
+  /** ACP sessions only (Plan 14 W3): the agent's OWN modes as the session's init event carried them —
+   *  null until the handshake has been seen, [] when it named none. What decides whether Build/Plan
+   *  exists HERE, per session; the static AGENT_SUPPORTS_PLAN_MODE table answers for the other kinds. */
+  acpModes?: AcpSessionMode[] | null;
   /** The permission mode Plan is holding for this session, if any — what returning to Build restores. */
   planReturn: string | null;
   /** False once the session has produced an event — see ModelPicker. */
@@ -264,7 +282,15 @@ export function Composer({ session, status, gitInfo, onOpenDiff, draft, onDraftC
   // Hidden exactly like the model menu is empty when the agent has no models: an option Realm cannot
   // transmit is worse than no option at all.
   const canSetPermissionMode = AGENT_SUPPORTS_PERMISSION_MODES[kind];
-  const canPlan = AGENT_SUPPORTS_PLAN_MODE[kind];
+  // Build/Plan (Plan 14 W3): static for the kinds whose adapters act on Realm's plan wire value,
+  // per-SESSION for ACP kinds — their mode ids are agent-defined, so the chip exists exactly when
+  // THIS session's handshake advertised a plan-equivalent. No handshake yet on a session that has
+  // started = the brief materialization window: the chip renders disabled (a static label) rather
+  // than promising a mapping that may not exist. A fresh session shows nothing at all.
+  const isAcpKind = kind.startsWith("acp:");
+  const acpPlan = isAcpKind ? acpPlanMode(acpModes) : null;
+  const canPlan = isAcpKind ? acpPlan !== null : AGENT_SUPPORTS_PLAN_MODE[kind];
+  const acpModesPending = isAcpKind && acpModes === null && !canSwitchAgent && status !== "error" && status !== "ended";
   const inPlan = session.permissionMode === PLAN_PERMISSION_MODE;
   // bypassPermissions must never be a one-click slip (U-M7): selecting it arms an inline confirm chip
   // for 5s while the chip simply stays on the current mode; only the explicit confirm applies it.
@@ -481,8 +507,15 @@ export function Composer({ session, status, gitInfo, onOpenDiff, draft, onDraftC
                     label={permissionLabel(session.permissionMode)} items={permissionItems} />
             )}
             {canPlan && (
-              <ChipMenu ariaLabel="Mode" title={inPlan ? "Mode: Plan — the agent researches and proposes, but does not edit" : "Mode: Build"}
+              <ChipMenu ariaLabel="Mode" title={`Mode: ${inPlan ? "Plan" : "Build"}. ${planMeaning(kind, acpPlan)}`}
                 icon={inPlan ? "plan" : "tool"} label={inPlan ? "Plan" : "Build"} items={modeItems} />
+            )}
+            {/* The materialize-honestly window: the session is live but the agent has not named its
+                modes yet. Disabled (a static label, out of the tab order) rather than absent, so the
+                chip does not pop into a row the user is already aiming at — and rather than enabled,
+                because offering Plan before the agent has said it exists would be a guess. */}
+            {!canPlan && acpModesPending && (
+              <ChipMenu ariaLabel="Mode" title="Waiting for the agent's modes" icon="tool" label="Build" items={[]} />
             )}
             <GitChip gitInfo={gitInfo} onOpenDiff={onOpenDiff} />
             {confirmBypass && (

--- a/apps/desktop/src/renderer/src/panes/session/SessionPane.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/SessionPane.tsx
@@ -230,6 +230,9 @@ export function SessionPane({ item, visible, focused = false }: PaneProps) {
               if (modelId !== null) await setSessionOptions(id, { model: modelId });
             })}
             onMode={(mode) => run(() => setSessionMode(id, mode))} planReturn={planReturn}
+            // The agent's own modes off THIS session's init event (Plan 14 W3): null = handshake not
+            // seen yet, [] = the agent named none — the difference between "wait" and "no Plan here".
+            acpModes={transcript.init ? transcript.init.availableModes ?? [] : null}
             canSwitchAgent={canSwitchAgent}
             agentProbe={agentProbe}
             mentionSkills={mentionSkills} staleMentions={staleMentions}

--- a/apps/desktop/src/renderer/src/panes/session/Transcript.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/Transcript.tsx
@@ -1,6 +1,6 @@
 import { Icon } from "@realm/ui";
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
-import type { SessionStatus } from "@realm/contracts";
+import { basenameOf, isImageMime, type SessionStatus } from "@realm/contracts";
 import type { PermissionDecision } from "../../state/store";
 import { Markdown } from "./Markdown";
 import { PermissionCard } from "./PermissionCard";
@@ -72,7 +72,24 @@ export function Transcript({ transcript, sessionStatus, onDecide, visible = true
               steps={it.steps.map((s) => ({ ...s, enter: isEntering(s.key) }))} />;
           const b = it.block, key = it.key, enter = isEntering(key);
           switch (b.kind) {
-            case "user": return <div key={key} className="msg-user-row" data-enter={enter || undefined}><div className="msg-user">{b.text}</div></div>;
+            case "user": return (
+              // Attachments render as their own line of file chips (Plan 14 W5): an attachment-only
+              // message has no text at all, and an empty bubble would look like a send that lost its
+              // words rather than one that carried files.
+              <div key={key} className="msg-user-row" data-enter={enter || undefined}>
+                <div className="msg-user">
+                  {b.text}
+                  {b.attachments && (
+                    <span className="msg-user-files" aria-label="Attached files">
+                      {b.attachments.map((a) => (
+                        <span key={a.path} className="msg-user-file" title={a.path}>
+                          <Icon name={isImageMime(a.mime) ? "image" : "artifact"} size={11} /> {basenameOf(a.path)}
+                        </span>
+                      ))}
+                    </span>
+                  )}
+                </div>
+              </div>);
             case "assistant": return <Markdown key={key} className="msg-assistant" text={b.text} streaming={b.streaming} enter={enter} />;
             case "thinking": return <Thinking key={key} text={b.text} enter={enter} />;
             case "tool": return <ToolCard key={key} block={b} sessionStatus={sessionStatus} enter={enter} />;

--- a/apps/desktop/src/renderer/src/panes/session/session-pane.test.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/session-pane.test.tsx
@@ -874,6 +874,44 @@ describe("prompter mode chip (Build / Plan)", () => {
   });
 });
 
+describe("attachment-only send (Plan 14 W5)", () => {
+  const png = { path: "/tmp/a.png", mime: "image/png", name: "a.png", size: 10 };
+  const pdf = { path: "/tmp/notes.pdf", mime: "application/pdf", name: "notes.pdf", size: 10 };
+
+  it("a deliverable attachment unlocks Send with an empty draft, and the send carries empty text", async () => {
+    const { api, store } = await mountFresh(); // claude: images are delivered inline
+    act(() => store.setState({ pendingAttachments: { se1: [png] } }));
+    const btn = screen.getByRole("button", { name: "Send" });
+    expect(btn).not.toBeDisabled();
+    expect(btn.title).toBe("Send (⌘↵)");
+    fireEvent.click(btn);
+    await waitFor(() => expect(api.sent).toEqual([{ id: "se1", text: "", attachments: [{ path: "/tmp/a.png", mime: "image/png" }] }]));
+  });
+
+  it("attachments the agent IGNORES cannot carry a message alone — Send stays off and says why", async () => {
+    // The named mutant's UI half: Claude drops non-images entirely, so a PDF-only send would deliver
+    // literally nothing. The gate refuses; the tooltip names the agent and the fix.
+    const { api, store } = await mountFresh();
+    act(() => store.setState({ pendingAttachments: { se1: [pdf] } }));
+    const btn = screen.getByRole("button", { name: "Send" });
+    expect(btn).toBeDisabled();
+    expect(btn.title).toBe("Claude ignores these attachments — add a message to send");
+    fireEvent.click(btn);
+    expect(api.sent).toEqual([]);
+    // One ignored + one deliverable: the deliverable one unlocks the send again.
+    act(() => store.setState({ pendingAttachments: { se1: [pdf, png] } }));
+    expect(screen.getByRole("button", { name: "Send" })).not.toBeDisabled();
+  });
+
+  it("an empty draft with no attachments still sends nothing", async () => {
+    const { api } = await mountFresh();
+    const btn = screen.getByRole("button", { name: "Send" });
+    expect(btn).toBeDisabled();
+    fireEvent.keyDown(screen.getByRole("textbox", { name: /message/i }), { key: "Enter", metaKey: true });
+    expect(api.sent).toEqual([]);
+  });
+});
+
 describe("ACP mode chip — per-session modes (Plan 14 W3)", () => {
   // The real cursor-agent 2026.07.25 triple, as the adapter's init event carries it.
   const CURSOR_MODES = [
@@ -1527,13 +1565,15 @@ describe("prompter attachments", () => {
     expect(chips()[0]).toContain("a.png");
   });
 
-  it("with attachments but no text the send button says why it is disabled", async () => {
+  it("with a deliverable attachment and no text the send button is LIVE — attachments carry the message (Plan 14 W5)", async () => {
+    // Until Plan 14 W5 this asserted the opposite (`sessions.send` required non-empty text). The
+    // relaxation is the plan's own: a Codex image rides as a localImage item with no text at all.
     await mountFor("codex", [picked("/x/a.png", "image/png")]);
     attach();
     await waitFor(() => expect(chips()).toHaveLength(1));
     const send = screen.getByRole("button", { name: "Send" });
-    expect(send).toBeDisabled();
-    expect(send).toHaveAttribute("title", "Add a message to send with these files");
+    expect(send).not.toBeDisabled();
+    expect(send).toHaveAttribute("title", "Send (⌘↵)");
   });
 
   it("shows no chip row and no notes with nothing attached", async () => {

--- a/apps/desktop/src/renderer/src/panes/session/session-pane.test.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/session-pane.test.tsx
@@ -874,6 +874,73 @@ describe("prompter mode chip (Build / Plan)", () => {
   });
 });
 
+describe("ACP mode chip — per-session modes (Plan 14 W3)", () => {
+  // The real cursor-agent 2026.07.25 triple, as the adapter's init event carries it.
+  const CURSOR_MODES = [
+    { id: "agent", name: "Agent", description: "Full agent capabilities with tool access" },
+    { id: "plan", name: "Plan", description: "Read-only mode for planning and designing before implementation" },
+    { id: "ask", name: "Ask", description: "Q&A mode - no edits or command execution" },
+  ];
+  const initEvent = (availableModes?: typeof CURSOR_MODES) =>
+    sessionEvent("init", { providerSessionId: "sess_0", model: "composer", tools: [], cwd: "/w", ...(availableModes ? { availableModes } : {}) });
+
+  /** A cursor session whose transcript already holds `events` (lastSeq > 0 ⇒ the session has started). */
+  async function mountCursor(events: ReturnType<typeof sessionEvent>[], extra: Partial<Parameters<typeof session>[2]> = {}) {
+    const api = fakeApi({ sessions: [session("se1", "s1", { status: "idle", agentKind: "acp:cursor", lastEventSeq: events.length, ...extra })] });
+    const store = createAppStore(api); await store.getState().boot();
+    store.setState({ sessionStatus: { se1: "idle" }, transcripts: { se1: { lastSeq: events.length, t: reduceAll(events) } } });
+    const r = render(<StoreContext.Provider value={store}><SessionPane item={item("i9", "s1", { kind: "session", refId: "se1", title: "s" })} visible /></StoreContext.Provider>);
+    return { api, store, ...r };
+  }
+
+  it("renders a DISABLED chip while a started session's handshake is still pending", async () => {
+    // The materialize-honestly window: events exist, no init yet. A static label, not a button —
+    // offering Plan before the agent has named its modes would be a guess.
+    await mountCursor([sessionEvent("user_message", { text: "go", attachments: [] })]);
+    expect(screen.queryByRole("button", { name: "Mode" })).toBeNull();
+    const waiting = document.querySelector('.ghost-chip[data-static][title="Waiting for the agent\'s modes"]');
+    expect(waiting).not.toBeNull();
+    expect(waiting).toHaveTextContent("Build");
+  });
+
+  it("enables the chip once the init event carries a plan-equivalent, described in the agent's own words", async () => {
+    await mountCursor([sessionEvent("user_message", { text: "go", attachments: [] }), initEvent(CURSOR_MODES)]);
+    const chip = screen.getByRole("button", { name: "Mode" });
+    expect(chip).toHaveTextContent("Build");
+    expect(chip.title).toContain("Cursor's own Plan mode");
+    expect(chip.title).toContain("Read-only mode for planning and designing before implementation");
+    expect(document.querySelector('.ghost-chip[data-static][title="Waiting for the agent\'s modes"]')).toBeNull();
+  });
+
+  it("shows NO chip for a session whose modes lack a plan-equivalent", async () => {
+    // The named mutant: a chip here would drive session/set_mode toward a mode that does not exist.
+    await mountCursor([sessionEvent("user_message", { text: "go", attachments: [] }),
+      initEvent([{ id: "agent", name: "Agent", description: "d" }, { id: "ask", name: "Ask", description: "d" }])]);
+    expect(screen.queryByRole("button", { name: "Mode" })).toBeNull();
+    expect(document.querySelector('.ghost-chip[data-static][title="Waiting for the agent\'s modes"]')).toBeNull();
+  });
+
+  it("shows NO chip when the agent named no modes at all", async () => {
+    await mountCursor([sessionEvent("user_message", { text: "go", attachments: [] }), initEvent()]);
+    expect(screen.queryByRole("button", { name: "Mode" })).toBeNull();
+    expect(document.querySelector('.ghost-chip[data-static][title="Waiting for the agent\'s modes"]')).toBeNull();
+  });
+
+  it("enters and leaves Plan WITHOUT the Claude-shaped permission park", async () => {
+    // Cursor's Plan is its own mode: there is no chosen permission to preserve, so nothing is parked
+    // and Build returns the row to its resting default.
+    const { store } = await mountCursor([sessionEvent("user_message", { text: "go", attachments: [] }), initEvent(CURSOR_MODES)]);
+    fireEvent.click(screen.getByRole("button", { name: "Mode" }));
+    fireEvent.click(screen.getByRole("menuitemcheckbox", { name: "Plan" }));
+    await waitFor(() => expect(store.getState().sessions.se1?.permissionMode).toBe("plan"));
+    expect(store.getState().planReturn.se1).toBeUndefined(); // no park for an agent with no permission axis
+    expect(screen.getByRole("button", { name: "Mode" })).toHaveTextContent("Plan");
+    fireEvent.click(screen.getByRole("button", { name: "Mode" }));
+    fireEvent.click(screen.getByRole("menuitemcheckbox", { name: "Build" }));
+    await waitFor(() => expect(store.getState().sessions.se1?.permissionMode).toBe("default"));
+  });
+});
+
 describe("prompter model picker", () => {
   const rowNames = () => screen.getAllByRole("option").map((n) => n.querySelector(".mp-row-name")!.textContent);
 

--- a/apps/desktop/src/renderer/src/panes/session/transcript-model.ts
+++ b/apps/desktop/src/renderer/src/panes/session/transcript-model.ts
@@ -1,4 +1,4 @@
-import type { SessionEvent } from "@realm/contracts";
+import type { AcpSessionMode, SessionEvent } from "@realm/contracts";
 
 export type Block =
   | { kind: "user"; text: string; ts: number }
@@ -14,7 +14,9 @@ export type Transcript = {
   /** Open permission requests, oldest first (an agent may ask for several tools at once). */
   pendingPermissions: PendingPermission[];
   usage: Usage;
-  init: { model: string; tools: string[]; providerSessionId: string } | null;
+  /** `availableModes`: the agent's OWN session modes as the init event carried them (Plan 14 W3) —
+   *  undefined when the agent named none. Per-session ground truth for the ACP Build/Plan chip. */
+  init: { model: string; tools: string[]; providerSessionId: string; availableModes?: AcpSessionMode[] } | null;
 };
 
 /** Stable render identity for a block. Tool calls key on their own id so a card keeps its expanded
@@ -61,7 +63,7 @@ export function reduceTranscript(t: Transcript, e: SessionEvent): Transcript {
     }
     case "error": blocks.push({ kind: "error", message: e.payload.message, ts: e.ts }); return { ...t, blocks };
     case "usage": return { ...t, usage: e.payload };
-    case "init": return { ...t, init: { model: e.payload.model, tools: e.payload.tools, providerSessionId: e.payload.providerSessionId } };
+    case "init": return { ...t, init: { model: e.payload.model, tools: e.payload.tools, providerSessionId: e.payload.providerSessionId, ...(e.payload.availableModes ? { availableModes: e.payload.availableModes } : {}) } };
     case "status": return t;
   }
 }

--- a/apps/desktop/src/renderer/src/panes/session/transcript-model.ts
+++ b/apps/desktop/src/renderer/src/panes/session/transcript-model.ts
@@ -1,7 +1,9 @@
 import type { AcpSessionMode, SessionEvent } from "@realm/contracts";
 
 export type Block =
-  | { kind: "user"; text: string; ts: number }
+  /** `attachments` present only when the message carried any — an attachment-only message (Plan 14
+   *  W5) still renders a bubble naming its files rather than an empty one. */
+  | { kind: "user"; text: string; attachments?: { path: string; mime: string }[]; ts: number }
   | { kind: "assistant"; messageId: string; text: string; streaming: boolean; ts: number }
   | { kind: "thinking"; messageId: string; text: string; ts: number }
   | { kind: "tool"; toolUseId: string; name: string; input: Record<string, unknown>; result: { content: string; isError: boolean } | null; ts: number }
@@ -33,7 +35,7 @@ const findLast = (blocks: Block[], pred: (b: Block) => boolean): number => { for
 export function reduceTranscript(t: Transcript, e: SessionEvent): Transcript {
   const blocks = t.blocks.slice(); const last = blocks.at(-1);
   switch (e.type) {
-    case "user_message": blocks.push({ kind: "user", text: e.payload.text, ts: e.ts }); return { ...t, blocks };
+    case "user_message": blocks.push({ kind: "user", text: e.payload.text, ...(e.payload.attachments.length ? { attachments: e.payload.attachments } : {}), ts: e.ts }); return { ...t, blocks };
     case "assistant_delta": {
       if (last?.kind === "assistant" && last.messageId === e.payload.messageId && last.streaming) blocks[blocks.length - 1] = { ...last, text: last.text + e.payload.delta };
       else blocks.push({ kind: "assistant", messageId: e.payload.messageId, text: e.payload.delta, streaming: true, ts: e.ts });

--- a/apps/desktop/src/renderer/src/panes/settings/SettingsPage.tsx
+++ b/apps/desktop/src/renderer/src/panes/settings/SettingsPage.tsx
@@ -188,6 +188,9 @@ function AppTab() {
             </label>
           ))}
         </fieldset>
+        {/* One line, not a switch (Plan 14 W5): the OS setting is the control, and styles.css's global
+            prefers-reduced-motion kill is what makes this sentence true. */}
+        <p className="settings-hint">Realm follows the system's Reduce Motion setting everywhere — with it on, animations and transitions are disabled app-wide.</p>
       </div>
 
       <div className="field"><span>Notifications</span>

--- a/apps/desktop/src/renderer/src/panes/space/SpacePage.tsx
+++ b/apps/desktop/src/renderer/src/panes/space/SpacePage.tsx
@@ -1,4 +1,4 @@
-import { AGENT_META, SPACE_COLORS, SPACE_ICONS, type Checkpoint, type Session } from "@realm/contracts";
+import { AGENT_META, SPACE_COLORS, SPACE_ICONS, type Checkpoint, type Environment, type Session, type Ship } from "@realm/contracts";
 import { Icon } from "@realm/ui";
 import { useEffect, useRef, useState } from "react";
 import { useApp, type SpacePageTab } from "../../state/store";
@@ -200,18 +200,33 @@ function SessionsTab({ spaceId }: { spaceId: string }) {
 
 const CP_KIND_LABEL: Record<Checkpoint["kind"], string> = { turn: "Turn", "pre-restore": "Undo point", manual: "Manual" };
 
+/** The push leg's outcome as row copy. Verbatim from the log — a row must never say more than the
+ *  push actually did (a rejected push saying "pushed" is the named W1 mutant, on the write side). */
+const PUSH_STATE_LABEL: Record<Ship["pushState"], string> = {
+  pushed: "pushed", "up-to-date": "up to date", "no-remote": "no remote", "no-upstream": "no upstream",
+  rejected: "push rejected", detached: "detached", skipped: "not pushed", failed: "push failed",
+};
+
+/** One row per union member, typed so the sort below cannot silently drop a source. */
+type HistoryRow =
+  | { kind: "checkpoint"; at: number; key: string; c: Checkpoint; env: Environment }
+  | { kind: "ship"; at: number; key: string; ship: Ship };
+
 /**
- * The History tab: the union of `checkpoints.list` across this space's environments, newest first.
+ * The History tab: checkpoints ∪ ships (Plan 14 W1), interleaved newest first.
  *
- * Checkpoints ONLY, and the empty copy says so: ships (the diff pane's commit/push/PR results) are
- * per-run client state (`shipResults`, keyed by cwd, gone on reload) — there is no durable ship log
- * server-side, and this tab does not invent one. Restoring goes through the existing checkpoints
- * sheet, which owns the preview/acknowledge flow.
+ * Checkpoints come from `checkpoints.list` across this space's environments; ships from the durable
+ * `ships.list` log — one row per commit/push that actually happened, surviving reload, so the old
+ * "commits are not recorded durably" apology is gone because it stopped being true. The two get
+ * distinct row treatments: a checkpoint row opens the checkpoints sheet (restore lives there); a
+ * ship row is a record — its one action is the PR link, when the ship produced one.
  */
 function HistoryTab({ spaceId }: { spaceId: string }) {
   const environments = useApp((s) => s.environments);
   const checkpoints = useApp((s) => s.checkpoints);
+  const ships = useApp((s) => s.ships[spaceId]);
   const refreshCheckpoints = useApp((s) => s.refreshCheckpoints);
+  const refreshShips = useApp((s) => s.refreshShips);
   const openCheckpoints = useApp((s) => s.openCheckpoints);
   const run = useApp((s) => s.run);
   const envs = Object.values(environments).filter((e) => e.spaceId === spaceId);
@@ -219,30 +234,48 @@ function HistoryTab({ spaceId }: { spaceId: string }) {
   useEffect(() => {
     for (const id of envIdsKey.split(",")) if (id) run(() => refreshCheckpoints(id, null));
   }, [envIdsKey, refreshCheckpoints, run]);
+  useEffect(() => { run(() => refreshShips(spaceId)); }, [spaceId, refreshShips, run]);
 
-  const all = envs
-    .flatMap((e) => (checkpoints[e.id] ?? []).map((c) => ({ c, env: e })))
-    .sort((a, b) => b.c.createdAt - a.c.createdAt);
+  const all: HistoryRow[] = [
+    ...envs.flatMap((e) => (checkpoints[e.id] ?? []).map((c): HistoryRow => ({ kind: "checkpoint", at: c.createdAt, key: `cp-${c.id}`, c, env: e }))),
+    ...(ships ?? []).map((s): HistoryRow => ({ kind: "ship", at: s.createdAt, key: `ship-${s.id}`, ship: s })),
+  ].sort((a, b) => b.at - a.at);
 
-  if (envs.length === 0 || all.length === 0) {
+  if (all.length === 0) {
     return (
       <p className="env-empty">
-        No checkpoints yet — Realm takes one before every turn, so this fills up as the space works.
-        Commits shipped from the diff pane are not recorded durably, so they do not appear here.
+        Nothing here yet — Realm takes a checkpoint before every turn and records every commit shipped
+        from the diff pane, so this fills up as the space works.
       </p>
     );
   }
   return (
     <ul className="page-list">
-      {all.map(({ c, env }) => (
-        <li key={c.id}>
-          <button type="button" className="page-row" aria-label={`${c.label} — open checkpoints for ${env.branch ?? env.path}`}
-            onClick={() => run(() => openCheckpoints(env.id, null))}>
-            <span className="cp-kind">{CP_KIND_LABEL[c.kind]}</span>
-            <span className="page-row-title">{c.label}</span>
-            <span className="page-row-dim">{env.branch ?? env.path.replace(/\/+$/, "").split("/").pop()}</span>
-            <span className="page-row-dim">{relativeTime(c.createdAt, Date.now())}</span>
+      {all.map((row) => row.kind === "checkpoint" ? (
+        <li key={row.key}>
+          <button type="button" className="page-row" aria-label={`${row.c.label} — open checkpoints for ${row.env.branch ?? row.env.path}`}
+            onClick={() => run(() => openCheckpoints(row.env.id, null))}>
+            <span className="cp-kind">{CP_KIND_LABEL[row.c.kind]}</span>
+            <span className="page-row-title">{row.c.label}</span>
+            <span className="page-row-dim">{row.env.branch ?? row.env.path.replace(/\/+$/, "").split("/").pop()}</span>
+            <span className="page-row-dim">{relativeTime(row.at, Date.now())}</span>
           </button>
+        </li>
+      ) : (
+        <li key={row.key}>
+          <div className="page-row ship-row" aria-label={`Shipped ${row.ship.subject}`}>
+            <span className="cp-kind ship-kind"><Icon name="commit" size={12} /> Ship</span>
+            <span className="page-row-title">{row.ship.subject}</span>
+            <span className="page-row-dim"><code className="ship-sha">{row.ship.sha.slice(0, 7)}</code></span>
+            {row.ship.branch && <span className="page-row-dim"><Icon name="branch" size={11} /> {row.ship.branch}</span>}
+            <span className="page-row-dim">{PUSH_STATE_LABEL[row.ship.pushState]}</span>
+            {row.ship.prUrl && (
+              <span className="page-row-dim">
+                <a href={row.ship.prUrl} target="_blank" rel="noreferrer"><Icon name="pullRequest" size={11} /> PR</a>
+              </span>
+            )}
+            <span className="page-row-dim">{relativeTime(row.at, Date.now())}</span>
+          </div>
         </li>
       ))}
     </ul>

--- a/apps/desktop/src/renderer/src/panes/space/SpacePage.tsx
+++ b/apps/desktop/src/renderer/src/panes/space/SpacePage.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from "react";
 import { useApp, type SpacePageTab } from "../../state/store";
 import { relativeTime } from "../../components/CheckpointsSheet";
 import { McpSection } from "../../components/sidebar/McpSection";
+import { BrowserOrigins } from "../../components/sidebar/BrowserOrigins";
 import { SkillsPanel } from "../../components/settings/SkillsPanel";
 import { MemoryPanel } from "../../components/settings/MemoryPanel";
 import type { PaneProps } from "../registry";
@@ -350,7 +351,12 @@ export function SpacePage({ item }: PaneProps) {
           {tab === "skills" && <SkillsPanel spaceId={spaceId} />}
           {/* Plan 9's gateway-era MCP surface IS this tab — one settings surface for one set of
               servers, exactly as it was in the retired sheet. */}
-          {tab === "connections" && <McpSection spaceId={spaceId} />}
+          {tab === "connections" && <>
+            <McpSection spaceId={spaceId} />
+            {/* The per-space browser origin allowlist (Plan 14 W4) — same tab as the other things
+                agents reach out through. Its own settings-panel block, below the servers. */}
+            <div className="form settings-panel"><BrowserOrigins spaceId={spaceId} /></div>
+          </>}
           {tab === "sessions" && <SessionsTab spaceId={spaceId} />}
           {tab === "history" && <HistoryTab spaceId={spaceId} />}
         </div>

--- a/apps/desktop/src/renderer/src/panes/space/space-page.test.tsx
+++ b/apps/desktop/src/renderer/src/panes/space/space-page.test.tsx
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { render, screen, act, fireEvent, waitFor, within } from "@testing-library/react";
 import { SpacePage } from "./SpacePage";
 import { StoreContext, createAppStore } from "../../state/store";
-import { fakeApi, checkpoint, item, session, type FakeData } from "../../state/store.test-fakes";
+import { fakeApi, checkpoint, item, session, shipRow, type FakeData } from "../../state/store.test-fakes";
 import type { Environment } from "@realm/contracts";
 
 /** The page pane as PaneHost mounts it: an item whose refId is the SPACE id (Plan 12 W3). */
@@ -60,7 +60,7 @@ describe("SpacePage · General", () => {
     fireEvent.click(screen.getByRole("radio", { name: "Sessions" }));
     expect(screen.getByText(/No sessions in this space yet/)).toBeInTheDocument();
     fireEvent.click(screen.getByRole("radio", { name: "History" }));
-    expect(screen.getByText(/No checkpoints yet/)).toBeInTheDocument();
+    expect(screen.getByText(/Nothing here yet/)).toBeInTheDocument();
     fireEvent.click(screen.getByRole("radio", { name: "General" }));
     expect(screen.getByRole("textbox", { name: "Space name" })).toBeInTheDocument();
   });
@@ -208,10 +208,60 @@ describe("the History tab", () => {
     await waitFor(() => expect(store.getState().sheet).toEqual({ kind: "checkpoints", environmentId: "envA", sessionId: null }));
   });
 
-  it("the empty state says checkpoints will come — and is honest that ships are not recorded", async () => {
+  it("the empty state names both sources — and the old not-recorded-durably apology is gone (W1)", async () => {
     await mount({ environments: { s1: [envs[0]!] }, checkpoints: { envA: [] } });
     fireEvent.click(screen.getByRole("radio", { name: "History" }));
-    expect(await screen.findByText(/not recorded durably/)).toBeInTheDocument();
+    expect(await screen.findByText(/records every commit shipped/)).toBeInTheDocument();
+    expect(screen.queryByText(/not recorded durably/)).toBeNull();
+  });
+
+  /* ——— Plan 14 W1: ships interleave with checkpoints. ——— */
+
+  it("interleaves ships with checkpoints by time — dropping either source is the named mutant", async () => {
+    await mount({
+      environments: { s1: [envs[0]!] },
+      checkpoints: { envA: [
+        checkpoint("cpA", "envA", { label: "older turn", createdAt: 1000 }),
+        checkpoint("cpB", "envA", { label: "newest turn", createdAt: 3000 }),
+      ] },
+      ships: { s1: [shipRow("sh1", "s1", { subject: "the middle ship", createdAt: 2000 })] },
+    });
+    fireEvent.click(screen.getByRole("radio", { name: "History" }));
+    await screen.findByText("the middle ship");
+    const titles = [...document.querySelectorAll(".page-row-title")].map((el) => el.textContent);
+    expect(titles).toEqual(["newest turn", "the middle ship", "older turn"]);
+  });
+
+  it("a ship row shows sha, branch, its ACTUAL push state and links the PR when there is one", async () => {
+    await mount({
+      environments: { s1: [envs[0]!] }, checkpoints: { envA: [] },
+      ships: { s1: [
+        shipRow("sh1", "s1", { subject: "landed", sha: "abcdef1234", branch: "main", pushState: "pushed", prUrl: "https://github.com/acme/w/pull/9", createdAt: 2000 }),
+        shipRow("sh2", "s1", { subject: "stuck", sha: "1234abcdef", branch: "realm/fix", pushState: "rejected", prUrl: null, createdAt: 1000 }),
+      ] },
+    });
+    fireEvent.click(screen.getByRole("radio", { name: "History" }));
+    const landed = (await screen.findByText("landed")).closest(".ship-row") as HTMLElement;
+    expect(within(landed).getByText("abcdef1")).toBeInTheDocument();
+    expect(within(landed).getByText(/main/)).toBeInTheDocument();
+    expect(within(landed).getByText("pushed")).toBeInTheDocument();
+    expect(within(landed).getByRole("link", { name: /PR/ })).toHaveAttribute("href", "https://github.com/acme/w/pull/9");
+    // A rejected push says so — a ship row may never claim more than the push actually did.
+    const stuck = screen.getByText("stuck").closest(".ship-row") as HTMLElement;
+    expect(within(stuck).getByText("push rejected")).toBeInTheDocument();
+    expect(within(stuck).queryByText(/^pushed$/)).toBeNull();
+    expect(within(stuck).queryByRole("link")).toBeNull();
+  });
+
+  it("lists only THIS space's ships and asks only for them", async () => {
+    const { api } = await mount({
+      environments: { s1: [envs[0]!] }, checkpoints: { envA: [] },
+      ships: { s1: [shipRow("sh1", "s1", { subject: "ours" })], s2: [shipRow("sh2", "s2", { subject: "theirs" })] },
+    });
+    fireEvent.click(screen.getByRole("radio", { name: "History" }));
+    await screen.findByText("ours");
+    expect(screen.queryByText("theirs")).toBeNull();
+    expect(api.calls.filter((c) => c.startsWith("listShips"))).toEqual(["listShips:s1"]);
   });
 });
 

--- a/apps/desktop/src/renderer/src/state/live-api.ts
+++ b/apps/desktop/src/renderer/src/state/live-api.ts
@@ -63,6 +63,7 @@ export const liveApi = (): Api => ({
   stagePaths: async (cwd, paths) => { await rpc().call("workspace.stage", { cwd, paths }); },
   unstagePaths: async (cwd, paths) => { await rpc().call("workspace.unstage", { cwd, paths }); },
   ship: (input) => rpc().call("workspace.ship", input),
+  listShips: (spaceId, cursor = null, limit) => rpc().call("ships.list", { spaceId, cursor, ...(limit !== undefined ? { limit } : {}) }),
   createItem: (spaceId, kind, title, refId) => rpc().call("items.create", { spaceId, kind, title, refId }),
   worktreeStatus: (id) => rpc().call("environments.worktreeStatus", { id }),
   removeWorktree: async (id, acknowledge) => { await rpc().call("environments.removeWorktree", { id, acknowledge }); },

--- a/apps/desktop/src/renderer/src/state/store.test-fakes.ts
+++ b/apps/desktop/src/renderer/src/state/store.test-fakes.ts
@@ -515,6 +515,7 @@ export function fakeApi(overrides: FakeData = {}): FakeApi {
     },
     addMcpServer: async (input: AddMcpServerInput) => {
       calls.push(`addMcpServer:${input.name}`);
+      mcpWrites.push(input);
       const keys = Object.keys(input.transport === "stdio" ? input.env ?? {} : input.headers ?? {});
       const s = mcpServer(`mcp${++n}`, {
         name: input.name, transport: input.transport,
@@ -528,6 +529,7 @@ export function fakeApi(overrides: FakeData = {}): FakeApi {
     },
     updateMcpServer: async (input: UpdateMcpServerInput) => {
       calls.push(`updateMcpServer:${input.id}`);
+      mcpWrites.push(input);
       const i = data.mcpServers.findIndex((x) => x.id === input.id);
       if (i < 0) throw new Error(`no mcp server ${input.id}`);
       const cur = data.mcpServers[i]!;

--- a/apps/desktop/src/renderer/src/state/store.test-fakes.ts
+++ b/apps/desktop/src/renderer/src/state/store.test-fakes.ts
@@ -1,6 +1,6 @@
 /** Shared in-memory Api fake for renderer tests (store, sidebar, palette). Not a test file itself. */
 import { MCP_SECRET_STORAGE_NOTE, MEMORY_DOC_MAX } from "@realm/contracts";
-import type { AgentsFileState, Attachment, Checkpoint, DiffSummary, Environment, FileDiff, GitInfo, Item, McpCall, McpServer, McpTool, MemorySources, MemoryState, Notification, Profile, Project, RestorePreview, Session, ShipResult, Skill, Space, StoredSessionEvent, WorktreeStatus } from "@realm/contracts";
+import type { AgentsFileState, Attachment, Checkpoint, DiffSummary, Environment, FileDiff, GitInfo, Item, McpCall, McpServer, McpTool, MemorySources, MemoryState, Notification, Profile, Project, RestorePreview, Session, Ship, ShipResult, Skill, Space, StoredSessionEvent, WorktreeStatus } from "@realm/contracts";
 import type { AddMcpServerInput, AgentProbe, Api, McpTestResult, PickedAttachment, UpdateMcpServerInput } from "./store";
 
 export const profile = (id: string, name: string, extra: Partial<Profile> = {}): Profile =>
@@ -40,6 +40,11 @@ export const mcpCall = (id: string, sessionId: string, extra: Partial<McpCall> =
   ({ id, sessionId, serverId: "mcp1", serverName: "srv1", tool: "echo", argsJson: "{}", resultSummary: "ok",
     ok: true, durationMs: 120, ts: 0, ...extra });
 
+/** A durable ship-log row (Plan 14 W1). */
+export const shipRow = (id: string, spaceId: string, extra: Partial<Ship> = {}): Ship =>
+  ({ id, environmentId: "01ARZ3NDEKTSV4RRFFQ69G5FAV", spaceId, branch: "main", sha: `sha-${id}`,
+    subject: `shipped ${id}`, prUrl: null, pushState: "pushed", createdAt: 0, ...extra });
+
 /** A feed row (W5). Defaults to an unread, already-acted session_done; ids must sort as ULIDs do. */
 export const notification = (id: string, extra: Partial<Notification> = {}): Notification =>
   ({ id, category: "session_done", spaceId: "s1", sessionId: null, refId: null, title: "a session",
@@ -67,6 +72,9 @@ export type FakeData = {
   worktreeStatus?: Record<string, WorktreeStatus>;
   /** `checkpoints.list` by environment id (W4). */
   checkpoints?: Record<string, Checkpoint[]>;
+  /** `ships.list` by space id (Plan 14 W1). Unordered on the way in — the fake sorts newest-first
+   *  like the real store. */
+  ships?: Record<string, Ship[]>;
   /** `checkpoints.preview` by checkpoint id. Mutate between calls to simulate the checkout moving
    *  under an open confirmation, which is exactly what the acknowledgement exists to catch. */
   checkpointPreview?: Record<string, RestorePreview>;
@@ -159,6 +167,7 @@ export function fakeApi(overrides: FakeData = {}): FakeApi {
     },
     worktreeStatus: overrides.worktreeStatus ?? {},
     checkpoints: overrides.checkpoints ?? {},
+    ships: overrides.ships ?? {},
     checkpointPreview: overrides.checkpointPreview ?? {},
     skills: overrides.skills ?? {},
     skillsRoot: overrides.skillsRoot ?? "/realm-home/skills",
@@ -430,7 +439,7 @@ export function fakeApi(overrides: FakeData = {}): FakeApi {
     stagePaths: async (cwd, paths) => { calls.push(`stage:${cwd}|${paths.join(",")}`); },
     unstagePaths: async (cwd, paths) => { calls.push(`unstage:${cwd}|${paths.join(",")}`); },
     ship: async (input) => {
-      calls.push(`ship:${input.cwd}|commit=${input.commit}|msg=${input.message}|push=${input.push}|upstream=${input.setUpstream}|pr=${input.openPr}`);
+      calls.push(`ship:${input.cwd}|commit=${input.commit}|msg=${input.message}|push=${input.push}|upstream=${input.setUpstream}|pr=${input.openPr}|env=${input.environmentId}`);
       await wait("ship");
       return data.shipResult;
     },
@@ -456,6 +465,17 @@ export function fakeApi(overrides: FakeData = {}): FakeApi {
         const i = list.findIndex((e) => e.id === id);
         if (i >= 0) list.splice(i, 1);
       }
+    },
+    listShips: async (spaceId, cursor = null, limit) => {
+      calls.push(`listShips:${spaceId}`);
+      const cap = Math.max(1, Math.min(limit ?? 100, 200));
+      let rows = [...(data.ships[spaceId] ?? [])].sort((a, b) => b.createdAt - a.createdAt || (a.id < b.id ? 1 : a.id > b.id ? -1 : 0));
+      if (cursor) {
+        const i = cursor.indexOf(":"); const at = Number(cursor.slice(0, i)); const id = cursor.slice(i + 1);
+        rows = rows.filter((x) => x.createdAt < at || (x.createdAt === at && x.id < id));
+      }
+      const page = rows.slice(0, cap);
+      return { ships: page, nextCursor: page.length === cap && page.length > 0 ? `${page.at(-1)!.createdAt}:${page.at(-1)!.id}` : null };
     },
     listCheckpoints: async (environmentId, sessionId) => {
       calls.push(`listCheckpoints:${environmentId}|${sessionId ?? "*"}`);

--- a/apps/desktop/src/renderer/src/state/store.test.ts
+++ b/apps/desktop/src/renderer/src/state/store.test.ts
@@ -1937,6 +1937,37 @@ describe("openDestinationPage", () => {
   });
 });
 
+describe("openProfilePage (Plan 14 W2)", () => {
+  it("creates ONE profile page in the active space with the sentinel refId, and dedups later opens", async () => {
+    const api = fakeApi();
+    const store = createAppStore(api);
+    await store.getState().boot(); // active: s1 (profile p1)
+    await store.getState().openProfilePage();
+    const page = store.getState().items.find((i) => i.kind === "profile-page")!;
+    expect(page).toMatchObject({ spaceId: "s1", title: "Profile", refId: PAGE_REF_IDS["profile-page"] });
+    expect(allItems(store.getState().layout!)).toContain(page.id);
+    await store.getState().openProfilePage();
+    expect(api.calls.filter((c) => c.startsWith("createItem:") && c.includes("profile-page"))).toHaveLength(1);
+    expect(store.getState().items.filter((i) => i.kind === "profile-page")).toHaveLength(1);
+  });
+
+  it("lands on the asked-for section, keyed by the ACTIVE space's profile", async () => {
+    const store = createAppStore(fakeApi());
+    await store.getState().boot(); // s1 → p1
+    await store.getState().openProfilePage("memory");
+    expect(store.getState().profilePageTab.p1).toBe("memory");
+    expect(store.getState().profilePageTab.p2).toBeUndefined();
+  });
+
+  it("with no active space (mid-boot) it is a no-op rather than an item with nowhere to live", async () => {
+    const api = fakeApi({ spaces: [] });
+    const store = createAppStore(api);
+    await store.getState().boot();
+    await store.getState().openProfilePage();
+    expect(api.calls.some((c) => c.startsWith("createItem:"))).toBe(false);
+  });
+});
+
 /** The `mcpServers` guard moved off the retired sheet (Plan 12 W3): `mcpPanelSpaceId` — set by the
  *  Connections panel's mount/unmount — decides whether a `mcp.list` response may land. */
 describe("refreshMcpServers guard (space page era)", () => {

--- a/apps/desktop/src/renderer/src/state/store.ts
+++ b/apps/desktop/src/renderer/src/state/store.ts
@@ -1,7 +1,7 @@
 import { createStore, useStore, type StoreApi } from "zustand";
 import {
   allItems, closeItem as layoutClose, emptyLayout, findLeafOfItem, firstLeaf, gridPreset, itemIdOfLeaf, openItem as layoutOpen, splitLeaf, updateSizes, AgentKindSchema, LayoutSchema, PLAN_PERMISSION_MODE,
-  AGENT_SKILL_SUPPORT, basenameOf, formatAttachmentSize, MAX_ATTACHMENT_BYTES, mentionIds, mimeForPath, PAGE_REF_IDS,
+  AGENT_SKILL_SUPPORT, AGENT_SUPPORTS_PERMISSION_MODES, basenameOf, formatAttachmentSize, MAX_ATTACHMENT_BYTES, mentionIds, mimeForPath, PAGE_REF_IDS,
   DEFAULT_PERMISSION_MODE_KEY, NOTIFICATIONS_DISABLED_KEY, NOTIFICATION_CATEGORIES, PERMISSION_MODES,
   type DestinationPageKind, type NotificationCategory,
   type AgentKind, type Attachment, type Checkpoint, type DiffSummary, type Environment, type FileDiff, type GitInfo, type Item, type Layout, type McpCall, type McpOauthStatus, type McpServer, type McpServerStatus, type McpTransport, type MemorySources, type MemoryState, type MethodResult, type Notification, type PresetName, type Profile, type Project, type RestorePreview, type RestoreResult, type Session, type SessionMode, type SessionStatus, type Ship, type ShipResult, type Skill, type Space, type StoredSessionEvent, type WorktreeAck, type WorktreeStatus,
@@ -1533,13 +1533,19 @@ export function createAppStore(api: Api): StoreApi<AppState> {
         const s = get().sessions[id];
         if (!s) return;
         const inPlan = s.permissionMode === PLAN_PERMISSION_MODE;
+        // The park is for agents whose Plan REPLACES a real permission axis (Claude, Codex — the
+        // kinds Realm can set a permission mode on at all). An ACP agent's Plan is its own mode
+        // (Plan 14 W3): there is no chosen permission to preserve, so leaving Plan simply returns
+        // the row to its resting "default" — parking would fabricate Claude-shaped semantics on an
+        // agent that never had them.
+        const parks = AGENT_SUPPORTS_PERMISSION_MODES[s.agentKind];
         if (mode === "plan") {
           if (inPlan) return;
-          set({ planReturn: { ...get().planReturn, [id]: s.permissionMode } });
+          if (parks) set({ planReturn: { ...get().planReturn, [id]: s.permissionMode } });
           await get().setSessionOptions(id, { permissionMode: PLAN_PERMISSION_MODE });
         } else {
           if (!inPlan) return;
-          const back = get().planReturn[id] ?? "default";
+          const back = parks ? get().planReturn[id] ?? "default" : "default";
           const { [id]: _used, ...planReturn } = get().planReturn;
           set({ planReturn });
           await get().setSessionOptions(id, { permissionMode: back });

--- a/apps/desktop/src/renderer/src/state/store.ts
+++ b/apps/desktop/src/renderer/src/state/store.ts
@@ -4,7 +4,7 @@ import {
   AGENT_SKILL_SUPPORT, basenameOf, formatAttachmentSize, MAX_ATTACHMENT_BYTES, mentionIds, mimeForPath, PAGE_REF_IDS,
   DEFAULT_PERMISSION_MODE_KEY, NOTIFICATIONS_DISABLED_KEY, NOTIFICATION_CATEGORIES, PERMISSION_MODES,
   type DestinationPageKind, type NotificationCategory,
-  type AgentKind, type Attachment, type Checkpoint, type DiffSummary, type Environment, type FileDiff, type GitInfo, type Item, type Layout, type McpCall, type McpOauthStatus, type McpServer, type McpServerStatus, type McpTransport, type MemorySources, type MemoryState, type MethodResult, type Notification, type PresetName, type Profile, type Project, type RestorePreview, type RestoreResult, type Session, type SessionMode, type SessionStatus, type ShipResult, type Skill, type Space, type StoredSessionEvent, type WorktreeAck, type WorktreeStatus,
+  type AgentKind, type Attachment, type Checkpoint, type DiffSummary, type Environment, type FileDiff, type GitInfo, type Item, type Layout, type McpCall, type McpOauthStatus, type McpServer, type McpServerStatus, type McpTransport, type MemorySources, type MemoryState, type MethodResult, type Notification, type PresetName, type Profile, type Project, type RestorePreview, type RestoreResult, type Session, type SessionMode, type SessionStatus, type Ship, type ShipResult, type Skill, type Space, type StoredSessionEvent, type WorktreeAck, type WorktreeStatus,
 } from "@realm/contracts";
 import { createContext, useCallback, useContext, useSyncExternalStore } from "react";
 import { SHEET_MIN_WIDTH, complementOf, snapBrowserLeaves } from "./no-overlay";
@@ -210,6 +210,8 @@ export type Api = {
   /** `mcp.calls.list` — Realm's own call log (Activity), newest first. `before` pages backward by the
    *  composite `{ ts, id }` cursor (W1 amendment); omitted, it starts from the top. */
   mcpCallsList(params: McpCallsFilter & { before?: { ts: number; id: string }; limit?: number }): Promise<{ calls: McpCall[] }>;
+  /** `ships.list` (Plan 14 W1): one page of a space's durable ship log, newest first. */
+  listShips(spaceId: string, cursor?: string | null, limit?: number): Promise<{ ships: Ship[]; nextCursor: string | null }>;
   /** `notifications.list` (Plan 12 W5): one page of the global feed, plus the server's unread count —
    *  the ONE source every unread badge renders. */
   listNotifications(cursor: string | null, limit?: number): Promise<{ notifications: Notification[]; nextCursor: string | null; unread: number }>;
@@ -234,6 +236,9 @@ export const DESTINATION_PAGE_TITLES: Record<DestinationPageKind, string> = {
   "connections-page": "Connections",
   "notifications-page": "Notifications",
   "settings-page": "Settings",
+  // Static like the rest: the page header renders the live profile name; the item row's title has
+  // nothing to go stale against (Plan 14 W2).
+  "profile-page": "Profile",
 };
 
 /** Feed page size (W5). Modest: the page is a glance at what waited, not an archive browser —
@@ -241,7 +246,10 @@ export const DESTINATION_PAGE_TITLES: Record<DestinationPageKind, string> = {
 export const NOTIFICATIONS_PAGE = 50;
 
 /** What the diff pane sends to `workspace.ship`. `cwd` is the environment's checkout. */
-export type ShipInput = { cwd: string; commit: boolean; message: string; push: boolean; setUpstream: boolean; openPr: boolean };
+export type ShipInput = { cwd: string; commit: boolean; message: string; push: boolean; setUpstream: boolean; openPr: boolean;
+  /** The pane's environment — the durable log's attribution (Plan 14 W1). The diff pane always has
+   *  one (its item's refId IS the environment id), so every pane-driven ship names it. */
+  environmentId: string };
 
 /**
  * One file's patch, keyed by which side of the index it is. Two sides of one path are two entries:
@@ -433,6 +441,9 @@ export type AppState = {
   worktreeAckStale: string | null;
   /** `checkpoints.list` by environment id (W4). Absent = never asked. */
   checkpoints: Record<string, Checkpoint[]>;
+  /** `ships.list` first page by space id (Plan 14 W1) — the History tab's other half. Absent = never
+   *  asked; the `ships.changed` handler only refreshes spaces already held here. */
+  ships: Record<string, Ship[]>;
   /** The checkpoint the sheet is asking about, as the preview it is showing. Null = the list state;
    *  the preview carries its own `checkpointId`, so there is nothing else to remember. */
   checkpointPreview: RestorePreview | null;
@@ -702,6 +713,9 @@ export type AppState = {
   openCheckpoints(environmentId: string, sessionId?: string | null): Promise<void>;
   /** Re-list without opening anything — what the `checkpoints.changed` broadcast triggers. */
   refreshCheckpoints(environmentId: string, sessionId: string | null): Promise<void>;
+  /** Re-fetch one space's ship log (first page — the History tab's glance, not an archive browser);
+   *  what the History tab mounts and the `ships.changed` broadcast triggers for held spaces. */
+  refreshShips(spaceId: string): Promise<void>;
   /** Move the sheet from its list state into its confirm state, with a freshly read preview. */
   askRestoreCheckpoint(id: string): Promise<void>;
   /** Back to the list, forgetting the preview. */
@@ -1058,7 +1072,7 @@ export function createAppStore(api: Api): StoreApi<AppState> {
       sessions: {}, sessionStatus: {}, sessionSpace: {}, transcripts: {}, agentProbe: [], settingsPrefs: null, tccRows: null, drafts: {}, pendingAttachments: {}, draftMentions: {}, spaceSkills: {}, skillsRoot: "", spaceMemory: {}, sessionMemorySources: {}, planReturn: {}, gitInfo: {},
       diffs: {}, diffLoading: {}, patches: {}, commitMessages: {}, shipResults: {}, shipping: {},
       worktreeStatuses: {}, worktreeAckStale: null,
-      checkpoints: {}, checkpointPreview: null, checkpointAckStale: false, restoreResult: null,
+      checkpoints: {}, ships: {}, checkpointPreview: null, checkpointAckStale: false, restoreResult: null,
       terminalPanel: {}, sessionTerminals: {},
       machineName: "", connectors: {},
       mcpServers: [], mcpProviders: [], mcpToolsError: {},
@@ -1903,6 +1917,10 @@ export function createAppStore(api: Api): StoreApi<AppState> {
       async refreshCheckpoints(environmentId, sessionId) {
         const list = await api.listCheckpoints(environmentId, sessionId);
         set({ checkpoints: { ...get().checkpoints, [environmentId]: list } });
+      },
+      async refreshShips(spaceId) {
+        const { ships } = await api.listShips(spaceId);
+        set({ ships: { ...get().ships, [spaceId]: ships } });
       },
       async captureCheckpoint(environmentId, sessionId) {
         await api.captureCheckpoint(environmentId, sessionId);

--- a/apps/desktop/src/renderer/src/state/store.ts
+++ b/apps/desktop/src/renderer/src/state/store.ts
@@ -302,6 +302,8 @@ export function parseTerminalPanels(raw: unknown): Record<string, TerminalPanel>
 /** The space page's tab rail (Plan 12 W3). "connections" is what the retired sheet called "mcp" —
  *  openers that used `tab: "mcp"` (the plus-menu's "Manage connections…") map to it. */
 export type SpacePageTab = "general" | "memory" | "skills" | "connections" | "sessions" | "history";
+/** The profile page's rail (Plan 14 W2). */
+export type ProfilePageTab = "skills" | "connections" | "memory";
 
 /** Sessions are never created through a sheet (W3): "+"/⌘N/palette create one instantly and every
  *  choice lives on the prompter's chips. What remains here is genuinely form-shaped. */
@@ -483,6 +485,10 @@ export type AppState = {
    *  space's tab — and with it another space's data fetch — onto a different space's page. Absent =
    *  "general". */
   spacePageTab: Record<string, SpacePageTab>;
+  /** The profile page's tab, per PROFILE id (Plan 14 W2) — in the store, not component state, because
+   *  openers land on a section ("Edit in profile" on an MCP row lands on Connections; the memory
+   *  row's on Memory) whether or not the page is already open. */
+  profilePageTab: Record<string, ProfilePageTab>;
   /** The last `mcp.tools.list` error per server id, `null` once a refresh succeeds. A RESULT, not an
    *  exception (see the Api doc comment) — kept apart from `error` so it renders inline on the row that
    *  caused it instead of stealing the app's one error banner. */
@@ -671,6 +677,12 @@ export type AppState = {
   openSpacePage(spaceId: string, tab?: SpacePageTab): Promise<void>;
   /** The page's tab, per space — see `spacePageTab`. */
   setSpacePageTab(spaceId: string, tab: SpacePageTab): void;
+  /** Open (or focus) the ACTIVE space's profile page (Plan 14 W2) — a `profile-page` destination item
+   *  (sentinel refId; the page derives its profile live from the item's space). `tab` lands the page
+   *  on a section — the retargeted "Edit in profile" affordances pass one. */
+  openProfilePage(tab?: ProfilePageTab): Promise<void>;
+  /** The profile page's tab, per profile — see `profilePageTab`. */
+  setProfilePageTab(profileId: string, tab: ProfilePageTab): void;
   /** Open (or focus) a sidebar destination page (Plan 12 W4: Library, Connections) in the ACTIVE
    *  space's layout. One page item per space, deduped by KIND — the refId is the kind's well-known
    *  sentinel (`PAGE_REF_IDS`), and the item's `spaceId` is the vantage its scope groups read from. */
@@ -1068,7 +1080,7 @@ export function createAppStore(api: Api): StoreApi<AppState> {
       allItems: [], lastAgentKind: null, renamingItemId: null,
       connectionState: "connected",
       paletteOpen: false, sheet: null, browserRects: [], sheetSnap: null, browserActions: {}, browserDriving: {},
-      spacePageTab: {}, mcpPanelSpaceId: null,
+      spacePageTab: {}, profilePageTab: {}, mcpPanelSpaceId: null,
       sessions: {}, sessionStatus: {}, sessionSpace: {}, transcripts: {}, agentProbe: [], settingsPrefs: null, tccRows: null, drafts: {}, pendingAttachments: {}, draftMentions: {}, spaceSkills: {}, skillsRoot: "", spaceMemory: {}, sessionMemorySources: {}, planReturn: {}, gitInfo: {},
       diffs: {}, diffLoading: {}, patches: {}, commitMessages: {}, shipResults: {}, shipping: {},
       worktreeStatuses: {}, worktreeAckStale: null,
@@ -1795,6 +1807,16 @@ export function createAppStore(api: Api): StoreApi<AppState> {
         await adoptItem(spaceId, created.id, null);
       },
       setSpacePageTab(spaceId, tab) { set({ spacePageTab: { ...get().spacePageTab, [spaceId]: tab } }); },
+      async openProfilePage(tab) {
+        // The tab is keyed by PROFILE — resolved from the active space, the same vantage the page
+        // itself renders from, so the section the opener lands on is the section the page shows.
+        const spaceId = get().activeSpaceId;
+        const space = get().spaces.find((x) => x.id === spaceId);
+        if (!space) return;
+        if (tab) get().setProfilePageTab(space.profileId, tab);
+        await get().openDestinationPage("profile-page");
+      },
+      setProfilePageTab(profileId, tab) { set({ profilePageTab: { ...get().profilePageTab, [profileId]: tab } }); },
       async refreshSettingsPrefs() {
         const [rawDisabled, rawMode] = await Promise.all([
           api.getSetting(NOTIFICATIONS_DISABLED_KEY), api.getSetting(DEFAULT_PERMISSION_MODE_KEY),

--- a/apps/desktop/src/renderer/src/state/store.ts
+++ b/apps/desktop/src/renderer/src/state/store.ts
@@ -10,6 +10,7 @@ import { createContext, useCallback, useContext, useSyncExternalStore } from "re
 import { SHEET_MIN_WIDTH, complementOf, snapBrowserLeaves } from "./no-overlay";
 import type { ThemePref } from "../theme/useTheme";
 import { emptyTranscript, reduceTranscript, type Transcript } from "../panes/session/transcript-model";
+import { allowlistKey, getBrowserBridges, parseAllowlist } from "../panes/browser/browser-client";
 
 export type CreateSpaceInput = { name: string; icon: string; profileId: string; color?: string };
 export type UpdateSpaceInput = { id: string; name?: string; icon?: string; color?: string; profileId?: string };
@@ -467,6 +468,10 @@ export type AppState = {
    *  and the hub's held status, it dials nothing, so refreshing on menu open never probes a server.
    *  `mcp.serverStatus` broadcasts patch it live; absent = never fetched, rendered as such. */
   connectors: Record<string, McpServer[]>;
+  /** The per-space browser origin allowlist (Plan 14 W4), by space id — `browser.allowedOrigins:<id>`
+   *  as last fetched. null = no list = allow everything (W1's default posture); absent = never
+   *  fetched. The Connections tab's Browser origins section reads and writes this. */
+  browserAllowlists: Record<string, string[] | null>;
   /** MCP servers for the space whose Connections tab is currently mounted (W6) — `mcp.list`'s
    *  per-space projection. Empty until `refreshMcpServers` runs; McpSection fetches on mount. */
   mcpServers: McpServer[];
@@ -607,6 +612,11 @@ export type AppState = {
   moveSessionToNewWorktree(sessionId: string): Promise<void>;
   /** Fetch a space's servers into `connectors` (plus-menu open, `mcp.changed`). */
   refreshConnectors(spaceId: string): Promise<void>;
+  /** Fetch a space's browser origin allowlist into `browserAllowlists` (Connections tab mount). */
+  refreshBrowserAllowlist(spaceId: string): Promise<void>;
+  /** Persist a space's browser origin allowlist AND push it into every live browser view of that
+   *  space, so the fence moves without a pane reopen (Plan 14 W4). null = back to allow-all. */
+  setBrowserAllowlist(spaceId: string, allowlist: string[] | null): Promise<void>;
   /** Refresh `agentProbe`. Unforced calls (prompter mount, onboarding) ride the server's TTL cache and
    *  are deduped here too; `force` is the install card's "Check again" and its window-focus refresh. */
   probeAgents(force?: boolean): Promise<void>;
@@ -1086,7 +1096,7 @@ export function createAppStore(api: Api): StoreApi<AppState> {
       worktreeStatuses: {}, worktreeAckStale: null,
       checkpoints: {}, ships: {}, checkpointPreview: null, checkpointAckStale: false, restoreResult: null,
       terminalPanel: {}, sessionTerminals: {},
-      machineName: "", connectors: {},
+      machineName: "", connectors: {}, browserAllowlists: {},
       mcpServers: [], mcpProviders: [], mcpToolsError: {},
       profileMemory: {},
       mcpCalls: [], mcpCallsFilter: {}, mcpCallsHasMore: false,
@@ -1575,6 +1585,24 @@ export function createAppStore(api: Api): StoreApi<AppState> {
       async refreshConnectors(spaceId) {
         const { servers } = await api.listMcpServers(spaceId);
         set({ connectors: { ...get().connectors, [spaceId]: servers } });
+      },
+      async refreshBrowserAllowlist(spaceId) {
+        const list = parseAllowlist(await api.getSetting(allowlistKey(spaceId)));
+        set({ browserAllowlists: { ...get().browserAllowlists, [spaceId]: list } });
+      },
+      async setBrowserAllowlist(spaceId, allowlist) {
+        await api.setSetting(allowlistKey(spaceId), allowlist);
+        set({ browserAllowlists: { ...get().browserAllowlists, [spaceId]: allowlist } });
+        // The live half of the write (Plan 14 W4): every open browser view of THIS space is re-fenced
+        // now — new panes read the setting at create, but a pane already open would otherwise keep
+        // enforcing the old list until it was closed and reopened. Open panes always belong to the
+        // active space's layout, so another space's rows have no views to re-point (and this space's
+        // items would be the wrong list to consult).
+        if (get().activeSpaceId !== spaceId) return;
+        const { host } = getBrowserBridges();
+        for (const it of get().items) {
+          if (it.kind === "browser") void host.setAllowlist(it.refId, allowlist);
+        }
       },
       async probeAgents(force = false) {
         // Mount-storm guard: a split of four session panes asks four times in the same tick. The server

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -472,6 +472,11 @@ button.panel-title:hover { background: var(--rl-hover); }
    14px 16px padding, 85% max — and, copying Ara exactly, ragged-left (text-align: right). */
 .msg-user { max-width: 85%; padding: 14px 16px; border-radius: var(--r-float); background: var(--rl-raised); text-align: right;
   font-size: 15px; line-height: 1.6; white-space: pre-wrap; overflow-wrap: anywhere; }
+/* Attached-file chips inside the user bubble (Plan 14 W5) — an attachment-only message still shows
+   WHAT it carried. Flex so the pre-wrap bubble's whitespace rules don't mangle the chip row. */
+.msg-user-files { display: flex; flex-wrap: wrap; gap: 6px; justify-content: flex-end; margin-top: 2px; }
+.msg-user-file { display: inline-flex; align-items: center; gap: 4px; padding: 2px 8px; border-radius: var(--r-ctl);
+  border: 1px solid var(--rl-line); font-size: 12px; color: var(--rl-text-dim); white-space: nowrap; }
 /* Ara refresh §4: assistant prose is plain — 15px/1.6, no card. */
 .msg-assistant { max-width: 72ch; font-size: 15px; line-height: 1.6; }
 .md { line-height: 1.55; overflow-wrap: anywhere; }

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -1157,6 +1157,14 @@ button.panel-title:hover { background: var(--rl-hover); }
 .page-row-dim { flex: none; display: inline-flex; align-items: center; gap: 3px; margin-left: auto; font-size: 11.5px; color: var(--rl-text-faint); }
 .page-row-dim + .page-row-dim { margin-left: 10px; }
 .page-row .cp-kind { flex: none; }
+/* A ship row (Plan 14 W1) is a RECORD, not a door: no hover invitation, no pointer — only its PR
+   link is interactive. The kind badge keeps cp-kind's metrics so the two treatments align. */
+.ship-row { cursor: default; }
+.ship-row:hover { background: none; }
+.ship-kind { display: inline-flex; align-items: center; gap: 4px; }
+.ship-sha { font-size: 11px; }
+.ship-row a { display: inline-flex; align-items: center; gap: 3px; color: var(--rl-accent); text-decoration: none; }
+.ship-row a:hover { text-decoration: underline; }
 /* The sidebar header's whole title row is the page's front door. */
 .space-title { display: inline-flex; align-items: center; gap: 6px; min-width: 0; padding: 2px 4px; margin: -2px -4px;
   border: none; border-radius: var(--r-chip); background: none; color: inherit; font: inherit; cursor: pointer; }

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -1096,6 +1096,9 @@ button.panel-title:hover { background: var(--rl-hover); }
 /* The two kinds of prose here: a NOTE is a disclosure the panel exists to make (always visible, dim,
    set off by a left tick); a HINT is auxiliary fine print (faint). */
 .settings-note { margin: 0; padding: 6px 10px; border-left: 2px solid var(--rl-line-strong); font-size: 11.5px; line-height: 1.5; color: var(--rl-text-dim); }
+/* Browser origins (Plan 14 W4): the add form is one inline row inside the field. */
+.origin-add { display: flex; gap: 8px; }
+.origin-add input { flex: 1; }
 .settings-note code { font: 10.5px var(--font-mono); }
 .settings-hint { margin: 0; font-size: 11px; line-height: 1.5; color: var(--rl-text-faint); }
 .settings-hint[data-tone="danger"] { color: var(--rl-danger); }

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -1165,6 +1165,11 @@ button.panel-title:hover { background: var(--rl-hover); }
 .ship-sha { font-size: 11px; }
 .ship-row a { display: inline-flex; align-items: center; gap: 3px; color: var(--rl-accent); text-decoration: none; }
 .ship-row a:hover { text-decoration: underline; }
+/* The profile page's space chips (Plan 14 W2): the profile's spaces as jump targets, under the head. */
+.profile-spaces { display: flex; flex-wrap: wrap; gap: 6px; margin: 2px 0 10px; }
+.profile-chip { display: inline-flex; align-items: center; gap: 5px; padding: 3px 10px; font-size: 12px;
+  border: 1px solid var(--rl-line-strong); border-radius: 999px; background: none; color: var(--rl-text-dim); cursor: pointer; }
+.profile-chip:hover { background: var(--rl-hover); color: var(--rl-text-bright); }
 /* The sidebar header's whole title row is the page's front door. */
 .space-title { display: inline-flex; align-items: center; gap: 6px; min-width: 0; padding: 2px 4px; margin: -2px -4px;
   border: none; border-radius: var(--r-chip); background: none; color: inherit; font: inherit; cursor: pointer; }

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -25,6 +25,7 @@ import { McpOauth } from "./mcp/oauth";
 import type { McpServerStatus } from "@realm/contracts";
 import { MemoryService } from "./memory/service";
 import { NotificationsStore } from "./store/notifications";
+import { ShipsStore } from "./store/ships";
 import { NotificationsService } from "./notifications/service";
 import { ClaudeAdapter, CodexAdapter, AcpAdapter, FakeAdapter, type AdapterRegistry } from "@realm/adapters";
 import { GitInfoService } from "./workspace/git-info";
@@ -226,9 +227,17 @@ export async function createApp(opts: { home: string; port: number; adapters?: A
   browserAgents = new BrowserAgentService({ settings, sessions, rpc, skillsRoot: skills.root, fallbackKind: opts.browserAgent?.fallbackKind, timeouts: opts.browserAgent?.timeouts });
   mcpGateway.registerProvider(createBrowserAgentProvider({ browsers: browsersStore, browserService: browsers, mcp, bridge: browserBridge, broker: browserBroker, rpc, constraints: browserAgents }));
   mcpGateway.registerProvider(createRealmAgentProvider(browserAgents, mcp));
+  // The durable ship log (Plan 14 W1): GitWriteService stays a pure git service — the recorder is the
+  // one seam through which a settled ship becomes a row, and the broadcast rides the same write so a
+  // History tab already open sees the ship land.
+  const ships = new ShipsStore(db);
+  const gitWrite = new GitWriteService({ shipLog: (entry) => {
+    ships.record(entry);
+    rpc.broadcast("ships.changed", { spaceId: entry.spaceId });
+  } });
   registerMethods({
     rpc, home: opts.home, version: SERVER_VERSION, machineName: await machineName(),
-    profiles, spaces, projects, environments, envService, items, settings, skills, mcp, hub: mcpHub, gateway: mcpGateway, oauth, calls: mcpCalls, memory, terminals, browsers, browserBridge, sessions, gitInfo: new GitInfoService(), gitDiff: new GitDiffService(), gitWrite: new GitWriteService(), ports, checkpoints, notifications,
+    profiles, spaces, projects, environments, envService, items, settings, skills, mcp, hub: mcpHub, gateway: mcpGateway, oauth, calls: mcpCalls, memory, terminals, browsers, browserBridge, sessions, gitInfo: new GitInfoService(), gitDiff: new GitDiffService(), gitWrite, ships, ports, checkpoints, notifications,
   });
   sessions.markStaleOnBoot();
   terminals.restoreAll();

--- a/apps/server/src/checkpoints/service.test.ts
+++ b/apps/server/src/checkpoints/service.test.ts
@@ -202,7 +202,10 @@ describe("retention", () => {
     expect(made.slice(0, 5).some((id) => store.get(id) !== null)).toBe(false);
   });
 
-  it("never prunes the undo of the last restore, however old it gets", async () => {
+  // Timeout headroom, not a behaviour change: a restore plus KEEP+5 real-git captures runs ~2s alone
+  // but crosses vitest's 5s default under a fully parallel suite — Plan 14 W1 added more real-git
+  // test files, and this was the one test the extra contention pushed over.
+  it("never prunes the undo of the last restore, however old it gets", { timeout: 20_000 }, async () => {
     initRepo(folder);
     const env = primary();
     const first = await svc.capture({ environmentId: env.id, sessionId: null, kind: "turn", label: "turn 1" });

--- a/apps/server/src/db/migrations.ts
+++ b/apps/server/src/db/migrations.ts
@@ -229,4 +229,31 @@ export const migrations: string[] = [
   CREATE INDEX notifications_unread ON notifications(read_at) WHERE read_at IS NULL;
   CREATE INDEX notifications_dedup ON notifications(category, ref_id);
   `,
+  // v13 — the durable ship log (Plan 14 W1). One row per `workspace.ship` that changed something
+  // durable (a commit was made, or a push reached the remote), written by GitWriteService.ship at the
+  // moment the legs settle. `push_state` records the push leg's ACTUAL outcome — a commit whose push
+  // was rejected logs `rejected`; a commit-only ship logs `skipped`.
+  //
+  // Plain TEXT references, no foreign keys — the notifications posture: a ship row is a LOG, and
+  // "branch X was shipped from worktree Y" stays true (and stays worth showing on the History tab)
+  // after that worktree is removed or its space deleted.
+  //
+  // NOTE (merge coordination): Plan 13 W1 also appends a v13 migration in its own worktree. Whichever
+  // branch merges second renumbers by moving this block after the other's — the SQL is self-contained,
+  // so the fix is a one-line reordering of this array.
+  `
+  CREATE TABLE ships (
+    id TEXT PRIMARY KEY,
+    environment_id TEXT NOT NULL,
+    space_id TEXT NOT NULL,
+    branch TEXT,
+    sha TEXT NOT NULL,
+    subject TEXT NOT NULL,
+    pr_url TEXT,
+    push_state TEXT NOT NULL,
+    created_at INTEGER NOT NULL);
+  -- Every listing is "this space, newest first"; id DESC is the same-millisecond tiebreak the
+  -- notifications feed uses, so keyset pagination can never skip or repeat a row.
+  CREATE INDEX ships_space ON ships(space_id, created_at DESC, id DESC);
+  `,
 ];

--- a/apps/server/src/rpc/methods.test.ts
+++ b/apps/server/src/rpc/methods.test.ts
@@ -392,3 +392,73 @@ describe("diff and the git write path over rpc", () => {
     c.close();
   });
 });
+
+/** The durable ship log over the wire (Plan 14 W1): attribution, listing, and the broadcast. The
+ *  WHEN-a-row-logs rules live in git-write.test.ts; the cursor rules in store/ships.test.ts. */
+describe("the ship log over rpc", () => {
+  const git = (cwd: string, ...args: string[]) =>
+    execFileSync("git", ["-c", "user.email=t@example.com", "-c", "user.name=t", "-c", "commit.gpgsign=false", ...args], { cwd, encoding: "utf8" });
+
+  async function bootRepoSpace() {
+    const { c } = await boot();
+    const prof = (await c.call("profiles.create", { name: "Work" })).result;
+    const space = (await c.call("spaces.create", { profileId: prof.id, name: "Versed" })).result;
+    const cwd = space.folderPath;
+    git(cwd, "init", "-b", "main");
+    git(cwd, "config", "user.email", "t@example.com");
+    git(cwd, "config", "user.name", "t");
+    git(cwd, "config", "commit.gpgsign", "false");
+    writeFileSync(join(cwd, "a.txt"), "one\n");
+    git(cwd, "add", "."); git(cwd, "commit", "-m", "init");
+    return { c, space, cwd };
+  }
+
+  it("a ship that names its environment writes a row, lists it, and broadcasts ships.changed", async () => {
+    const { c, space } = await bootRepoSpace();
+    const env = (await c.call("environments.createWorktree", { spaceId: space.id, title: "log me" })).result;
+    writeFileSync(join(env.path, "a.txt"), "edited\n");
+    await c.call("workspace.stage", { cwd: env.path, paths: ["a.txt"] });
+    const ship = (await c.call("workspace.ship", { cwd: env.path, commit: true, message: "one change", push: false, openPr: false, environmentId: env.id })).result;
+    expect(ship.commit.state).toBe("committed");
+    await waitFor(() => c.events.some((e) => e.event === "ships.changed" && e.payload.spaceId === space.id));
+    const { ships, nextCursor } = (await c.call("ships.list", { spaceId: space.id })).result;
+    expect(nextCursor).toBeNull();
+    expect(ships).toHaveLength(1);
+    expect(ships[0]).toMatchObject({ environmentId: env.id, spaceId: space.id, branch: "realm/log-me",
+      subject: "one change", prUrl: null, pushState: "skipped" });
+    expect(ships[0].sha).toBe(git(env.path, "rev-parse", "HEAD").trim());
+    c.close();
+  });
+
+  it("refuses an environment whose path is not the shipped cwd — nothing mis-files silently", async () => {
+    const { c, space, cwd } = await bootRepoSpace();
+    const env = (await c.call("environments.createWorktree", { spaceId: space.id, title: "elsewhere" })).result;
+    writeFileSync(join(cwd, "a.txt"), "edited\n");
+    await c.call("workspace.stage", { cwd, paths: ["a.txt"] });
+    // The space folder's cwd with the WORKTREE's environment id: refused, and no commit happened.
+    const r = await c.call("workspace.ship", { cwd, commit: true, message: "m", push: false, openPr: false, environmentId: env.id });
+    expect(r.ok).toBe(false);
+    expect(r.error.code).toBe("ENVIRONMENT_MISMATCH");
+    expect(git(cwd, "log", "--oneline").trim().split("\n")).toHaveLength(1);
+    expect((await c.call("ships.list", { spaceId: space.id })).result.ships).toEqual([]);
+    c.close();
+  });
+
+  it("an environment-less ship still ships, and logs nothing", async () => {
+    const { c, space, cwd } = await bootRepoSpace();
+    writeFileSync(join(cwd, "a.txt"), "edited\n");
+    await c.call("workspace.stage", { cwd, paths: ["a.txt"] });
+    const ship = (await c.call("workspace.ship", { cwd, commit: true, message: "m", push: false, openPr: false })).result;
+    expect(ship.commit.state).toBe("committed");
+    expect((await c.call("ships.list", { spaceId: space.id })).result.ships).toEqual([]);
+    c.close();
+  });
+
+  it("ships.list refuses an unknown space instead of answering an empty page", async () => {
+    const { c } = await bootRepoSpace();
+    const r = await c.call("ships.list", { spaceId: "01ARZ3NDEKTSV4RRFFQ69G5FA9" });
+    expect(r.ok).toBe(false);
+    expect(r.error.code).toBe("NOT_FOUND");
+    c.close();
+  });
+});

--- a/apps/server/src/rpc/methods.ts
+++ b/apps/server/src/rpc/methods.ts
@@ -24,6 +24,7 @@ import type { NotificationsService } from "../notifications/service";
 import type { GitInfoService } from "../workspace/git-info";
 import type { GitDiffService } from "../workspace/git-diff";
 import type { GitWriteService } from "../workspace/git-write";
+import type { ShipsStore } from "../store/ships";
 import type { PortAllocator } from "../workspace/ports";
 import { NotFoundError, RpcError } from "../store/rows";
 
@@ -33,7 +34,7 @@ type Result<M extends MethodName> = MethodResult<M> | Promise<MethodResult<M>>;
 
 export type Deps = {
   rpc: RpcServer; home: string; version: string; machineName: string;
-  profiles: ProfilesStore; spaces: SpacesStore; projects: ProjectsStore; environments: EnvironmentsStore; envService: EnvironmentService; items: ItemsStore; settings: SettingsStore; skills: SkillsService; mcp: McpService; hub: McpHub; gateway: McpGateway; oauth: McpOauth; calls: McpCallLogStore; memory: MemoryService; terminals: TerminalService; browsers: BrowserService; browserBridge: BrowserHostBridge; sessions: SessionService; gitInfo: GitInfoService; gitDiff: GitDiffService; gitWrite: GitWriteService; ports: PortAllocator; checkpoints: CheckpointService; notifications: NotificationsService;
+  profiles: ProfilesStore; spaces: SpacesStore; projects: ProjectsStore; environments: EnvironmentsStore; envService: EnvironmentService; items: ItemsStore; settings: SettingsStore; skills: SkillsService; mcp: McpService; hub: McpHub; gateway: McpGateway; oauth: McpOauth; calls: McpCallLogStore; memory: MemoryService; terminals: TerminalService; browsers: BrowserService; browserBridge: BrowserHostBridge; sessions: SessionService; gitInfo: GitInfoService; gitDiff: GitDiffService; gitWrite: GitWriteService; ships: ShipsStore; ports: PortAllocator; checkpoints: CheckpointService; notifications: NotificationsService;
 };
 
 export function registerMethods(d: Deps): void {
@@ -53,11 +54,28 @@ export function registerMethods(d: Deps): void {
   reg("workspace.stage", async (p) => { await d.gitWrite.stage(p.cwd, p.paths); changed(p.cwd); return { ok: true as const }; });
   reg("workspace.unstage", async (p) => { await d.gitWrite.unstage(p.cwd, p.paths); changed(p.cwd); return { ok: true as const }; });
   reg("workspace.ship", async (p) => {
-    const result = await d.gitWrite.ship(p);
+    // Ship-log attribution (Plan 14 W1): the pane NAMES its environment; the row records that checkout
+    // and that checkout's space, never a path-guess (a path can be registered in two spaces). The named
+    // environment must actually be the checkout being shipped — a mismatch would file the row under a
+    // different tree than the one the commit landed in, so it is refused, not silently mis-logged.
+    let log: { environmentId: string; spaceId: string } | null = null;
+    if (p.environmentId !== null) {
+      const env = d.environments.get(p.environmentId);
+      if (!env) throw new NotFoundError("environment", p.environmentId);
+      if (env.path !== p.cwd) throw new RpcError("ENVIRONMENT_MISMATCH", `environment ${p.environmentId} is at ${env.path}, not ${p.cwd}`);
+      log = { environmentId: env.id, spaceId: env.spaceId };
+    }
+    const result = await d.gitWrite.ship({ ...p, log });
     // Broadcast even when a step reported a problem: a commit that succeeded before a push that was
     // rejected still moved the tree, and the pane must show that.
     changed(p.cwd);
     return result;
+  });
+  // The durable ship log (Plan 14 W1). Space-checked like every per-space listing: a typo'd id should
+  // say so, not answer an empty page for a space that is not there.
+  reg("ships.list", (p) => {
+    if (!d.spaces.get(p.spaceId)) throw new NotFoundError("space", p.spaceId);
+    return d.ships.list(p);
   });
 
   reg("profiles.list", () => d.profiles.list());

--- a/apps/server/src/store/ships.test.ts
+++ b/apps/server/src/store/ships.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { openDatabase, type Db } from "../db/database";
+import { ShipsStore, type ShipInsert } from "./ships";
+
+let db: Db; let store: ShipsStore;
+
+const row = (extra: Partial<ShipInsert> = {}): ShipInsert =>
+  ({ environmentId: "01ARZ3NDEKTSV4RRFFQ69G5FAV", spaceId: "01ARZ3NDEKTSV4RRFFQ69G5FA0", branch: "main",
+    sha: "abc123", subject: "a change", prUrl: null, pushState: "pushed", ...extra });
+
+beforeEach(() => {
+  db = openDatabase(join(mkdtempSync(join(tmpdir(), "realm-shipstore-")), "realm.db"));
+  store = new ShipsStore(db);
+});
+
+/** Force a row's created_at so ordering tests don't depend on Date.now ties. */
+const at = (id: string, createdAt: number) => db.prepare("UPDATE ships SET created_at = ? WHERE id = ?").run(createdAt, id);
+
+describe("ShipsStore — record", () => {
+  it("round-trips every column, including the nullable ones", () => {
+    const s = store.record(row({ branch: null, prUrl: "https://github.com/o/r/pull/7", pushState: "rejected" }));
+    const { ships } = store.list({ spaceId: s.spaceId, cursor: null, limit: 10 });
+    expect(ships).toHaveLength(1);
+    expect(ships[0]).toMatchObject({ id: s.id, environmentId: s.environmentId, spaceId: s.spaceId,
+      branch: null, sha: "abc123", subject: "a change", prUrl: "https://github.com/o/r/pull/7", pushState: "rejected" });
+    expect(ships[0]!.createdAt).toBeGreaterThan(0);
+  });
+});
+
+describe("ShipsStore — per-space listing (the named W1 mutant: rows crossing spaces)", () => {
+  it("lists only the asked-for space's ships, however the timestamps interleave", () => {
+    const a = store.record(row({ spaceId: "01ARZ3NDEKTSV4RRFFQ69G5FA1", subject: "s1 old" })); at(a.id, 100);
+    const b = store.record(row({ spaceId: "01ARZ3NDEKTSV4RRFFQ69G5FA2", subject: "s2 mid" })); at(b.id, 200);
+    const c = store.record(row({ spaceId: "01ARZ3NDEKTSV4RRFFQ69G5FA1", subject: "s1 new" })); at(c.id, 300);
+    const s1 = store.list({ spaceId: "01ARZ3NDEKTSV4RRFFQ69G5FA1", cursor: null, limit: 10 });
+    expect(s1.ships.map((s) => s.subject)).toEqual(["s1 new", "s1 old"]);
+    const s2 = store.list({ spaceId: "01ARZ3NDEKTSV4RRFFQ69G5FA2", cursor: null, limit: 10 });
+    expect(s2.ships.map((s) => s.subject)).toEqual(["s2 mid"]);
+  });
+
+  it("an unknown space lists nothing (the RPC layer, not the store, turns that into NOT_FOUND)", () => {
+    store.record(row());
+    expect(store.list({ spaceId: "01ARZ3NDEKTSV4RRFFQ69G5FA9", cursor: null, limit: 10 }).ships).toEqual([]);
+  });
+});
+
+describe("ShipsStore — feed order and pagination (the notifications cursor, verbatim)", () => {
+  it("lists newest first with id as the same-millisecond tiebreak", () => {
+    const a = store.record(row({ subject: "a" })); at(a.id, 100);
+    const b = store.record(row({ subject: "b" })); at(b.id, 200);
+    const c = store.record(row({ subject: "c" })); at(c.id, 200);
+    const { ships } = store.list({ spaceId: a.spaceId, cursor: null, limit: 10 });
+    expect(ships.map((s) => s.subject).slice(0, 2).sort()).toEqual(["b", "c"]);
+    expect(ships.map((s) => s.subject)[2]).toBe("a");
+  });
+
+  it("pages by keyset cursor without skipping or repeating across a same-millisecond boundary", () => {
+    const ids: string[] = [];
+    for (let i = 0; i < 5; i++) { const s = store.record(row({ subject: `n${i}` })); at(s.id, i < 3 ? 100 : 200); ids.push(s.id); }
+    const spaceId = row().spaceId;
+    const first = store.list({ spaceId, cursor: null, limit: 2 });
+    expect(first.nextCursor).not.toBeNull();
+    const second = store.list({ spaceId, cursor: first.nextCursor, limit: 2 });
+    const third = store.list({ spaceId, cursor: second.nextCursor, limit: 2 });
+    const seen = [...first.ships, ...second.ships, ...third.ships].map((s) => s.id);
+    expect(new Set(seen).size).toBe(5);
+    expect(seen).toHaveLength(5);
+    expect(third.ships).toHaveLength(1);
+    expect(third.nextCursor).toBeNull();
+  });
+
+  it("the cursor never leaks another space's rows into a page", () => {
+    // Same timestamps in two spaces: paging space A with a cursor cut mid-millisecond must still
+    // only ever answer space A.
+    for (let i = 0; i < 3; i++) { const s = store.record(row({ spaceId: "01ARZ3NDEKTSV4RRFFQ69G5FA1" })); at(s.id, 100); }
+    for (let i = 0; i < 3; i++) { const s = store.record(row({ spaceId: "01ARZ3NDEKTSV4RRFFQ69G5FA2" })); at(s.id, 100); }
+    const first = store.list({ spaceId: "01ARZ3NDEKTSV4RRFFQ69G5FA1", cursor: null, limit: 2 });
+    const second = store.list({ spaceId: "01ARZ3NDEKTSV4RRFFQ69G5FA1", cursor: first.nextCursor, limit: 10 });
+    for (const s of [...first.ships, ...second.ships]) expect(s.spaceId).toBe("01ARZ3NDEKTSV4RRFFQ69G5FA1");
+    expect(first.ships.length + second.ships.length).toBe(3);
+  });
+
+  it("treats a mangled cursor as the first page rather than throwing", () => {
+    const s = store.record(row());
+    expect(store.list({ spaceId: s.spaceId, cursor: "not-a-cursor", limit: 10 }).ships).toHaveLength(1);
+    expect(store.list({ spaceId: s.spaceId, cursor: "NaN:xyz", limit: 10 }).ships).toHaveLength(1);
+  });
+});

--- a/apps/server/src/store/ships.ts
+++ b/apps/server/src/store/ships.ts
@@ -1,0 +1,56 @@
+import type { Db } from "../db/database";
+import { newId, type Ship } from "@realm/contracts";
+import { now } from "./rows";
+
+type Row = { id: string; environment_id: string; space_id: string; branch: string | null; sha: string;
+  subject: string; pr_url: string | null; push_state: Ship["pushState"]; created_at: number };
+const toShip = (r: Row): Ship => ({
+  id: r.id, environmentId: r.environment_id, spaceId: r.space_id, branch: r.branch, sha: r.sha,
+  subject: r.subject, prUrl: r.pr_url, pushState: r.push_state, createdAt: r.created_at,
+});
+
+export type ShipInsert = {
+  environmentId: string; spaceId: string; branch: string | null; sha: string; subject: string;
+  prUrl: string | null; pushState: Ship["pushState"];
+};
+
+/**
+ * Rows only — the rule for WHEN a ship logs (something durable happened) lives in
+ * `GitWriteService.ship`, the one writer. Feed order and pagination are the notifications store's,
+ * verbatim: `created_at DESC, id DESC`, keyset cursor `${createdAt}:${id}`.
+ */
+export class ShipsStore {
+  constructor(private db: Db) {}
+
+  record(input: ShipInsert): Ship {
+    const id = newId();
+    this.db.prepare("INSERT INTO ships (id, environment_id, space_id, branch, sha, subject, pr_url, push_state, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)")
+      .run(id, input.environmentId, input.spaceId, input.branch, input.sha, input.subject, input.prUrl, input.pushState, now());
+    return toShip(this.db.prepare("SELECT * FROM ships WHERE id = ?").get(id) as Row);
+  }
+
+  /** One page of one space's log. The `space_id = ?` filter is load-bearing (a named W1 mutant):
+   *  two spaces' ships must never appear in one listing, however their timestamps interleave. */
+  list(input: { spaceId: string; cursor: string | null; limit: number }): { ships: Ship[]; nextCursor: string | null } {
+    const parsed = parseCursor(input.cursor);
+    const rows = (parsed
+      ? this.db.prepare("SELECT * FROM ships WHERE space_id = ? AND (created_at < ? OR (created_at = ? AND id < ?)) ORDER BY created_at DESC, id DESC LIMIT ?")
+          .all(input.spaceId, parsed.createdAt, parsed.createdAt, parsed.id, input.limit)
+      : this.db.prepare("SELECT * FROM ships WHERE space_id = ? ORDER BY created_at DESC, id DESC LIMIT ?").all(input.spaceId, input.limit)) as Row[];
+    const last = rows.at(-1);
+    // A short page IS the end; only a full page might have more behind it.
+    const nextCursor = rows.length === input.limit && last ? `${last.created_at}:${last.id}` : null;
+    return { ships: rows.map(toShip), nextCursor };
+  }
+}
+
+/** A cursor that does not parse reads as "no cursor" (first page) — it is opaque client state, and a
+ *  stale or mangled one should degrade to a fresh listing, not an error. */
+function parseCursor(cursor: string | null): { createdAt: number; id: string } | null {
+  if (!cursor) return null;
+  const i = cursor.indexOf(":");
+  if (i <= 0) return null;
+  const createdAt = Number(cursor.slice(0, i));
+  const id = cursor.slice(i + 1);
+  return Number.isFinite(createdAt) && id ? { createdAt, id } : null;
+}

--- a/apps/server/src/workspace/git-write.test.ts
+++ b/apps/server/src/workspace/git-write.test.ts
@@ -361,3 +361,141 @@ describe("compareUrl", () => {
       .toBe("https://github.com/acme/widgets/compare/main...feat/a%23b?expand=1");
   });
 });
+
+/**
+ * The durable ship log (Plan 14 W1). The recorder is the seam the RPC layer wires to ShipsStore; here
+ * it is an array, so every assertion is about WHAT `ship` decided to record and WHEN — the storage
+ * rules (per-space listing, cursors) have their own suite in store/ships.test.ts.
+ */
+describe("ship — the durable log", () => {
+  const LOG = { environmentId: "01ARZ3NDEKTSV4RRFFQ69G5FAV", spaceId: "01ARZ3NDEKTSV4RRFFQ69G5FA0" };
+  function logSvc(gh?: string) {
+    const entries: import("./git-write").ShipLogEntry[] = [];
+    const service = new GitWriteService({ ghCommand: gh ?? join(tmpdir(), "realm-no-such-gh"), shipLog: (e) => entries.push(e) });
+    return { service, entries };
+  }
+
+  it("logs a committed-and-pushed ship with its sha, subject, branch and pushed state", async () => {
+    const repo = makeRepo(); const bare = attachRemote(repo);
+    const { service, entries } = logSvc();
+    try {
+      writeFileSync(join(repo, "a.txt"), "A\n"); git(repo, "add", "-A");
+      const r = await service.ship({ cwd: repo, commit: true, message: "Add a thing\n\nwhy", push: true, setUpstream: true, openPr: false, log: LOG });
+      expect(r.push.state).toBe("pushed");
+      expect(entries).toHaveLength(1);
+      expect(entries[0]).toEqual({ ...LOG, branch: "main", sha: git(repo, "rev-parse", "HEAD").trim(),
+        subject: "Add a thing", prUrl: null, pushState: "pushed" });
+    } finally { rmSync(repo, { recursive: true, force: true }); rmSync(bare, { recursive: true, force: true }); }
+  });
+
+  it("a commit whose push was rejected logs with pushState rejected — never pushed (the named mutant)", async () => {
+    const repo = makeRepo(); const bare = attachRemote(repo);
+    const other = mkdtempSync(join(tmpdir(), "realm-other-"));
+    const { service, entries } = logSvc();
+    try {
+      git(repo, "push", "-u", "origin", "main");
+      execFileSync("git", [...IDENT, "clone", "-q", bare, other]);
+      writeFileSync(join(other, "theirs.txt"), "theirs\n");
+      execFileSync("git", [...IDENT, "add", "-A"], { cwd: other });
+      execFileSync("git", [...IDENT, "commit", "-qm", "theirs"], { cwd: other });
+      execFileSync("git", [...IDENT, "push", "-q"], { cwd: other });
+
+      writeFileSync(join(repo, "mine.txt"), "mine\n"); git(repo, "add", "-A");
+      const r = await service.ship({ cwd: repo, commit: true, message: "mine", push: true, setUpstream: false, openPr: false, log: LOG });
+      expect(r.push.state).toBe("rejected");
+      // The commit HAPPENED, so the ship logs — with the push leg's real outcome on the row.
+      expect(entries).toHaveLength(1);
+      expect(entries[0]).toMatchObject({ subject: "mine", pushState: "rejected" });
+      expect(entries[0]!.pushState).not.toBe("pushed");
+    } finally { for (const d of [repo, bare, other]) rmSync(d, { recursive: true, force: true }); }
+  });
+
+  it("a commit whose branch has no upstream still logs, with pushState no-upstream", async () => {
+    const repo = makeRepo(); const bare = attachRemote(repo);
+    const { service, entries } = logSvc();
+    try {
+      writeFileSync(join(repo, "a.txt"), "A\n"); git(repo, "add", "-A");
+      await service.ship({ cwd: repo, commit: true, message: "m", push: true, setUpstream: false, openPr: false, log: LOG });
+      expect(entries).toHaveLength(1);
+      expect(entries[0]).toMatchObject({ pushState: "no-upstream", branch: "main" });
+    } finally { rmSync(repo, { recursive: true, force: true }); rmSync(bare, { recursive: true, force: true }); }
+  });
+
+  it("a commit-only ship logs with pushState skipped", async () => {
+    const repo = makeRepo();
+    const { service, entries } = logSvc();
+    try {
+      writeFileSync(join(repo, "a.txt"), "A\n"); git(repo, "add", "-A");
+      await service.ship({ cwd: repo, commit: true, message: "local only", push: false, setUpstream: false, openPr: false, log: LOG });
+      expect(entries).toHaveLength(1);
+      expect(entries[0]).toMatchObject({ subject: "local only", pushState: "skipped", prUrl: null });
+    } finally { rmSync(repo, { recursive: true, force: true }); }
+  });
+
+  it("the push-only retry logs the commit it sent, read off HEAD", async () => {
+    const repo = makeRepo(); const bare = attachRemote(repo);
+    const { service, entries } = logSvc();
+    try {
+      writeFileSync(join(repo, "a.txt"), "A\n"); git(repo, "add", "-A");
+      // First ship: no upstream — logs its own row. The RETRY (commit: false) is the flow under test.
+      await service.ship({ cwd: repo, commit: true, message: "Retry me", push: true, setUpstream: false, openPr: false, log: LOG });
+      await service.ship({ cwd: repo, commit: false, message: "", push: true, setUpstream: true, openPr: false, log: LOG });
+      expect(entries).toHaveLength(2);
+      expect(entries[1]).toEqual({ ...LOG, branch: "main", sha: git(repo, "rev-parse", "HEAD").trim(),
+        subject: "Retry me", prUrl: null, pushState: "pushed" });
+    } finally { rmSync(repo, { recursive: true, force: true }); rmSync(bare, { recursive: true, force: true }); }
+  });
+
+  it("records the PR URL when the PR leg produced one", async () => {
+    const repo = makeRepo(); const bare = attachGitHubLookalike(repo);
+    const gh = stubGh(`case "$1 $2" in
+  "pr view") exit 1 ;;
+  "pr create") echo "https://github.com/acme/widgets/pull/7"; exit 0 ;;
+esac
+exit 1`);
+    const { service, entries } = logSvc(gh);
+    try {
+      writeFileSync(join(repo, "a.txt"), "A\n"); git(repo, "add", "-A");
+      await service.ship({ cwd: repo, commit: true, message: "m", push: true, setUpstream: true, openPr: true, log: LOG });
+      expect(entries).toHaveLength(1);
+      expect(entries[0]).toMatchObject({ pushState: "pushed", prUrl: "https://github.com/acme/widgets/pull/7" });
+    } finally { rmSync(repo, { recursive: true, force: true }); rmSync(bare, { recursive: true, force: true }); }
+  });
+
+  it("logs nothing when nothing durable happened — no commit, no push", async () => {
+    const repo = makeRepo();
+    const { service, entries } = logSvc();
+    try {
+      // Nothing staged, push not asked for: the ship is a no-op and the log must say nothing.
+      await service.ship({ cwd: repo, commit: true, message: "empty", push: false, setUpstream: false, openPr: false, log: LOG });
+      // A push that answers up-to-date moved nothing either.
+      const bare = attachRemote(repo);
+      try {
+        git(repo, "push", "-u", "origin", "main");
+        await service.ship({ cwd: repo, commit: false, message: "", push: true, setUpstream: false, openPr: false, log: LOG });
+      } finally { rmSync(bare, { recursive: true, force: true }); }
+      expect(entries).toEqual([]);
+    } finally { rmSync(repo, { recursive: true, force: true }); }
+  });
+
+  it("logs nothing without attribution — an environment-less ship ships exactly as before", async () => {
+    const repo = makeRepo(); const bare = attachRemote(repo);
+    const { service, entries } = logSvc();
+    try {
+      writeFileSync(join(repo, "a.txt"), "A\n"); git(repo, "add", "-A");
+      const r = await service.ship({ cwd: repo, commit: true, message: "m", push: true, setUpstream: true, openPr: false });
+      expect(r.push.state).toBe("pushed");
+      expect(entries).toEqual([]);
+    } finally { rmSync(repo, { recursive: true, force: true }); rmSync(bare, { recursive: true, force: true }); }
+  });
+
+  it("a recorder that throws never changes the ship's own outcome", async () => {
+    const repo = makeRepo();
+    const service = new GitWriteService({ ghCommand: join(tmpdir(), "realm-no-such-gh"), shipLog: () => { throw new Error("db locked"); } });
+    try {
+      writeFileSync(join(repo, "a.txt"), "A\n"); git(repo, "add", "-A");
+      const r = await service.ship({ cwd: repo, commit: true, message: "m", push: false, setUpstream: false, openPr: false, log: LOG });
+      expect(r.commit.state).toBe("committed");
+    } finally { rmSync(repo, { recursive: true, force: true }); }
+  });
+});

--- a/apps/server/src/workspace/git-write.ts
+++ b/apps/server/src/workspace/git-write.ts
@@ -31,7 +31,21 @@ export type ShipInput = {
   /** Only ever true because the user was shown "this branch has no upstream" and said yes. */
   setUpstream: boolean;
   openPr: boolean;
+  /** Attribution for the durable ship log (Plan 14 W1): which environment row (and so which space)
+   *  this checkout is. Resolved by the RPC layer from the id the PANE named — never guessed from the
+   *  path, which can be registered in two spaces. Absent/null = an unattributed ship, which ships
+   *  exactly as before and logs nothing. */
+  log?: { environmentId: string; spaceId: string } | null;
 };
+
+/** What `ship` hands the log the moment its legs settle (Plan 14 W1). `pushState` is the push leg's
+ *  ACTUAL outcome — the row records what happened, not what was hoped. */
+export type ShipLogEntry = {
+  environmentId: string; spaceId: string;
+  branch: string | null; sha: string; subject: string; prUrl: string | null;
+  pushState: PushOutcome["state"];
+};
+export type ShipLogRecorder = (entry: ShipLogEntry) => void;
 
 /**
  * The git write path (Plan 7 W3): staging, and commit → push → open PR as one action.
@@ -56,10 +70,12 @@ export class GitWriteService {
   private git: GitRun;
   private run: RunCommand;
   private gh: string;
-  constructor(opts: { git?: GitRun; run?: RunCommand; ghCommand?: string } = {}) {
+  private shipLog: ShipLogRecorder | null;
+  constructor(opts: { git?: GitRun; run?: RunCommand; ghCommand?: string; shipLog?: ShipLogRecorder } = {}) {
     this.git = opts.git ?? gitCapture;
     this.run = opts.run ?? runCommand;
     this.gh = opts.ghCommand ?? "gh";
+    this.shipLog = opts.shipLog ?? null;
   }
 
   /** The checkout root, so a path from the diff list means the same thing here as it did there. */
@@ -140,12 +156,54 @@ export class GitWriteService {
     // A failed commit means the tree is not what the user meant to publish. Pushing anyway would send
     // the previous commit under the impression that this one went out.
     const canPush = input.push && commit.state !== "failed" && commit.state !== "no-identity";
-    const push = canPush ? await this.doPush(root, input.setUpstream) : pushOutcome("skipped", { reason: input.push ? "the commit did not happen" : null });
-    const onRemote = push.state === "pushed" || push.state === "up-to-date";
-    const pr = input.openPr
-      ? onRemote ? await this.doPr(root, push.remote, push.branch, input.message) : prOutcome("skipped", { reason: "the branch is not on the remote yet" })
-      : prOutcome("skipped", {});
-    return { commit, push, pr };
+    // The push and PR legs run under a finally so the log is written with whatever HAS settled even
+    // when a later leg crashes outright (a killed push): a commit that happened must log (Plan 14 W1).
+    let push: PushOutcome | null = null;
+    let pr: PrOutcome | null = null;
+    try {
+      push = canPush ? await this.doPush(root, input.setUpstream) : pushOutcome("skipped", { reason: input.push ? "the commit did not happen" : null });
+      const onRemote = push.state === "pushed" || push.state === "up-to-date";
+      pr = input.openPr
+        ? onRemote ? await this.doPr(root, push.remote, push.branch, input.message) : prOutcome("skipped", { reason: "the branch is not on the remote yet" })
+        : prOutcome("skipped", {});
+      return { commit, push, pr };
+    } finally {
+      await this.logShip(input, root, commit, push, canPush, pr);
+    }
+  }
+
+  /**
+   * The durable ship log's one write site (Plan 14 W1), reached however `ship` exits.
+   *
+   * A row is written when something durable happened: a commit was made this call, or a push reached
+   * the remote (the retry flow, where the commit leg was deliberately skipped). `pushState` is the
+   * push leg's outcome VERBATIM — a rejected or failed push after a successful commit logs as exactly
+   * that, never as `pushed`. A push leg that was entered but never settled (the process was killed
+   * mid-push) logs `failed`: attempted-and-unaccounted-for is a failure, not a skip.
+   *
+   * Logging is subordinate to shipping: a log-write error is swallowed, because the ship's own result
+   * (or its own error) is what the user acted on and must be what they see.
+   */
+  private async logShip(input: ShipInput, root: string, commit: CommitOutcome, push: PushOutcome | null, pushAttempted: boolean, pr: PrOutcome | null): Promise<void> {
+    if (!this.shipLog || !input.log) return;
+    try {
+      const pushState: PushOutcome["state"] = push ? push.state : pushAttempted ? "failed" : "skipped";
+      const landed = commit.state === "committed" || pushState === "pushed";
+      if (!landed) return;
+      // The retry flow commits nothing, so the row's sha/subject are read off HEAD — the commit the
+      // push just sent. `sha` empty means there is no commit anywhere, and nothing to record.
+      const sha = commit.sha ?? (await this.git(root, ["rev-parse", "HEAD"])).stdout.trim();
+      if (!sha) return;
+      const subject = commit.subject ?? (await this.git(root, ["log", "-1", "--format=%s"])).stdout.trim();
+      const branch = push?.branch ?? (await this.currentBranch(root));
+      this.shipLog({ environmentId: input.log.environmentId, spaceId: input.log.spaceId, branch, sha, subject, prUrl: pr?.url ?? null, pushState });
+    } catch { /* see doc comment: the log must never change the ship's own outcome */ }
+  }
+
+  /** The checked-out branch name, or null for detached HEAD — the log's branch column. */
+  private async currentBranch(root: string): Promise<string | null> {
+    const name = (await this.git(root, ["rev-parse", "--abbrev-ref", "HEAD"])).stdout.trim();
+    return name === "" || name === "HEAD" ? null : name;
   }
 
   private async doCommit(root: string, message: string): Promise<CommitOutcome> {

--- a/packages/adapters/src/acp/acp-adapter.test.ts
+++ b/packages/adapters/src/acp/acp-adapter.test.ts
@@ -636,6 +636,73 @@ describe("AcpAdapter", () => {
     await handle.dispose();
   });
 
+  it("captures the agent's advertised modes on the init event, verbatim (Plan 14 W3)", async () => {
+    const { handle, evs } = await booted();
+    expect(of(evs, "init")[0]!.payload.availableModes).toEqual([
+      { id: "agent", name: "Agent", description: "Full agent capabilities with tool access" },
+      { id: "plan", name: "Plan", description: "Read-only mode for planning and designing before implementation" },
+      { id: "ask", name: "Ask", description: "Q&A mode - no edits or command execution" },
+    ]);
+    await handle.dispose();
+  });
+
+  it("claims no modes on the init event when the agent named none", async () => {
+    const { handle, evs } = await booted({}, { env: { FAKE_ACP_NOMODES: "1" } });
+    expect(of(evs, "init")[0]!.payload).not.toHaveProperty("availableModes");
+    await handle.dispose();
+  });
+
+  it("translates Plan and Build onto the AGENT'S own mode ids, in that order", async () => {
+    const { handle, evs } = await booted();
+    await handle.setOptions({ permissionMode: "plan" });
+    // Leaving Plan restores a Realm PERMISSION id on the wire ("default" here) — for the mode axis
+    // that means Build, which is Cursor's `agent`, never the Realm string itself.
+    await handle.setOptions({ permissionMode: "default" });
+    await turn(handle, evs, "REVEAL");
+    const journal = JSON.parse(texts(evs)[0]!) as { calls: { method: string; params: { modeId?: string } }[] };
+    expect(journal.calls.filter((c) => c.method === "session/set_mode").map((c) => c.params.modeId)).toEqual(["plan", "agent"]);
+    await handle.dispose();
+  });
+
+  it("sends NOTHING to session/set_mode when the agent advertises no plan-equivalent", async () => {
+    // The named mutant: forwarding Realm's id would collide with Cursor's `plan` by luck today and be
+    // a foreign-id rejection (or an accidental match) on any other agent.
+    const logs: string[] = [];
+    const { handle, evs } = await booted({ onLog: (l) => logs.push(l) }, { env: { FAKE_ACP_NOPLANMODE: "1" } });
+    await handle.setOptions({ permissionMode: "plan" });
+    await turn(handle, evs, "REVEAL");
+    const journal = JSON.parse(texts(evs)[0]!) as { calls: { method: string }[] };
+    expect(journal.calls.filter((c) => c.method === "session/set_mode")).toEqual([]);
+    expect(logs.join("\n")).toContain("no advertised mode maps onto Plan");
+    await handle.dispose();
+  });
+
+  it("sends NOTHING to session/set_mode when the agent advertised no modes at all", async () => {
+    const { handle, evs } = await booted({}, { env: { FAKE_ACP_NOMODES: "1" } });
+    await handle.setOptions({ permissionMode: "default" });
+    await turn(handle, evs, "REVEAL");
+    const journal = JSON.parse(texts(evs)[0]!) as { calls: { method: string }[] };
+    expect(journal.calls.filter((c) => c.method === "session/set_mode")).toEqual([]);
+    await handle.dispose();
+  });
+
+  it("re-enters Plan at boot — with the agent's own id — when the session's row says plan", async () => {
+    const { handle, evs } = await booted({ permissionMode: "plan" });
+    await turn(handle, evs, "REVEAL");
+    const journal = JSON.parse(texts(evs)[0]!) as { calls: { method: string; params: { modeId?: string } }[] };
+    expect(journal.calls.filter((c) => c.method === "session/set_mode").map((c) => c.params.modeId)).toEqual(["plan"]);
+    await handle.dispose();
+  });
+
+  it("boots a plan-rowed session silently when the agent has no plan mode to enter", async () => {
+    const { handle, evs } = await booted({ permissionMode: "plan" }, { env: { FAKE_ACP_NOPLANMODE: "1" } });
+    await turn(handle, evs, "REVEAL");
+    const journal = JSON.parse(texts(evs)[0]!) as { calls: { method: string }[] };
+    expect(journal.calls.filter((c) => c.method === "session/set_mode")).toEqual([]);
+    expect(errors(evs)).toEqual([]); // no plan-equivalent is not a failure; the session runs in its default mode
+    await handle.dispose();
+  });
+
   it("emits no error on a deliberate dispose, and ends the stream", async () => {
     const { handle, evs, done } = await booted();
     await handle.dispose();

--- a/packages/adapters/src/acp/acp-adapter.test.ts
+++ b/packages/adapters/src/acp/acp-adapter.test.ts
@@ -590,6 +590,16 @@ describe("AcpAdapter", () => {
     await linked.handle.dispose();
   });
 
+  it("attachment-only: no empty text block is manufactured — the attachments ARE the prompt (Plan 14 W5)", async () => {
+    const { handle, evs } = await booted();
+    await handle.send({ text: "", attachments: [{ path: "/tmp/notes.txt", mime: "text/plain" }] });
+    await waitFor(() => expect(texts(evs)).toHaveLength(1));
+    expect(JSON.parse(texts(evs)[0]!)).toEqual([
+      { type: "resource_link", uri: "file:///tmp/notes.txt", name: "notes.txt", mimeType: "text/plain" },
+    ]);
+    await handle.dispose();
+  });
+
   it("links non-image attachments rather than embedding them", async () => {
     const { handle, evs } = await booted();
     // Cursor reports embeddedContext:false, so a `resource` block would be rejected outright.

--- a/packages/adapters/src/acp/acp-adapter.ts
+++ b/packages/adapters/src/acp/acp-adapter.ts
@@ -464,9 +464,11 @@ export class AcpAdapter implements AgentAdapter {
       }
     })();
 
-    /** `prompt: ContentBlock[]` (§3). Images inline only where the agent accepts them; everything else links. */
+    /** `prompt: ContentBlock[]` (§3). Images inline only where the agent accepts them; everything else
+     *  links. Attachment-only messages (Plan 14 W5): no empty text block is manufactured — every
+     *  attachment yields a block of its own (image or resource_link), so the prompt is never empty. */
     const promptFor = async (m: UserMessage): Promise<Bag[]> => {
-      const blocks: Bag[] = [{ type: "text", text: m.text }];
+      const blocks: Bag[] = m.text ? [{ type: "text", text: m.text }] : [];
       for (const a of m.attachments) {
         // Cursor reports embeddedContext:false, so a `resource` block is never an option — a link it is.
         const link = { type: "resource_link", uri: `file://${a.path}`, name: basename(a.path), mimeType: a.mime };

--- a/packages/adapters/src/acp/acp-adapter.ts
+++ b/packages/adapters/src/acp/acp-adapter.ts
@@ -1,7 +1,7 @@
 import { basename, dirname, join, resolve, sep } from "node:path";
 import { tmpdir } from "node:os";
 import { readFile, realpath, stat, writeFile } from "node:fs/promises";
-import { sessionEvent, type AgentKind, type SessionEvent } from "@realm/contracts";
+import { acpBuildMode, acpPlanMode, PLAN_PERMISSION_MODE, sessionEvent, type AcpSessionMode, type AgentKind, type SessionEvent } from "@realm/contracts";
 import { AsyncQueue } from "../event-queue";
 import { JsonRpcCallError, StdioJsonRpc, withTimeout, type JsonRpcId } from "../jsonrpc/stdio";
 import { createAcpMapper } from "./map-acp";
@@ -237,6 +237,11 @@ export class AcpAdapter implements AgentAdapter {
     let sessionId: string | null = null;
     let imagesAllowed = false;
     let authMethods: unknown[] = [];
+    /** `modes.availableModes` from `session/new`/`session/load`, verbatim (Plan 14 W3). What Plan and
+     *  Build translate through — `session/set_mode` only ever transmits one of THESE ids. */
+    let availableModes: AcpSessionMode[] = [];
+    /** `modes.currentModeId` at boot — `acpBuildMode`'s fallback when the agent has no `agent` id. */
+    let bootModeId: string | null = null;
     /** True only for the duration of `session/load`, whose replay Realm has already persisted. */
     let replaying = false;
     let disposed = false;
@@ -423,13 +428,33 @@ export class AcpAdapter implements AgentAdapter {
             log(`session/set_model ${opts.model} failed (${message(e)}); staying on the agent's default`);
           }
         }
+        // The agent's own modes, captured verbatim (Plan 14 W3). Both installed agents answer
+        // `session/new` with `modes` (Cursor: agent/plan/ask, verified live 2026-09-01); a build that
+        // omits it simply has no Plan here, and the init event carries no claim it does.
+        const modesBag = obj(session.modes);
+        availableModes = (Array.isArray(modesBag.availableModes) ? modesBag.availableModes : [])
+          .map(obj)
+          .filter((m): m is Bag & { id: string; name: string } => typeof m.id === "string" && typeof m.name === "string")
+          .map((m) => ({ id: m.id, name: m.name, ...(typeof m.description === "string" ? { description: m.description } : {}) }));
+        bootModeId = str(modesBag.currentModeId) || null;
         events.push(sessionEvent("init", {
           providerSessionId: id,
           model: pinned ? str(opts.model) : str(obj(session.models).currentModelId) || str(opts.model),
           tools: [],
           cwd: opts.cwd,
+          ...(availableModes.length ? { availableModes } : {}),
         }));
         events.push(sessionEvent("status", { status: "idle" }));
+        // A session persisted in Plan resumes in Plan (the row's permissionMode carries the Realm-side
+        // record of the mode axis; see PLAN_PERMISSION_MODE). Only ever the AGENT'S OWN id, and only
+        // when it advertised one — with no plan-equivalent the session honestly stays in its default
+        // mode and the prompter shows no Plan chip either. Best-effort like setOptions: a refusal is
+        // a log line, not a boot failure.
+        const bootPlan = opts.permissionMode === PLAN_PERMISSION_MODE ? acpPlanMode(availableModes) : null;
+        if (bootPlan && bootPlan.id !== bootModeId) {
+          try { await ask("session/set_mode", { sessionId: id, modeId: bootPlan.id }, INITIALIZE_TIMEOUT_MS); }
+          catch (e) { log(`session/set_mode at boot failed: ${message(e)}`); }
+        }
       } catch (e) {
         if (disposed) return;
         fail(acpBootFailureMessage(e, spec, authMethods));
@@ -493,7 +518,16 @@ export class AcpAdapter implements AgentAdapter {
           try { await rpc!.request(method, params); }
           catch (e) { log(`${method} failed: ${message(e)}`); }
         };
-        if (o.permissionMode !== undefined) await attempt("session/set_mode", { sessionId, modeId: o.permissionMode });
+        if (o.permissionMode !== undefined) {
+          // The mode axis, translated (Plan 14 W3): Realm's plan wire value maps onto the agent's own
+          // plan-equivalent, anything else onto its Build mode. NEVER `o.permissionMode` itself — ACP
+          // mode ids are agent-defined, and `session/set_mode` with a Realm id ("plan" happens to
+          // collide on Cursor today, "acceptEdits" never would) is a foreign-id rejection at best and
+          // an accidental match at worst. No equivalent advertised → nothing is sent at all.
+          const target = o.permissionMode === PLAN_PERMISSION_MODE ? acpPlanMode(availableModes) : acpBuildMode(availableModes, bootModeId);
+          if (target) await attempt("session/set_mode", { sessionId, modeId: target.id });
+          else log(`no advertised mode maps onto ${o.permissionMode === PLAN_PERMISSION_MODE ? "Plan" : "Build"}; session/set_mode not sent`);
+        }
         if (o.model !== undefined) await attempt("session/set_model", { sessionId, modelId: o.model });
       },
       dispose: async () => {

--- a/packages/adapters/src/acp/fixtures/fake-acp-agent.mjs
+++ b/packages/adapters/src/acp/fixtures/fake-acp-agent.mjs
@@ -31,6 +31,8 @@
  * fail -32603 with data (Cursor's shape), FAKE_ACP_LOADFAIL=1 makes session/load fail, FAKE_ACP_NOLOAD=1 drops
  * the loadSession capability, FAKE_ACP_NOIMAGE=1 drops the image prompt capability, FAKE_ACP_ALLOWONLY=1 offers no reject option, and FAKE_ACP_LOAD_ASKS=1
  * makes session/load call fs/read_text_file and session/request_permission back on us mid-replay.
+ * FAKE_ACP_NOMODES=1 omits `modes` from session/new and session/load (a build that names none),
+ * FAKE_ACP_NOPLANMODE=1 advertises modes without a plan-equivalent (agent/ask only).
  * FAKE_ACP_MUTE_INITIALIZE=1, FAKE_ACP_MUTE_SESSION_NEW=1 and FAKE_ACP_MUTE_SESSION_LOAD=1 leave that request unanswered forever.
  * FAKE_ACP_SET_MODEL_OK=1 makes session/set_model succeed (it fails -32601 by default), and
  * FAKE_ACP_MODEL_GARBAGE=1 pollutes session/new's availableModels with malformed rows.
@@ -62,6 +64,17 @@ const ask = (method, params) => {
   return new Promise((resolve) => pendingRequests.set(id, resolve));
 };
 const promptText = (prompt) => (Array.isArray(prompt) ? prompt : []).map((b) => (b && typeof b.text === "string" ? b.text : "")).join(" ");
+
+/** `modes` as the real cursor-agent 2026.07.25 returns them from session/new (and session/load). */
+const sessionModes = () => {
+  if (process.env.FAKE_ACP_NOMODES) return {};
+  const availableModes = [
+    { id: "agent", name: "Agent", description: "Full agent capabilities with tool access" },
+    ...(process.env.FAKE_ACP_NOPLANMODE ? [] : [{ id: "plan", name: "Plan", description: "Read-only mode for planning and designing before implementation" }]),
+    { id: "ask", name: "Ask", description: "Q&A mode - no edits or command execution" },
+  ];
+  return { modes: { currentModeId: "agent", availableModes } };
+};
 
 // FAKE_ACP_ALLOWONLY drops the reject options, the case where no optionId can carry a deny.
 const PERMISSION_OPTIONS = [
@@ -166,7 +179,7 @@ async function loadSession(id, params) {
     ]);
     journal.replayAsks = { read, permission };
   }
-  ok(id, {});
+  ok(id, sessionModes());
 }
 
 function handleRequest(id, method, params) {
@@ -192,7 +205,7 @@ function handleRequest(id, method, params) {
       if (process.env.FAKE_ACP_STARTFAIL) { fail(id, -32603, "Internal error", { message: "Failed to initialize session services", details: "[unauthenticated] Error" }); return; }
       journal.newParams = params;
       if (process.env.FAKE_ACP_NOSESSIONID) { ok(id, {}); return; }
-      ok(id, { sessionId: `sess_${nextSessionN++}`, models: { currentModelId: "fake-model-1", availableModels: process.env.FAKE_ACP_MODEL_GARBAGE
+      ok(id, { sessionId: `sess_${nextSessionN++}`, ...sessionModes(), models: { currentModelId: "fake-model-1", availableModels: process.env.FAKE_ACP_MODEL_GARBAGE
         // Rows a real preview build could plausibly emit around the good ones: no modelId, wrong types,
         // blank ids, plus one nameless-but-valid id. Only the well-formed survive parseAcpModels.
         ? [null, 42, "composer", { name: "No id" }, { modelId: "", name: "Blank id" }, { modelId: "fake-model-1", name: "Fake 1" }, { modelId: 7, name: "Numeric id" }, { modelId: "fake-model-2" }]

--- a/packages/adapters/src/acp/fixtures/fake-acp-agent.mjs
+++ b/packages/adapters/src/acp/fixtures/fake-acp-agent.mjs
@@ -147,7 +147,10 @@ async function runTurn(id, sessionId, prompt) {
     return;
   }
   if (text.includes("HANG")) return; // resolved only by session/cancel
-  if (text.includes("ECHO")) message(sessionId, JSON.stringify(prompt));
+  // An attachment-only prompt has no text block at all (Plan 14 W5) — echoed like ECHO, for the same
+  // input-shape assertions.
+  const hasTextBlock = Array.isArray(prompt) && prompt.some((b) => b && b.type === "text");
+  if (text.includes("ECHO") || !hasTextBlock) message(sessionId, JSON.stringify(prompt));
   else if (text.includes("REVEAL")) message(sessionId, JSON.stringify(journal));
   else if (text.includes("PERMIT2")) await Promise.all([permitTurn(sessionId, 0), permitTurn(sessionId, 1)]);
   else if (text.includes("PERMIT")) await permitTurn(sessionId, 0);

--- a/packages/adapters/src/claude/claude-adapter.test.ts
+++ b/packages/adapters/src/claude/claude-adapter.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { ClaudeAdapter, claudeAllowedTools, claudeMcpServers } from "./claude-adapter";
 import type { SessionEvent } from "@realm/contracts";
 import type { StartOptions } from "../types";
-import { readFileSync } from "node:fs"; import { join, dirname } from "node:path"; import { fileURLToPath } from "node:url";
+import { readFileSync, writeFileSync } from "node:fs"; import { tmpdir } from "node:os"; import { join, dirname } from "node:path"; import { fileURLToPath } from "node:url";
 const fixture = JSON.parse(readFileSync(join(dirname(fileURLToPath(import.meta.url)), "fixtures", "turn.json"), "utf8")) as unknown[];
 
 type FakeOpts = {
@@ -21,6 +21,8 @@ type FakeOpts = {
   hang?: boolean;
   /** like the real SDK: reject iteration when options.abortController aborts */
   abortable?: boolean;
+  /** record each user message pulled off the prompt stream (content-shape assertions) */
+  capture?: unknown[];
 };
 function fakeQuery(opts: FakeOpts, calls: string[] = []) {
   return ({ prompt, options }: { prompt: AsyncIterable<unknown>; options: Record<string, unknown> }) => {
@@ -28,6 +30,7 @@ function fakeQuery(opts: FakeOpts, calls: string[] = []) {
       for (const l of opts.stderr ?? []) (options.stderr as (d: string) => void)(l);
       const it = prompt[Symbol.asyncIterator](); const first = await it.next();
       if (first.done) return;
+      opts.capture?.push(first.value);
       let n = 0; let asked = false;
       for (const m of fixture) {
         if (opts.throwAfter !== undefined && n++ >= opts.throwAfter) throw new Error("sdk exploded");
@@ -129,6 +132,33 @@ describe("ClaudeAdapter", () => {
     await h.send({ text: "hi", attachments: [] }); const got = await c; await h.dispose();
     const err = got.find((e) => e.type === "error");
     expect(err?.type === "error" && err.payload.message).toBe("turn failed");
+  });
+  it("attachment-only: an image carries the message with NO empty text block (Plan 14 W5)", async () => {
+    // The Messages API rejects `text: ""` — an image-only send must be image blocks alone.
+    const png = join(tmpdir(), `realm-claude-attach-${Date.now()}.png`);
+    writeFileSync(png, Buffer.from([1, 2, 3, 4]));
+    const capture: unknown[] = [];
+    const a = new ClaudeAdapter({ query: fakeQuery({ capture }) as never });
+    const h = a.start({ cwd: "/tmp", mcpServers: [] });
+    const c = collectUntil(h.events, (e) => e.type === "status" && e.payload.status === "idle");
+    await h.send({ text: "", attachments: [{ path: png, mime: "image/png" }] });
+    await c; await h.dispose();
+    const content = (capture[0] as { message: { content: Array<Record<string, unknown>> } }).message.content;
+    expect(content).toHaveLength(1);
+    expect(content[0]).toMatchObject({ type: "image" });
+  });
+  it("attachment-only where Claude ignores everything: the minimal honest stub, never empty content", async () => {
+    // The named mutant: no text + non-image attachments (which this adapter skips) would otherwise be
+    // a literally empty content array, which the API rejects. The prompter's send-gate refuses this
+    // combination; the stub is the wire-level net for any other caller.
+    const capture: unknown[] = [];
+    const a = new ClaudeAdapter({ query: fakeQuery({ capture }) as never });
+    const h = a.start({ cwd: "/tmp", mcpServers: [] });
+    const c = collectUntil(h.events, (e) => e.type === "status" && e.payload.status === "idle");
+    await h.send({ text: "", attachments: [{ path: "/tmp/notes.pdf", mime: "application/pdf" }] });
+    await c; await h.dispose();
+    const content = (capture[0] as { message: { content: Array<Record<string, unknown>> } }).message.content;
+    expect(content).toEqual([{ type: "text", text: "(attached files)" }]);
   });
   it("send with an unreadable attachment emits error and does not start running", async () => {
     const a = new ClaudeAdapter({ query: fakeQuery({ hang: true }) as never });

--- a/packages/adapters/src/claude/claude-adapter.ts
+++ b/packages/adapters/src/claude/claude-adapter.ts
@@ -204,7 +204,13 @@ export class ClaudeAdapter implements AgentAdapter {
         // as the command's argument. `name` is the frontmatter name, which is how the plugin registers
         // the skill (a prepend built from the directory id would target nothing when the two differ).
         const text = m.skill ? `/realm:${m.skill.name} ${m.text}` : m.text;
-        const content: Array<Record<string, unknown>> = [{ type: "text", text }, ...images];
+        // Attachment-only messages (Plan 14 W5): the Messages API rejects an empty text block, so one
+        // is only included when there is text. Images can carry a message alone — but a send whose
+        // attachments were ALL skipped above (Claude ignores non-images) would be literally empty
+        // content, which the API also rejects; the minimal honest stub says what the user did. The
+        // prompter's send-gate refuses that combination up front, so this is the wire-level net.
+        const content: Array<Record<string, unknown>> = [...(text ? [{ type: "text", text }] : []), ...images];
+        if (content.length === 0) content.push({ type: "text", text: "(attached files)" });
         input.push({ type: "user", message: { role: "user", content: content as never }, parent_tool_use_id: null, session_id: "" } as SDKUserMessage);
       },
       respondPermission: resolvePermission,

--- a/packages/adapters/src/codex/codex-adapter.test.ts
+++ b/packages/adapters/src/codex/codex-adapter.test.ts
@@ -156,6 +156,23 @@ describe("CodexAdapter", () => {
     await handle.dispose();
   });
 
+  it("attachment-only: an image-only send is just the localImage item — no empty text item (Plan 14 W5)", async () => {
+    const { handle, evs } = await booted();
+    await handle.send({ text: "", attachments: [{ path: "/tmp/shot.png", mime: "image/png" }] });
+    await waitFor(() => expect(texts(evs)).toHaveLength(1));
+    expect(JSON.parse(texts(evs)[0]!)).toEqual([{ type: "localImage", path: "/tmp/shot.png" }]);
+    await handle.dispose();
+  });
+
+  it("attachment-only files: the file list stands alone, no leading blank lines (Plan 14 W5)", async () => {
+    const { handle, evs } = await booted();
+    // The path carries the ECHO trigger — the file list becomes the text item, which is the point.
+    await handle.send({ text: "", attachments: [{ path: "/tmp/ECHO-notes.txt", mime: "text/plain" }] });
+    await waitFor(() => expect(texts(evs)).toHaveLength(1));
+    expect(JSON.parse(texts(evs)[0]!)).toEqual([{ type: "text", text: "Attached files:\n- /tmp/ECHO-notes.txt", text_elements: [] }]);
+    await handle.dispose();
+  });
+
   it("sends only a text block when there are no attachments", async () => {
     const { handle, evs } = await booted();
     await handle.send({ text: "ECHO", attachments: [] });

--- a/packages/adapters/src/codex/codex-adapter.ts
+++ b/packages/adapters/src/codex/codex-adapter.ts
@@ -446,9 +446,13 @@ export class CodexAdapter implements AgentAdapter {
       const files = m.attachments.filter((a) => !a.mime.startsWith("image/"));
       // Codex reads local images off disk, so no base64. Anything else is named in the text and left for the
       // agent to open with its own tools.
-      const text = files.length ? `${m.text}\n\nAttached files:\n${files.map((a) => `- ${a.path}`).join("\n")}` : m.text;
+      const fileList = `Attached files:\n${files.map((a) => `- ${a.path}`).join("\n")}`;
+      // Attachment-only messages (Plan 14 W5): with no text, the file list stands alone (no leading
+      // blank lines), and an images-only send carries just the localImage items — the `UserInput`
+      // union takes any mix, so an empty-string text item is never manufactured to fill space.
+      const text = files.length ? (m.text ? `${m.text}\n\n${fileList}` : fileList) : m.text;
       return [
-        { type: "text", text, text_elements: [] },
+        ...(text ? [{ type: "text", text, text_elements: [] }] : []),
         // A resolved @-mention (W4) rides as Codex's NATIVE skill input item, beside the text — the
         // app-server `UserInput` union has a `skill` variant, which beats munging `$name` into the
         // text. `name` is the frontmatter name (what skills/list reports); `path` is the library

--- a/packages/adapters/src/codex/fixtures/fake-codex-server.mjs
+++ b/packages/adapters/src/codex/fixtures/fake-codex-server.mjs
@@ -301,6 +301,9 @@ function handleRequest(id, method, params) {
       if (text.includes("APPROVE")) { void streamApprovalTurn(params.threadId, turnId, text); return; }
       if (text.includes("ODDBALL")) { void streamOddballTurn(params.threadId, turnId, text); return; }
       if (text.includes("ECHO")) { void streamEchoTurn(params.threadId, turnId, text, params.input); return; }
+      // Attachment-only sends carry no text item at all (Plan 14 W5) — echo those too, so tests can
+      // assert the exact input shape without a text trigger to hang one on.
+      if (!params.input.some((part) => part && part.type === "text")) { void streamEchoTurn(params.threadId, turnId, text, params.input); return; }
       void streamMessageTurn(params.threadId, turnId, text);
       return;
     }

--- a/packages/contracts/src/attachments.ts
+++ b/packages/contracts/src/attachments.ts
@@ -78,6 +78,13 @@ export function basenameOf(path: string): string {
  * This table MIRRORS the adapters; it does not govern them. The divergence between the three is
  * deliberate (each protocol wants something different), so the point of naming it here is that the
  * prompter can tell the user which one they are getting BEFORE they press send.
+ *
+ * Attachment-only messages (Plan 14 W5): `sessions.send` accepts empty text when attachments are
+ * present, and each adapter was re-read for that case — Claude includes no empty text block (the
+ * Messages API rejects `text: ""`; all-ignored attachments get the "(attached files)" stub so content
+ * is never empty), Codex includes no empty text item (localImage items / the file list ARE the
+ * message), ACP includes no empty text block (every attachment is its own block). `ignored`
+ * attachments cannot carry a message alone; the prompter's send-gate refuses that combination.
  */
 export type AttachmentDisposition = "inline" | "path" | "link" | "ignored";
 

--- a/packages/contracts/src/entities.test.ts
+++ b/packages/contracts/src/entities.test.ts
@@ -49,6 +49,11 @@ describe("destination-page sentinels (Plan 12 W4)", () => {
     for (const id of Object.values(PAGE_REF_IDS)) expect(IdSchema.safeParse(id).success).toBe(true);
   });
 
+  it("profile-page (Plan 14 W2) took the next free sentinel — …005 — without colliding with an existing one", () => {
+    expect(PAGE_REF_IDS["profile-page"]).toBe("00000000000000000000000005");
+    expect(Object.entries(PAGE_REF_IDS).filter(([k]) => k !== "profile-page").map(([, v]) => v)).not.toContain("00000000000000000000000005");
+  });
+
   it("sentinels are distinct, and unmintable: their timestamp component is the 1970 epoch", () => {
     const ids = Object.values(PAGE_REF_IDS);
     expect(new Set(ids).size).toBe(ids.length);

--- a/packages/contracts/src/entities.ts
+++ b/packages/contracts/src/entities.ts
@@ -29,7 +29,7 @@ export type Project = z.infer<typeof ProjectSchema>;
  *  ENVIRONMENT id: a diff is a view of a checkout, and several sessions may share one.
  *  `space-page` (Plan 12 W3) follows that precedent: its `refId` is the SPACE id itself — the pane is
  *  the space's own page (General/Memory/Skills/Connections/Sessions/History), one per space. */
-export const ItemKindSchema = z.enum(["session", "terminal", "browser", "simulator", "artifact", "context", "diff", "space-page", "library-page", "connections-page", "notifications-page", "settings-page"]);
+export const ItemKindSchema = z.enum(["session", "terminal", "browser", "simulator", "artifact", "context", "diff", "space-page", "library-page", "connections-page", "notifications-page", "settings-page", "profile-page"]);
 export type ItemKind = z.infer<typeof ItemKindSchema>;
 
 /**
@@ -48,6 +48,10 @@ export const PAGE_REF_IDS = {
   "connections-page": "00000000000000000000000002",
   "notifications-page": "00000000000000000000000003",
   "settings-page": "00000000000000000000000004",
+  // Plan 14 W2. The page shows the VANTAGE space's profile — the profile is derived live from
+  // `item.spaceId`, never stored in the item, so a space moved between profiles moves its page's
+  // subject with it (and a page can never keep editing a profile its space has left).
+  "profile-page": "00000000000000000000000005",
 } as const;
 export type DestinationPageKind = keyof typeof PAGE_REF_IDS;
 

--- a/packages/contracts/src/presets.test.ts
+++ b/packages/contracts/src/presets.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { SPACE_COLORS, SPACE_ICONS, pickSpaceColor, AGENT_CLI_COMMANDS, AGENT_META, AGENT_MODELS, AGENT_LOGIN_HINTS, AGENT_SUPPORTS_PERMISSION_MODES, AGENT_SUPPORTS_PLAN_MODE, DEFAULT_MODEL_LABEL, PERMISSION_MODES, PLAN_PERMISSION_MODE, SELECTABLE_AGENT_KINDS, SESSION_MODES } from "./presets";
+import { SPACE_COLORS, SPACE_ICONS, pickSpaceColor, acpBuildMode, acpPlanMode, AGENT_CLI_COMMANDS, AGENT_META, AGENT_MODELS, AGENT_LOGIN_HINTS, AGENT_SUPPORTS_PERMISSION_MODES, AGENT_SUPPORTS_PLAN_MODE, DEFAULT_MODEL_LABEL, PERMISSION_MODES, PLAN_PERMISSION_MODE, SELECTABLE_AGENT_KINDS, SESSION_MODES, type AcpSessionMode } from "./presets";
 import { AgentKindSchema } from "./entities";
 describe("presets", () => {
   it("has at least 8 colors and icons", () => { expect(SPACE_COLORS.length).toBeGreaterThanOrEqual(8); expect(SPACE_ICONS.length).toBeGreaterThanOrEqual(8); });
@@ -117,5 +117,40 @@ describe("SELECTABLE_AGENT_KINDS", () => {
     expect(SELECTABLE_AGENT_KINDS).not.toContain("fake");       // scripted dev adapter
     expect(AGENT_META["acp:gemini"]).toBeDefined();
     expect(AGENT_META.fake).toBeDefined();
+  });
+});
+
+describe("acpPlanMode / acpBuildMode (Plan 14 W3)", () => {
+  // The real cursor-agent 2026.07.25 handshake, captured live 2026-09-01.
+  const CURSOR: AcpSessionMode[] = [
+    { id: "agent", name: "Agent", description: "Full agent capabilities with tool access" },
+    { id: "plan", name: "Plan", description: "Read-only mode for planning and designing before implementation" },
+    { id: "ask", name: "Ask", description: "Q&A mode - no edits or command execution" },
+  ];
+  it("finds Cursor's plan mode by the agent's own id", () => {
+    expect(acpPlanMode(CURSOR)?.id).toBe("plan");
+    expect(acpPlanMode(CURSOR)?.description).toContain("Read-only");
+  });
+  it("matches on id, never on a name that merely sounds like Plan", () => {
+    // The lie the per-session capability exists to end: a mode Realm HOPES means plan-only.
+    expect(acpPlanMode([{ id: "design", name: "Plan" }, { id: "agent", name: "Agent" }])).toBeNull();
+  });
+  it("answers null for no modes at all", () => {
+    expect(acpPlanMode([])).toBeNull();
+    expect(acpPlanMode(null)).toBeNull();
+    expect(acpPlanMode(undefined)).toBeNull();
+  });
+  it("maps Build onto the agent's `agent` mode when it has one", () => {
+    expect(acpBuildMode(CURSOR, null)?.id).toBe("agent");
+    // …even when the session booted elsewhere: `agent` is the mode Build claims to be.
+    expect(acpBuildMode(CURSOR, "ask")?.id).toBe("agent");
+  });
+  it("falls back to the boot mode, but never to the plan mode itself", () => {
+    const noAgent: AcpSessionMode[] = [{ id: "chat", name: "Chat" }, { id: "plan", name: "Plan" }];
+    expect(acpBuildMode(noAgent, "chat")?.id).toBe("chat");
+    // Booted in plan with no `agent` id: leaving Plan has nowhere honest to go.
+    expect(acpBuildMode(noAgent, "plan")).toBeNull();
+    expect(acpBuildMode(noAgent, null)).toBeNull();
+    expect(acpBuildMode(null, "agent")).toBeNull();
   });
 });

--- a/packages/contracts/src/presets.ts
+++ b/packages/contracts/src/presets.ts
@@ -42,12 +42,15 @@ export const DEFAULT_MODEL_LABEL = {
 /**
  * Agent kinds whose permission model Realm can actually control.
  *
- * ACP mode ids are agent-defined (Cursor uses `agent`/`plan`/`ask`), so Realm's own Claude-derived ids are
- * never transmitted: `AcpAdapter.start()` does not read `permissionMode` at all, and `session/set_mode` with a
- * foreign id is rejected. Offering the picker there would be a lie about what the agent is allowed to do.
+ * ACP mode ids are agent-defined (Cursor uses `agent`/`plan`/`ask` — re-verified live 2026-09-01 against
+ * cursor-agent 2026.07.25), so Realm's own Claude-derived ids are never transmitted: `AcpAdapter.start()`
+ * does not read `permissionMode` as a permission at all, and `session/set_mode` with a foreign id is
+ * rejected. Offering the picker there would be a lie about what the agent is allowed to do.
  *
- * Follow-up (not in this change): read the `modes.availableModes` that `session/new` returns and map Realm's
- * modes onto them, then flip the ACP kinds to `true`.
+ * Plan 14 W3 took the mode-axis half of the old follow-up: the PLAN mapping now exists per session
+ * (`acpPlanMode` over the captured `availableModes`). The PERMISSION axis stays false — Cursor's
+ * `agent`/`plan`/`ask` are what-the-agent-is-doing modes, none of them a "how freely may it act" level,
+ * so there is still nothing honest to map Ask/Accept edits/Full access onto.
  */
 export const AGENT_SUPPORTS_PERMISSION_MODES = {
   claude: true, codex: true, "acp:cursor": false, "acp:gemini": false, fake: true,
@@ -120,16 +123,46 @@ export type SessionMode = (typeof SESSION_MODES)[number]["id"];
  *
  * - `claude` — Claude Code's own `permissionMode: "plan"`.
  * - `codex` — `codexPolicyFor("plan")` starts the thread read-only under an untrusted approval policy.
- * - `acp:cursor` / `acp:gemini` — false for the same reason they have no permission picker: ACP mode
- *   ids are agent-defined, `AcpAdapter.start()` never reads `permissionMode`, and `session/set_mode`
- *   rejects a foreign id. Cursor does have a `plan` mode; Realm just has no way to name it yet. The
- *   follow-up is the same one: read `modes.availableModes` from `session/new` and map onto it.
+ * - `acp:cursor` / `acp:gemini` — false HERE because the honest answer is per-session, not per-kind
+ *   (Plan 14 W3): ACP mode ids are agent-defined, so whether Plan exists is whatever THIS session's
+ *   `session/new` handshake advertised in `modes.availableModes` (captured on the init event). The
+ *   prompter answers with `acpPlanMode` over those; this static entry is only the pre-handshake
+ *   floor — no chip until the agent has named its modes.
  * - `fake` — the scripted dev adapter ignores the field entirely, but stays true so the development
  *   prompter shows the same controls as a real one (as it already does for permission modes).
  */
 export const AGENT_SUPPORTS_PLAN_MODE = {
   claude: true, codex: true, "acp:cursor": false, "acp:gemini": false, fake: true,
 } as const satisfies Record<import("./entities").AgentKind, boolean>;
+
+/** One advertised ACP session mode, as `session/new`'s `modes.availableModes` carries it. */
+export type AcpSessionMode = { id: string; name: string; description?: string };
+
+/**
+ * The advertised mode Realm treats as Plan-equivalent, or null when the agent offers none.
+ *
+ * Matched on the AGENT'S OWN id being literally `"plan"` — verified live against cursor-agent
+ * 2026.07.25 (`agent`/`plan`/`ask`, with `plan` described as "Read-only mode for planning and
+ * designing before implementation"). Deliberately no fuzzy name matching: a mode Realm merely hopes
+ * means Plan is exactly the lie the per-session capability exists to end. What `session/set_mode`
+ * transmits is the matched mode's own id, never Realm's.
+ */
+export function acpPlanMode(modes: readonly AcpSessionMode[] | null | undefined): AcpSessionMode | null {
+  return modes?.find((m) => m.id === "plan") ?? null;
+}
+
+/**
+ * The advertised mode Build maps back onto: the agent's `agent` mode when it has one (Cursor's
+ * default), else the mode the session BOOTED in — provided that is not the plan mode itself.
+ * Null means leaving Plan has nowhere honest to go, and the adapter sends nothing.
+ */
+export function acpBuildMode(modes: readonly AcpSessionMode[] | null | undefined, bootModeId: string | null): AcpSessionMode | null {
+  if (!modes) return null;
+  const agent = modes.find((m) => m.id === "agent");
+  if (agent) return agent;
+  const boot = modes.find((m) => m.id === bootModeId);
+  return boot && boot.id !== "plan" ? boot : null;
+}
 
 /**
  * Display metadata per agent kind (icon names come from @realm/ui's icon set).

--- a/packages/contracts/src/rpc.test.ts
+++ b/packages/contracts/src/rpc.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, expectTypeOf, it } from "vitest";
-import { RpcRequestSchema, RpcResponseSchema, RpcEventSchema, parseWireMessage, type MethodParams } from "./rpc";
+import { Methods, RpcRequestSchema, RpcResponseSchema, RpcEventSchema, parseWireMessage, type MethodParams } from "./rpc";
 
 describe("rpc envelope", () => {
   it("parses a request", () => {
@@ -20,5 +20,19 @@ describe("rpc envelope", () => {
   it("MethodParams<profiles.create> allows omitting defaulted icon/color", () => {
     expectTypeOf({ name: "Work" }).toMatchTypeOf<MethodParams<"profiles.create">>();
     expectTypeOf({ name: "Work", icon: "user", color: "#000" }).toMatchTypeOf<MethodParams<"profiles.create">>();
+  });
+});
+
+describe("sessions.send params (Plan 14 W5 — attachment-only messages)", () => {
+  const schema = Methods["sessions.send"].params;
+  const id = "01ARZ3NDEKTSV4RRFFQ69G5FAV";
+  it("accepts text alone and attachments alone", () => {
+    expect(schema.safeParse({ id, text: "hi" }).success).toBe(true);
+    expect(schema.safeParse({ id, text: "", attachments: [{ path: "/a.png", mime: "image/png" }] }).success).toBe(true);
+  });
+  it("REFUSES empty text with zero attachments — a message that says nothing at all", () => {
+    // The named mutant: relaxing text.min(1) must not open the door to genuinely empty sends.
+    expect(schema.safeParse({ id, text: "" }).success).toBe(false);
+    expect(schema.safeParse({ id, text: "", attachments: [] }).success).toBe(false);
   });
 });

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -603,7 +603,10 @@ export const Methods = {
   /** `mentions`: the skill ids the prompter recognised as `@`-mentions in `text` (Plan 8 W4). The
    *  server re-validates each against the live library before anything resolves — a raw `@name` never
    *  reaches an agent wire, and a stale id degrades to plain text (see `mentions.ts`). */
-  "sessions.send":   { params: z.object({ id: IdSchema, text: z.string().min(1), attachments: z.array(z.object({ path: z.string(), mime: z.string() })).default([]), mentions: z.array(SkillIdSchema).max(32).default([]) }), result: z.object({ ok: z.literal(true) }) },
+  /** `text` may be empty ONLY when attachments carry the message (Plan 14 W5 — attachment-only
+   *  sends). A message with neither is nothing at all and is refused here, not by an adapter. */
+  "sessions.send":   { params: z.object({ id: IdSchema, text: z.string(), attachments: z.array(z.object({ path: z.string(), mime: z.string() })).default([]), mentions: z.array(SkillIdSchema).max(32).default([]) })
+    .refine((p) => p.text.length > 0 || p.attachments.length > 0, { message: "a message needs text or at least one attachment" }), result: z.object({ ok: z.literal(true) }) },
   "sessions.interrupt": { params: z.object({ id: IdSchema }), result: z.object({ ok: z.literal(true) }) },
   "sessions.respondPermission": { params: z.object({ id: IdSchema, requestId: z.string(), decision: z.enum(["allow", "allow_always", "deny"]) }), result: z.object({ ok: z.literal(true) }) },
   "sessions.setOptions": { params: z.object({ id: IdSchema, model: z.string().optional(), effort: z.string().optional(), permissionMode: z.string().optional() }), result: SessionSchema },

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -140,6 +140,31 @@ export type PrOutcome = z.infer<typeof PrOutcomeSchema>;
 export const ShipResultSchema = z.object({ commit: CommitOutcomeSchema, push: PushOutcomeSchema, pr: PrOutcomeSchema });
 export type ShipResult = z.infer<typeof ShipResultSchema>;
 
+/**
+ * One durable ship-log row (Plan 14 W1): what a `workspace.ship` actually DID to a checkout, written
+ * the moment the legs settle — never what was hoped. A row exists when something durable happened (a
+ * commit was made, or a push reached the remote); `pushState` then records the push leg verbatim, so
+ * a commit whose push was rejected logs `rejected`, not silence and not `pushed`.
+ *
+ * Like a notification, this is a LOG: plain references, no foreign keys server-side — the record of a
+ * ship stays true (and stays worth showing) after its worktree is removed.
+ */
+export const ShipSchema = z.object({
+  id: IdSchema,
+  environmentId: IdSchema,
+  spaceId: IdSchema,
+  /** Null when HEAD was detached at commit time — the commit still happened and still logs. */
+  branch: z.string().nullable(),
+  sha: z.string(),
+  subject: z.string(),
+  /** The PR/compare URL when the PR leg produced one; null when it was skipped or had none. */
+  prUrl: z.string().nullable(),
+  /** The push leg's outcome, verbatim (`PushOutcomeSchema.state`). `skipped` = a commit-only ship. */
+  pushState: PushOutcomeSchema.shape.state,
+  createdAt: z.number().int(),
+});
+export type Ship = z.infer<typeof ShipSchema>;
+
 /** What removing a worktree would destroy, asked of git at the moment of asking (Plan 7 W2).
  *  `environments.removeWorktree` re-reads these and refuses unless the acknowledgement matches, so
  *  a confirmation the user gave before the agent wrote another file fails closed. */
@@ -529,8 +554,20 @@ export const Methods = {
     params: z.object({
       cwd: z.string(), commit: z.boolean().default(true), message: z.string().default(""),
       push: z.boolean().default(true), setUpstream: z.boolean().default(false), openPr: z.boolean().default(false),
+      /** Which checkout row this ship belongs to, for the durable log (Plan 14 W1). The pane names its
+       *  environment rather than the server guessing from `cwd` — a path can be registered in two
+       *  spaces, and a guess is exactly how a ship row lands in the wrong one. Null (an environment-less
+       *  caller) ships exactly as before and logs nothing. */
+      environmentId: IdSchema.nullable().default(null),
     }),
     result: ShipResultSchema,
+  },
+  /** The durable ship log (Plan 14 W1), newest first, one space at a time — the space page's History
+   *  tab interleaves these with checkpoints. Cursor pagination exactly as `notifications.list`:
+   *  `cursor` is the previous page's `nextCursor`, opaque to clients. */
+  "ships.list": {
+    params: z.object({ spaceId: IdSchema, cursor: z.string().nullable().default(null), limit: z.number().int().min(1).max(200).default(100) }),
+    result: z.object({ ships: z.array(ShipSchema), nextCursor: z.string().nullable() }),
   },
 
   /**
@@ -620,6 +657,9 @@ export const Events = {
    *  went through; clients refresh every diff they hold, because two panes on the same repository may
    *  have asked from two different subdirectories and only the server knows they are the same tree. */
   "workspace.changed": z.object({ cwd: z.string() }),
+  /** A ship-log row was written for this space (Plan 14 W1) — clients holding the space's ship list
+   *  (the space page History tab) re-fetch; everyone else ignores it. */
+  "ships.changed":    z.object({ spaceId: IdSchema }),
   "terminal.data":    z.object({ terminalId: IdSchema, data: z.string() }),
   "terminal.exit":    z.object({ terminalId: IdSchema, exitCode: z.number().int() }),
   /** ephemeral = not persisted (seq = -1), e.g. assistant_delta */

--- a/packages/contracts/src/session-events.ts
+++ b/packages/contracts/src/session-events.ts
@@ -17,6 +17,12 @@ const P = {
     /** The instruction files the agent says it loaded — Codex `thread/start` `instructionSources`, W3's
      *  ground truth for the memory pane. Absent for agents that report nothing (all the others today). */
     instructionSources: z.array(z.string()).optional(),
+    /** The agent's OWN session modes — ACP `session/new`/`session/load` `modes.availableModes`,
+     *  captured verbatim (Plan 14 W3). Per-session ground truth for the Build/Plan chip on ACP
+     *  sessions: the chip only appears when THIS list carries a Plan-equivalent (`acpPlanMode`).
+     *  Absent for agents whose plan support is static (Claude, Codex) and for ACP builds that
+     *  returned no `modes`. */
+    availableModes: z.array(z.object({ id: z.string(), name: z.string(), description: z.string().optional() })).optional(),
   }),
 } as const;
 

--- a/packages/ui/src/Icon.tsx
+++ b/packages/ui/src/Icon.tsx
@@ -30,6 +30,7 @@ export const icons = {
   "connections-page": PlugSocketIcon,
   "notifications-page": Notification02Icon,
   "settings-page": Settings01Icon,
+  "profile-page": UserIcon,
 } as const;
 /** Hugeicons names plus the vendored provider marks — one namespace, so callers (and `AGENT_META`)
  *  never have to know which pack a glyph came from. */


### PR DESCRIPTION
Five chores made real, each with live or empirical proof. **2260 tests** (rebased over the model-catalog merge; the union in `acp-adapter` keeps both the model pin and the modes capture).

- **Ship log** (migration v13): `ship()` records what actually happened — a crashed push still logs its commit with the leg's true state. History interleaves checkpoints ∪ ships and drops its apology copy.
- **Profile page** (`…005`): the defining-scope home — bannerless editors for the profile's own items, "Edit in profile" jumps land here, profile pill opens it.
- **Cursor plan mode**: per-session, from the agent's own `availableModes` (agent/plan/ask verified live); `session/set_mode` only ever transmits the agent's id; the chip materializes honestly (absent → waiting → enabled) and Realm's permission-park logic stays off Cursor.
- **Browser allowlist editor**: origins-only validation, posture stated, guardrail-not-security sentence, and live panes re-fence on change (IPC asserted).
- **Attachment-only messages**: `sessions.send` now accepts them — and fixing that exposed that all three adapters sent empty text blocks their protocols reject; each now composes honestly, and the user bubble shows file chips.

Also: the chronic checkpoints-retention "flake" root-caused (vitest 5s default under git contention) and given evidence-backed headroom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)