### PR TITLE
Destination pages in the focused pane, and toast clicks that land on the notification

### DIFF
--- a/apps/desktop/src/renderer/src/components/CommandPalette.tsx
+++ b/apps/desktop/src/renderer/src/components/CommandPalette.tsx
@@ -1,5 +1,5 @@
 import { Icon } from "@realm/ui";
-import { AGENT_META, PRESETS, SELECTABLE_AGENT_KINDS, emptyLayout, itemIdOfLeaf, allItems as openItemIds, type Item, type PresetName, type SearchResults, type SearchSnippet } from "@realm/contracts";
+import { AGENT_META, PRESETS, SELECTABLE_AGENT_KINDS, emptyLayout, itemIdOfLeaf, allItems as openItemIds, type DestinationPageKind, type Item, type PresetName, type SearchResults, type SearchSnippet } from "@realm/contracts";
 import { Fragment, useEffect, useMemo, useRef, useState, type KeyboardEvent as ReactKeyboardEvent, type ReactNode } from "react";
 import type { StoreApi } from "zustand";
 import { centerOverComplement } from "../state/no-overlay";
@@ -80,6 +80,15 @@ const PALETTE_WIDTH = 560;
 /** Layout presets moved here from the retired topbar LayoutMenu (spec amendment §A1). */
 const PRESET_LABELS: Record<PresetName, string> = { one: "1-up", "two-col": "2 columns", "three-col": "3 columns", "grid-2x2": "2×2 grid", "grid-3x3": "3×3 grid" };
 
+/** The sidebar destinations, in the nav's own order, paired with the noun their entries read as
+ *  ("Open library"). The kind doubles as the icon name — these pages own the icon of their kind. */
+const DESTINATIONS: [DestinationPageKind, string][] = [
+  ["library-page", "library"],
+  ["connections-page", "connections"],
+  ["notifications-page", "notifications"],
+  ["settings-page", "settings"],
+];
+
 export function CommandPalette() {
   const open = useApp((s) => s.paletteOpen);
   if (!open) return null;
@@ -123,6 +132,7 @@ function PaletteBody() {
   const openSpacePage = useApp((s) => s.openSpacePage);
   const setSpacesOpen = useApp((s) => s.setSpacesOpen);
   const openDestinationPage = useApp((s) => s.openDestinationPage);
+  const destinationPageElsewhere = useApp((s) => s.destinationPageElsewhere);
   const openProfilePage = useApp((s) => s.openProfilePage);
   const openActivity = useApp((s) => s.openActivity);
   const setPaletteOpen = useApp((s) => s.setPaletteOpen);
@@ -254,12 +264,15 @@ function PaletteBody() {
       // The active space's PROFILE page (Plan 14 W2) — same gate: the page needs a layout to live in.
       ...(activeSpaceId ? [act("open-profile", "Open profile", "profile-page", () => run(() => openProfilePage()))] : []),
       // The sidebar destinations (W4) — gated like "Open space": the page needs a layout to live in.
-      ...(activeSpaceId ? [
-        act("open-library", "Open library", "library-page", () => run(() => openDestinationPage("library-page"))),
-        act("open-connections", "Open connections", "connections-page", () => run(() => openDestinationPage("connections-page"))),
-        act("open-notifications", "Open notifications", "notifications-page", () => run(() => openDestinationPage("notifications-page"))),
-        act("open-settings", "Open settings", "settings-page", () => run(() => openDestinationPage("settings-page"))),
-      ] : []),
+      // Each carries a second entry while — and only while — its page sits in a pane that is not the
+      // focused one, which is the one situation where the placement changes the outcome. That is the
+      // same choice the sidebar row spells ⌥-click, so neither surface can do what the other cannot.
+      ...(activeSpaceId ? DESTINATIONS.flatMap(([kind, noun]) => [
+        act(`open-${noun}`, `Open ${noun}`, kind, () => run(() => openDestinationPage(kind))),
+        ...(destinationPageElsewhere(kind)
+          ? [act(`open-${noun}-here`, `Open ${noun} in this pane`, kind, () => run(() => openDestinationPage(kind, "here")))]
+          : []),
+      ]) : []),
       // Global (every space's calls, W7) — unlike the space page above, it never needs an activeSpaceId.
       act("mcp-activity", "MCP Activity", "tool", () => run(() => openActivity())),
       act("split-right", "Split right", "layout", () => run(() => splitFocused("row")), <kbd>⌘\</kbd>),
@@ -284,7 +297,7 @@ function PaletteBody() {
     return [...open, ...activeRest, ...others, ...actions, ...themes];
   }, [spaces, activeSpaceId, items, allItems, layout, focusedLeafId, sessions, sessionStatus, themePref, drafts, dispatchDraft,
       selectSpace, openItem, newTerminal, newBrowser, openDocuments, newSession, newSessionInstant, newSessionInWorktree, splitFocused, closeFromLayout, requestRename,
-      interruptSession, jumpToPermission, applyPreset, setThemePref, openSheet, openSpacePage, openDestinationPage, openProfilePage, openActivity, setSpacesOpen, run,
+      interruptSession, jumpToPermission, applyPreset, setThemePref, openSheet, openSpacePage, openDestinationPage, destinationPageElsewhere, openProfilePage, openActivity, setSpacesOpen, run,
       groups, zoomedLeaf, activatePaneGroup, newPaneGroup, toggleFocusPane]);
 
   // Empty query: everything, grouped under faint section headers. With a query: a flat list ranked

--- a/apps/desktop/src/renderer/src/components/command-palette.test.tsx
+++ b/apps/desktop/src/renderer/src/components/command-palette.test.tsx
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { render, screen, fireEvent, waitFor, renderHook, act } from "@testing-library/react";
 import { CommandPalette, matchScore, relTime, usePaletteHotkey } from "./CommandPalette";
 import { StoreContext, createAppStore } from "../state/store";
+import { findLeafOfItem } from "@realm/contracts";
 import { fakeApi, item, session } from "../state/store.test-fakes";
 
 async function mount(over: Parameters<typeof fakeApi>[0] = {}) {
@@ -264,6 +265,23 @@ describe("Open library / Open connections (Plan 12 W4)", () => {
     fireEvent.click(screen.getByRole("option", { name: /Open library/ }));
     await waitFor(() => expect(store.getState().items.some((i) => i.kind === "library-page")).toBe(true));
     expect(store.getState().items.filter((i) => i.kind === "library-page")).toHaveLength(1);
+  });
+
+  it("the second placement is offered only while the page sits in a pane that is not the focused one", async () => {
+    const { store } = await mount();
+    fireEvent.change(input(), { target: { value: "open library" } });
+    // One entry while the plain open would land in the focused pane anyway — a palette that always
+    // listed both would be advertising a choice with one outcome.
+    expect(options().filter((o) => o!.includes("Open library"))).toHaveLength(1);
+    await act(async () => {
+      await store.getState().openDestinationPage("library-page");
+      await store.getState().splitFocused("row");
+    });
+    const page = store.getState().items.find((i) => i.kind === "library-page")!;
+    const other = store.getState().focusedLeafId!;
+    await waitFor(() => expect(options().filter((o) => o!.includes("Open library"))).toHaveLength(2));
+    fireEvent.click(screen.getByRole("option", { name: /Open library in this pane/ }));
+    await waitFor(() => expect(findLeafOfItem(store.getState().layout!, page.id)!.id).toBe(other));
   });
 
   it("Open connections opens the connections-page item", async () => {

--- a/apps/desktop/src/renderer/src/components/sidebar/Destinations.tsx
+++ b/apps/desktop/src/renderer/src/components/sidebar/Destinations.tsx
@@ -1,4 +1,6 @@
 import { Icon } from "@realm/ui";
+import type { ComponentProps, ReactNode } from "react";
+import type { DestinationPageKind } from "@realm/contracts";
 import { useApp } from "../../state/store";
 
 /**
@@ -11,37 +13,54 @@ import { useApp } from "../../state/store";
  * than absence.
  */
 export function Destinations() {
-  const openDestinationPage = useApp((s) => s.openDestinationPage);
-  const run = useApp((s) => s.run);
   // The server's count, verbatim (`notifications.list`/`notifications.changed`) — never a client-side
   // tally of rows, which would be a second derivation site that could disagree with the page's header.
   const unread = useApp((s) => s.notificationsUnread);
   return (
     <nav className="sb-destinations" aria-label="Destinations">
-      <button className="item-row dest-row" onClick={() => run(() => openDestinationPage("library-page"))}>
-        <Icon name="library-page" size={16} /><span>Library</span>
-      </button>
-      <button className="item-row dest-row" onClick={() => run(() => openDestinationPage("connections-page"))}>
-        <Icon name="connections-page" size={16} /><span>Connections</span>
-      </button>
+      <DestRow kind="library-page" label="Library" />
+      <DestRow kind="connections-page" label="Connections" />
       {/* W5: the feed row. The pill appears only when something is actually unread — a permanent
           zero would be dead chrome, which this nav bans. */}
-      <button className="item-row dest-row" onClick={() => run(() => openDestinationPage("notifications-page"))}>
-        <Icon name="notifications-page" size={16} /><span>Notifications</span>
+      <DestRow kind="notifications-page" label="Notifications">
         {unread > 0 && <span className="status-pill dest-count" data-tone="warning" aria-label={`${unread} unread`}>{unread}</span>}
-      </button>
+      </DestRow>
       {/* Settings moved here off the space strip's left slot: it is an app-level page like the three
           above it, and the strip is a rail about spaces — the gear was the only thing in it that
           wasn't one, and it cost the strip a slot it needed. Ungated like its neighbours, because
           `openDestinationPage` already no-ops with no active space; a disabled row is what this nav
           bans. */}
-      <button className="item-row dest-row" onClick={() => run(() => openDestinationPage("settings-page"))}>
-        <Icon name="settings" size={16} /><span>Settings</span>
-      </button>
+      <DestRow kind="settings-page" label="Settings" icon="settings" />
       {/* Seam (Plan 14 W5, deliberately unbuilt): when Plan 13's Tasks lens lands, its row goes here
           with a running-tasks count pill on the Notifications pattern above — server-derived count,
           rendered only when non-zero. Not stubbed now: a row for a page that does not exist yet is
           exactly the dead chrome this nav bans. */}
     </nav>
+  );
+}
+
+/**
+ * One destination row. A plain click homes: one page per space, so a second click goes to the pane that
+ * already holds it, wherever that is. ⌥-click puts the page in the focused pane instead — the gesture
+ * for "I want this here", which until now was a drag.
+ *
+ * The tooltip appears only while the two would differ, so a row that has nothing to offer says nothing
+ * rather than teaching a modifier that does the same thing as no modifier.
+ */
+function DestRow({ kind, label, icon, children }: {
+  kind: DestinationPageKind; label: string;
+  /** Defaults to the kind's own icon; Settings wears the gear it wore in the space strip. */
+  icon?: ComponentProps<typeof Icon>["name"];
+  children?: ReactNode;
+}) {
+  const openDestinationPage = useApp((s) => s.openDestinationPage);
+  const elsewhere = useApp((s) => s.destinationPageElsewhere(kind));
+  const run = useApp((s) => s.run);
+  return (
+    <button className="item-row dest-row" title={elsewhere ? `⌥-click to open ${label} in the focused pane` : undefined}
+      onClick={(e) => run(() => openDestinationPage(kind, e.altKey ? "here" : "reuse"))}>
+      <Icon name={icon ?? kind} size={16} /><span>{label}</span>
+      {children}
+    </button>
   );
 }

--- a/apps/desktop/src/renderer/src/components/sidebar/ItemContextMenu.tsx
+++ b/apps/desktop/src/renderer/src/components/sidebar/ItemContextMenu.tsx
@@ -6,7 +6,8 @@ import { Menu } from "../Menu";
 export type ItemMenuState = { item: Item; x: number; y: number } | null;
 
 /** Right-click menu shared by pinned tiles and list rows: Pin/Unpin, Archive/Unarchive (sessions only),
- *  Rename (inline, via `onRename`),
+ *  Rename (inline, via `onRename`), Open here (move the pane into the focused one, offered only while
+ *  it is open somewhere else),
  *  Focus/Unfocus (fill the space with this pane, offered only while it is open), Move to group… (when
  *  the space has more than one), Move to space… (sessions only), Close
  *  (layout-only, offered only while the item is open), Delete (destructive, always offered). */
@@ -33,6 +34,8 @@ export function useItemContextMenu(onRename: (item: Item) => void) {
   const spaces = useApp((s) => s.spaces);
   const activeSpaceId = useApp((s) => s.activeSpaceId);
   const openCheckpoints = useApp((s) => s.openCheckpoints);
+  const openItem = useApp((s) => s.openItem);
+  const focusedLeafId = useApp((s) => s.focusedLeafId);
   const run = useApp((s) => s.run);
   const onContextMenu = useCallback((item: Item) => (e: MouseEvent) => {
     e.preventDefault(); setConfirmingDelete(false); setMovingToSpace(false); setMovingToGroup(false);
@@ -54,6 +57,9 @@ export function useItemContextMenu(onRename: (item: Item) => void) {
   const inActiveGroup = !!holder && !!groups && holder.id === groups.activeGroupId;
   const leafId = holder && menu ? findLeafOfItem(holder.layout, menu.item.id)?.id ?? null : null;
   const isFocused = inActiveGroup && !!leafId && activeGroup(groups!).zoomedLeafId === leafId;
+  // Open in a pane that is not the one on screen: the only case where "here" is not what a plain row
+  // click already does — an unopened row opens into the focused leaf anyway.
+  const elsewhere = !!holder && (!inActiveGroup || leafId !== focusedLeafId);
   const otherGroups = groups?.groups.filter((g) => g.id !== holder?.id) ?? [];
   const element = menu ? (
     <Menu at={{ x: menu.x, y: menu.y }}
@@ -77,6 +83,14 @@ export function useItemContextMenu(onRename: (item: Item) => void) {
                    onSelect: () => run(() => archiveItem(menu.item.id, !menu.item.archived)) }]
               : []),
             { label: "Rename", onSelect: () => onRename(menu.item) },
+            // A plain row click goes TO the pane, which is right when you meant "take me there" and
+            // wrong when you meant "put it in front of me". Naming the focused leaf is what turns
+            // openItem's homing into a move, and it moves across pane groups too — the drag this
+            // replaces could only ever reach the arrangement already on screen.
+            ...(elsewhere
+              ? [{ label: "Open here", title: "Move this pane into the focused one",
+                   onSelect: () => run(() => openItem(menu.item.id, focusedLeafId)) }]
+              : []),
             // The focus gesture the pane bar also carries — offered here because the sidebar row is
             // where you are when you decide a pane deserves the whole space.
             ...(inActiveGroup && leafId

--- a/apps/desktop/src/renderer/src/components/sidebar/ItemList.tsx
+++ b/apps/desktop/src/renderer/src/components/sidebar/ItemList.tsx
@@ -60,7 +60,8 @@ export function ItemGlyph({ layout, itemId }: { layout: Layout; itemId: string }
  *  SPACE group (everything else): no x, no glyph, just click-to-open. "archived" = the shelf: no x, no
  *  glyph, and the row's click RESTORES before it opens (see below). Row clicks call openItem either
  *  way, but the store treats an already-open item as "go there" (focus its pane, no layout change);
- *  only SPACE rows actually open into the focused leaf. Moving an open item is drag-only. */
+ *  only SPACE rows actually open into the focused leaf. Moving an open item is a drag, or the row
+ *  menu's "Open here". */
 export function ItemList({ items, variant, layout: groupLayout }: {
   items: Item[]; variant: "open" | "space" | "archived";
   /** The layout the quadrant glyph is drawn against — the owning GROUP's tree, which for a group that

--- a/apps/desktop/src/renderer/src/components/sidebar/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/components/sidebar/sidebar.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { render, screen, fireEvent, waitFor, act, within } from "@testing-library/react";
-import { allItems, type Layout } from "@realm/contracts";
+import { allItems, findLeafOfItem, type Layout } from "@realm/contracts";
 import { Sidebar } from "./Sidebar";
 import { StoreContext, createAppStore } from "../../state/store";
 import { fakeApi, iconAsset, item, session, space } from "../../state/store.test-fakes";
@@ -391,6 +391,34 @@ describe("Arc sidebar", () => {
     expect(api.calls).toContain("deleteItem:i2");
   });
 
+  it("THE homing mutant: the row menu's Open here brings the pane INTO the focused leaf", async () => {
+    const layout: Layout = { type: "leaf", id: "L1", itemId: "i1" };
+    const api = fakeApi({
+      spaces: [space("s1", "p1", "Versed", { layout })],
+      items: { s1: [item("i1", "s1", { title: "Alpha" })] },
+    });
+    const { store } = await mount(api);
+    await act(async () => { await store.getState().splitFocused("row"); });
+    const other = store.getState().focusedLeafId!;
+    expect(other).not.toBe("L1");
+    fireEvent.contextMenu(screen.getByRole("button", { name: "Alpha" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Open here" }));
+    await waitFor(() => expect(findLeafOfItem(store.getState().layout!, "i1")!.id).toBe(other));
+  });
+
+  it("…and it is absent wherever a plain click would land in the same place anyway", async () => {
+    const layout: Layout = { type: "leaf", id: "L1", itemId: "i1" };
+    const api = fakeApi({
+      spaces: [space("s1", "p1", "Versed", { layout })],
+      items: { s1: [item("i1", "s1", { title: "Alpha" }), item("i2", "s1", { title: "Beta" })] },
+    });
+    await mount(api);
+    fireEvent.contextMenu(screen.getByRole("button", { name: "Alpha" })); // open, and its leaf is the focused one
+    expect(screen.queryByRole("menuitem", { name: "Open here" })).not.toBeInTheDocument();
+    fireEvent.contextMenu(screen.getByRole("button", { name: "Beta" })); // not open at all: a click opens it here
+    expect(screen.queryByRole("menuitem", { name: "Open here" })).not.toBeInTheDocument();
+  });
+
   it("Delete on an OPEN item removes it from both the layout and the item list", async () => {
     const layout: Layout = { type: "leaf", id: "L1", itemId: "i1" };
     const api = fakeApi({
@@ -638,6 +666,25 @@ describe("sidebar destinations (Plan 12 W4)", () => {
     fireEvent.click(within(nav).getByRole("button", { name: "Library" }));
     await waitFor(() => expect(store.getState().items.filter((i) => i.kind === "library-page")).toHaveLength(1));
     expect(api.calls.filter((c) => c.startsWith("createItem:") && c.includes("library-page"))).toHaveLength(1);
+  });
+
+  it("THE modifier-ignored mutant: ⌥-clicking a destination row brings its page to the focused pane", async () => {
+    const { store } = await mount();
+    const nav = screen.getByRole("navigation", { name: "Destinations" });
+    const row = () => within(nav).getByRole("button", { name: "Library" });
+    // Nothing to choose between yet: the page does not exist, so a plain click already lands here.
+    expect(row()).not.toHaveAttribute("title");
+    fireEvent.click(row());
+    await waitFor(() => expect(store.getState().items.some((i) => i.kind === "library-page")).toBe(true));
+    const page = store.getState().items.find((i) => i.kind === "library-page")!;
+    const home = store.getState().focusedLeafId!;
+    await act(async () => { await store.getState().splitFocused("row"); });
+    const other = store.getState().focusedLeafId!;
+    expect(other).not.toBe(home);
+    // Now the two placements differ, and the row says so before it is used.
+    await waitFor(() => expect(row()).toHaveAttribute("title", expect.stringContaining("⌥")));
+    fireEvent.click(row(), { altKey: true });
+    await waitFor(() => expect(findLeafOfItem(store.getState().layout!, page.id)!.id).toBe(other));
   });
 
   // Moved off the space strip's left slot, which is the profile chip now. Same contract it had there:

--- a/apps/desktop/src/renderer/src/state/store-notifications.test.ts
+++ b/apps/desktop/src/renderer/src/state/store-notifications.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { createAppStore } from "./store";
 import { fakeApi, item, notification, session } from "./store.test-fakes";
-import { NOTIFICATIONS_DESKTOP_KEY } from "@realm/contracts";
+import { allItems, navEntry, NOTIFICATIONS_DESKTOP_KEY } from "@realm/contracts";
 
 const boot = async (overrides: Parameters<typeof fakeApi>[0] = {}) => {
   const api = fakeApi(overrides);
@@ -211,5 +211,76 @@ describe("store — the desktop (OS) hop", () => {
   it("…and a click on a row that no longer exists is a quiet no-op, never a throw", async () => {
     const { store } = await boot();
     await expect(store.getState().activateDesktopNotification("gone")).resolves.toBeUndefined();
+  });
+
+  it("THE any-permission mutant: a permission toast lands on the session ITS row names, not on whichever one is waiting", async () => {
+    // Both sessions are waiting, and one of them is in the space already on screen — which is exactly
+    // the session an argument-less jumpToPermission would prefer. The row names the other one.
+    const { store } = await boot({
+      items: { s1: [item("i1", "s1", { kind: "session", refId: "se1", title: "S" })], s2: [item("i2", "s2", { kind: "session", refId: "se2", title: "T" })] },
+      sessions: [session("se1", "s1", { status: "waiting_permission" }), session("se2", "s2", { status: "waiting_permission" })],
+      notifications: [notification("p1", { category: "permission", sessionId: "se2", spaceId: "s2", refId: "req1", actedAt: null })],
+    });
+    await store.getState().refreshAllSessions();
+    expect(store.getState().activeSpaceId).toBe("s1");
+    await store.getState().activateDesktopNotification("p1");
+    expect(store.getState().activeSpaceId).toBe("s2");
+    const pane = store.getState().items.find((i) => i.refId === "se2")!;
+    // The FOCUSED pane holds it — which is the half that surfaces the card, not just the space switch.
+    expect(navEntry(store.getState().paneHistory, store.getState().focusedLeafId!)).toEqual({ itemId: pane.id, view: null });
+  });
+
+  it("a row with no session opens the FEED with that row selected — an mcp_health toast has no pane to land on", async () => {
+    const { api, store } = await boot({
+      notifications: [notification("h1", { category: "mcp_health", sessionId: null, refId: "srv1", title: "srv1 stopped answering", actedAt: null })],
+    });
+    await store.getState().activateDesktopNotification("h1");
+    const page = store.getState().items.find((i) => i.kind === "notifications-page");
+    expect(page).toBeTruthy();
+    expect(allItems(store.getState().layout!)).toContain(page!.id);
+    expect(store.getState().notificationsSelectedId).toBe("h1");
+    expect(api.calls).toContain("markNotificationsRead:h1");
+  });
+
+  it("…and that landing is a STOP on the pane's trail, so the arrows retrace it like an in-page click", async () => {
+    const { store } = await boot({ notifications: [notification("b1", { category: "budget", sessionId: null, refId: "2026-09:0.8" })] });
+    await store.getState().activateDesktopNotification("b1");
+    const leaf = store.getState().focusedLeafId!;
+    await store.getState().stepPaneNav(leaf, -1);
+    expect(store.getState().notificationsSelectedId).toBeNull(); // back to the bare list
+    await store.getState().stepPaneNav(leaf, 1);
+    expect(store.getState().notificationsSelectedId).toBe("b1");
+  });
+
+  it("a session row whose pane no longer exists falls back to the feed rather than a space switch that opens nothing", async () => {
+    const { store } = await boot({
+      items: { s1: [item("i1", "s1", { kind: "session", refId: "se1", title: "S" })], s2: [] },
+      sessions: [session("se1", "s1"), session("se2", "s2")],
+      notifications: [notification("d1", { category: "session_done", sessionId: "se2", spaceId: "s2" })],
+    });
+    await store.getState().refreshAllSessions();
+    await store.getState().activateDesktopNotification("d1");
+    expect(store.getState().activeSpaceId).toBe("s2");
+    expect(store.getState().notificationsSelectedId).toBe("d1");
+  });
+
+  it("THE read-after-the-jump mutant: the row is stamped read BEFORE the app goes anywhere", async () => {
+    const { api, store } = await boot({ notifications: [notification("a1", { category: "agent_probe", sessionId: null, refId: "claude" })] });
+    await store.getState().activateDesktopNotification("a1");
+    // The row is read because the user clicked it, not because the landing below turned out to be
+    // reachable — so the read lands before the page the jump has to create.
+    const order = api.calls.filter((c) => c === "markNotificationsRead:a1" || c.startsWith("createItem:"));
+    expect(order).toHaveLength(2);
+    expect(order[0]).toBe("markNotificationsRead:a1");
+  });
+
+  it("…and a row whose feed page is ALREADY open is selected in it, rather than opening a second one", async () => {
+    const { store } = await boot({
+      notifications: [notification("h2", { category: "mcp_health", sessionId: null, refId: "srv2", actedAt: null })],
+    });
+    await store.getState().openDestinationPage("notifications-page");
+    await store.getState().activateDesktopNotification("h2");
+    expect(store.getState().items.filter((i) => i.kind === "notifications-page")).toHaveLength(1);
+    expect(store.getState().notificationsSelectedId).toBe("h2");
   });
 });

--- a/apps/desktop/src/renderer/src/state/store.test.ts
+++ b/apps/desktop/src/renderer/src/state/store.test.ts
@@ -2384,6 +2384,46 @@ describe("openDestinationPage", () => {
     await store.getState().openDestinationPage("library-page");
     expect(api.calls.some((c) => c.startsWith("createItem:"))).toBe(false);
   });
+
+  it("THE homing mutant: a `here` placement MOVES an open page into the focused pane, where a plain open goes to it", async () => {
+    const api = fakeApi();
+    const store = createAppStore(api);
+    await store.getState().boot();
+    await store.getState().openDestinationPage("library-page");
+    const page = store.getState().items.find((i) => i.kind === "library-page")!;
+    const home = store.getState().focusedLeafId!;
+    await store.getState().splitFocused("row");
+    const other = store.getState().focusedLeafId!;
+    expect(other).not.toBe(home);
+
+    // Plain: one page per space, so this is "go there" — the focus moves to the pane, not the pane
+    // to the focus, and the empty half of the split stays empty.
+    await store.getState().openDestinationPage("library-page");
+    expect(store.getState().focusedLeafId).toBe(home);
+    expect(findLeafOfItem(store.getState().layout!, page.id)!.id).toBe(home);
+
+    store.getState().focusLeaf(other);
+    await store.getState().openDestinationPage("library-page", "here");
+    expect(findLeafOfItem(store.getState().layout!, page.id)!.id).toBe(other);
+    // Still one page: a placement is about WHERE it lands, never about how many there are.
+    expect(store.getState().items.filter((i) => i.kind === "library-page")).toHaveLength(1);
+  });
+
+  it("destinationPageElsewhere is the gate both surfaces read — false whenever the placement would change nothing", async () => {
+    const api = fakeApi();
+    const store = createAppStore(api);
+    await store.getState().boot();
+    expect(store.getState().destinationPageElsewhere("library-page")).toBe(false); // no page: a plain open already lands here
+    await store.getState().openDestinationPage("library-page");
+    expect(store.getState().destinationPageElsewhere("library-page")).toBe(false); // the page IS the focused pane
+    await store.getState().splitFocused("row");
+    expect(store.getState().destinationPageElsewhere("library-page")).toBe(true);  // now it is somewhere to be brought FROM
+    const page = store.getState().items.find((i) => i.kind === "library-page")!;
+    await store.getState().closeFromLayout(page.id);
+    // The item outlives its pane; with no pane holding it, both placements open one.
+    expect(store.getState().items.some((i) => i.id === page.id)).toBe(true);
+    expect(store.getState().destinationPageElsewhere("library-page")).toBe(false);
+  });
 });
 
 describe("openProfilePage (Plan 14 W2)", () => {

--- a/apps/desktop/src/renderer/src/state/store.ts
+++ b/apps/desktop/src/renderer/src/state/store.ts
@@ -366,6 +366,19 @@ export const DESTINATION_PAGE_TITLES: Record<DestinationPageKind, string> = {
   "profile-page": "Profile",
 };
 
+/**
+ * Where an activated destination page lands.
+ *
+ * `reuse` is the plain click: one page per space, so a second activation goes to the pane that already
+ * holds it — including one in a pane group that is not on screen, which the plain click will switch to.
+ * `here` overrides that homing and moves the page into the focused pane instead.
+ *
+ * They only differ once the page is open somewhere else. A page that does not exist yet is created in
+ * the focused pane under either placement, which is why the surfaces offering `here` gate on
+ * `destinationPageElsewhere` rather than advertising a choice that has one outcome.
+ */
+export type DestinationPlacement = "reuse" | "here";
+
 /** Feed page size (W5). Modest: the page is a glance at what waited, not an archive browser —
  *  "Load more" pages further on the server's cursor. */
 export const NOTIFICATIONS_PAGE = 50;
@@ -1090,8 +1103,13 @@ export type AppState = {
   setProfilePageTab(profileId: string, tab: ProfilePageTab): void;
   /** Open (or focus) a sidebar destination page (Plan 12 W4: Library, Connections) in the ACTIVE
    *  space's layout. One page item per space, deduped by KIND — the refId is the kind's well-known
-   *  sentinel (`PAGE_REF_IDS`), and the item's `spaceId` is the vantage its scope groups read from. */
-  openDestinationPage(kind: DestinationPageKind): Promise<void>;
+   *  sentinel (`PAGE_REF_IDS`), and the item's `spaceId` is the vantage its scope groups read from.
+   *  Returns the page item's id — null only when there is no active space to put it in — which is what
+   *  a caller needs to then address something INSIDE the page it just opened. */
+  openDestinationPage(kind: DestinationPageKind, placement?: DestinationPlacement): Promise<string | null>;
+  /** True when `kind`'s page is open in a pane that is not the focused one: the only case in which a
+   *  `here` placement does something the plain click does not. */
+  destinationPageElsewhere(kind: DestinationPageKind): boolean;
   /** Read both Settings-page preference keys into `settingsPrefs` (Plan 12 W6). Junk in a row —
    *  an unknown category, a mode PERMISSION_MODES doesn't name — is dropped/defaulted here, once,
    *  so the page never renders a state the server would not honor. */
@@ -2891,20 +2909,42 @@ export function createAppStore(api: Api): StoreApi<AppState> {
         const created = await api.createItem(spaceId, "space-page", "Overview", spaceId);
         await adoptItem(spaceId, created.id, null);
       },
-      async openDestinationPage(kind) {
+      async openDestinationPage(kind, placement = "reuse") {
         // The page lives in the ACTIVE space's layout — that space is the vantage its scope groups
         // ("This space" / "From <profile>" / "Everywhere") are computed from. No active space
         // (mid-boot) → no-op, openSpacePage's guard.
         const spaceId = get().activeSpaceId;
-        if (!spaceId) return;
+        if (!spaceId) return null;
         // One page per space, deduped by KIND (`items` only ever holds the active space's items).
         // The named W4 mutant: a second click accumulating a second Library pane.
         const existing = get().items.find((i) => i.kind === kind);
-        if (existing) { await get().openItem(existing.id); return; }
+        if (existing) {
+          // Naming the focused leaf is what makes openItem MOVE the pane; passing null is what makes it
+          // home to wherever the pane already sits. With nothing focused there is no "here" to mean, so
+          // the null falls through to homing on its own rather than needing a second branch.
+          await get().openItem(existing.id, placement === "here" ? get().focusedLeafId : null);
+          return existing.id;
+        }
         // Static title (the page header owns the live copy); refId is the kind's well-known sentinel —
         // there is no row behind these pages, and identity is really the kind (see PAGE_REF_IDS).
         const created = await api.createItem(spaceId, kind, DESTINATION_PAGE_TITLES[kind], PAGE_REF_IDS[kind]);
         await adoptItem(spaceId, created.id, null);
+        return created.id;
+      },
+      destinationPageElsewhere(kind) {
+        const it = get().items.find((i) => i.kind === kind);
+        if (!it) return false; // no page yet — a plain click already creates it in the focused pane
+        const gs = get().groups;
+        if (!gs) {
+          const leaf = findLeafOfItem(get().layout ?? emptyLayout(), it.id);
+          return leaf !== null && leaf.id !== get().focusedLeafId;
+        }
+        const holder = groupOfItem(gs, it.id);
+        if (!holder) return false; // the item exists but no pane holds it: both placements would open one
+        // A page held by a group that is not on screen is elsewhere by the strongest reading — the plain
+        // click swaps the whole arrangement to reach it.
+        if (holder.id !== gs.activeGroupId) return true;
+        return findLeafOfItem(holder.layout, it.id)?.id !== get().focusedLeafId;
       },
       setSpacePageTab(spaceId, tab) { set({ spacePageTab: { ...get().spacePageTab, [spaceId]: tab } }); },
       async openProfilePage(tab) {

--- a/apps/desktop/src/renderer/src/state/store.ts
+++ b/apps/desktop/src/renderer/src/state/store.ts
@@ -881,13 +881,17 @@ export type AppState = {
   refreshSessions(): Promise<void>;
   /** Seed sessionSpace + statuses for every space (boot, reconnect, unknown-session broadcasts). */
   refreshAllSessions(): Promise<void>;
-  /** Jump to a waiting_permission session anywhere: switch space if needed, open its item, focus it. */
-  jumpToPermission(): Promise<void>;
+  /** Put a waiting_permission session's pane in front of the user — switching space if needed — which
+   *  is what surfaces its card, since Transcript autofocuses the first pending permission of a focused
+   *  pane. With no argument it chooses one (the active space first); a permission notification passes
+   *  the session its own row names. False when there was nothing to land on. */
+  jumpToPermission(sessionId?: string | null): Promise<boolean>;
   /** Load (or catch up) a session's transcript: fetch events after the last known seq and reduce them. */
   /** Bring a session's pane to the front, switching space first when it lives in another one.
    *  Shared by the notifications feed and the Usage tab's leaderboard so "go to session" means the
-   *  same thing from both — including the space switch, which is the half that is easy to forget. */
-  revealSession(sessionId: string, spaceId: string | null): Promise<void>;
+   *  same thing from both — including the space switch, which is the half that is easy to forget.
+   *  False when the space holds no item for that session, so a caller with a fallback can take it. */
+  revealSession(sessionId: string, spaceId: string | null): Promise<boolean>;
   openSession(id: string): Promise<void>;
   /** Persisted events apply at once; ephemeral `assistant_delta`s are buffered and land on the next
    *  painted frame — see `pendingDeltas` for why that is where the app's power goes. */
@@ -1169,8 +1173,12 @@ export type AppState = {
    *  the held feed, and auto-reads a `session_done` for the session pane the user is looking at (the
    *  renderer is the one honest holder of focus — see the server service's doc comment). */
   applyNotificationsChanged(payload: { notification: Notification | null; unread: number }): void;
-  /** The row's jump affordance: land on the notification's session (switching space if needed) and
-   *  mark it read — it has, by definition, been seen. */
+  /** Land on the thing the notification is ABOUT, and mark the row read — it has, by definition, been
+   *  seen. A row naming a session lands on that session's pane (a `permission` through
+   *  jumpToPermission, whose focus move is what pops the card); every other row — an MCP server, a
+   *  probe, a budget ceiling — has no pane of its own, so it lands on the feed page with the row
+   *  selected, which is also where a session whose item is gone ends up. Either way the landing is a
+   *  stop on the pane's trail, exactly as clicking the row inside the page would leave it. */
   openNotificationTarget(n: Notification): Promise<void>;
   /** A clicked OS toast, by row id (main knows nothing but the id). Resolves the row from the held
    *  feed — refetching once if the page was never opened — and lands on it like any other jump. */
@@ -2271,16 +2279,21 @@ export function createAppStore(api: Api): StoreApi<AppState> {
         for (const s of all) { sessionSpace[s.id] = s.spaceId; sessionStatus[s.id] = s.status; }
         set({ sessionSpace, sessionStatus });
       },
-      async jumpToPermission() {
+      async jumpToPermission(sessionId = null) {
+        const spaceOf = (id: string) => get().sessionSpace[id] ?? get().sessions[id]?.spaceId ?? null;
+        // Two callers with two different amounts of knowledge. The palette's "Respond to pending
+        // permission" names nothing and has to CHOOSE: one in the active space first, so answering a
+        // question does not drag the user out of the space they are working in. A permission
+        // notification names its own session and skips the choice entirely — including when that
+        // session is no longer waiting, because a row whose question was answered in another window
+        // still belongs on its own pane rather than on whichever session happens to be waiting now.
         const waiting = Object.entries(get().sessionStatus).filter(([, st]) => st === "waiting_permission").map(([id]) => id);
-        if (waiting.length === 0) return;
-        // Prefer one in the active space (no context switch); otherwise the first known anywhere.
         const active = get().activeSpaceId;
-        const sid = waiting.find((id) => (get().sessionSpace[id] ?? get().sessions[id]?.spaceId) === active) ?? waiting[0]!;
-        const spaceId = get().sessionSpace[sid] ?? get().sessions[sid]?.spaceId;
-        if (spaceId && spaceId !== get().activeSpaceId) await get().selectSpace(spaceId);
-        const item = get().items.find((i) => i.kind === "session" && i.refId === sid);
-        if (item) await get().openItem(item.id); // opens into the focused leaf and focuses it
+        const sid = sessionId ?? waiting.find((id) => spaceOf(id) === active) ?? waiting[0] ?? null;
+        if (!sid) return false;
+        // Landing the pane in the FOCUSED leaf is what surfaces the card: Transcript autofocuses the
+        // first pending permission of a focused pane (U-H4). There is nothing further to open.
+        return get().revealSession(sid, spaceOf(sid));
       },
       async openSession(id) {
         if (loading.has(id)) return;
@@ -3117,11 +3130,32 @@ export function createAppStore(api: Api): StoreApi<AppState> {
         const target = get().sessionSpace[sessionId] ?? spaceId;
         if (target && target !== get().activeSpaceId) await get().selectSpace(target);
         const item = get().items.find((i) => i.kind === "session" && i.refId === sessionId);
-        if (item) await get().openItem(item.id);
+        // A session with no item in the space it claims has no pane to be brought forward — the space
+        // switch above already happened, so callers need to hear that the jump did NOT land rather
+        // than leave the user somewhere new with nothing opened.
+        if (!item) return false;
+        await get().openItem(item.id);
+        return true;
       },
       async openNotificationTarget(n) {
-        if (n.sessionId) await get().revealSession(n.sessionId, n.spaceId);
+        // Read first, before anything moves: the row is read because the user clicked it, not because
+        // a landing turned out to be reachable. selectNotification below then finds it already read
+        // and has nothing left to stamp, so one click is one markRead however many surfaces it
+        // passes through.
         if (n.readAt === null) await get().markNotificationsRead([n.id]);
+        // A row that names a session is about that session's pane; `permission` goes through
+        // jumpToPermission because putting the pane in the focused leaf is what pops its card open.
+        const landed = n.sessionId !== null && (n.category === "permission"
+          ? await get().jumpToPermission(n.sessionId)
+          : await get().revealSession(n.sessionId, n.spaceId));
+        if (landed) return;
+        // Everything else — an MCP server that fell over, a probe that stopped answering, a budget
+        // ceiling — has no pane of its own, and neither does a session whose item is gone. For those
+        // the feed row IS the thing the notification is about, so the click lands on the page with the
+        // row selected: selectNotification is the in-page click's own path, which is what makes this
+        // landing a stop on the pane's trail rather than a jump the arrows cannot retrace.
+        const pageItemId = await get().openDestinationPage("notifications-page");
+        if (pageItemId) await get().selectNotification(pageItemId, n.id);
       },
       async activateDesktopNotification(id) {
         // Main hands back an id and nothing else. The feed may never have been loaded — a toast is


### PR DESCRIPTION
Two navigation gaps, one PR.

**Destination placement.** `openDestinationPage` always homed a Library/Connections/Notifications/Settings page to wherever its pane already sat, including a pane group that was off screen. It now takes a placement: `reuse` (the plain click, unchanged) or `here`, which moves the page into the focused pane. The two only differ once the page is open somewhere else — a page that does not exist yet is created in the focused pane either way — so every surface offering `here` gates on the new `destinationPageElsewhere`.

Offered three ways: ⌥-click on the sidebar row, an "Open here" entry folded into the existing `useItemContextMenu` rather than a second menu, and a gated twin in the command palette.

**Toast clicks.** `openNotificationTarget` only navigated when the row named a session; `mcp_health`, `agent_probe` and `budget` rows went nowhere at all, and nothing ever opened the feed page or selected the row inside it. Now a row naming a session lands on that session's pane — a `permission` row through `jumpToPermission`, whose focus move is what makes the transcript autofocus the card — and everything else lands on the feed with the row selected, which is also where a session whose item has been deleted ends up.

`jumpToPermission` now delegates to `revealSession` instead of carrying its own copy of the space-switch-then-open, and `revealSession` reports whether it actually found a pane so a caller can take its fallback.

Main still sends only the row id; the split described at `main/index.ts:409-412` is intact. No RPC or contract changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)