### PR TITLE
Plan 16 — global search and session forks

### DIFF
--- a/apps/desktop/src/renderer/src/components/CheckpointsSheet.tsx
+++ b/apps/desktop/src/renderer/src/components/CheckpointsSheet.tsx
@@ -101,6 +101,7 @@ export function CheckpointsSheet({ environmentId, sessionId }: { environmentId: 
   const preview = useApp((s) => s.checkpointPreview);
   const result = useApp((s) => s.restoreResult);
   const ask = useApp((s) => s.askRestoreCheckpoint);
+  const fork = useApp((s) => s.forkFromCheckpoint);
   const capture = useApp((s) => s.captureCheckpoint);
   const closeSheet = useApp((s) => s.closeSheet);
   const run = useApp((s) => s.run);
@@ -126,10 +127,22 @@ export function CheckpointsSheet({ environmentId, sessionId }: { environmentId: 
                   <span className="cp-kind">{KIND_LABEL[c.kind]}</span>
                   <span className="cp-label">{c.label}</span>
                   <span className="cp-when">{relativeTime(c.createdAt, now)}</span>
+                  {/* Fork (Plan 16 W3): only for checkpoints a session's turn took — a fork carries an
+                      ancestor transcript, and a manual/environment checkpoint has none to carry. */}
+                  {c.sessionId && (
+                    <button type="button" className="btn-quiet" onClick={() => run(() => fork(c.id))}>Fork</button>
+                  )}
                   <button type="button" className="btn-quiet" onClick={() => run(() => ask(c.id))}>Restore</button>
                 </li>
               ))}
             </ul>
+            {(list ?? []).some((c) => c.sessionId !== null) && (
+              <p className="cp-note">
+                Fork opens a NEW worktree restored to that checkpoint, with a new session beside the old
+                one. It is a workspace fork: the agent&rsquo;s conversation cannot be rewound, so the
+                ancestor transcript is carried into the new session as text (capped, and it says so).
+              </p>
+            )}
             <div className="sheet-actions">
               <button type="button" className="btn-quiet" onClick={() => run(() => capture(environmentId, sessionId))}>Checkpoint now</button>
               <span className="diff-head-spacer" />

--- a/apps/desktop/src/renderer/src/components/CommandPalette.tsx
+++ b/apps/desktop/src/renderer/src/components/CommandPalette.tsx
@@ -1,5 +1,5 @@
 import { Icon } from "@realm/ui";
-import { AGENT_META, PRESETS, SELECTABLE_AGENT_KINDS, emptyLayout, itemIdOfLeaf, allItems as openItemIds, type Item, type PresetName } from "@realm/contracts";
+import { AGENT_META, PRESETS, SELECTABLE_AGENT_KINDS, emptyLayout, itemIdOfLeaf, allItems as openItemIds, type Item, type PresetName, type SearchResults, type SearchSnippet } from "@realm/contracts";
 import { Fragment, useEffect, useMemo, useRef, useState, type KeyboardEvent as ReactKeyboardEvent, type ReactNode } from "react";
 import type { StoreApi } from "zustand";
 import { centerOverComplement } from "../state/no-overlay";
@@ -7,7 +7,20 @@ import { useApp, useBrowserRects, type AppState } from "../state/store";
 import type { ThemePref } from "../theme/useTheme";
 import { ItemGlyph } from "./sidebar/ItemList";
 
-type Entry = { id: string; label: string; hint?: ReactNode; icon: ReactNode; run: () => void; section: string; disabled?: boolean };
+type Entry = { id: string; label: string; hint?: ReactNode; icon: ReactNode; run: () => void; section: string; disabled?: boolean;
+  /** A deep-search row (Plan 16 W2): rendered below the instant rows, under its group header even
+   *  while a query is typed (instant rows go flat with a query; these stay grouped). */
+  deep?: boolean };
+
+/** How long a keystroke rests before `search.query` goes out. The instant rows never wait on this —
+ *  deep results only ever APPEND below them when the answer lands. */
+export const SEARCH_DEBOUNCE_MS = 120;
+/** One character matches everything and helps no one; deep search starts at two. */
+export const SEARCH_MIN_QUERY = 2;
+
+function Snippet({ parts }: { parts: SearchSnippet }) {
+  return <span className="palette-snippet">{parts.map((p, i) => p.match ? <mark key={i}>{p.text}</mark> : <span key={i}>{p.text}</span>)}</span>;
+}
 
 /** ⌘K toggles the palette. Bound separately from useGlobalHotkeys: it must fire while the palette
  *  itself is open (and its input focused), which the global guard forbids. */
@@ -106,6 +119,7 @@ function PaletteBody() {
   const openActivity = useApp((s) => s.openActivity);
   const setPaletteOpen = useApp((s) => s.setPaletteOpen);
   const refreshAllItems = useApp((s) => s.refreshAllItems);
+  const searchDeep = useApp((s) => s.searchDeep);
   const run = useApp((s) => s.run);
   const [query, setQuery] = useState("");
   const [index, setIndex] = useState(0);
@@ -120,6 +134,29 @@ function PaletteBody() {
 
   // Cross-space listings come from items.listAll; refresh on every open so ages/titles are current.
   useEffect(() => { run(() => refreshAllItems()); }, [refreshAllItems, run]);
+
+  // Deep search (Plan 16 W2): debounced and stale-guarded. THE instant-palette doctrine, restated
+  // where it could be broken: nothing above this effect awaits it — the instant rows are computed
+  // synchronously from state, and these results only ever append BELOW them when the answer lands.
+  const [deep, setDeep] = useState<{ forQuery: string; results: SearchResults } | null>(null);
+  const [searching, setSearching] = useState(false);
+  const searchSeq = useRef(0);
+  const deepQuery = query.trim();
+  useEffect(() => {
+    const seq = ++searchSeq.current;
+    if (deepQuery.length < SEARCH_MIN_QUERY) { setDeep(null); setSearching(false); return; }
+    setSearching(true);
+    const t = setTimeout(() => {
+      searchDeep(deepQuery)
+        .then((results) => {
+          if (searchSeq.current !== seq) return; // a newer keystroke owns the pane now
+          setDeep(results ? { forQuery: deepQuery, results } : null);
+          setSearching(false);
+        })
+        .catch(() => { if (searchSeq.current === seq) { setDeep(null); setSearching(false); } });
+    }, SEARCH_DEBOUNCE_MS);
+    return () => clearTimeout(t);
+  }, [deepQuery, searchDeep]);
 
   const entries = useMemo<Entry[]>(() => {
     const l = layout ?? emptyLayout();
@@ -220,15 +257,72 @@ function PaletteBody() {
       .sort((a, b) => b.score - a.score || a.i - b.i)
       .map((x) => x.e);
   }, [entries, q]);
-  const sel = Math.min(index, Math.max(0, filtered.length - 1));
+
+  // Deep rows (Plan 16 W2), grouped Sessions / Skills / Memory / Items and appended after the
+  // instant rows. Item hits already matched instantly (subsequence matching subsumes word matching)
+  // are dropped rather than shown twice.
+  const deepEntries = useMemo<Entry[]>(() => {
+    if (!q || !deep || deep.forQuery !== q) return [];
+    const shown = new Set(filtered.map((e) => e.id));
+    const r = deep.results;
+    const out: Entry[] = [];
+    for (const h of r.sessions) {
+      out.push({
+        id: `deep-session:${h.sessionId}:${h.seq}`, deep: true, section: "Sessions",
+        label: h.title, icon: <Icon name="session" size={15} />, hint: <Snippet parts={h.snippet} />,
+        // Jump = open the session (scroll-to-event is not cheap today: transcript block keys are
+        // index-based, not seq-based — the hit's `seq` is on the wire for the day it becomes so).
+        run: () => run(async () => {
+          const it = allItems.find((x) => x.kind === "session" && x.refId === h.sessionId)
+            ?? items.find((x) => x.kind === "session" && x.refId === h.sessionId);
+          if (h.spaceId !== activeSpaceId) await selectSpace(h.spaceId);
+          if (it) await openItem(it.id);
+        }),
+      });
+    }
+    for (const h of r.skills) {
+      out.push({
+        id: `deep-skill:${h.id}`, deep: true, section: "Skills", label: h.name,
+        icon: <Icon name="library-page" size={15} />, hint: <Snippet parts={h.snippet} />,
+        run: () => run(() => openDestinationPage("library-page")),
+      });
+    }
+    for (const h of r.memory) {
+      out.push({
+        id: `deep-memory:${h.scope}:${h.spaceId ?? h.profileId}`, deep: true, section: "Memory", label: h.title,
+        icon: <Icon name="context" size={15} />, hint: <Snippet parts={h.snippet} />,
+        run: () => run(async () => {
+          if (h.scope === "profile") { await openProfilePage("memory"); return; }
+          if (!h.spaceId) return;
+          if (h.spaceId !== activeSpaceId) await selectSpace(h.spaceId);
+          await openSpacePage(h.spaceId, "memory");
+        }),
+      });
+    }
+    for (const h of r.items) {
+      if (shown.has(`item:${h.itemId}`)) continue; // already an instant row above
+      out.push({
+        id: `deep-item:${h.itemId}`, deep: true, section: "Items", label: h.title,
+        icon: <Icon name={h.itemKind} size={15} />, hint: <Snippet parts={h.snippet} />,
+        run: () => run(async () => {
+          if (h.spaceId !== activeSpaceId) await selectSpace(h.spaceId);
+          await openItem(h.itemId);
+        }),
+      });
+    }
+    return out;
+  }, [q, deep, filtered, allItems, items, activeSpaceId, selectSpace, openItem, openDestinationPage, openProfilePage, openSpacePage, run]);
+
+  const combined = q ? [...filtered, ...deepEntries] : filtered;
+  const sel = Math.min(index, Math.max(0, combined.length - 1));
 
   useEffect(() => { listRef.current?.querySelector<HTMLElement>(`[data-index="${sel}"]`)?.scrollIntoView?.({ block: "nearest" }); }, [sel]);
 
   const pick = (e: Entry | undefined) => { if (!e || e.disabled) return; e.run(); close(); };
   const onKeyDown = (e: ReactKeyboardEvent) => {
-    if (e.key === "ArrowDown") { e.preventDefault(); setIndex(Math.min(filtered.length - 1, sel + 1)); }
+    if (e.key === "ArrowDown") { e.preventDefault(); setIndex(Math.min(combined.length - 1, sel + 1)); }
     else if (e.key === "ArrowUp") { e.preventDefault(); setIndex(Math.max(0, sel - 1)); }
-    else if (e.key === "Enter") { e.preventDefault(); pick(filtered[sel]); }
+    else if (e.key === "Enter") { e.preventDefault(); pick(combined[sel]); }
     else if (e.key === "Escape") { e.preventDefault(); close(); }
   };
 
@@ -238,15 +332,19 @@ function PaletteBody() {
         <div className="palette-input">
           <Icon name="search" size={16} />
           <input autoFocus role="combobox" aria-label="Command palette" aria-expanded="true" aria-controls="palette-list" aria-autocomplete="list"
-            aria-activedescendant={filtered[sel] ? `palette-opt-${sel}` : undefined}
+            aria-activedescendant={combined[sel] ? `palette-opt-${sel}` : undefined}
             placeholder="Search…" value={query} onChange={(e) => { setQuery(e.target.value); setIndex(0); }} onKeyDown={onKeyDown} />
           <kbd>esc</kbd>
         </div>
         <div id="palette-list" ref={listRef} role="listbox" className="palette-list">
-          {filtered.length === 0 && <div className="palette-empty muted">No matches</div>}
-          {filtered.map((e, i) => (
+          {/* Honest quiet states: while a deep query is in flight an empty list says so; only a
+              settled empty answer says "No matches". Instant rows render regardless, immediately. */}
+          {combined.length === 0 && (searching
+            ? <div className="palette-empty muted">Searching…</div>
+            : <div className="palette-empty muted">No matches</div>)}
+          {combined.map((e, i) => (
             <Fragment key={e.id}>
-              {!q && (i === 0 || filtered[i - 1]!.section !== e.section) && (
+              {(!q || e.deep) && (i === 0 || combined[i - 1]!.section !== e.section) && (
                 <div className="palette-sec" role="presentation">{e.section}</div>
               )}
               <div id={`palette-opt-${i}`} role="option" aria-selected={i === sel} aria-disabled={e.disabled || undefined} data-index={i}
@@ -257,6 +355,7 @@ function PaletteBody() {
               </div>
             </Fragment>
           ))}
+          {searching && combined.length > 0 && <div className="palette-empty muted">Searching…</div>}
         </div>
       </div>
     </div>

--- a/apps/desktop/src/renderer/src/components/checkpoints.test.tsx
+++ b/apps/desktop/src/renderer/src/components/checkpoints.test.tsx
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import type { Environment } from "@realm/contracts";
 import { StoreContext, createAppStore } from "../state/store";
-import { checkpoint, fakeApi, preview } from "../state/store.test-fakes";
+import { checkpoint, fakeApi, preview, session } from "../state/store.test-fakes";
 import { CheckpointsSheet, relativeTime, restoreSentence } from "./CheckpointsSheet";
 
 const PATH = "/tmp/worktrees/s1/fix-login";
@@ -146,5 +146,53 @@ describe("CheckpointsSheet", () => {
   it("explains the empty state rather than showing a blank list", async () => {
     await open({ checkpoints: [] });
     expect(screen.getByText(/Realm takes one before every message/)).toBeInTheDocument();
+  });
+});
+
+describe("Fork from here (Plan 16 W3)", () => {
+  const turnCp = () => checkpoint("cp1", "env1", { label: "Add the login form", sessionId: "se1", createdAt: Date.now() - 120_000 });
+
+  async function openWithSession() {
+    const api = fakeApi({
+      environments: { s1: [env] },
+      sessions: [session("se1", "s1", { title: "Login work", environmentId: "env1", cwd: PATH })],
+      checkpoints: { env1: [turnCp()] },
+      checkpointPreview: { cp1: preview("cp1", "env1", { path: PATH, label: "Add the login form" }) },
+    });
+    const store = createAppStore(api);
+    await store.getState().boot();
+    await store.getState().openCheckpoints("env1", null);
+    render(<StoreContext.Provider value={store}><CheckpointsSheet environmentId="env1" sessionId={null} /></StoreContext.Provider>);
+    return { api, store };
+  }
+
+  it("offers Fork only on checkpoints a session's turn took, with the honest workspace-fork copy", async () => {
+    await openWithSession();
+    expect(screen.getByRole("button", { name: "Fork" })).toBeInTheDocument();
+    expect(screen.getByText(/conversation cannot be rewound/)).toBeInTheDocument();
+    expect(screen.getByText(/carried into the new session as text/)).toBeInTheDocument();
+  });
+
+  it("hides Fork (and the copy) for environment-level checkpoints — there is no session to fork", async () => {
+    await open(); // default checkpoint(): sessionId null
+    expect(screen.queryByRole("button", { name: "Fork" })).toBeNull();
+    expect(screen.queryByText(/conversation cannot be rewound/)).toBeNull();
+  });
+
+  it("Fork calls sessions.fork, closes the sheet, and opens the NEW session's pane — the ancestor untouched", async () => {
+    const { api, store } = await openWithSession();
+    const rowsBefore = JSON.stringify(api.data.sessions.find((x) => x.id === "se1"));
+    fireEvent.click(screen.getByRole("button", { name: "Fork" }));
+    await waitFor(() => expect(api.calls).toContain("forkSession:cp1"));
+    await waitFor(() => expect(store.getState().sheet).toBeNull());
+    const forked = api.data.sessions.find((x) => x.dispatchedBy?.kind === "fork")!;
+    expect(forked.dispatchedBy).toEqual({ kind: "fork", sessionId: "se1" });
+    // The new pane is adopted into the layout and its environment merged.
+    await waitFor(() => {
+      const item = store.getState().items.find((i) => i.kind === "session" && i.refId === forked.id);
+      expect(item).toBeDefined();
+    });
+    expect(store.getState().environments[forked.environmentId]).toMatchObject({ kind: "worktree" });
+    expect(JSON.stringify(api.data.sessions.find((x) => x.id === "se1"))).toBe(rowsBefore);
   });
 });

--- a/apps/desktop/src/renderer/src/components/command-palette.test.tsx
+++ b/apps/desktop/src/renderer/src/components/command-palette.test.tsx
@@ -316,3 +316,95 @@ describe("Dispatch task (Plan 13 W2)", () => {
     expect(screen.queryByRole("option", { name: /Dispatch task/ })).toBeNull();
   });
 });
+
+describe("deep search (Plan 16 W2)", () => {
+  const snip = (pre: string, hit: string, post = "") =>
+    [{ text: pre, match: false }, { text: hit, match: true }, { text: post, match: false }];
+  const empty = { sessions: [], items: [], skills: [], memory: [] };
+
+  it("instant rows render synchronously while the deep query is still in flight — the no-await mutant", async () => {
+    const { api } = await mount({ items: { s1: [item("i1", "s1", { title: "Terminal" })] } });
+    api.delays["search"] = 60_000; // deep search effectively never answers inside this test
+    fireEvent.change(input(), { target: { value: "term" } });
+    // Deliberately NO waitFor: the instant path must not have awaited anything search-shaped.
+    expect(options().some((x) => x?.startsWith("Terminal"))).toBe(true);
+    expect(options().some((x) => x?.startsWith("New terminal"))).toBe(true);
+  });
+
+  it("appends grouped deep rows below the instant rows, and asks with the ACTIVE space's profile id", async () => {
+    const { api } = await mount({ searchResults: {
+      sessions: [{ sessionId: "sedeep", spaceId: "s1", title: "Login fix", seq: 5, snippet: snip("fix the ", "login", " flow") }],
+      items: [{ itemId: "ideep", spaceId: "s1", itemKind: "browser" as const, title: "Auth docs", snippet: snip("", "login", " docs") }],
+      skills: [{ id: "auth", name: "Auth helper", description: "does login things", snippet: snip("does ", "login", " things") }],
+      memory: [{ scope: "space" as const, profileId: null, spaceId: "s1", title: "Versed memory", snippet: snip("the ", "login", " rules") }],
+    } });
+    fireEvent.change(input(), { target: { value: "login" } });
+    await waitFor(() => expect(screen.getByRole("option", { name: /Login fix/ })).toBeInTheDocument());
+    expect(api.calls).toContain("search:p1:login"); // the profile travels; the server enforces the fence
+    // The four groups render their headers even mid-query (instant rows go flat; deep rows stay grouped).
+    const secs = Array.from(document.querySelectorAll(".palette-sec")).map((el) => el.textContent);
+    expect(secs).toEqual(["Sessions", "Skills", "Memory", "Items"]);
+    // Every deep row sits below every instant row.
+    const labels = options();
+    const firstDeep = labels.findIndex((x) => x?.includes("Login fix"));
+    for (const l of labels.slice(firstDeep)) expect(["Login fix", "Auth helper", "Versed memory", "Auth docs"].some((d) => l?.includes(d))).toBe(true);
+    // Snippets render with their matches emphasised.
+    expect(document.querySelectorAll(".palette-snippet mark").length).toBeGreaterThan(0);
+  });
+
+  it("a session hit opens that session's pane, selecting its space first", async () => {
+    const { store } = await mount({
+      items: { s1: [item("i1", "s1", { title: "Terminal" })], s2: [item("is2", "s2", { kind: "session", refId: "se2", title: "Elsewhere" })] },
+      sessions: [session("se2", "s2")],
+      searchResults: { ...empty, sessions: [{ sessionId: "se2", spaceId: "s2", title: "Elsewhere", seq: 3, snippet: snip("about ", "gadgets") }] },
+    });
+    fireEvent.change(input(), { target: { value: "gadgets" } });
+    fireEvent.click(await screen.findByRole("option", { name: /Elsewhere/ }));
+    await waitFor(() => expect(store.getState().activeSpaceId).toBe("s2"));
+    await waitFor(() => { const l = store.getState().layout!; expect(l.type === "leaf" && l.itemId).toBe("is2"); });
+    expect(store.getState().paletteOpen).toBe(false);
+  });
+
+  it("a skill hit routes to the Library page; a memory hit to the space page's Memory tab", async () => {
+    const { store, api } = await mount({ searchResults: { ...empty,
+      skills: [{ id: "auth", name: "Auth helper", description: "does login", snippet: snip("does ", "login") }],
+      memory: [{ scope: "space" as const, profileId: null, spaceId: "s1", title: "Versed memory", snippet: snip("the ", "login") }],
+    } });
+    act(() => store.setState({ layout: { type: "leaf", id: "L1", itemId: null }, focusedLeafId: "L1" }));
+    fireEvent.change(input(), { target: { value: "login" } });
+    fireEvent.click(await screen.findByRole("option", { name: /Auth helper/ }));
+    await waitFor(() => expect(api.calls.some((c) => c.startsWith("createItem:s1|library-page"))).toBe(true));
+    act(() => store.setState({ paletteOpen: true }));
+    fireEvent.change(input(), { target: { value: "login" } });
+    fireEvent.click(await screen.findByRole("option", { name: /Versed memory/ }));
+    await waitFor(() => expect(store.getState().spacePageTab["s1"]).toBe("memory"));
+  });
+
+  it("deep item hits already shown as instant rows are not repeated", async () => {
+    await mount({
+      items: { s1: [item("i1", "s1", { title: "Login docs" })] },
+      searchResults: { ...empty, items: [{ itemId: "i1", spaceId: "s1", itemKind: "terminal" as const, title: "Login docs", snippet: snip("", "Login", " docs") }] },
+    });
+    fireEvent.change(input(), { target: { value: "login" } });
+    // Give the deep answer time to land, then count: one row, not two.
+    await waitFor(() => expect(screen.getAllByRole("option").filter((o) => o.textContent?.includes("Login docs"))).toHaveLength(1));
+    expect(Array.from(document.querySelectorAll(".palette-sec")).map((el) => el.textContent)).toEqual([]);
+  });
+
+  it("quiet states are honest: 'Searching…' while in flight, 'No matches' only once settled empty", async () => {
+    const { api } = await mount({ searchResults: empty });
+    api.delays["search"] = 250;
+    fireEvent.change(input(), { target: { value: "zzzz" } });
+    await waitFor(() => expect(screen.getByText("Searching…")).toBeInTheDocument());
+    expect(screen.queryByText("No matches")).toBeNull(); // not settled yet — do not claim emptiness
+    await waitFor(() => expect(screen.getByText("No matches")).toBeInTheDocument());
+    expect(screen.queryByText("Searching…")).toBeNull();
+  });
+
+  it("below two characters no deep query is sent at all", async () => {
+    const { api } = await mount();
+    fireEvent.change(input(), { target: { value: "t" } });
+    await new Promise((r) => setTimeout(r, 250)); // well past the debounce
+    expect(api.calls.some((c) => c.startsWith("search:"))).toBe(false);
+  });
+});

--- a/apps/desktop/src/renderer/src/panes/space/SpacePage.tsx
+++ b/apps/desktop/src/renderer/src/panes/space/SpacePage.tsx
@@ -206,6 +206,7 @@ const ORIGIN_META: Record<DispatchKind, { icon: string; label: string }> = {
   agent_run: { icon: "bot", label: "Delegated via agent_run" },
   browser_agent_run: { icon: "browser", label: "Browser agent" },
   review: { icon: "diff", label: "Reviewer" },
+  fork: { icon: "branch", label: "Forked from a checkpoint" },
 };
 
 /**

--- a/apps/desktop/src/renderer/src/state/live-api.ts
+++ b/apps/desktop/src/renderer/src/state/live-api.ts
@@ -36,6 +36,7 @@ export const liveApi = (): Api => ({
   listAllSessions: () => rpc().call("sessions.listAll", {}),
   getSession: (id) => rpc().call("sessions.get", { id }),
   createSession: (input) => rpc().call("sessions.create", input),
+  forkSession: (checkpointId) => rpc().call("sessions.fork", { checkpointId }),
   listSkills: (spaceId) => rpc().call("skills.list", { spaceId }),
   setSkillEnabled: async (spaceId, id, enabled) => { await rpc().call("skills.setEnabled", { spaceId, id, enabled }); },
   promoteSkill: async (spaceId, id) => { await rpc().call("skills.promote", { spaceId, id }); },

--- a/apps/desktop/src/renderer/src/state/live-api.ts
+++ b/apps/desktop/src/renderer/src/state/live-api.ts
@@ -10,6 +10,7 @@ export const liveApi = (): Api => ({
   listSpaces: () => rpc().call("spaces.list", {}),
   listItems: (spaceId) => rpc().call("items.list", { spaceId }),
   listAllItems: () => rpc().call("items.listAll", {}),
+  search: (profileId, query) => rpc().call("search.query", { profileId, query }),
   listProjects: (spaceId) => rpc().call("projects.list", { spaceId }),
   listEnvironments: (spaceId) => rpc().call("environments.list", { spaceId }),
   createWorktree: (spaceId, title) => rpc().call("environments.createWorktree", { spaceId, title }),

--- a/apps/desktop/src/renderer/src/state/store.test-fakes.ts
+++ b/apps/desktop/src/renderer/src/state/store.test-fakes.ts
@@ -2,6 +2,7 @@
 import { MCP_SECRET_STORAGE_NOTE, MEMORY_DOC_MAX } from "@realm/contracts";
 import type { AgentsFileState, Attachment, Checkpoint, DiffSummary, Environment, FileDiff, GitInfo, Item, McpCall, McpServer, McpTool, MemorySources, MemoryState, Notification, Profile, Project, RestorePreview, ReviewResult, Session, Ship, ShipResult, Skill, Space, StoredSessionEvent, WorktreeStatus } from "@realm/contracts";
 import type { AddMcpServerInput, AgentProbe, Api, McpTestResult, PickedAttachment, UpdateMcpServerInput } from "./store";
+import type { SearchResults } from "@realm/contracts";
 
 export const profile = (id: string, name: string, extra: Partial<Profile> = {}): Profile =>
   ({ id, name, icon: "user", color: "#000000", sortOrder: 0, createdAt: 0, updatedAt: 0, ...extra });
@@ -128,6 +129,9 @@ export type FakeData = {
   notifications?: Notification[];
   /** Persisted review verdicts by environment id (Plan 13 W3) — what `review.get` answers. */
   reviews?: Record<string, ReviewResult | null>;
+  /** What `search.query` answers (Plan 16 W2), regardless of query — palette tests script the groups.
+   *  Delay it with `delays["search"]` to hold results in flight. */
+  searchResults?: SearchResults;
 };
 
 export type FakeApi = Api & {
@@ -200,6 +204,7 @@ export function fakeApi(overrides: FakeData = {}): FakeApi {
     profileDocDisabled: overrides.profileDocDisabled ?? {},
     notifications: overrides.notifications ?? [],
     reviews: overrides.reviews ?? {},
+    searchResults: overrides.searchResults ?? { sessions: [], items: [], skills: [], memory: [] },
   };
   let n = 100;
   const findSpace = (id: string) => { const s = data.spaces.find((x) => x.id === id); if (!s) throw new Error(`no space ${id}`); return s; };
@@ -230,6 +235,11 @@ export function fakeApi(overrides: FakeData = {}): FakeApi {
     listAllItems: async () => {
       calls.push("listAllItems");
       return Object.values(data.items).flat().slice().sort((a, b) => b.updatedAt - a.updatedAt);
+    },
+    search: async (profileId, query) => {
+      calls.push(`search:${profileId}:${query}`);
+      await wait("search");
+      return data.searchResults;
     },
     listProjects: async (sid) => { calls.push(`listProjects:${sid}`); await wait(`listProjects:${sid}`); return data.projects[sid] ?? []; },
     listEnvironments: async (sid) => { calls.push(`listEnvironments:${sid}`); await wait(`listEnvironments:${sid}`); return data.environments[sid] ?? []; },

--- a/apps/desktop/src/renderer/src/state/store.test-fakes.ts
+++ b/apps/desktop/src/renderer/src/state/store.test-fakes.ts
@@ -329,6 +329,23 @@ export function fakeApi(overrides: FakeData = {}): FakeApi {
       calls.push(`sendMessage:${id}=${text}${attachments.length ? ` +[${attachments.map((a) => `${a.path}:${a.mime}`).join(",")}]` : ""}`);
       sent.push({ id, text, attachments, ...(mentions.length ? { mentions } : {}) });
     },
+    forkSession: async (checkpointId) => {
+      calls.push(`forkSession:${checkpointId}`);
+      await wait("forkSession");
+      const cp = Object.values(data.checkpoints).flat().find((c) => c.id === checkpointId);
+      if (!cp?.sessionId) throw new Error("FORK_NO_SESSION");
+      const ancestor = data.sessions.find((x) => x.id === cp.sessionId);
+      const spaceId = ancestor?.spaceId ?? "s1";
+      const env: Environment = { id: `env${++n}`, spaceId, path: `/tmp/worktrees/${spaceId}/fork`, branch: "realm/fork",
+        kind: "worktree", portBlockStart: null, createdAt: 0, updatedAt: 0 };
+      (data.environments[spaceId] ??= []).push(env);
+      const sess = session(`se${++n}`, spaceId, { environmentId: env.id, cwd: env.path,
+        title: `Fork: ${ancestor?.title ?? "session"}`, dispatchedBy: { kind: "fork", sessionId: cp.sessionId } });
+      data.sessions.push(sess);
+      const it = item(`i${n}`, spaceId, { kind: "session", refId: sess.id, title: sess.title });
+      (data.items[spaceId] ??= []).push(it);
+      return { session: sess, itemId: it.id, environment: env };
+    },
     listSkills: async (spaceId) => { calls.push(`listSkills:${spaceId}`); return { root: data.skillsRoot, skills: [...(data.skills[spaceId] ?? [])] }; },
     setSkillEnabled: async (spaceId, id, enabled) => {
       calls.push(`setSkillEnabled:${spaceId}:${id}=${enabled}`);

--- a/apps/desktop/src/renderer/src/state/store.ts
+++ b/apps/desktop/src/renderer/src/state/store.ts
@@ -111,6 +111,9 @@ export type Api = {
   listAllSessions(): Promise<Session[]>;
   getSession(id: string): Promise<Session>;
   createSession(input: CreateSessionInput): Promise<{ session: Session; itemId: string }>;
+  /** `sessions.fork` (Plan 16 W3): a new worktree restored to the checkpoint + a new session carrying
+   *  the ancestor transcript as text. The ancestor is untouched. */
+  forkSession(checkpointId: string): Promise<{ session: Session; itemId: string; environment: Environment }>;
   /** `skills.list` for a space: the library folder and every skill in it, valid or not — the mention
    *  picker (W4) reads the skills, the settings panel (W5) also shows the root and the invalid rows. */
   listSkills(spaceId: string): Promise<{ root: string; skills: Skill[] }>;
@@ -808,6 +811,9 @@ export type AppState = {
   confirmRestoreCheckpoint(id: string): Promise<void>;
   /** `checkpoints.capture` — a point the user asked for, next to the ones every turn takes. */
   captureCheckpoint(environmentId: string, sessionId: string | null): Promise<void>;
+  /** "Fork from here" (Plan 16 W3): server makes worktree + session; this adopts the new pane and
+   *  closes the sheet. The ancestor session and its checkout are untouched — workspace fork only. */
+  forkFromCheckpoint(checkpointId: string): Promise<void>;
   /** Re-fetch this space's MCP servers. Called on `McpSection` mount (sheet open) and on `mcp.changed`
    *  while that space's settings sheet is the one showing. Applies the result only if the sheet is
    *  still open for this exact space — a slow response after the user closed or switched must not
@@ -2142,6 +2148,18 @@ export function createAppStore(api: Api): StoreApi<AppState> {
       async captureCheckpoint(environmentId, sessionId) {
         await api.captureCheckpoint(environmentId, sessionId);
         await get().refreshCheckpoints(environmentId, sessionId);
+      },
+      async forkFromCheckpoint(checkpointId) {
+        const { session, itemId, environment } = await api.forkSession(checkpointId);
+        if (isSpace(session.spaceId)) {
+          mergeSession(session);
+          set({ environments: { ...get().environments, [environment.id]: environment } });
+        }
+        // Close the sheet BEFORE adopting: adoptItem rewrites the layout, and the W2.4 snap must be
+        // unwound off the pre-sheet layout, not the post-adopt one.
+        set({ sheet: null, ...restoreSnap() });
+        await adoptItem(session.spaceId, itemId, null);
+        await get().openSession(session.id);
       },
       async askRestoreCheckpoint(id) {
         const preview = await api.previewCheckpoint(id);

--- a/apps/desktop/src/renderer/src/state/store.ts
+++ b/apps/desktop/src/renderer/src/state/store.ts
@@ -4,7 +4,7 @@ import {
   AGENT_SKILL_SUPPORT, AGENT_SUPPORTS_PERMISSION_MODES, basenameOf, formatAttachmentSize, MAX_ATTACHMENT_BYTES, mentionIds, mimeForPath, PAGE_REF_IDS,
   DEFAULT_PERMISSION_MODE_KEY, NOTIFICATIONS_DISABLED_KEY, NOTIFICATION_CATEGORIES, PERMISSION_MODES,
   type DestinationPageKind, type NotificationCategory,
-  type AgentKind, type Attachment, type Checkpoint, type DiffSummary, type Environment, type FileDiff, type GitInfo, type Item, type Layout, type McpCall, type McpOauthStatus, type McpServer, type McpServerStatus, type McpTransport, type MemorySources, type MemoryState, type MethodResult, type Notification, type PresetName, type Profile, type Project, type RestorePreview, type RestoreResult, type ReviewResult, type Session, type SessionMode, type SessionStatus, type Ship, type ShipResult, type Skill, type Space, type StoredSessionEvent, type WorktreeAck, type WorktreeStatus,
+  type AgentKind, type Attachment, type Checkpoint, type DiffSummary, type Environment, type FileDiff, type GitInfo, type Item, type Layout, type McpCall, type McpOauthStatus, type McpServer, type McpServerStatus, type McpTransport, type MemorySources, type MemoryState, type MethodResult, type Notification, type PresetName, type Profile, type Project, type RestorePreview, type RestoreResult, type ReviewResult, type SearchResults, type Session, type SessionMode, type SessionStatus, type Ship, type ShipResult, type Skill, type Space, type StoredSessionEvent, type WorktreeAck, type WorktreeStatus,
 } from "@realm/contracts";
 import { createContext, useCallback, useContext, useSyncExternalStore } from "react";
 import { SHEET_MIN_WIDTH, complementOf, snapBrowserLeaves } from "./no-overlay";
@@ -70,6 +70,9 @@ export type Api = {
   listItems(spaceId: string): Promise<Item[]>;
   /** Every item across every space, newest-updated first (command palette search). */
   listAllItems(): Promise<Item[]>;
+  /** `search.query` — deep search over ONE profile's transcripts, item titles, skills and memory
+   *  (Plan 16 W2). Profile scoping is the server's; the client only names which profile it is in. */
+  search(profileId: string, query: string): Promise<SearchResults>;
   listProjects(spaceId: string): Promise<Project[]>;
   /** Every checkout the space knows about: its primary, plus any worktree Realm made (W2). */
   listEnvironments(spaceId: string): Promise<Environment[]>;
@@ -550,6 +553,11 @@ export type AppState = {
   refreshSpaces(): Promise<void>;
   refreshItems(): Promise<void>;
   refreshAllItems(): Promise<void>;
+  /** Deep search scoped to the ACTIVE space's profile (Plan 16 W2). Returns results for the palette
+   *  to append below its instant rows — deliberately not stored in state: the palette owns the
+   *  debounce and the stale-response guard, and nothing else reads these. Null with no active space
+   *  (no profile to scope by — an unscoped search would be the leak W1 exists to prevent). */
+  searchDeep(query: string): Promise<SearchResults | null>;
   refreshProjects(): Promise<void>;
   refreshEnvironments(): Promise<void>;
   linkProject(rootPath: string): Promise<void>;
@@ -1230,6 +1238,12 @@ export function createAppStore(api: Api): StoreApi<AppState> {
       },
       async refreshAllItems() {
         set({ allItems: await api.listAllItems() });
+      },
+      async searchDeep(query) {
+        const sid = get().activeSpaceId; if (!sid) return null;
+        const profileId = get().spaces.find((sp) => sp.id === sid)?.profileId;
+        if (!profileId) return null;
+        return api.search(profileId, query);
       },
       async refreshProjects() {
         const sid = get().activeSpaceId; if (!sid) return;

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -430,6 +430,10 @@ button.panel-title:hover { background: var(--rl-hover); }
 .palette-icon { display: grid; place-items: center; width: 20px; color: var(--rl-text-dim); }
 .palette-label { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .palette-hint { font-size: 11px; color: var(--rl-text-dim); font-variant-numeric: tabular-nums; }
+/* Deep-search snippets (Plan 16 W2): one clipped line; matches brighten, they do not highlight —
+   a row is a glance, and a yellow smear would out-shout the label. */
+.palette-snippet { display: inline-block; max-width: 220px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.palette-snippet mark { background: transparent; color: var(--rl-text-bright); font-weight: 600; }
 .palette-empty { padding: 14px; text-align: center; }
 
 /* ── Session pane ──────────────────────────────────────────────────────── */

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -41,6 +41,7 @@ import { CheckpointsStore } from "./store/checkpoints";
 import { CheckpointGit } from "./workspace/checkpoints";
 import { CheckpointService } from "./checkpoints/service";
 import { SearchService } from "./search/service";
+import { ForkService } from "./sessions/fork";
 import { RpcServer } from "./rpc/server";
 import { registerMethods } from "./rpc/methods";
 import { machineName } from "./machine-name";
@@ -121,8 +122,9 @@ export async function createApp(opts: { home: string; port: number; adapters?: A
   // services genuinely need each other: SessionService checkpoints every turn, and CheckpointService
   // must refuse to restore under a live agent. One direction is the dependency; the other is this.
   let sessionService: SessionService | null = null;
+  const checkpointGit = new CheckpointGit();
   const checkpoints = new CheckpointService({
-    checkpoints: new CheckpointsStore(db), environments, sessions: sessionsStore, git: new CheckpointGit(),
+    checkpoints: new CheckpointsStore(db), environments, sessions: sessionsStore, git: checkpointGit,
     isEnvironmentBusy: (id) => sessionService?.isEnvironmentBusy(id) ?? false,
     notifications,
   });
@@ -217,6 +219,9 @@ export async function createApp(opts: { home: string; port: number; adapters?: A
   let browserAgents: BrowserAgentService | null = null;
   let agentRuns: AgentRunService | null = null;
   let reviews: ReviewService | null = null;
+  // Plan 16 W3: forked sessions carry ancestor context through the same extraSystemContext seam the
+  // delegation children use. Late-bound for the same knot: ForkService needs SessionService.create.
+  let forks: ForkService | null = null;
   const mcpGateway = new McpGateway({ hub: mcpHub, mcp, sessions: sessionsStore, calls: mcpCalls, rpc, servers: mcpServersStore, onOauthCallback: (url) => oauth.handleCallback(url),
     // A browser-agent child is only-mode (realm-browser and nothing else); an agent_run child — and
     // a reviewer child (W3) — is exclude-mode (the space's FULL surface minus the delegation
@@ -238,14 +243,15 @@ export async function createApp(opts: { home: string; port: number; adapters?: A
     permissionMode: (sessionId) => sessionsStore.get(sessionId)?.permissionMode ?? "plan",
     emit: (sessionId, ev) => sessionService?.emitExternal(sessionId, ev),
   });
-  const sessions = new SessionService({ db, rpc, sessions: sessionsStore, events: new SessionEventsStore(db), items, spaces, projects, environments, settings, worktrees, ports, terminals, adapters: opts.adapters ?? defaultAdapters(), skills, gateway: mcpGateway, memory, checkpoints, browserPermissions: browserBroker, notifications,
+  const sessionEvents = new SessionEventsStore(db);
+  const sessions = new SessionService({ db, rpc, sessions: sessionsStore, events: sessionEvents, items, spaces, projects, environments, settings, worktrees, ports, terminals, adapters: opts.adapters ?? defaultAdapters(), skills, gateway: mcpGateway, memory, checkpoints, browserPermissions: browserBroker, notifications,
     // One hook fanning out to BOTH delegation registries. `parentInterrupted` goes to either service
     // (they share the one engine, which owns the registry); the per-child seams try each registry —
     // a session is a child of at most one.
     browserAgents: {
       parentInterrupted: (id) => browserAgents?.parentInterrupted(id),
-      release: (id) => { browserAgents?.release(id); agentRuns?.release(id); reviews?.release(id); },
-      extraSystemContext: (id) => browserAgents?.extraSystemContext(id) ?? agentRuns?.extraSystemContext(id) ?? reviews?.extraSystemContext(id),
+      release: (id) => { browserAgents?.release(id); agentRuns?.release(id); reviews?.release(id); forks?.release(id); },
+      extraSystemContext: (id) => browserAgents?.extraSystemContext(id) ?? agentRuns?.extraSystemContext(id) ?? reviews?.extraSystemContext(id) ?? forks?.extraSystemContext(id),
       skillsFilter: (id) => agentRuns?.skillsFilter(id) ?? null,
     } });
   sessionService = sessions;
@@ -272,6 +278,11 @@ export async function createApp(opts: { home: string; port: number; adapters?: A
   // Global search (Plan 16 W1). The service reads; the index writes live in the stores' own choke
   // points (SessionEventsStore.append, ItemsStore) so no producer can skip them.
   const search = new SearchService({ db, settings, profiles, spaces, skills, memory });
+  // Session forks (Plan 16 W3). `createSession` is SessionService's own create — the fork's session
+  // is a session like any other (item, broadcast, adapter check), just dispatched by "fork".
+  forks = new ForkService({ checkpoints: new CheckpointsStore(db), environments, envService, worktrees,
+    sessionsStore, events: sessionEvents, settings, git: checkpointGit, rpc,
+    createSession: (input) => sessions.create(input) });
   const ships = new ShipsStore(db);
   const gitWrite = new GitWriteService({ shipLog: (entry) => {
     ships.record(entry);
@@ -279,7 +290,7 @@ export async function createApp(opts: { home: string; port: number; adapters?: A
   } });
   registerMethods({
     rpc, home: opts.home, version: SERVER_VERSION, machineName: await machineName(),
-    profiles, spaces, projects, environments, envService, items, settings, skills, mcp, hub: mcpHub, gateway: mcpGateway, oauth, calls: mcpCalls, memory, terminals, browsers, browserBridge, sessions, gitInfo: new GitInfoService(), gitDiff: new GitDiffService(), gitWrite, ships, ports, checkpoints, notifications, reviews, search,
+    profiles, spaces, projects, environments, envService, items, settings, skills, mcp, hub: mcpHub, gateway: mcpGateway, oauth, calls: mcpCalls, memory, terminals, browsers, browserBridge, sessions, gitInfo: new GitInfoService(), gitDiff: new GitDiffService(), gitWrite, ships, ports, checkpoints, notifications, reviews, search, forks,
   });
   sessions.markStaleOnBoot();
   // The pre-v15 event history reaches the search index here: chunked, yielding, resumable across

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -40,6 +40,7 @@ import { EnvironmentService } from "./environments/service";
 import { CheckpointsStore } from "./store/checkpoints";
 import { CheckpointGit } from "./workspace/checkpoints";
 import { CheckpointService } from "./checkpoints/service";
+import { SearchService } from "./search/service";
 import { RpcServer } from "./rpc/server";
 import { registerMethods } from "./rpc/methods";
 import { machineName } from "./machine-name";
@@ -268,6 +269,9 @@ export async function createApp(opts: { home: string; port: number; adapters?: A
   // The durable ship log (Plan 14 W1): GitWriteService stays a pure git service — the recorder is the
   // one seam through which a settled ship becomes a row, and the broadcast rides the same write so a
   // History tab already open sees the ship land.
+  // Global search (Plan 16 W1). The service reads; the index writes live in the stores' own choke
+  // points (SessionEventsStore.append, ItemsStore) so no producer can skip them.
+  const search = new SearchService({ db, settings, profiles, spaces, skills, memory });
   const ships = new ShipsStore(db);
   const gitWrite = new GitWriteService({ shipLog: (entry) => {
     ships.record(entry);
@@ -275,9 +279,13 @@ export async function createApp(opts: { home: string; port: number; adapters?: A
   } });
   registerMethods({
     rpc, home: opts.home, version: SERVER_VERSION, machineName: await machineName(),
-    profiles, spaces, projects, environments, envService, items, settings, skills, mcp, hub: mcpHub, gateway: mcpGateway, oauth, calls: mcpCalls, memory, terminals, browsers, browserBridge, sessions, gitInfo: new GitInfoService(), gitDiff: new GitDiffService(), gitWrite, ships, ports, checkpoints, notifications, reviews,
+    profiles, spaces, projects, environments, envService, items, settings, skills, mcp, hub: mcpHub, gateway: mcpGateway, oauth, calls: mcpCalls, memory, terminals, browsers, browserBridge, sessions, gitInfo: new GitInfoService(), gitDiff: new GitDiffService(), gitWrite, ships, ports, checkpoints, notifications, reviews, search,
   });
   sessions.markStaleOnBoot();
+  // The pre-v15 event history reaches the search index here: chunked, yielding, resumable across
+  // boots (SearchService.runBackfill's doc comment states the design). Fire-and-forget — search over
+  // the not-yet-covered range is merely incomplete while it runs, and a failure only pauses it.
+  void search.runBackfill();
   terminals.restoreAll();
   // The gateway must be accepting connections before any session can start (its listener mints the URL
   // every `sessions.create` → send hands an adapter), and well before the RPC socket opens to clients.
@@ -286,6 +294,7 @@ export async function createApp(opts: { home: string; port: number; adapters?: A
   return {
     port, db, terminals, sessions, browserAgents, agentRuns, reviews, gateway: mcpGateway,
     close: async () => {
+      search.stop(); // before db.close: the backfill loop must not start a chunk on a closing handle
       terminals.closeAll();
       await sessions.closeAll();
       // Gateway before hub: stop accepting new proxied calls before the upstream clients they'd need go

--- a/apps/server/src/db/database.test.ts
+++ b/apps/server/src/db/database.test.ts
@@ -352,9 +352,12 @@ function v8McpFixture(path: string): { serverId: string } {
   db.exec("CREATE TABLE IF NOT EXISTS schema_version (version INTEGER PRIMARY KEY, applied_at INTEGER NOT NULL)");
   db.exec(V8_MCP_SERVERS);
   // The fixture is deliberately minimal — only the tables LATER migrations touch. v14 ALTERs
-  // sessions, so a stub of it must exist for the v9..v14 replay to run; its real v3 shape is
-  // exercised by the v4/v5 fixtures above.
+  // sessions and v15 reads items/session_events and writes settings, so stubs of those must exist
+  // for the v9..v15 replay to run; their real v1/v3 shapes are exercised by the v4/v5 fixtures above.
   db.exec("CREATE TABLE IF NOT EXISTS sessions (id TEXT PRIMARY KEY)");
+  db.exec("CREATE TABLE IF NOT EXISTS items (id TEXT PRIMARY KEY, title TEXT NOT NULL DEFAULT '')");
+  db.exec("CREATE TABLE IF NOT EXISTS session_events (seq INTEGER PRIMARY KEY AUTOINCREMENT)");
+  db.exec("CREATE TABLE IF NOT EXISTS settings (key TEXT PRIMARY KEY, value_json TEXT NOT NULL)");
   for (const v of [1, 2, 3, 4, 5, 6, 7, 8]) db.prepare("INSERT INTO schema_version (version, applied_at) VALUES (?, ?)").run(v, Date.now());
   db.prepare("INSERT INTO mcp_servers (id, name, transport, command, args_json, url, secrets_json, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)")
     .run("srv1", "airtable", "stdio", "/usr/bin/node", '["/abs/s.mjs"]', "", '{"AIRTABLE_API_KEY":"pat-x"}', 1, 1);
@@ -434,6 +437,44 @@ describe("migration v14 — dispatch origin (Plan 13 W1; renumbered past Plan 14
     const row = db.prepare("SELECT dispatched_by_kind, dispatched_by_session_id FROM sessions WHERE id = 'se1'").get() as { dispatched_by_kind: string | null; dispatched_by_session_id: string | null };
     expect(row.dispatched_by_kind).toBeNull();
     expect(row.dispatched_by_session_id).toBeNull();
+    db.close();
+  });
+});
+
+describe("migration v15 — the search index (Plan 16 W1)", () => {
+  // The v4 fixture again: real items and sessions, migrated the whole way forward.
+  const migrated = () => {
+    const p = join(mkdtempSync(join(tmpdir(), "realm-db-")), "realm.db");
+    v4Fixture(p);
+    // A pre-v15 transcript, inserted raw (no store, so no write-time indexing) before openDatabase
+    // replays the chain — exactly what an upgrading home holds.
+    const raw = new DatabaseSync(p);
+    raw.prepare("INSERT INTO session_events (session_id, ts, type, payload_json) VALUES ('se1', 1, 'user_message', ?)")
+      .run(JSON.stringify({ text: "an old pangolin question", attachments: [] }));
+    raw.close();
+    return { p, db: openDatabase(p) };
+  };
+
+  it("creates the FTS table and backfills item titles inline", () => {
+    const { db } = migrated();
+    const rows = db.prepare("SELECT text, ref FROM search_index WHERE kind = 'item'").all() as { text: string; ref: string }[];
+    expect(rows).toEqual([{ text: "versed", ref: "it-term" }]);
+    db.close();
+  });
+
+  it("does NOT backfill events inline — it freezes the resumable cursor for the boot-time backfill instead", () => {
+    const { db } = migrated();
+    expect((db.prepare("SELECT COUNT(*) AS n FROM search_index WHERE kind = 'session'").get() as { n: number }).n).toBe(0);
+    const cursor = JSON.parse((db.prepare("SELECT value_json FROM settings WHERE key = 'search.backfill'").get() as { value_json: string }).value_json) as { done: number; target: number };
+    expect(cursor.done).toBe(0);
+    expect(cursor.target).toBeGreaterThan(0); // MAX(seq) of the pre-existing history
+    db.close();
+  });
+
+  it("a fresh (no-history) home gets a closed cursor: done 0, target 0 — nothing to backfill", () => {
+    const db = openDatabase(join(mkdtempSync(join(tmpdir(), "realm-db-")), "realm.db"));
+    const cursor = JSON.parse((db.prepare("SELECT value_json FROM settings WHERE key = 'search.backfill'").get() as { value_json: string }).value_json) as { done: number; target: number };
+    expect(cursor).toEqual({ done: 0, target: 0 });
     db.close();
   });
 });

--- a/apps/server/src/db/migrations.ts
+++ b/apps/server/src/db/migrations.ts
@@ -267,4 +267,34 @@ export const migrations: string[] = [
   ALTER TABLE sessions ADD COLUMN dispatched_by_kind TEXT;
   ALTER TABLE sessions ADD COLUMN dispatched_by_session_id TEXT;
   `,
+  // v15 — the global search index (Plan 16 W1). FTS5, verified compiled into node:sqlite (unicode61
+  // and trigram tokenizers both present; this uses unicode61 with full diacritic folding). A plain
+  // contentful FTS5 table rather than external-content or contentless: the sources are heterogeneous
+  // (events keyed by integer seq, items by ULID), contentless tables cannot honestly DELETE without
+  // SQLite ≥3.43's contentless_delete, and the duplicated text is transcript-sized — cheap next to
+  // the payload_json that already stores it. `kind`/`ref`/`seq` are UNINDEXED metadata: kind is
+  // 'session' (ref = session id, seq = the event) or 'item' (ref = item id).
+  //
+  // What is NOT here, deliberately: no space_id and no profile_id. Scoping is a QUERY-TIME join
+  // through the live sessions/items→spaces tables (SearchService), because a space can be moved to
+  // another profile (spaces.update) and a profile id baked into the index would keep answering for
+  // the profile it used to be in. Skills and memory docs are not indexed at all — they are
+  // user-editable files (the library folder, `~/Realm/memory/*.md` whose paths the UI shows), so
+  // they are read live at query time; an index over files Realm does not own every write to would
+  // go stale the first time the user edits one in a text editor.
+  //
+  // Backfill: item titles inline (one small scan). Session events are backfilled CHUNKED ON BOOT
+  // (SearchService.runBackfill), resumable across restarts — a large history must not hold the
+  // migration transaction open for its whole scan. The settings row written here is the cursor:
+  // `target` is MAX(seq) at migration time, frozen so the boot-time backfill and write-time indexing
+  // (which starts with this same release, in SessionEventsStore.append) can never double-index a row.
+  `
+  CREATE VIRTUAL TABLE search_index USING fts5(
+    text, kind UNINDEXED, ref UNINDEXED, seq UNINDEXED,
+    tokenize = 'unicode61 remove_diacritics 2'
+  );
+  INSERT INTO search_index (text, kind, ref, seq) SELECT title, 'item', id, NULL FROM items;
+  INSERT INTO settings (key, value_json)
+    VALUES ('search.backfill', json_object('done', 0, 'target', COALESCE((SELECT MAX(seq) FROM session_events), 0)));
+  `,
 ];

--- a/apps/server/src/rpc/methods.ts
+++ b/apps/server/src/rpc/methods.ts
@@ -22,6 +22,7 @@ import type { BrowserHostBridge } from "../browsers/host-bridge";
 import type { SessionService } from "../sessions/service";
 import type { NotificationsService } from "../notifications/service";
 import type { ReviewService } from "../delegation/review";
+import type { SearchService } from "../search/service";
 import type { GitInfoService } from "../workspace/git-info";
 import type { GitDiffService } from "../workspace/git-diff";
 import type { GitWriteService } from "../workspace/git-write";
@@ -35,7 +36,7 @@ type Result<M extends MethodName> = MethodResult<M> | Promise<MethodResult<M>>;
 
 export type Deps = {
   rpc: RpcServer; home: string; version: string; machineName: string;
-  profiles: ProfilesStore; spaces: SpacesStore; projects: ProjectsStore; environments: EnvironmentsStore; envService: EnvironmentService; items: ItemsStore; settings: SettingsStore; skills: SkillsService; mcp: McpService; hub: McpHub; gateway: McpGateway; oauth: McpOauth; calls: McpCallLogStore; memory: MemoryService; terminals: TerminalService; browsers: BrowserService; browserBridge: BrowserHostBridge; sessions: SessionService; gitInfo: GitInfoService; gitDiff: GitDiffService; gitWrite: GitWriteService; ships: ShipsStore; ports: PortAllocator; checkpoints: CheckpointService; notifications: NotificationsService; reviews: ReviewService;
+  profiles: ProfilesStore; spaces: SpacesStore; projects: ProjectsStore; environments: EnvironmentsStore; envService: EnvironmentService; items: ItemsStore; settings: SettingsStore; skills: SkillsService; mcp: McpService; hub: McpHub; gateway: McpGateway; oauth: McpOauth; calls: McpCallLogStore; memory: MemoryService; terminals: TerminalService; browsers: BrowserService; browserBridge: BrowserHostBridge; sessions: SessionService; gitInfo: GitInfoService; gitDiff: GitDiffService; gitWrite: GitWriteService; ships: ShipsStore; ports: PortAllocator; checkpoints: CheckpointService; notifications: NotificationsService; reviews: ReviewService; search: SearchService;
 };
 
 export function registerMethods(d: Deps): void {
@@ -360,6 +361,10 @@ export function registerMethods(d: Deps): void {
     rpc.broadcast("checkpoints.changed", { environmentId: result.environmentId });
     return result;
   });
+
+  // Deep search (Plan 16 W1). Profile-scoped server-side — the service's joins are the enforcement,
+  // and the service itself checks the profile exists (a typo'd id should say so, not answer empty).
+  reg("search.query", (p) => d.search.query(p.profileId, p.query, p.limit));
 
   reg("items.list", (p) => d.items.list(p.spaceId));
   reg("items.listAll", () => d.items.listAll());

--- a/apps/server/src/rpc/methods.ts
+++ b/apps/server/src/rpc/methods.ts
@@ -23,6 +23,7 @@ import type { SessionService } from "../sessions/service";
 import type { NotificationsService } from "../notifications/service";
 import type { ReviewService } from "../delegation/review";
 import type { SearchService } from "../search/service";
+import type { ForkService } from "../sessions/fork";
 import type { GitInfoService } from "../workspace/git-info";
 import type { GitDiffService } from "../workspace/git-diff";
 import type { GitWriteService } from "../workspace/git-write";
@@ -36,7 +37,7 @@ type Result<M extends MethodName> = MethodResult<M> | Promise<MethodResult<M>>;
 
 export type Deps = {
   rpc: RpcServer; home: string; version: string; machineName: string;
-  profiles: ProfilesStore; spaces: SpacesStore; projects: ProjectsStore; environments: EnvironmentsStore; envService: EnvironmentService; items: ItemsStore; settings: SettingsStore; skills: SkillsService; mcp: McpService; hub: McpHub; gateway: McpGateway; oauth: McpOauth; calls: McpCallLogStore; memory: MemoryService; terminals: TerminalService; browsers: BrowserService; browserBridge: BrowserHostBridge; sessions: SessionService; gitInfo: GitInfoService; gitDiff: GitDiffService; gitWrite: GitWriteService; ships: ShipsStore; ports: PortAllocator; checkpoints: CheckpointService; notifications: NotificationsService; reviews: ReviewService; search: SearchService;
+  profiles: ProfilesStore; spaces: SpacesStore; projects: ProjectsStore; environments: EnvironmentsStore; envService: EnvironmentService; items: ItemsStore; settings: SettingsStore; skills: SkillsService; mcp: McpService; hub: McpHub; gateway: McpGateway; oauth: McpOauth; calls: McpCallLogStore; memory: MemoryService; terminals: TerminalService; browsers: BrowserService; browserBridge: BrowserHostBridge; sessions: SessionService; gitInfo: GitInfoService; gitDiff: GitDiffService; gitWrite: GitWriteService; ships: ShipsStore; ports: PortAllocator; checkpoints: CheckpointService; notifications: NotificationsService; reviews: ReviewService; search: SearchService; forks: ForkService;
 };
 
 export function registerMethods(d: Deps): void {
@@ -435,5 +436,9 @@ export function registerMethods(d: Deps): void {
   reg("sessions.setEnvironment", (p) => d.sessions.setEnvironment(p.id, p.environmentId));
   reg("sessions.events", (p) => d.sessions.events(p.id, p.afterSeq, p.limit));
   reg("sessions.openTerminal", (p) => d.sessions.openTerminal(p.id));
+  // "Fork from here" (Plan 16 W3): new worktree at the checkpoint's tree + new session carrying the
+  // ancestor transcript as text. The service broadcasts environments.changed; sessions.create's own
+  // items.changed already rode out of createSession.
+  reg("sessions.fork", (p) => d.forks.fork(p.checkpointId));
   reg("sessions.delete", async (p) => { await d.sessions.delete(p.id); return { ok: true as const }; });
 }

--- a/apps/server/src/search/service.test.ts
+++ b/apps/server/src/search/service.test.ts
@@ -112,13 +112,18 @@ describe("indexed sources — each write path pins its own FTS row", () => {
     expect(h.search.query(h.work.id, "flamingo").items).toHaveLength(0);
   });
 
-  it("deleting a session scrubs its transcript from the index", () => {
+  it("deleting a session scrubs its transcript from the index — the ROWS, not just the query view", () => {
     const h = harness();
     const s = h.newSession(h.alpha.id, h.envA.id);
     h.events.append(s.id, sessionEvent("user_message", { text: "ephemeral axolotl question", attachments: [] }));
     expect(h.search.query(h.work.id, "axolotl").sessions).toHaveLength(1);
     h.sessions.delete(s.id);
     expect(h.search.query(h.work.id, "axolotl").sessions).toHaveLength(0);
+    // The sessions join would hide an orphan from every query, so the query assertion above cannot
+    // see this on its own: the deleted transcript's TEXT must be gone from the database, not merely
+    // unreachable — a deleted session's words lingering in the FTS table is a privacy leak.
+    const orphans = h.db.prepare("SELECT COUNT(*) AS c FROM search_index WHERE kind = 'session' AND ref = ?").get(s.id) as { c: number };
+    expect(orphans.c).toBe(0);
   });
 
   it("a session-owned terminal item never surfaces (the palette's own hidden-item rule)", () => {

--- a/apps/server/src/search/service.test.ts
+++ b/apps/server/src/search/service.test.ts
@@ -1,0 +1,276 @@
+import { describe, expect, it } from "vitest";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { sessionEvent, type SearchSnippet } from "@realm/contracts";
+import { openDatabase } from "../db/database";
+import { ProfilesStore } from "../store/profiles";
+import { SpacesStore } from "../store/spaces";
+import { SettingsStore } from "../store/settings";
+import { ItemsStore } from "../store/items";
+import { SessionsStore, SessionEventsStore } from "../store/sessions";
+import { EnvironmentsStore } from "../store/environments";
+import { SkillsService } from "../skills/service";
+import { MemoryService } from "../memory/service";
+import { NotFoundError } from "../store/rows";
+import { BACKFILL_CHUNK, SEARCH_BACKFILL_KEY, SearchService, ftsExpression, liveMatches, liveSnippet, parseFtsSnippet, queryTokens } from "./service";
+
+function harness() {
+  const home = mkdtempSync(join(tmpdir(), "realm-search-"));
+  const db = openDatabase(join(home, "realm.db"));
+  const profiles = new ProfilesStore(db);
+  const spaces = new SpacesStore(db, home);
+  const settings = new SettingsStore(db);
+  const environments = new EnvironmentsStore(db);
+  const scopes = { profileIdOf: (sid: string) => spaces.get(sid)?.profileId ?? null };
+  const skills = new SkillsService({ home, settings, bundledDir: null, scopes });
+  const memory = new MemoryService({ home, settings, environments, claudeDir: join(home, "no-claude"), scopes });
+  const search = new SearchService({ db, settings, profiles, spaces, skills, memory });
+  const sessions = new SessionsStore(db);
+  const events = new SessionEventsStore(db);
+  const items = new ItemsStore(db);
+
+  const work = profiles.create({ name: "Work", icon: "u", color: "#000" });
+  const school = profiles.create({ name: "School", icon: "u", color: "#000" });
+  const alpha = spaces.create({ profileId: work.id, name: "Alpha", icon: "f" });
+  const beta = spaces.create({ profileId: school.id, name: "Beta", icon: "f" });
+  const envA = environments.ensurePrimary(alpha.id);
+  const envB = environments.ensurePrimary(beta.id);
+
+  const newSession = (spaceId: string, environmentId: string, title = "A session") =>
+    sessions.create({ spaceId, projectId: null, agentKind: "fake", model: null, effort: null, permissionMode: "default", environmentId, title });
+
+  return { home, db, profiles, spaces, settings, environments, skills, memory, search, sessions, events, items, work, school, alpha, beta, envA, envB, newSession };
+}
+
+const flat = (s: SearchSnippet) => s.map((p) => p.text).join("");
+const marked = (s: SearchSnippet) => s.filter((p) => p.match).map((p) => p.text).join("|");
+
+describe("query building", () => {
+  it("tokenizes on non-word runs, lowercased, unicode included", () => {
+    expect(queryTokens("Fix the  LOGIN—flow café")).toEqual(["fix", "the", "login", "flow", "café"]);
+  });
+  it("quotes every token and prefixes the last — FTS syntax can never leak in", () => {
+    expect(ftsExpression("fix AND (login:")).toBe('"fix" "and" "login"*');
+    expect(ftsExpression("  —  ")).toBeNull();
+  });
+  it("parses marked snippets into alternating segments", () => {
+    expect(parseFtsSnippet("say hello there")).toEqual([
+      { text: "say ", match: false }, { text: "hello", match: true }, { text: " there", match: false },
+    ]);
+  });
+  it("liveSnippet windows around the first hit and marks every in-window occurrence", () => {
+    const text = `${"x".repeat(200)} the magic word, and magic again`;
+    const snip = liveSnippet(text, ["magic"]);
+    expect(flat(snip)).toContain("magic word");
+    expect(flat(snip).startsWith("…")).toBe(true);
+    expect(marked(snip)).toBe("magic|magic");
+    expect(liveMatches(text, ["magic", "word"])).toBe(true);
+    expect(liveMatches(text, ["magic", "absent"])).toBe(false);
+  });
+});
+
+describe("indexed sources — each write path pins its own FTS row", () => {
+  it("user_message text is searchable the moment it is appended", () => {
+    const h = harness();
+    const s = h.newSession(h.alpha.id, h.envA.id);
+    h.events.append(s.id, sessionEvent("user_message", { text: "please refactor the flux capacitor", attachments: [] }));
+    const r = h.search.query(h.work.id, "flux capacitor");
+    expect(r.sessions).toHaveLength(1);
+    expect(r.sessions[0]).toMatchObject({ sessionId: s.id, spaceId: h.alpha.id });
+    expect(marked(r.sessions[0]!.snippet)).toContain("flux");
+  });
+
+  it("assistant_text is searchable; deltas, thinking and tool events are not indexed", () => {
+    const h = harness();
+    const s = h.newSession(h.alpha.id, h.envA.id);
+    h.events.append(s.id, sessionEvent("assistant_text", { messageId: "m1", text: "I rebuilt the zeppelin module" }));
+    h.events.append(s.id, sessionEvent("thinking", { messageId: "m2", text: "secret contemplation about quokkas" }));
+    h.events.append(s.id, sessionEvent("tool_result", { toolUseId: "t1", content: "grep found wombats everywhere", isError: false }));
+    expect(h.search.query(h.work.id, "zeppelin").sessions).toHaveLength(1);
+    expect(h.search.query(h.work.id, "quokkas").sessions).toHaveLength(0);
+    expect(h.search.query(h.work.id, "wombats").sessions).toHaveLength(0);
+  });
+
+  it("one session with many hits is one result row, carrying the best event's seq", () => {
+    const h = harness();
+    const s = h.newSession(h.alpha.id, h.envA.id);
+    for (let i = 0; i < 5; i++) h.events.append(s.id, sessionEvent("user_message", { text: `pelican number ${i}`, attachments: [] }));
+    const r = h.search.query(h.work.id, "pelican");
+    expect(r.sessions).toHaveLength(1);
+    expect(typeof r.sessions[0]!.seq).toBe("number");
+  });
+
+  it("item titles: indexed on create, moved on rename, scrubbed on delete", () => {
+    const h = harness();
+    const it1 = h.items.create({ spaceId: h.alpha.id, kind: "terminal", title: "ostrich dashboard", refId: h.envA.id });
+    expect(h.search.query(h.work.id, "ostrich").items.map((i) => i.itemId)).toEqual([it1.id]);
+    h.items.update({ id: it1.id, title: "flamingo dashboard" });
+    expect(h.search.query(h.work.id, "ostrich").items).toHaveLength(0);
+    expect(h.search.query(h.work.id, "flamingo").items.map((i) => i.itemId)).toEqual([it1.id]);
+    h.items.delete(it1.id);
+    expect(h.search.query(h.work.id, "flamingo").items).toHaveLength(0);
+  });
+
+  it("deleting a session scrubs its transcript from the index", () => {
+    const h = harness();
+    const s = h.newSession(h.alpha.id, h.envA.id);
+    h.events.append(s.id, sessionEvent("user_message", { text: "ephemeral axolotl question", attachments: [] }));
+    expect(h.search.query(h.work.id, "axolotl").sessions).toHaveLength(1);
+    h.sessions.delete(s.id);
+    expect(h.search.query(h.work.id, "axolotl").sessions).toHaveLength(0);
+  });
+
+  it("a session-owned terminal item never surfaces (the palette's own hidden-item rule)", () => {
+    const h = harness();
+    const s = h.newSession(h.alpha.id, h.envA.id);
+    const hidden = h.items.create({ spaceId: h.alpha.id, kind: "terminal", title: "hidden panel narwhal", refId: s.id });
+    h.sessions.setTerminalItem(s.id, hidden.id);
+    expect(h.search.query(h.work.id, "narwhal").items).toHaveLength(0);
+  });
+});
+
+describe("live sources — files are read at query time, never cached", () => {
+  it("finds a skill by name+description, including one dropped into the folder moments ago", () => {
+    const h = harness();
+    const dir = join(h.home, "skills", "tide-charts");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "SKILL.md"), "---\nname: Tide charts\ndescription: Predicts coastal tide tables\n---\nbody");
+    const r = h.search.query(h.work.id, "coastal tide");
+    expect(r.skills.map((s) => s.id)).toEqual(["tide-charts"]);
+    expect(marked(r.skills[0]!.snippet)).toContain("tide");
+  });
+
+  it("finds a space memory doc set through the service AND a direct file edit — the reason this source is live", () => {
+    const h = harness();
+    h.memory.set(h.alpha.id, "Always deploy with the tortoise script");
+    expect(h.search.query(h.work.id, "tortoise").memory).toMatchObject([{ scope: "space", spaceId: h.alpha.id }]);
+    // The panel shows the doc's path; a user editing it in a text editor must be searchable too.
+    writeFileSync(h.memory.docPath(h.alpha.id), "Now we prefer the hedgehog script");
+    expect(h.search.query(h.work.id, "tortoise").memory).toHaveLength(0);
+    expect(h.search.query(h.work.id, "hedgehog").memory).toHaveLength(1);
+  });
+
+  it("finds the profile memory doc, attributed to the profile", () => {
+    const h = harness();
+    h.memory.setProfile(h.work.id, "Company style: iguana casing everywhere");
+    const r = h.search.query(h.work.id, "iguana");
+    expect(r.memory).toMatchObject([{ scope: "profile", profileId: h.work.id, spaceId: null }]);
+    expect(r.memory[0]!.title).toContain("Work");
+  });
+});
+
+describe("profile scoping — the named mutant: a Work search must not surface School anything", () => {
+  it("transcripts, items, skills and memory are all fenced to the queried profile", () => {
+    const h = harness();
+    const sa = h.newSession(h.alpha.id, h.envA.id);
+    const sb = h.newSession(h.beta.id, h.envB.id);
+    h.events.append(sa.id, sessionEvent("user_message", { text: "work secret: giraffe payroll", attachments: [] }));
+    h.events.append(sb.id, sessionEvent("user_message", { text: "school secret: giraffe homework", attachments: [] }));
+    h.items.create({ spaceId: h.alpha.id, kind: "browser", title: "giraffe docs (work)", refId: sa.id });
+    h.items.create({ spaceId: h.beta.id, kind: "browser", title: "giraffe notes (school)", refId: sb.id });
+    h.memory.set(h.alpha.id, "work giraffe memory");
+    h.memory.set(h.beta.id, "school giraffe memory");
+
+    const workR = h.search.query(h.work.id, "giraffe");
+    expect(workR.sessions.map((x) => x.sessionId)).toEqual([sa.id]);
+    expect(workR.items.every((x) => x.spaceId === h.alpha.id)).toBe(true);
+    expect(workR.memory).toMatchObject([{ spaceId: h.alpha.id }]);
+    const schoolR = h.search.query(h.school.id, "giraffe");
+    expect(schoolR.sessions.map((x) => x.sessionId)).toEqual([sb.id]);
+    expect(schoolR.items.every((x) => x.spaceId === h.beta.id)).toBe(true);
+  });
+
+  it("a space moved to another profile answers for its NEW profile — nothing profile-shaped is baked into the index", () => {
+    const h = harness();
+    const s = h.newSession(h.alpha.id, h.envA.id);
+    h.events.append(s.id, sessionEvent("user_message", { text: "migratory albatross", attachments: [] }));
+    expect(h.search.query(h.work.id, "albatross").sessions).toHaveLength(1);
+    h.spaces.update({ id: h.alpha.id, profileId: h.school.id });
+    expect(h.search.query(h.work.id, "albatross").sessions).toHaveLength(0);
+    expect(h.search.query(h.school.id, "albatross").sessions).toHaveLength(1);
+  });
+
+  it("refuses an unknown profile rather than answering an empty page", () => {
+    const h = harness();
+    expect(() => h.search.query("01ARZ3NDEKTSV4RRFFQ69G5FAV", "x")).toThrow(NotFoundError);
+  });
+});
+
+describe("query hardening and quiet states", () => {
+  it("hostile FTS syntax is content, never syntax", () => {
+    const h = harness();
+    const s = h.newSession(h.alpha.id, h.envA.id);
+    h.events.append(s.id, sessionEvent("user_message", { text: 'the "quoted" AND cormorant NEAR stuff', attachments: [] }));
+    for (const q of ['"quoted" AND cormorant', "cormorant NEAR", 'x OR ""(', "-cormorant", "cormorant*)"]) {
+      expect(() => h.search.query(h.work.id, q)).not.toThrow();
+    }
+    expect(h.search.query(h.work.id, '"quoted" AND cormorant').sessions).toHaveLength(1);
+  });
+  it("a query with no word characters returns the empty groups", () => {
+    const h = harness();
+    expect(h.search.query(h.work.id, "—…!!")).toEqual({ sessions: [], items: [], skills: [], memory: [] });
+  });
+});
+
+describe("backfill — chunked, resumable, never double-indexing", () => {
+  /** Raw event inserts bypass the store's write-time indexing, simulating a pre-v15 history. */
+  function rawEvents(h: ReturnType<typeof harness>, sessionId: string, n: number, word: string) {
+    const ins = h.db.prepare("INSERT INTO session_events (session_id, ts, type, payload_json) VALUES (?, ?, 'user_message', ?)");
+    for (let i = 0; i < n; i++) ins.run(sessionId, i, JSON.stringify({ text: `${word} ${i}`, attachments: [] }));
+  }
+  const maxSeq = (h: ReturnType<typeof harness>) => (h.db.prepare("SELECT MAX(seq) AS m FROM session_events").get() as { m: number }).m;
+  const indexedCount = (h: ReturnType<typeof harness>) =>
+    (h.db.prepare("SELECT COUNT(*) AS c FROM search_index WHERE kind = 'session'").get() as { c: number }).c;
+
+  it("indexes a multi-chunk history to completion and closes the cursor", async () => {
+    const h = harness();
+    const s = h.newSession(h.alpha.id, h.envA.id);
+    rawEvents(h, s.id, BACKFILL_CHUNK + 50, "cassowary");
+    h.settings.set(SEARCH_BACKFILL_KEY, { done: 0, target: maxSeq(h) });
+    const logs: string[] = [];
+    await h.search.runBackfill((l) => logs.push(l));
+    expect(indexedCount(h)).toBe(BACKFILL_CHUNK + 50);
+    expect(h.search.query(h.work.id, "cassowary").sessions).toHaveLength(1);
+    const cursor = h.settings.get(SEARCH_BACKFILL_KEY) as { done: number; target: number };
+    expect(cursor.done).toBe(cursor.target);
+    expect(logs.length).toBeGreaterThan(0);
+  });
+
+  it("resumes from the persisted cursor: rows at or before `done` are never re-scanned", async () => {
+    const h = harness();
+    const s = h.newSession(h.alpha.id, h.envA.id);
+    rawEvents(h, s.id, 10, "kookaburra");
+    const target = maxSeq(h);
+    // Simulate a crash after the first 4 were indexed: cursor persisted, rows present.
+    const first = h.db.prepare("SELECT seq, payload_json FROM session_events ORDER BY seq LIMIT 4").all() as { seq: number; payload_json: string }[];
+    const ins = h.db.prepare("INSERT INTO search_index (text, kind, ref, seq) VALUES (?, 'session', ?, ?)");
+    for (const r of first) ins.run((JSON.parse(r.payload_json) as { text: string }).text, s.id, r.seq);
+    h.settings.set(SEARCH_BACKFILL_KEY, { done: first.at(-1)!.seq, target });
+    await h.search.runBackfill(() => {});
+    expect(indexedCount(h)).toBe(10); // 4 pre-existing + 6 resumed, no duplicates
+  });
+
+  it("events past the frozen target are write-time indexed exactly once, even with a backfill pending", async () => {
+    const h = harness();
+    const s = h.newSession(h.alpha.id, h.envA.id);
+    rawEvents(h, s.id, 3, "old-history");
+    h.settings.set(SEARCH_BACKFILL_KEY, { done: 0, target: maxSeq(h) });
+    // A new event lands through the store while the backfill has not run yet.
+    h.events.append(s.id, sessionEvent("user_message", { text: "fresh capybara message", attachments: [] }));
+    await h.search.runBackfill(() => {});
+    const rows = h.db.prepare("SELECT COUNT(*) AS c FROM search_index WHERE kind = 'session' AND text LIKE '%capybara%'").get() as { c: number };
+    expect(rows.c).toBe(1);
+    expect(indexedCount(h)).toBe(4);
+  });
+
+  it("stop() halts before the next chunk (shutdown must not race db.close)", async () => {
+    const h = harness();
+    const s = h.newSession(h.alpha.id, h.envA.id);
+    rawEvents(h, s.id, 5, "stopped");
+    h.settings.set(SEARCH_BACKFILL_KEY, { done: 0, target: maxSeq(h) });
+    h.search.stop();
+    await h.search.runBackfill(() => {});
+    expect(indexedCount(h)).toBe(0);
+  });
+});

--- a/apps/server/src/search/service.ts
+++ b/apps/server/src/search/service.ts
@@ -1,0 +1,277 @@
+import type { ItemKind, ItemSearchHit, MemorySearchHit, SearchResults, SearchSnippet, SessionSearchHit, SkillSearchHit } from "@realm/contracts";
+import { SEARCH_GROUP_LIMIT } from "@realm/contracts";
+import type { Db } from "../db/database";
+import type { SettingsStore } from "../store/settings";
+import type { ProfilesStore } from "../store/profiles";
+import type { SpacesStore } from "../store/spaces";
+import type { SkillsService } from "../skills/service";
+import type { MemoryService } from "../memory/service";
+import { NotFoundError } from "../store/rows";
+
+/** The resumable event-backfill cursor, written by migration v15 and advanced by `runBackfill`.
+ *  `done` is the last seq indexed; `target` is frozen at migration time — events past it are indexed
+ *  at write time (SessionEventsStore.append), so the two writers can never double-index a row. */
+export const SEARCH_BACKFILL_KEY = "search.backfill";
+/** Events scanned per backfill transaction. Small enough that one chunk never blocks the (sync)
+ *  event loop noticeably; the loop yields between chunks so RPC stays responsive during a large
+ *  history's first boot on this schema. */
+export const BACKFILL_CHUNK = 500;
+
+/** Snippet window bounds for the live (file-backed) sources, roughly matching what FTS5's own
+ *  `snippet()` yields for the indexed ones. */
+const LIVE_SNIPPET_BEFORE = 32;
+const LIVE_SNIPPET_WINDOW = 120;
+
+/** FTS5 snippet markers. Control bytes so they cannot collide with query syntax; they never reach the
+ *  wire — `parseFtsSnippet` turns them into `{text, match}` segments. */
+const MARK_START = "\u0001";
+const MARK_END = "\u0002";
+
+/**
+ * Lowercased word tokens of a query. The split mirrors what unicode61 treats as separators closely
+ * enough for the live sources; FTS applies its own tokenizer to the quoted tokens.
+ */
+export function queryTokens(raw: string): string[] {
+  return raw.toLowerCase().split(/[^\p{L}\p{N}_]+/u).filter((t) => t !== "");
+}
+
+/**
+ * A raw palette query as a safe FTS5 MATCH expression: every token double-quoted (so `AND`, `-`,
+ * `:` and stray quotes are content, never syntax), the last token a prefix query — the palette
+ * searches while the user is mid-word. Null when the query holds no word characters at all.
+ */
+export function ftsExpression(raw: string): string | null {
+  const tokens = queryTokens(raw);
+  if (tokens.length === 0) return null;
+  return tokens.map((t, i) => `"${t}"${i === tokens.length - 1 ? "*" : ""}`).join(" ");
+}
+
+/** FTS5 `snippet()` output (with the control-byte markers) as alternating segments. */
+export function parseFtsSnippet(s: string): SearchSnippet {
+  const out: SearchSnippet = [];
+  let i = 0, match = false;
+  while (i < s.length) {
+    const next = s.indexOf(match ? MARK_END : MARK_START, i);
+    const end = next === -1 ? s.length : next;
+    if (end > i) out.push({ text: s.slice(i, end), match });
+    if (next === -1) break;
+    i = next + 1; match = !match;
+  }
+  return out;
+}
+
+/**
+ * Whether live (unindexed, file-backed) text matches the query: every token a substring,
+ * case-insensitive. Deliberately LOOSER than FTS's word-prefix semantics — a live source that
+ * over-matches slightly is a row the user can ignore; one that under-matches is a skill they
+ * cannot find.
+ */
+export function liveMatches(text: string, tokens: string[]): boolean {
+  if (tokens.length === 0) return false;
+  const lower = text.toLowerCase();
+  return tokens.every((t) => lower.includes(t));
+}
+
+/** A windowed snippet of live text with every in-window token occurrence marked. */
+export function liveSnippet(text: string, tokens: string[]): SearchSnippet {
+  const lower = text.toLowerCase();
+  // Every occurrence of every token, as [start, end) ranges, merged where they overlap.
+  const ranges: [number, number][] = [];
+  for (const t of tokens) {
+    for (let at = lower.indexOf(t); at !== -1; at = lower.indexOf(t, at + 1)) ranges.push([at, at + t.length]);
+  }
+  ranges.sort((a, b) => a[0] - b[0] || a[1] - b[1]);
+  const merged: [number, number][] = [];
+  for (const r of ranges) {
+    const last = merged.at(-1);
+    if (last && r[0] <= last[1]) last[1] = Math.max(last[1], r[1]); else merged.push([...r] as [number, number]);
+  }
+  const first = merged[0]?.[0] ?? 0;
+  const start = Math.max(0, first - LIVE_SNIPPET_BEFORE);
+  const end = Math.min(text.length, start + LIVE_SNIPPET_WINDOW);
+  const out: SearchSnippet = [];
+  if (start > 0) out.push({ text: "…", match: false });
+  let i = start;
+  for (const [a, b] of merged) {
+    if (b <= start || a >= end) continue;
+    const ca = Math.max(a, start), cb = Math.min(b, end);
+    if (ca > i) out.push({ text: text.slice(i, ca), match: false });
+    out.push({ text: text.slice(ca, cb), match: true });
+    i = cb;
+  }
+  if (i < end) out.push({ text: text.slice(i, end), match: false });
+  if (end < text.length) out.push({ text: "…", match: false });
+  return out;
+}
+
+type SessionRow = { session_id: string; seq: number; space_id: string; title: string; snip: string };
+type ItemRow = { item_id: string; space_id: string; item_kind: ItemKind; title: string; snip: string };
+
+/**
+ * Global search (Plan 16 W1), scoped to ONE profile per query.
+ *
+ * Two kinds of source, split by who owns the writes:
+ *
+ *  - **DB-backed text** (session user/assistant events, item titles) is FTS5-indexed at write time —
+ *    every write path runs through a store choke point that also writes the index row, so the index
+ *    can never miss a source. Scoping is a query-time join through the LIVE sessions/items→spaces
+ *    tables: a space moved to another profile answers for its new profile immediately, because
+ *    nothing profile-shaped is baked into the index.
+ *  - **File-backed text** (skills, memory documents) is read live at query time. Both are files the
+ *    user is invited to edit outside Realm (the library folder in Finder, the memory doc at a path
+ *    the panel displays), so any index over them would be a cache with no invalidation story. They
+ *    are small and few; a debounced palette query affords the reads.
+ */
+export class SearchService {
+  private stopped = false;
+  constructor(private d: {
+    db: Db; settings: SettingsStore; profiles: ProfilesStore; spaces: SpacesStore;
+    skills: SkillsService; memory: MemoryService;
+  }) {}
+
+  query(profileId: string, raw: string, limit = SEARCH_GROUP_LIMIT): SearchResults {
+    if (!this.d.profiles.get(profileId)) throw new NotFoundError("profile", profileId);
+    const expr = ftsExpression(raw);
+    const tokens = queryTokens(raw);
+    if (!expr) return { sessions: [], items: [], skills: [], memory: [] };
+    return {
+      sessions: this.sessions(profileId, expr, limit),
+      items: this.items(profileId, expr, limit),
+      skills: this.skills(profileId, tokens, limit),
+      memory: this.memory(profileId, tokens, limit),
+    };
+  }
+
+  /** Transcript hits, best (bm25) first, at most one per session — a session that said the word ten
+   *  times is one place to jump to, not ten rows. */
+  private sessions(profileId: string, expr: string, limit: number): SessionSearchHit[] {
+    const rows = this.d.db.prepare(`
+      SELECT search_index.ref AS session_id, search_index.seq AS seq, s.space_id, s.title,
+             snippet(search_index, 0, ?, ?, '…', 12) AS snip
+      FROM search_index
+      JOIN sessions s ON s.id = search_index.ref
+      JOIN spaces sp ON sp.id = s.space_id
+      WHERE search_index MATCH ? AND search_index.kind = 'session' AND sp.profile_id = ?
+      ORDER BY bm25(search_index) LIMIT ?`)
+      .all(MARK_START, MARK_END, expr, profileId, limit * 4) as SessionRow[];
+    const seen = new Set<string>();
+    const out: SessionSearchHit[] = [];
+    for (const r of rows) {
+      if (seen.has(r.session_id)) continue;
+      seen.add(r.session_id);
+      out.push({ sessionId: r.session_id, spaceId: r.space_id, title: r.title, seq: Number(r.seq), snippet: parseFtsSnippet(r.snip) });
+      if (out.length >= limit) break;
+    }
+    return out;
+  }
+
+  private items(profileId: string, expr: string, limit: number): ItemSearchHit[] {
+    const rows = this.d.db.prepare(`
+      SELECT search_index.ref AS item_id, i.space_id, i.kind AS item_kind, i.title,
+             snippet(search_index, 0, ?, ?, '…', 12) AS snip
+      FROM search_index
+      JOIN items i ON i.id = search_index.ref
+      JOIN spaces sp ON sp.id = i.space_id
+      WHERE search_index MATCH ? AND search_index.kind = 'item' AND sp.profile_id = ?
+        AND i.id NOT IN (SELECT terminal_item_id FROM sessions WHERE terminal_item_id IS NOT NULL)
+      ORDER BY bm25(search_index) LIMIT ?`)
+      .all(MARK_START, MARK_END, expr, profileId, limit) as ItemRow[];
+    return rows.map((r) => ({ itemId: r.item_id, spaceId: r.space_id, itemKind: r.item_kind, title: r.title, snippet: parseFtsSnippet(r.snip) }));
+  }
+
+  /** Skills whose scope reaches any space of this profile, matched live against name + description.
+   *  The union across the profile's spaces IS the scoping — `SkillsService.list` already answers the
+   *  reach question per space, and search must not grow a second copy of that rule. */
+  private skills(profileId: string, tokens: string[], limit: number): SkillSearchHit[] {
+    const out = new Map<string, SkillSearchHit>();
+    for (const sp of this.d.spaces.list(profileId)) {
+      for (const sk of this.d.skills.list(sp.id).skills) {
+        if (!sk.valid || out.has(sk.id)) continue;
+        const haystack = `${sk.name} ${sk.description}`;
+        if (!liveMatches(haystack, tokens)) continue;
+        const source = liveMatches(sk.description, tokens) ? sk.description : haystack;
+        out.set(sk.id, { id: sk.id, name: sk.name, description: sk.description, snippet: liveSnippet(source, tokens) });
+      }
+      if (out.size >= limit) break;
+    }
+    return [...out.values()].slice(0, limit);
+  }
+
+  /** Memory documents of this profile's world: the profile doc, then each of its spaces' docs. */
+  private memory(profileId: string, tokens: string[], limit: number): MemorySearchHit[] {
+    const out: MemorySearchHit[] = [];
+    const profile = this.d.profiles.get(profileId);
+    const profileDoc = this.d.memory.readProfileDoc(profileId);
+    if (profile && liveMatches(profileDoc, tokens)) {
+      out.push({ scope: "profile", profileId, spaceId: null, title: `${profile.name} profile memory`, snippet: liveSnippet(profileDoc, tokens) });
+    }
+    for (const sp of this.d.spaces.list(profileId)) {
+      if (out.length >= limit) break;
+      const doc = this.d.memory.readDoc(sp.id);
+      if (!liveMatches(doc, tokens)) continue;
+      out.push({ scope: "space", profileId: null, spaceId: sp.id, title: `${sp.name} memory`, snippet: liveSnippet(doc, tokens) });
+    }
+    return out.slice(0, limit);
+  }
+
+  /**
+   * Index the pre-v15 event history, in chunks, resuming across restarts.
+   *
+   * The design, stated: migration v15 froze a cursor (`done: 0, target: MAX(seq)` at that moment)
+   * instead of scanning inside the migration transaction. Each chunk here reads up to
+   * `BACKFILL_CHUNK` matching events past `done`, writes their FTS rows and the advanced cursor in
+   * one transaction, then yields the event loop. A crash mid-way resumes from the persisted `done`
+   * on next boot; events past `target` are write-time indexed and never touched here. A chunk that
+   * comes back short means the scan reached `target` — the cursor is closed by setting `done` to it.
+   * There is no wall-clock time-box: the per-chunk yield keeps the server responsive, and the work
+   * is bounded by the history that existed at migration time.
+   *
+   * An event whose session is deleted DURING the backfill can leave an orphan FTS row (the delete
+   * scrubbed by ref before this chunk inserted); it is invisible to every query (the sessions join
+   * fails) and costs a few bytes — accepted.
+   */
+  async runBackfill(onLog: (line: string) => void = (l) => console.error(l)): Promise<void> {
+    for (;;) {
+      if (this.stopped) return;
+      const cursor = this.readCursor();
+      if (!cursor || cursor.done >= cursor.target) return;
+      try {
+        const rows = this.d.db.prepare(`
+          SELECT seq, session_id, payload_json FROM session_events
+          WHERE seq > ? AND seq <= ? AND type IN ('user_message', 'assistant_text')
+          ORDER BY seq LIMIT ?`).all(cursor.done, cursor.target, BACKFILL_CHUNK) as { seq: number; session_id: string; payload_json: string }[];
+        const done = rows.length < BACKFILL_CHUNK ? cursor.target : Number(rows.at(-1)!.seq);
+        this.d.db.exec("BEGIN");
+        try {
+          const ins = this.d.db.prepare("INSERT INTO search_index (text, kind, ref, seq) VALUES (?, 'session', ?, ?)");
+          for (const r of rows) {
+            let text: unknown;
+            try { text = (JSON.parse(r.payload_json) as { text?: unknown }).text; } catch { continue; }
+            if (typeof text !== "string" || text.trim() === "") continue;
+            ins.run(text, r.session_id, r.seq);
+          }
+          this.d.settings.set(SEARCH_BACKFILL_KEY, { done, target: cursor.target });
+          this.d.db.exec("COMMIT");
+        } catch (e) { this.d.db.exec("ROLLBACK"); throw e; }
+        if (rows.length > 0) onLog(`[search] backfilled ${rows.length} events (through seq ${done} of ${cursor.target})`);
+      } catch (e) {
+        // A failed chunk (disk full, db closing under shutdown) leaves the cursor where it was; the
+        // next boot resumes. Search over the not-yet-covered range is merely incomplete, never wrong.
+        onLog(`[search] backfill paused: ${e instanceof Error ? e.message : String(e)}`);
+        return;
+      }
+      await new Promise((r) => setImmediate(r));
+    }
+  }
+
+  /** Halt the backfill loop before its next chunk — called at app close so it never races db.close. */
+  stop(): void { this.stopped = true; }
+
+  private readCursor(): { done: number; target: number } | null {
+    const v = this.d.settings.get(SEARCH_BACKFILL_KEY);
+    if (!v || typeof v !== "object") return null;
+    const { done, target } = v as { done?: unknown; target?: unknown };
+    if (typeof done !== "number" || typeof target !== "number") return null;
+    return { done, target };
+  }
+}

--- a/apps/server/src/sessions/fork-integration.test.ts
+++ b/apps/server/src/sessions/fork-integration.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it, afterEach } from "vitest";
+import WebSocket from "ws";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { FakeAdapter } from "@realm/adapters";
+import type { StartOptions } from "@realm/adapters";
+import { createApp, type App } from "../app";
+import { waitFor } from "../test-utils";
+
+/**
+ * Plan 16 through the real RPC surface, real database, real repository, real (scripted) adapter:
+ *
+ *  - a session's text is searchable the moment its events persist, profile-scoped (`search.query`);
+ *  - `sessions.fork` makes a NEW worktree at the checkpoint's tree and a NEW session whose adapter
+ *    start actually RECEIVES the carried ancestor context — the app.ts fan-out wiring the unit tests
+ *    cannot see;
+ *  - the ancestor's transcript is byte-identical across the fork.
+ */
+let app: App;
+afterEach(async () => { await app?.close(); });
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Any = any;
+async function client(port: number) {
+  const ws = await new Promise<WebSocket>((res, rej) => { const w = new WebSocket(`ws://127.0.0.1:${port}`); w.once("open", () => res(w)); w.once("error", rej); });
+  const pending = new Map<string, (v: Any) => void>();
+  ws.on("message", (d) => { const m = JSON.parse(d.toString()); if ("id" in m) pending.get(m.id)?.(m); });
+  let n = 0;
+  const call = (method: string, params: unknown) => new Promise<Any>((res, rej) => {
+    const id = String(++n);
+    const timer = setTimeout(() => { pending.delete(id); rej(new Error(`rpc ${method} (#${id}) timed out`)); }, 10_000);
+    pending.set(id, (v) => { clearTimeout(timer); res(v); });
+    ws.send(JSON.stringify({ id, method, params }));
+  });
+  return { call, close: () => ws.close() };
+}
+
+function git(cwd: string, ...args: string[]): string {
+  return execFileSync("git", ["-c", "user.email=t@example.com", "-c", "user.name=t", "-c", "commit.gpgsign=false", ...args], { cwd, encoding: "utf8" });
+}
+
+/** A FakeAdapter that remembers every StartOptions it was handed — the seam that proves the fork
+ *  context actually reaches an adapter start, rather than merely existing in a settings row. */
+class RecordingFake extends FakeAdapter {
+  starts: StartOptions[] = [];
+  override start(o: StartOptions) { this.starts.push(o); return super.start(o); }
+}
+
+describe("fork + search over rpc (Plan 16)", () => {
+  it("indexes live session text profile-scoped; forks into a new worktree whose session starts with the carried context", async () => {
+    const home = mkdtempSync(join(tmpdir(), "realm-forkint-"));
+    if (!resolve(home).startsWith(resolve(tmpdir()))) throw new Error(`refusing to run against ${home}`);
+    const fake = new RecordingFake({ script: [{ on: "go", emit: [{ kind: "text", text: "the walrus is assembled" }] }], delayMs: 5 });
+    app = await createApp({ home, port: 0, adapters: { fake } });
+    const c = await client(app.port);
+    const p = (await c.call("profiles.create", { name: "Work" })).result;
+    const other = (await c.call("profiles.create", { name: "School" })).result;
+    const sp = (await c.call("spaces.create", { profileId: p.id, name: "S" })).result;
+    git(sp.folderPath, "init", "-q", "-b", "main");
+    writeFileSync(join(sp.folderPath, "a.txt"), "one\n");
+    git(sp.folderPath, "add", "."); git(sp.folderPath, "commit", "-qm", "init");
+
+    // A real turn: send → per-turn checkpoint → scripted answer → idle.
+    const { session } = (await c.call("sessions.create", { spaceId: sp.id, agentKind: "fake" })).result;
+    await c.call("sessions.send", { id: session.id, text: "go build the walrus" });
+    await waitFor(async () => (await c.call("sessions.get", { id: session.id })).result.status === "idle");
+
+    // W1 live leg: both sides of the turn are searchable NOW, and only inside their own profile.
+    const hits = (await c.call("search.query", { profileId: p.id, query: "walrus" })).result;
+    expect(hits.sessions).toHaveLength(1);
+    expect(hits.sessions[0].sessionId).toBe(session.id);
+    const foreign = (await c.call("search.query", { profileId: other.id, query: "walrus" })).result;
+    expect(foreign.sessions).toHaveLength(0);
+
+    // The turn's checkpoint — captured before the message — is what we fork from.
+    const env = (await c.call("environments.list", { spaceId: sp.id })).result[0];
+    const cps = (await c.call("checkpoints.list", { environmentId: env.id, sessionId: session.id })).result;
+    expect(cps.length).toBeGreaterThan(0);
+    const eventsBefore = JSON.stringify((await c.call("sessions.events", { id: session.id, afterSeq: 0 })).result);
+
+    const fork = (await c.call("sessions.fork", { checkpointId: cps[0].id })).result;
+    expect(fork.session.dispatchedBy).toEqual({ kind: "fork", sessionId: session.id });
+    expect(fork.environment.kind).toBe("worktree");
+    expect(fork.environment.path).not.toBe(env.path);
+    expect(readFileSync(join(fork.environment.path, "a.txt"), "utf8")).toBe("one\n");
+
+    // The wiring that only an app-level test can see: the forked session's adapter START carries the
+    // fenced summary-of-ancestor through the extraSystemContext fan-out.
+    const startsBefore = fake.starts.length;
+    await c.call("sessions.send", { id: fork.session.id, text: "continue" });
+    await waitFor(async () => (await c.call("sessions.get", { id: fork.session.id })).result.status === "idle");
+    const forkStart = fake.starts[startsBefore]!;
+    expect(forkStart.cwd).toBe(fork.environment.path);
+    expect(forkStart.systemContext).toContain("# Forked session");
+    expect(forkStart.systemContext).toContain("go build the walrus");
+    expect(forkStart.systemContext).toContain("could not be rewound");
+    // …and the ancestor's own start never carried one.
+    expect(fake.starts[0]!.systemContext ?? "").not.toContain("# Forked session");
+
+    // The ancestor's transcript is byte-identical across all of it.
+    expect(JSON.stringify((await c.call("sessions.events", { id: session.id, afterSeq: 0 })).result)).toBe(eventsBefore);
+    c.close();
+  });
+});

--- a/apps/server/src/sessions/fork.test.ts
+++ b/apps/server/src/sessions/fork.test.ts
@@ -1,0 +1,267 @@
+import { describe, expect, it } from "vitest";
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { sessionEvent, type Checkpoint } from "@realm/contracts";
+import { openDatabase } from "../db/database";
+import { ProfilesStore } from "../store/profiles";
+import { SpacesStore } from "../store/spaces";
+import { SettingsStore } from "../store/settings";
+import { ItemsStore } from "../store/items";
+import { CheckpointsStore } from "../store/checkpoints";
+import { SessionsStore, SessionEventsStore } from "../store/sessions";
+import { EnvironmentsStore } from "../store/environments";
+import { PortAllocator } from "../workspace/ports";
+import { WorktreeService } from "../workspace/worktrees";
+import { CheckpointGit } from "../workspace/checkpoints";
+import { CheckpointService } from "../checkpoints/service";
+import { EnvironmentService } from "../environments/service";
+import { FORK_CONTEXT_MAX, ForkService, buildForkContext, forkContextKey, forkTitle } from "./fork";
+import type { CreateSessionInput } from "./service";
+
+function git(cwd: string, ...args: string[]): string {
+  return execFileSync("git", ["-c", "user.email=t@example.com", "-c", "user.name=t", "-c", "commit.gpgsign=false", ...args], { cwd, encoding: "utf8" });
+}
+function initRepo(dir: string): void {
+  git(dir, "init", "-b", "main");
+  writeFileSync(join(dir, "a.txt"), "one\n");
+  git(dir, "add", "."); git(dir, "commit", "-m", "init");
+}
+
+function harness() {
+  const home = mkdtempSync(join(tmpdir(), "realm-fork-"));
+  const db = openDatabase(join(home, "realm.db"));
+  const profiles = new ProfilesStore(db);
+  const spaces = new SpacesStore(db, home);
+  const settings = new SettingsStore(db);
+  const environments = new EnvironmentsStore(db);
+  const sessionsStore = new SessionsStore(db);
+  const events = new SessionEventsStore(db);
+  const items = new ItemsStore(db);
+  const cpStore = new CheckpointsStore(db);
+  const cpGit = new CheckpointGit();
+  const worktrees = new WorktreeService(home);
+  const envService = new EnvironmentService({ environments, spaces, worktrees, ports: new PortAllocator(db, { probe: async () => true }) });
+  const checkpoints = new CheckpointService({ checkpoints: cpStore, environments, sessions: sessionsStore, git: cpGit });
+
+  const p = profiles.create({ name: "W", icon: "x", color: "#000" });
+  const space = spaces.create({ profileId: p.id, name: "S", icon: "f" });
+  const env = environments.ensurePrimary(space.id);
+  initRepo(env.path);
+
+  const broadcasts: { event: string; payload: unknown }[] = [];
+  const createSession = (input: CreateSessionInput) => {
+    const session = sessionsStore.create({
+      spaceId: input.spaceId, projectId: input.projectId, agentKind: input.agentKind, model: input.model,
+      effort: input.effort, permissionMode: input.permissionMode ?? "default",
+      environmentId: input.environmentId!, title: input.title ?? "s", dispatchedBy: input.dispatchedBy ?? null,
+    });
+    const item = items.create({ spaceId: input.spaceId, kind: "session", title: session.title, refId: session.id });
+    return { session, itemId: item.id };
+  };
+  const forks = new ForkService({
+    checkpoints: cpStore, environments, envService, worktrees, sessionsStore, events, settings, git: cpGit,
+    rpc: { broadcast: (event: string, payload: unknown) => broadcasts.push({ event, payload }) } as never,
+    createSession,
+  });
+
+  const newSession = (title = "Fix the login flow") => sessionsStore.create({
+    spaceId: space.id, projectId: null, agentKind: "fake", model: "m1", effort: "high",
+    permissionMode: "acceptEdits", environmentId: env.id, title,
+  });
+  const capture = async (sessionId: string | null, label = "a turn") =>
+    (await checkpoints.capture({ environmentId: env.id, sessionId, kind: sessionId ? "turn" : "manual", label }))!;
+
+  return { home, db, settings, environments, sessionsStore, events, items, cpStore, cpGit, envService, checkpoints, forks, broadcasts, space, env, newSession, capture };
+}
+
+/** Everything durable about the ancestor, for byte-identity assertions across a fork. */
+function ancestorSnapshot(h: ReturnType<typeof harness>, sessionId: string) {
+  return {
+    session: JSON.stringify(h.db.prepare("SELECT * FROM sessions WHERE id = ?").get(sessionId)),
+    events: JSON.stringify(h.db.prepare("SELECT * FROM session_events WHERE session_id = ? ORDER BY seq").all(sessionId)),
+    checkpoints: JSON.stringify(h.db.prepare("SELECT * FROM checkpoints WHERE environment_id = ? ORDER BY rowid").all(h.env.id)),
+    refs: git(h.env.path, "for-each-ref", "--format=%(refname) %(objectname)", "refs/realm/"),
+    worktreeFiles: git(h.env.path, "status", "--porcelain"),
+  };
+}
+
+describe("buildForkContext — the fenced, capped summary-of-ancestor", () => {
+  it("fences user/assistant turns and states what it is", () => {
+    const ctx = buildForkContext({ ancestorTitle: "Login fix", checkpointLabel: "add tests",
+      turns: [{ role: "user", text: "please fix login" }, { role: "assistant", text: "done, tests added" }] });
+    expect(ctx).toContain('forked from "Login fix" at the checkpoint "add tests"');
+    expect(ctx).toContain("could not be rewound");
+    expect(ctx).toContain("```transcript\nUser: please fix login\n\nAssistant: done, tests added\n```");
+  });
+
+  it("escalates the fence past any backtick run in the transcript — content can never break out", () => {
+    const ctx = buildForkContext({ ancestorTitle: "t", checkpointLabel: "l",
+      turns: [{ role: "assistant", text: "use ```bash\nrm -rf\n``` carefully" }] });
+    expect(ctx).toContain("````transcript");
+    expect(ctx.trimEnd().endsWith("````")).toBe(true);
+  });
+
+  it("truncates a long transcript to the CAP, keeps the tail, and says so — the unbounded mutant", () => {
+    const turns = Array.from({ length: 400 }, (_, i) => ({ role: "user" as const, text: `turn ${i}: ${"x".repeat(200)}` }));
+    const ctx = buildForkContext({ ancestorTitle: "t", checkpointLabel: "l", turns });
+    expect(ctx.length).toBeLessThan(FORK_CONTEXT_MAX + 1_000); // body capped; header is the slack
+    expect(ctx).toContain("truncated to its newest 24,000 characters");
+    expect(ctx).not.toContain("turn 0:");         // the oldest turns fell off…
+    expect(ctx).toContain("turn 399:");           // …the newest survived
+  });
+
+  it("an ancestor with no spoken turns carries no fence and says so", () => {
+    const ctx = buildForkContext({ ancestorTitle: "t", checkpointLabel: "l", turns: [] });
+    expect(ctx).toContain("no transcript is carried");
+    expect(ctx).not.toContain("```");
+  });
+
+  it("forkTitle clips to TITLE_MAX", () => {
+    expect(forkTitle("short")).toBe("Fork: short");
+    expect(forkTitle("x".repeat(100)).length).toBeLessThanOrEqual(40);
+  });
+});
+
+describe("ForkService.fork — the workspace fork", () => {
+  it("restores the NEW worktree to the checkpoint's tree while the ancestor stays byte-untouched — the cardinal mutant", async () => {
+    const h = harness();
+    const s = h.newSession();
+    h.events.append(s.id, sessionEvent("user_message", { text: "please change things", attachments: [] }, 1_000));
+    h.events.append(s.id, sessionEvent("assistant_text", { messageId: "m1", text: "changed them" }, 2_000));
+
+    // The state the checkpoint captures: a tracked edit plus an untracked file.
+    writeFileSync(join(h.env.path, "a.txt"), "two\n");
+    writeFileSync(join(h.env.path, "b.txt"), "bee\n");
+    const cp = await h.capture(s.id, "please change things");
+
+    // The ancestor moves ON after the checkpoint — and so does its transcript.
+    writeFileSync(join(h.env.path, "a.txt"), "three\n");
+    writeFileSync(join(h.env.path, "c.txt"), "sea\n");
+    h.events.append(s.id, sessionEvent("user_message", { text: "post-checkpoint request", attachments: [] }, cp.createdAt + 10));
+    const before = ancestorSnapshot(h, s.id);
+
+    const { session, itemId, environment } = await h.forks.fork(cp.id);
+
+    // The fork: a worktree under Realm's home, at the checkpoint's captured state.
+    expect(environment.kind).toBe("worktree");
+    expect(environment.path).not.toBe(h.env.path);
+    expect(environment.path.startsWith(join(h.home, "worktrees"))).toBe(true);
+    expect(readFileSync(join(environment.path, "a.txt"), "utf8")).toBe("two\n");
+    expect(readFileSync(join(environment.path, "b.txt"), "utf8")).toBe("bee\n");   // untracked captured
+    expect(existsSync(join(environment.path, "c.txt"))).toBe(false);               // postdates the checkpoint
+
+    // The ancestor: every durable byte exactly as it was, working tree included.
+    expect(ancestorSnapshot(h, s.id)).toEqual(before);
+    expect(readFileSync(join(h.env.path, "a.txt"), "utf8")).toBe("three\n");
+    expect(readFileSync(join(h.env.path, "c.txt"), "utf8")).toBe("sea\n");
+
+    // The new session: pinned to the fork, agent setup copied, origin recorded with the parent link.
+    expect(session.environmentId).toBe(environment.id);
+    expect(session).toMatchObject({ agentKind: "fake", model: "m1", effort: "high", permissionMode: "acceptEdits" });
+    expect(session.dispatchedBy).toEqual({ kind: "fork", sessionId: s.id });
+    expect(session.title).toBe("Fork: Fix the login flow");
+    expect(h.items.get(itemId)!.refId).toBe(session.id);
+
+    // The carried context: the transcript up to the checkpoint, not the turn after it.
+    const ctx = h.forks.extraSystemContext(session.id)!;
+    expect(ctx).toContain("please change things");
+    expect(ctx).toContain("changed them");
+    expect(ctx).not.toContain("post-checkpoint request");
+    expect(h.broadcasts).toContainEqual({ event: "environments.changed", payload: { spaceId: h.space.id } });
+  });
+
+  it("carries the staged/unstaged split into the fork", async () => {
+    const h = harness();
+    const s = h.newSession();
+    writeFileSync(join(h.env.path, "a.txt"), "staged\n");
+    git(h.env.path, "add", "a.txt");
+    writeFileSync(join(h.env.path, "a.txt"), "staged-then-edited\n");
+    const cp = await h.capture(s.id);
+    const { environment } = await h.forks.fork(cp.id);
+    expect(readFileSync(join(environment.path, "a.txt"), "utf8")).toBe("staged-then-edited\n");
+    expect(git(environment.path, "diff", "--cached", "--name-only")).toContain("a.txt");
+    expect(git(environment.path, "diff", "--name-only")).toContain("a.txt"); // the unstaged half too
+  });
+
+  it("moves the fork's OWN fresh branch back to the checkpoint's commit — later ancestor commits are not in the fork", async () => {
+    const h = harness();
+    const s = h.newSession();
+    const cp = await h.capture(s.id);
+    writeFileSync(join(h.env.path, "later.txt"), "later\n");
+    git(h.env.path, "add", "."); git(h.env.path, "commit", "-m", "later");
+    const laterSha = git(h.env.path, "rev-parse", "HEAD").trim();
+    const { environment } = await h.forks.fork(cp.id);
+    expect(git(environment.path, "rev-parse", "HEAD").trim()).toBe(cp.headSha);
+    expect(git(environment.path, "rev-parse", "HEAD").trim()).not.toBe(laterSha);
+    expect(existsSync(join(environment.path, "later.txt"))).toBe(false);
+    // …and the ancestor's own branch did not move.
+    expect(git(h.env.path, "rev-parse", "HEAD").trim()).toBe(laterSha);
+  });
+
+  it("refuses a checkpoint no session took (FORK_NO_SESSION) — including one whose session was since deleted (ON DELETE SET NULL)", async () => {
+    const h = harness();
+    const manual = await h.capture(null, "manual point");
+    await expect(h.forks.fork(manual.id)).rejects.toMatchObject({ code: "FORK_NO_SESSION" });
+    const s = h.newSession();
+    const cp = await h.capture(s.id);
+    h.sessionsStore.delete(s.id);
+    await expect(h.forks.fork(cp.id)).rejects.toMatchObject({ code: "FORK_NO_SESSION" });
+  });
+
+  it("refuses when the checkpoint's objects are gone (CHECKPOINT_GONE), creating nothing", async () => {
+    const h = harness();
+    const s = h.newSession();
+    const cp = await h.capture(s.id);
+    git(h.env.path, "update-ref", "-d", cp.ref);
+    await expect(h.forks.fork(cp.id)).rejects.toMatchObject({ code: "CHECKPOINT_GONE" });
+    expect(h.environments.list(h.space.id).filter((e) => e.kind === "worktree")).toHaveLength(0);
+  });
+
+  it("unwinds the half-made worktree when extraction fails — no stranded row, no stranded directory", async () => {
+    const h = harness();
+    const s = h.newSession();
+    const cp = await h.capture(s.id);
+    // Corrupt the stored worktree tree so `read-tree` fails after the worktree exists. The ref still
+    // resolves to the commit, so the intact check passes — this is exactly the mid-fork failure.
+    h.db.prepare("UPDATE checkpoints SET worktree_tree = ? WHERE id = ?")
+      .run("0000000000000000000000000000000000000000", cp.id);
+    await expect(h.forks.fork(cp.id)).rejects.toMatchObject({ code: "FORK_FAILED" });
+    expect(h.environments.list(h.space.id).filter((e) => e.kind === "worktree")).toHaveLength(0);
+    expect(git(h.env.path, "worktree", "list")).not.toContain("worktrees"); // registration gone too
+    expect(h.sessionsStore.list(h.space.id).filter((x) => x.dispatchedBy?.kind === "fork")).toHaveLength(0);
+  });
+
+  it("two forks of one checkpoint coexist — names disambiguate, nothing collides", async () => {
+    const h = harness();
+    const s = h.newSession();
+    const cp = await h.capture(s.id);
+    const a = await h.forks.fork(cp.id);
+    const b = await h.forks.fork(cp.id);
+    expect(a.environment.path).not.toBe(b.environment.path);
+    expect(a.session.id).not.toBe(b.session.id);
+    expect(readFileSync(join(b.environment.path, "a.txt"), "utf8")).toBe("one\n");
+  });
+
+  it("the ancestor's checkpoints stay the ancestor's: the fork's fresh environment has none", async () => {
+    const h = harness();
+    const s = h.newSession();
+    const cp = await h.capture(s.id);
+    const { environment } = await h.forks.fork(cp.id);
+    expect(h.cpStore.list(environment.id)).toHaveLength(0);
+    expect(h.cpStore.list(h.env.id).map((c: Checkpoint) => c.id)).toContain(cp.id);
+  });
+
+  it("release() forgets a deleted fork's carried context", async () => {
+    const h = harness();
+    const s = h.newSession();
+    h.events.append(s.id, sessionEvent("user_message", { text: "remember me", attachments: [] }, 1_000));
+    const cp = await h.capture(s.id);
+    const { session } = await h.forks.fork(cp.id);
+    expect(h.forks.extraSystemContext(session.id)).toContain("remember me");
+    h.forks.release(session.id);
+    expect(h.forks.extraSystemContext(session.id)).toBeUndefined();
+    expect(h.settings.get(forkContextKey(session.id))).toBeNull();
+  });
+});

--- a/apps/server/src/sessions/fork.ts
+++ b/apps/server/src/sessions/fork.ts
@@ -1,0 +1,165 @@
+import { existsSync } from "node:fs";
+import type { Environment, Session } from "@realm/contracts";
+import type { CheckpointsStore } from "../store/checkpoints";
+import type { EnvironmentsStore } from "../store/environments";
+import type { SessionsStore, SessionEventsStore } from "../store/sessions";
+import type { SettingsStore } from "../store/settings";
+import type { EnvironmentService } from "../environments/service";
+import type { WorktreeService } from "../workspace/worktrees";
+import type { CheckpointGit } from "../workspace/checkpoints";
+import type { RpcServer } from "../rpc/server";
+import type { CreateSessionInput } from "./service";
+import { TITLE_MAX } from "./service";
+import { NotFoundError, RpcError } from "../store/rows";
+
+/**
+ * The cap on ancestor transcript carried into a fork, in characters (~6k tokens). Truncation keeps
+ * the TAIL — the turns nearest the checkpoint are the context the fork is forking from — and the
+ * carried text SAYS it was truncated and to what, because a silently shortened memory is the failure
+ * mode this whole feature exists to be honest about.
+ */
+export const FORK_CONTEXT_MAX = 24_000;
+
+/** The settings key holding one forked session's carried context, read on every adapter start. */
+export const forkContextKey = (sessionId: string): string => `fork.context:${sessionId}`;
+
+/**
+ * The fenced summary-of-ancestor a forked session starts with.
+ *
+ * Plain speech turns only (user/assistant text — tool chatter is bulk, not context), fenced with a
+ * backtick run longer than any in the content so transcript text can never break out of the block.
+ * The header states the one hard truth of this feature: the provider conversation CANNOT be rewound
+ * (`AGENT_CONVERSATION_REWIND` is false for every adapter Realm ships), so this is a workspace fork
+ * with context carried as text — the same sentence the UI shows.
+ */
+export function buildForkContext(input: {
+  ancestorTitle: string; checkpointLabel: string;
+  turns: { role: "user" | "assistant"; text: string }[];
+  max?: number;
+}): string {
+  const max = input.max ?? FORK_CONTEXT_MAX;
+  const blocks = input.turns.map((t) => `${t.role === "user" ? "User" : "Assistant"}: ${t.text}`);
+  let body = blocks.join("\n\n");
+  let truncated = false;
+  if (body.length > max) {
+    // Keep the tail; cut forward to the next turn boundary so the carried text never opens mid-block.
+    const tail = body.slice(body.length - max);
+    const boundary = tail.indexOf("\n\n");
+    body = boundary === -1 ? tail : tail.slice(boundary + 2);
+    truncated = true;
+  }
+  const fence = "`".repeat(Math.max(3, ...(body.match(/`+/g) ?? []).map((r) => r.length + 1)));
+  const carried = input.turns.length === 0
+    ? "The ancestor had no conversation before that checkpoint, so no transcript is carried."
+    : `The ancestor transcript up to that checkpoint is carried below as plain text${truncated
+      ? ` — truncated to its newest ${max.toLocaleString("en-US")} characters; earlier turns are omitted`
+      : ""}.`;
+  return [
+    "# Forked session",
+    `This session was forked from "${input.ancestorTitle}" at the checkpoint "${input.checkpointLabel}". ` +
+    "The fork restored the WORKSPACE: this checkout is a new worktree matching that checkpoint's files. " +
+    "The provider conversation could not be rewound, so this is a fresh conversation. " + carried,
+    ...(input.turns.length === 0 ? [] : [`${fence}transcript\n${body}\n${fence}`]),
+  ].join("\n\n");
+}
+
+/** `Fork: <ancestor title>`, clipped to the same TITLE_MAX every other title obeys. */
+export function forkTitle(ancestorTitle: string): string {
+  const t = `Fork: ${ancestorTitle}`;
+  return t.length > TITLE_MAX ? `${t.slice(0, TITLE_MAX - 1).trimEnd()}…` : t;
+}
+
+export type ForkDeps = {
+  checkpoints: CheckpointsStore;
+  environments: EnvironmentsStore;
+  envService: EnvironmentService;
+  worktrees: WorktreeService;
+  sessionsStore: SessionsStore;
+  events: SessionEventsStore;
+  settings: SettingsStore;
+  git: CheckpointGit;
+  rpc: RpcServer;
+  /** SessionService.create, injected as a seam (the service depends back on this one for the fork
+   *  context, the late-bound-closure knot app.ts ties everywhere). */
+  createSession: (input: CreateSessionInput) => { session: Session; itemId: string };
+};
+
+/**
+ * "Fork from here" (Plan 16 W3).
+ *
+ * The cardinal rule, stated where it is enforced: **the ancestor is never touched.** The restore
+ * machinery runs against a worktree this service just created (`CheckpointGit.extract`), never
+ * against the checkpoint's own environment — the ancestor's worktree, session row, events and
+ * checkpoint refs are all left byte-identical. What the fork produces is additive only: one
+ * worktree, one environment row, one session (+item), one settings row carrying the context.
+ */
+export class ForkService {
+  constructor(private d: ForkDeps) {}
+
+  /** The carried context for a forked session, re-injected on every adapter start of that session
+   *  (the same standing-context posture memory docs have). Undefined for every other session. */
+  extraSystemContext(sessionId: string): string | undefined {
+    const v = this.d.settings.get(forkContextKey(sessionId));
+    return typeof v === "string" && v.length > 0 ? v : undefined;
+  }
+
+  /** Forget a deleted session's carried context — wired into the session-release fan-out. */
+  release(sessionId: string): void {
+    this.d.settings.set(forkContextKey(sessionId), null);
+  }
+
+  async fork(checkpointId: string): Promise<{ session: Session; itemId: string; environment: Environment }> {
+    const cp = this.d.checkpoints.require(checkpointId);
+    if (!cp.sessionId) {
+      throw new RpcError("FORK_NO_SESSION", "this checkpoint was not taken by a session's turn, so there is no session to fork");
+    }
+    const ancestor = this.d.sessionsStore.get(cp.sessionId);
+    if (!ancestor) {
+      throw new RpcError("FORK_SESSION_GONE", "the session this checkpoint belongs to has been deleted; there is nothing to fork");
+    }
+    const env = this.d.environments.get(cp.environmentId);
+    if (!env) throw new NotFoundError("environment", cp.environmentId);
+    if (!existsSync(env.path) || !await this.d.git.isRepository(env.path)) {
+      throw new RpcError("NOT_A_REPOSITORY", `${env.path} is not a git repository any more; the checkpoint cannot be forked`);
+    }
+    if (!await this.d.git.refIntact(env.path, cp.ref, cp.commitSha)) {
+      throw new RpcError("CHECKPOINT_GONE", "this checkpoint's git objects are no longer in the repository");
+    }
+
+    // The carried context is built BEFORE anything is created: it reads only the ancestor's rows, and
+    // a failure here (there isn't one to have, but discipline) must not leave a half-made fork.
+    const context = buildForkContext({
+      ancestorTitle: ancestor.title, checkpointLabel: cp.label,
+      turns: this.d.events.transcript(ancestor.id, cp.createdAt),
+    });
+
+    // A NEW worktree, branched from the ancestor environment's HEAD (Plan 7's seam — the same repo,
+    // whose shared ref store is what lets `extract` resolve the checkpoint's trees from inside it)…
+    const forked = await this.d.envService.createWorktree({
+      spaceId: env.spaceId, title: forkTitle(ancestor.title), from: env.id,
+    });
+    let session: Session, itemId: string;
+    try {
+      // …restored to the checkpoint's captured state. `extract`, NEVER `restore`: restore's cwd
+      // would be the ancestor's checkout, and rewriting that in place is the one thing a fork must
+      // be incapable of.
+      await this.d.git.extract({ cwd: forked.path, state: cp.state });
+
+      ({ session, itemId } = this.d.createSession({
+        spaceId: env.spaceId, projectId: null, agentKind: ancestor.agentKind,
+        model: ancestor.model, effort: ancestor.effort, permissionMode: ancestor.permissionMode,
+        environmentId: forked.id, title: forkTitle(ancestor.title),
+        dispatchedBy: { kind: "fork", sessionId: ancestor.id },
+      }));
+    } catch (e) {
+      // Unwind the fresh worktree (made moments ago, handed to nobody) rather than strand it. The
+      // ancestor needs no unwinding — nothing above wrote to it.
+      await this.d.worktrees.discard(env.path, forked.path, forked.branch ?? "").catch(() => {});
+      try { this.d.environments.delete(forked.id); } catch { /* the original error is the one to report */ }
+      throw e;
+    }
+    this.d.settings.set(forkContextKey(session.id), context);
+    this.d.rpc.broadcast("environments.changed", { spaceId: env.spaceId });
+    return { session, itemId, environment: this.d.environments.get(forked.id) ?? forked };
+  }
+}

--- a/apps/server/src/store/items.ts
+++ b/apps/server/src/store/items.ts
@@ -40,16 +40,27 @@ export class ItemsStore {
     const id = newId(); const t = now();
     this.db.prepare("INSERT INTO items (id, space_id, kind, title, sort_order, pinned, ref_id, created_at, updated_at) VALUES (?, ?, ?, ?, ?, 0, ?, ?, ?)")
       .run(id, input.spaceId, input.kind, input.title, max + 1, input.refId, t, t);
+    // The search index's item-title source (Plan 16 W1), written at the same choke point every item
+    // creation passes through. Session-owned terminal items land here too and are filtered out at
+    // QUERY time (the same NOT_SESSION_OWNED rule the listings use), because ownership is decided
+    // after this insert.
+    this.db.prepare("INSERT INTO search_index (text, kind, ref, seq) VALUES (?, 'item', ?, NULL)").run(input.title, id);
     return this.get(id)!;
   }
   update(input: { id: string; title?: string; pinned?: boolean; sortOrder?: number }): Item {
     const cur = this.get(input.id); if (!cur) throw new NotFoundError("item", input.id);
     this.db.prepare("UPDATE items SET title = ?, pinned = ?, sort_order = ?, updated_at = ? WHERE id = ?")
       .run(input.title ?? cur.title, (input.pinned ?? cur.pinned) ? 1 : 0, input.sortOrder ?? cur.sortOrder, now(), input.id);
+    // A rename must move the index row, or search keeps finding the old name and never the new one.
+    if (input.title !== undefined && input.title !== cur.title) {
+      this.db.prepare("DELETE FROM search_index WHERE kind = 'item' AND ref = ?").run(input.id);
+      this.db.prepare("INSERT INTO search_index (text, kind, ref, seq) VALUES (?, 'item', ?, NULL)").run(input.title, input.id);
+    }
     return this.get(input.id)!;
   }
   delete(id: string): void {
     if (!this.get(id)) throw new NotFoundError("item", id);
+    this.db.prepare("DELETE FROM search_index WHERE kind = 'item' AND ref = ?").run(id);
     this.db.prepare("DELETE FROM items WHERE id = ?").run(id);
   }
 }

--- a/apps/server/src/store/sessions.ts
+++ b/apps/server/src/store/sessions.ts
@@ -85,6 +85,10 @@ export class SessionsStore {
   }
   delete(id: string): void {
     if (!this.get(id)) throw new NotFoundError("session", id);
+    // The FTS rows do not cascade (virtual tables have no foreign keys), so a deleted session's
+    // transcript is scrubbed from the index here — search must not keep quoting a transcript whose
+    // events are gone.
+    this.db.prepare("DELETE FROM search_index WHERE kind = 'session' AND ref = ?").run(id);
     this.db.prepare("DELETE FROM sessions WHERE id = ?").run(id);
   }
 }
@@ -96,7 +100,16 @@ export class SessionEventsStore {
   append(sessionId: string, event: SessionEvent): StoredSessionEvent {
     const r = this.db.prepare("INSERT INTO session_events (session_id, ts, type, payload_json) VALUES (?, ?, ?, ?)")
       .run(sessionId, event.ts, event.type, JSON.stringify(event.payload));
-    return { seq: Number(r.lastInsertRowid), sessionId, event };
+    const seq = Number(r.lastInsertRowid);
+    // The search index's session source (Plan 16 W1), written HERE — the one choke point every
+    // persisted event passes through — so no producer (pump, emitExternal, boot's synthetic denies)
+    // can skip it, and so the FTS row commits in the same transaction as the event when the caller
+    // (SessionService.persist) holds one. Only the two spoken-text types are search material.
+    if ((event.type === "user_message" || event.type === "assistant_text") && event.payload.text.trim() !== "") {
+      this.db.prepare("INSERT INTO search_index (text, kind, ref, seq) VALUES (?, 'session', ?, ?)")
+        .run(event.payload.text, sessionId, seq);
+    }
+    return { seq, sessionId, event };
   }
   /** Any persisted event at all — the authority behind the `sessions.setAgent` guard. */
   hasAny(sessionId: string): boolean {

--- a/apps/server/src/store/sessions.ts
+++ b/apps/server/src/store/sessions.ts
@@ -139,6 +139,26 @@ export class SessionEventsStore {
     return p.success ? p.data : null;
   }
 
+  /**
+   * The session's SPOKEN transcript — user/assistant text only — up to `upToTs`, ascending (Plan 16
+   * W3's fork context). The cut is by event timestamp against the checkpoint's `createdAt`: a turn
+   * checkpoint is captured BEFORE its user_message event is minted, so that turn's events carry later
+   * timestamps and fall on the far side — "up to the checkpoint" means up to but not including the
+   * turn it fronted. An honest approximation (clock, not causality), and stated as one.
+   */
+  transcript(sessionId: string, upToTs: number): { role: "user" | "assistant"; text: string }[] {
+    const rows = this.db.prepare(
+      "SELECT type, payload_json FROM session_events WHERE session_id = ? AND ts <= ? AND type IN ('user_message', 'assistant_text') ORDER BY seq")
+      .all(sessionId, upToTs) as Pick<EventRow, "type" | "payload_json">[];
+    const out: { role: "user" | "assistant"; text: string }[] = [];
+    for (const r of rows) {
+      let text: unknown; try { text = (JSON.parse(r.payload_json) as { text?: unknown }).text; } catch { continue; }
+      if (typeof text !== "string" || text.trim() === "") continue;
+      out.push({ role: r.type === "user_message" ? "user" : "assistant", text });
+    }
+    return out;
+  }
+
   /** Events with seq > afterSeq, ascending. Rows that fail schema validation (e.g. from an older build) are skipped. */
   listAfter(sessionId: string, afterSeq: number, limit: number): StoredSessionEvent[] {
     const rows = this.db.prepare("SELECT * FROM session_events WHERE session_id = ? AND seq > ? ORDER BY seq LIMIT ?").all(sessionId, afterSeq, limit) as EventRow[];

--- a/apps/server/src/workspace/checkpoints.ts
+++ b/apps/server/src/workspace/checkpoints.ts
@@ -309,8 +309,38 @@ export class CheckpointGit {
       headMoved = true;
     }
 
-    const applied = await this.git(root, ["read-tree", "--reset", "-u", input.state.worktreeTree]);
-    if (applied.code !== 0) throw new RpcError("RESTORE_FAILED", gitReason(applied));
+    const filesRemoved = await this.applyTrees(root, input.state, "RESTORE_FAILED");
+    return { headMoved, headReason: headMoved ? null : reason, filesRemoved };
+  }
+
+  /**
+   * Write this checkpoint's captured trees into a DIFFERENT, freshly created worktree — Plan 16 W3's
+   * fork. The tree steps are `restore`'s exactly (`applyTrees`); the HEAD rule is deliberately NOT:
+   * the target's branch is one the caller minted for the fork moments ago, so HEAD is moved to the
+   * checkpoint's own commit whenever that commit still exists — there is no user branch to protect,
+   * and a fork left ahead of its own files would show phantom "uncommitted deletions".
+   *
+   * NEVER point this at the checkpoint's own environment. Restoring in place is `restore`'s job, and
+   * only it carries the acknowledgement flow that makes in-place rewriting survivable. ForkService is
+   * the one caller, and it only ever passes the worktree it just created.
+   */
+  async extract(input: { cwd: string; state: CapturedState }): Promise<{ headMoved: boolean; filesRemoved: number }> {
+    const root = await this.root(input.cwd);
+    let headMoved = false;
+    if (input.state.headSha && (await this.git(root, ["cat-file", "-e", `${input.state.headSha}^{commit}`])).code === 0) {
+      const reset = await this.git(root, ["reset", "--soft", input.state.headSha]);
+      if (reset.code !== 0) throw new RpcError("FORK_FAILED", gitReason(reset));
+      headMoved = true;
+    }
+    const filesRemoved = await this.applyTrees(root, input.state, "FORK_FAILED");
+    return { headMoved, filesRemoved };
+  }
+
+  /** Steps 2–4 of the restore recipe (see `restore`'s doc comment): working tree from
+   *  `worktreeTree`, untracked survivors deleted, index from `indexTree`. */
+  private async applyTrees(root: string, state: CapturedState, errorCode: string): Promise<number> {
+    const applied = await this.git(root, ["read-tree", "--reset", "-u", state.worktreeTree]);
+    if (applied.code !== 0) throw new RpcError(errorCode, gitReason(applied));
 
     let filesRemoved = 0;
     for (const path of await this.untracked(root)) {
@@ -318,9 +348,9 @@ export class CheckpointGit {
       catch { /* a directory, a race, a permission — the tree is already correct for everything else */ }
     }
 
-    const index = await this.git(root, ["read-tree", input.state.indexTree]);
-    if (index.code !== 0) throw new RpcError("RESTORE_FAILED", gitReason(index));
-    return { headMoved, headReason: headMoved ? null : reason, filesRemoved };
+    const index = await this.git(root, ["read-tree", state.indexTree]);
+    if (index.code !== 0) throw new RpcError(errorCode, gitReason(index));
+    return filesRemoved;
   }
 
   /** Drop the hidden refs for these checkpoints. The objects become unreachable and are collected by

--- a/packages/contracts/src/entities.ts
+++ b/packages/contracts/src/entities.ts
@@ -144,12 +144,14 @@ export type AgentKind = z.infer<typeof AgentKindSchema>;
  * — the seam W2's Tasks lens filters on. `agent_run`/`browser_agent_run` are the two delegation
  * tools; `user-dispatch` is W2's ⌘⇧↩ composer gesture (the one origin with no parent agent);
  * `review` is W3's reviewer recipe (the diff pane's "Request review" or the `agent_review` tool —
- * `sessionId` is the requesting session for the tool path, null for the user's click). A session the
+ * `sessionId` is the requesting session for the tool path, null for the user's click); `fork` is
+ * Plan 16 W3's "Fork from here" — `sessionId` is the ANCESTOR session the fork carried context from,
+ * which that fork leaves byte-untouched. A session the
  * user created normally has no dispatch origin at all (`dispatchedBy: null`), which is why this is
  * nullable rather than having a "user" member: absence IS the ordinary case, and no backfill invents
  * one.
  */
-export const DispatchKindSchema = z.enum(["agent_run", "browser_agent_run", "user-dispatch", "review"]);
+export const DispatchKindSchema = z.enum(["agent_run", "browser_agent_run", "user-dispatch", "review", "fork"]);
 export type DispatchKind = z.infer<typeof DispatchKindSchema>;
 export const DispatchedBySchema = z.object({
   /** The delegating session, or null for an origin with no parent agent (`user-dispatch`). */

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -15,3 +15,4 @@ export * from "./notifications";
 export * from "./review";
 export * from "./browser-agent";
 export * from "./delegation";
+export * from "./search";

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -659,6 +659,20 @@ export const Methods = {
   /** Get-or-create the session's terminal side panel (W4), at the session's cwd. Idempotent: the pty is
    *  spawned on the FIRST call and only then — a session whose panel is never opened never has one. */
   "sessions.openTerminal": { params: z.object({ id: IdSchema }), result: z.object({ terminalId: IdSchema, itemId: IdSchema }) },
+  /**
+   * "Fork from here" (Plan 16 W3): a NEW worktree restored to this checkpoint's captured tree, plus a
+   * NEW session pinned to it, `dispatchedBy: { kind: "fork", sessionId: <ancestor> }`. The ancestor
+   * session, its environment and its checkpoints are left byte-untouched — the restore machinery runs
+   * against the fresh worktree only, never in place. The provider conversation CANNOT be rewound
+   * (AGENT_CONVERSATION_REWIND is false for every adapter), so the fork is a WORKSPACE fork: the
+   * ancestor transcript up to the checkpoint rides into the new session as fenced text, truncated at
+   * a stated cap — and the UI says exactly that.
+   *
+   * Refused when the checkpoint was not taken by a session turn (FORK_NO_SESSION — there is no
+   * transcript or agent setup to fork), when that session has since been deleted (FORK_SESSION_GONE),
+   * and when the checkpoint's git objects are gone (CHECKPOINT_GONE).
+   */
+  "sessions.fork": { params: z.object({ checkpointId: IdSchema }), result: z.object({ session: SessionSchema, itemId: IdSchema, environment: EnvironmentSchema }) },
   "sessions.delete":  { params: z.object({ id: IdSchema }), result: z.object({ ok: z.literal(true) }) },
 } as const;
 

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -8,6 +8,7 @@ import { McpCallSchema, McpSecretsSchema, McpServerNameSchema, McpServerSchema, 
 import { MEMORY_DOC_MAX, MemorySourcesSchema, MemoryStateSchema } from "./memory";
 import { NotificationSchema } from "./notifications";
 import { ReviewResultSchema } from "./review";
+import { SEARCH_GROUP_LIMIT, SEARCH_GROUP_LIMIT_MAX, SEARCH_QUERY_MAX, SearchResultsSchema } from "./search";
 
 export const RpcRequestSchema = z.object({ id: z.string(), method: z.string(), params: z.unknown() });
 export const RpcErrorSchema = z.object({ code: z.string(), message: z.string() });
@@ -314,6 +315,20 @@ export const Methods = {
    * rewriting a working tree under a live agent's feet corrupts whatever it is halfway through.
    */
   "checkpoints.restore": { params: z.object({ id: IdSchema, acknowledge: RestoreAckSchema }), result: RestoreResultSchema },
+
+  /**
+   * Deep search across ONE profile's world (Plan 16 W1): session transcripts (user + assistant text)
+   * and item titles from the FTS index, skills and memory documents read live off disk at query time
+   * (they are user-editable files; an index over them would only ever be a way to be wrong).
+   *
+   * Profile scoping is enforced HERE, by the server's space→profile join — a Work search must not
+   * surface a School transcript, and no client-side filter is trusted with that. `limit` caps each
+   * GROUP, not the whole answer.
+   */
+  "search.query": {
+    params: z.object({ profileId: IdSchema, query: z.string().min(1).max(SEARCH_QUERY_MAX), limit: z.number().int().min(1).max(SEARCH_GROUP_LIMIT_MAX).default(SEARCH_GROUP_LIMIT) }),
+    result: SearchResultsSchema,
+  },
 
   "items.list":   { params: z.object({ spaceId: IdSchema }), result: z.array(ItemSchema) },
   /** Every item across every space (command palette search); newest-updated first. */

--- a/packages/contracts/src/search.ts
+++ b/packages/contracts/src/search.ts
@@ -1,0 +1,73 @@
+import { z } from "zod";
+import { IdSchema } from "./ids";
+import { ItemKindSchema } from "./entities";
+
+/** Longest query the wire accepts. Anything a person types in a palette fits; anything longer is a
+ *  paste that FTS would only choke on. */
+export const SEARCH_QUERY_MAX = 256;
+/** Default and ceiling for per-group result counts. The palette appends below its instant rows, so a
+ *  group is a glance, not a page. */
+export const SEARCH_GROUP_LIMIT = 8;
+export const SEARCH_GROUP_LIMIT_MAX = 20;
+
+/**
+ * A snippet as alternating runs of plain and matched text. Sent as segments rather than a marked-up
+ * string so the renderer never parses markers out of user content (transcript text can contain any
+ * bytes, including whatever marker we might have chosen).
+ */
+export const SearchSnippetSchema = z.array(z.object({ text: z.string(), match: z.boolean() }));
+export type SearchSnippet = z.infer<typeof SearchSnippetSchema>;
+
+/** One transcript hit: a user/assistant event whose text matched. `seq` names the exact event, should
+ *  a future transcript learn to scroll to it; today Enter opens the session. */
+export const SessionSearchHitSchema = z.object({
+  sessionId: IdSchema,
+  spaceId: IdSchema,
+  /** The session's current title — display, not match material. */
+  title: z.string(),
+  seq: z.number().int(),
+  snippet: SearchSnippetSchema,
+});
+export type SessionSearchHit = z.infer<typeof SessionSearchHitSchema>;
+
+export const ItemSearchHitSchema = z.object({
+  itemId: IdSchema,
+  spaceId: IdSchema,
+  itemKind: ItemKindSchema,
+  title: z.string(),
+  snippet: SearchSnippetSchema,
+});
+export type ItemSearchHit = z.infer<typeof ItemSearchHitSchema>;
+
+export const SkillSearchHitSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  description: z.string(),
+  snippet: SearchSnippetSchema,
+});
+export type SkillSearchHit = z.infer<typeof SkillSearchHitSchema>;
+
+/** A memory-document hit: this profile's own doc, or one of its spaces' docs. Exactly one of
+ *  `profileId`/`spaceId` is set — it is where Enter navigates. */
+export const MemorySearchHitSchema = z.object({
+  scope: z.enum(["profile", "space"]),
+  profileId: IdSchema.nullable(),
+  spaceId: IdSchema.nullable(),
+  /** What to call the document: the space's name, or the profile's. */
+  title: z.string(),
+  snippet: SearchSnippetSchema,
+});
+export type MemorySearchHit = z.infer<typeof MemorySearchHitSchema>;
+
+/**
+ * `search.query`'s answer, grouped the way the palette renders it. Every group is scoped to the ONE
+ * profile the caller named — a Work search never carries a School transcript, and the scoping is
+ * enforced server-side at query time (the space→profile join), never by the client filtering.
+ */
+export const SearchResultsSchema = z.object({
+  sessions: z.array(SessionSearchHitSchema),
+  items: z.array(ItemSearchHitSchema),
+  skills: z.array(SkillSearchHitSchema),
+  memory: z.array(MemorySearchHitSchema),
+});
+export type SearchResults = z.infer<typeof SearchResultsSchema>;


### PR DESCRIPTION
The last plan on the roadmap. **2440 tests** (rebased over Plan 15), live-proven against the built server.

- **Search**: FTS5 (verified compiled into node:sqlite before any code) over session transcripts and item titles, indexed at write time; skills and memory searched live off disk because Realm doesn't own every write to those files — an index there would lie, and a test pins that a direct file edit is searchable immediately. Migration v15 backfills resumably (chunked, crash-safe cursor, frozen target so backfill and write-time indexing provably never overlap). Profile-scoped at query time: Work never surfaces School. Deleting a session scrubs its text from the index — the privacy mutant that initially survived.
- **Palette deep search**: results append under the instant rows, which are structurally unable to wait on a query.
- **Forks**: "Fork from here" on a checkpoint — a fresh worktree restored via the non-destructive tree extraction (never the in-place restore; the fork-into-ancestor mutant is the cardinal one and it dies), a new session carrying a capped, fence-escaped ancestor summary via the systemContext seam, and the honest sentence in the UI: workspace fork, context carried as text — no provider conversation can be rewound. Ancestor proven byte-untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)