### PR TITLE
Sidebar: an icon ladder, a truthful split mark, a dissolved list bottom, and the lights inline with the panes

### DIFF
--- a/apps/desktop/scripts/sidebar-collapsed-live.mjs
+++ b/apps/desktop/scripts/sidebar-collapsed-live.mjs
@@ -1,0 +1,271 @@
+/**
+ * Live check for the collapsed sidebar's window chrome (run with: node apps/desktop/scripts/sidebar-collapsed-live.mjs)
+ *
+ * Boots the REAL app on a scratch REALM_HOME and measures the thing the collapse was changed for:
+ * with the sidebar collapsed there is no rail, the content starts at the very top of the window, and
+ * the macOS traffic lights sit inline with the first pane's bar without landing on anything.
+ *
+ * All of it is layout, so none of it is visible to jsdom — a shell test can only see that a div with
+ * the right class exists, not that the button inside it is reachable or that the bar underneath left
+ * room for three OS-drawn circles the web contents cannot even paint.
+ *
+ * The traffic lights are drawn by the window server, above the web view, so a screenshot of the page
+ * does not contain them. Their box is therefore taken from the placement main asks for
+ * (trafficLightPosition x:12, y:14) plus the fixed size AppKit gives them, and asserted against — the
+ * comment on LIGHTS is the contract, and main/index.ts carries its other half.
+ *
+ * Ports: env-overridable. Touches only a scratch dir; kills only the process it started.
+ */
+import { spawn } from "node:child_process";
+import { connect } from "node:net";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
+const CDP_PORT = Number(process.env.LIVE_CDP_PORT ?? 9340), SERVER_PORT = Number(process.env.LIVE_SERVER_PORT ?? 8906);
+const scratch = fs.mkdtempSync(path.join(os.tmpdir(), "realm-sidebar-collapsed-"));
+let electron = null;
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+/** The lights as AppKit draws them for `titleBarStyle: "hiddenInset"`: three 12px circles on a 20px
+ *  pitch, with main placing the group's top-left at (12, 14). So they occupy x 12..64 and y 14..26.
+ *  `right` is rounded up to 66 for the half-pixel the shadow adds. If main ever moves them, this
+ *  number and the 76px of padding on .sb-corner move together. */
+const LIGHTS = { left: 12, top: 14, right: 66, bottom: 30 };
+
+async function portFree(port) {
+  return new Promise((resolve) => {
+    const s = connect({ port, host: "127.0.0.1" });
+    s.once("connect", () => { s.destroy(); resolve(false); });
+    s.once("error", () => resolve(true));
+  });
+}
+
+async function until(fn, ms, tag) {
+  const t0 = Date.now();
+  for (;;) {
+    const v = await fn();
+    if (v) return v;
+    if (Date.now() - t0 > ms) throw new Error(`timeout:${tag}`);
+    await sleep(150);
+  }
+}
+
+function cdp(wsUrl) {
+  const ws = new WebSocket(wsUrl);
+  let id = 0;
+  const pending = new Map();
+  const events = [];
+  const ready = new Promise((res) => ws.addEventListener("open", res));
+  ws.addEventListener("message", (m) => {
+    const msg = JSON.parse(m.data);
+    if (msg.id !== undefined) pending.get(msg.id)?.(msg);
+    else if (msg.method === "Runtime.consoleAPICalled" && msg.params.type === "error") {
+      events.push(msg.params.args.map((a) => a.value ?? a.description ?? "").join(" "));
+    }
+  });
+  return {
+    ready, events,
+    send: (method, params) => new Promise((res, rej) => {
+      const i = ++id;
+      pending.set(i, (msg) => (msg.error ? rej(new Error(msg.error.message)) : res(msg.result)));
+      ws.send(JSON.stringify({ id: i, method, params }));
+    }),
+    close: () => ws.close(),
+  };
+}
+
+async function evalIn(c, expr) {
+  const r = await c.send("Runtime.evaluate", { expression: expr, awaitPromise: true, returnByValue: true });
+  if (r.exceptionDetails) throw new Error(`page exception: ${r.exceptionDetails.exception?.description ?? r.exceptionDetails.text}`);
+  return r.result.value;
+}
+
+const check = (name, cond, detail) => {
+  if (!cond) process.exitCode = 1;
+  console.log(`${cond ? "PASS" : "FAIL"} ${name}${detail !== undefined ? " " + JSON.stringify(detail) : ""}`);
+};
+
+const collapse = (c) => evalIn(c, `(() => { document.querySelector('.sb-toggle').click(); return true; })()`);
+
+/** Every laid-out fact the checks below read, in one round trip. */
+const PROBE = `(() => {
+  const box = (sel) => { const e = document.querySelector(sel); if (!e) return null;
+    const r = e.getBoundingClientRect();
+    return { top: Math.round(r.top), left: Math.round(r.left), right: Math.round(r.right), bottom: Math.round(r.bottom), w: Math.round(r.width), h: Math.round(r.height) }; };
+  const bars = [...document.querySelectorAll('.panel')].map((p) => {
+    const bar = p.querySelector(':scope > .panel-bar');
+    if (!bar) return null;
+    const first = bar.firstElementChild?.getBoundingClientRect();
+    const r = bar.getBoundingClientRect();
+    return { first: p.hasAttribute('data-first-leaf'), barLeft: Math.round(r.left), barTop: Math.round(r.top),
+             contentLeft: first ? Math.round(first.left) : null, padLeft: Math.round(parseFloat(getComputedStyle(bar).paddingLeft)) };
+  }).filter(Boolean);
+  return {
+    rail: !!document.querySelector('.sb-rail'),
+    sidebar: box('.sidebar'), corner: box('.sb-corner'), main: box('.main'),
+    panehost: box('.panehost'), groupBar: box('.group-bar'), toggle: box('.sb-toggle'),
+    groupBarPadLeft: document.querySelector('.group-bar') ? Math.round(parseFloat(getComputedStyle(document.querySelector('.group-bar')).paddingLeft)) : null,
+    bars,
+  };
+})()`;
+
+async function main() {
+  for (const p of [CDP_PORT, SERVER_PORT]) {
+    if (!(await portFree(p))) throw new Error(`port ${p} is in use — refusing to run`);
+  }
+
+  const wrapper = path.join(scratch, "wrapper.mjs");
+  fs.writeFileSync(wrapper, [
+    'import { app } from "electron";',
+    'app.setPath("userData", process.env.LIVE_USER_DATA);',
+    "await import(process.env.LIVE_MAIN);",
+  ].join("\n"));
+  const electronBin = process.platform === "darwin"
+    ? path.join(repoRoot, "node_modules/.pnpm/electron@37.10.3/node_modules/electron/dist/Electron.app/Contents/MacOS/Electron")
+    : path.join(repoRoot, "apps/desktop/node_modules/.bin/electron");
+  electron = spawn(electronBin, [wrapper], {
+    env: {
+      ...process.env,
+      REALM_HOME: path.join(scratch, "home"),
+      REALM_ENABLE_FAKE_AGENT: "1",
+      REALM_PORT: String(SERVER_PORT),
+      REALM_DEVTOOLS_PORT: String(CDP_PORT),
+      REALM_SERVER_ENTRY: path.join(repoRoot, "apps/server/dist/main.js"),
+      LIVE_USER_DATA: path.join(scratch, "userData"),
+      LIVE_MAIN: path.join(repoRoot, "apps/desktop/out/main/index.js"),
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  electron.stderr.on("data", () => {}); electron.stdout.on("data", () => {});
+
+  const targets = () => fetch(`http://127.0.0.1:${CDP_PORT}/json/list`).then((r) => r.json()).catch(() => []);
+  const rendererTarget = await until(async () => (await targets()).find((t) => t.type === "page" && t.url.startsWith("file://")), 30000, "renderer target");
+  const c = cdp(rendererTarget.webSocketDebuggerUrl);
+  await c.ready;
+  await c.send("Runtime.enable");
+  await c.send("Page.enable");
+
+  await until(() => evalIn(c, `!!document.querySelector('.onboarding input:not([type=radio])')`), 20000, "onboarding");
+  await evalIn(c, `(() => {
+    const input = document.querySelector('.onboarding input:not([type=radio])');
+    const set = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value').set;
+    set.call(input, 'Live'); input.dispatchEvent(new Event('input', { bubbles: true }));
+    input.closest('form').requestSubmit();
+    return true; })()`);
+  await until(() => evalIn(c, `!!document.querySelector('.composer')`), 20000, "composer");
+  await c.send("Emulation.setDeviceMetricsOverride", { width: 1200, height: 800, deviceScaleFactor: 1, mobile: false });
+  await sleep(400);
+
+  const open = await evalIn(c, PROBE);
+  check("with the sidebar open the lights sit in its 40px head row, clear of any pane",
+    open.sidebar?.w === 280 && open.main.left === 280 && open.toggle.top >= 0 && open.toggle.bottom <= 40,
+    { sidebarW: open.sidebar?.w, mainLeft: open.main.left, toggle: open.toggle });
+
+  /* Two panes, both holding a session, made the way a user makes them — splitting alone leaves the
+     new leaf EMPTY, and an empty leaf renders no bar at all, so there would be nothing to measure.
+     Done while the sidebar is open because the sidebar is the only way to fill that leaf. */
+  await evalIn(c, `(() => { document.querySelector('.new-row').click(); return true; })()`);
+  await until(() => evalIn(c, `document.querySelectorAll('.space-body .item').length >= 2`), 15000, "a second session");
+  await evalIn(c, `(() => {
+    const inline = document.querySelector('.panel-bar button[aria-label^="Split"][aria-label$="right"]');
+    if (inline) { inline.click(); return true; }
+    document.querySelector('.panel-bar button[aria-label^="Pane menu"]').click();
+    return true; })()`);
+  await evalIn(c, `(() => {
+    const it = [...document.querySelectorAll('[role="menuitem"]')].find((m) => m.textContent.startsWith('Split right'));
+    if (it) it.click();
+    return true; })()`);
+  await until(() => evalIn(c, `document.querySelectorAll('.panehost .panel').length === 2`), 15000, "two panes");
+  await evalIn(c, `(() => {
+    const row = [...document.querySelectorAll('.item-list .item-row')].find((r) => !r.querySelector('.item-glyph'));
+    row.click(); return true; })()`);
+  await until(() => evalIn(c, `document.querySelectorAll('.panehost .panel-bar').length === 2`), 15000, "two pane bars");
+  await sleep(300);
+
+  /* ── Collapsed: no rail, no band of height, content at y=0 ───────────────────────────────── */
+  await collapse(c);
+  await until(() => evalIn(c, `!!document.querySelector('.sb-corner')`), 5000, "the corner");
+  await sleep(300);
+  const one = await evalIn(c, PROBE);
+
+  check("the rail is gone", one.rail === false && one.sidebar === null, { rail: one.rail, sidebar: one.sidebar });
+  // The regression this replaces: a 38px full-width strip above the content. The panes now start at
+  // the window's own top edge, so collapsing costs no height at all.
+  check("collapsing costs no height — the pane host still starts at the top of the window",
+    one.panehost.top === 0 && one.main.top === 0 && one.main.left === 0,
+    { panehostTop: one.panehost.top, mainTop: one.main.top, mainLeft: one.main.left });
+  const bar = one.bars.find((b) => b.first);
+  check("the leftmost pane's bar is the strip under the lights, sitting at the very top of the window",
+    !!bar && bar.barTop === 0 && bar.barLeft === 0, one.bars);
+
+  /* ── The lights land on that bar without hitting anything ────────────────────────────────── */
+  check("the first pane's bar leaves the lights their whole width before its own content starts",
+    bar.contentLeft >= LIGHTS.right, { contentLeft: bar.contentLeft, lightsRight: LIGHTS.right, padLeft: bar.padLeft });
+  check("the corner clears the lights before the toggle, so the two never overlap",
+    one.toggle.left >= LIGHTS.right, { toggleLeft: one.toggle.left, lightsRight: LIGHTS.right });
+  check("the toggle still sits in the same 40px band it occupied inside the sidebar",
+    one.toggle.top >= 0 && one.toggle.bottom <= 40, one.toggle);
+  check("the toggle stops short of the bar's content, so the corner and the bar do not fight for a row",
+    one.toggle.right <= bar.contentLeft, { toggleRight: one.toggle.right, contentLeft: bar.contentLeft });
+
+  /* ── The toggle is actually reachable, not buried under the pane ─────────────────────────── */
+  // Panes are positioned elements, so a corner rendered before .main would be painted over by the
+  // first pane's bar and hit-test to it. This is the check that catches that.
+  const hit = await evalIn(c, `(() => {
+    const t = document.querySelector('.sb-toggle').getBoundingClientRect();
+    const el = document.elementFromPoint(t.left + t.width / 2, t.top + t.height / 2);
+    return { tag: el?.tagName, cls: el?.className, inToggle: !!el?.closest('.sb-toggle') };
+  })()`);
+  check("a click at the toggle's centre lands on the toggle, not on the pane behind it", hit.inToggle, hit);
+
+  /* ── Only the FIRST pane reserves the corner ─────────────────────────────────────────────── */
+  const otherBars = one.bars.filter((b) => !b.first);
+  check("in a split only the leftmost pane reserves the corner — every other bar keeps its normal rail",
+    otherBars.length > 0 && otherBars.every((b) => b.padLeft <= 20),
+    { first: bar.padLeft, others: otherBars.map((b) => b.padLeft) });
+
+  /* ── With a group bar on top, IT takes the corner and the pane bar gives it back ─────────── */
+  // The group bar renders above the pane host, so with two groups it is the strip the lights land on.
+  // Reaching it means going back through the sidebar, which is the only place groups are made.
+  await collapse(c);
+  await until(() => evalIn(c, `!!document.querySelector('.sidebar')`), 5000, "the sidebar back");
+  await evalIn(c, `(() => { document.querySelector('.group-new').click(); return true; })()`);
+  await until(() => evalIn(c, `!!document.querySelector('.group-bar')`), 15000, "a second pane group");
+  await collapse(c);
+  await until(() => evalIn(c, `!!document.querySelector('.sb-corner')`), 5000, "the corner again");
+  await sleep(400);
+  const grouped = await evalIn(c, PROBE);
+  check("the group bar takes the lights when it is on top, and takes the 40px with them",
+    grouped.groupBar?.top === 0 && grouped.groupBarPadLeft >= LIGHTS.right && grouped.groupBar.h >= 40,
+    { top: grouped.groupBar?.top, padLeft: grouped.groupBarPadLeft, h: grouped.groupBar?.h });
+  check("…and the pane bar underneath is no longer indented, because it is no longer under them",
+    grouped.bars.every((b) => b.padLeft <= 20), grouped.bars.map((b) => ({ first: b.first, padLeft: b.padLeft })));
+
+  /* ── And the way back ────────────────────────────────────────────────────────────────────── */
+  await evalIn(c, `(() => { document.elementFromPoint(...(() => { const t = document.querySelector('.sb-toggle').getBoundingClientRect(); return [t.left + t.width / 2, t.top + t.height / 2]; })()).closest('.sb-toggle').click(); return true; })()`);
+  await until(() => evalIn(c, `!!document.querySelector('.sidebar')`), 5000, "the sidebar restored");
+  const back = await evalIn(c, PROBE);
+  check("clicking the corner's toggle brings the sidebar back", back.sidebar?.w === 280 && back.corner === null,
+    { sidebarW: back.sidebar?.w, corner: back.corner });
+
+  await collapse(c);
+  await sleep(400);
+  const shot = await c.send("Page.captureScreenshot", { format: "png", clip: { x: 0, y: 0, width: 700, height: 120, scale: 2 } });
+  const out = path.join(os.tmpdir(), "realm-sidebar-collapsed-top.png");
+  fs.writeFileSync(out, Buffer.from(shot.data, "base64"));
+  console.log(`SCREENSHOT top ${out}`);
+
+  const errs = c.events.filter((e) => !e.includes("Autofill"));
+  check("no renderer console errors", errs.length === 0, errs.slice(0, 5));
+  c.close();
+}
+
+main()
+  .catch((e) => { console.error("ERROR", e.message); process.exitCode = 1; })
+  .finally(() => {
+    electron?.kill("SIGTERM");
+    setTimeout(() => { electron?.kill("SIGKILL"); fs.rmSync(scratch, { recursive: true, force: true }); process.exit(process.exitCode ?? 0); }, 1200);
+  });

--- a/apps/desktop/scripts/sidebar-fade-live.mjs
+++ b/apps/desktop/scripts/sidebar-fade-live.mjs
@@ -1,0 +1,299 @@
+/**
+ * Live check for the sidebar list's bottom fade (run with: node apps/desktop/scripts/sidebar-fade-live.mjs)
+ *
+ * Boots the REAL app on a scratch REALM_HOME and proves the two things a jsdom test cannot, because
+ * both need real layout and real compositing:
+ *
+ *   1. Clearance. Scrolled to the end, the LAST session row sits entirely above the fade band. The
+ *      band is supposed to dissolve empty gutter, not the row someone scrolled down to read, and the
+ *      only thing holding that apart is .space-body's bottom padding matching --fade-h.
+ *   2. The blur actually composites. The sidebar is a macOS vibrancy column, not an opaque panel, and
+ *      a backdrop-filter over a vibrant material is a different question from one over a solid
+ *      surface — it can silently resolve to nothing. jsdom has neither a backdrop nor a filter.
+ *
+ * Both are paired with a mutant that reproduces the bug they pin: the padding is taken away for the
+ * first, the backdrop-filter for the second, and each measurement has to move.
+ *
+ * Ports: env-overridable. Touches only a scratch dir; kills only the process it started.
+ */
+import { spawn } from "node:child_process";
+import { connect } from "node:net";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
+const CDP_PORT = Number(process.env.LIVE_CDP_PORT ?? 9339), SERVER_PORT = Number(process.env.LIVE_SERVER_PORT ?? 8905);
+const scratch = fs.mkdtempSync(path.join(os.tmpdir(), "realm-sidebar-fade-"));
+let electron = null;
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+async function portFree(port) {
+  return new Promise((resolve) => {
+    const s = connect({ port, host: "127.0.0.1" });
+    s.once("connect", () => { s.destroy(); resolve(false); });
+    s.once("error", () => resolve(true));
+  });
+}
+
+async function until(fn, ms, tag) {
+  const t0 = Date.now();
+  for (;;) {
+    const v = await fn();
+    if (v) return v;
+    if (Date.now() - t0 > ms) throw new Error(`timeout:${tag}`);
+    await sleep(150);
+  }
+}
+
+function cdp(wsUrl) {
+  const ws = new WebSocket(wsUrl);
+  let id = 0;
+  const pending = new Map();
+  const events = [];
+  const ready = new Promise((res) => ws.addEventListener("open", res));
+  ws.addEventListener("message", (m) => {
+    const msg = JSON.parse(m.data);
+    if (msg.id !== undefined) pending.get(msg.id)?.(msg);
+    else if (msg.method === "Runtime.consoleAPICalled" && msg.params.type === "error") {
+      events.push(msg.params.args.map((a) => a.value ?? a.description ?? "").join(" "));
+    }
+  });
+  return {
+    ready, events,
+    send: (method, params) => new Promise((res, rej) => {
+      const i = ++id;
+      pending.set(i, (msg) => (msg.error ? rej(new Error(msg.error.message)) : res(msg.result)));
+      ws.send(JSON.stringify({ id: i, method, params }));
+    }),
+    close: () => ws.close(),
+  };
+}
+
+async function evalIn(c, expr) {
+  const r = await c.send("Runtime.evaluate", { expression: expr, awaitPromise: true, returnByValue: true });
+  if (r.exceptionDetails) throw new Error(`page exception: ${r.exceptionDetails.exception?.description ?? r.exceptionDetails.text}`);
+  return r.result.value;
+}
+
+const check = (name, cond, detail) => {
+  if (!cond) process.exitCode = 1;
+  console.log(`${cond ? "PASS" : "FAIL"} ${name}${detail !== undefined ? " " + JSON.stringify(detail) : ""}`);
+};
+
+/** Mean horizontal gradient energy per row of a clip — how sharp the edges in it are. Blur destroys
+ *  the hard boundaries of glyphs, so the same strip of rows measured with and without the backdrop
+ *  filter differs here even though both are the same content at the same scroll offset. A hash
+ *  comparison cannot be used: a vibrancy material dithers, so two captures of an untouched surface
+ *  are already not bit-identical. */
+/** Mean luminance of a clip — used to ask whether the band tints the column it sits over. A
+ *  backdrop-filter over a VIBRANT material is not the same operation as one over an opaque panel;
+ *  it can average the material toward a different tone and leave a visible band across the sidebar
+ *  even where there is no content under it to dissolve. */
+const MEANLUM = (b64) => `(async () => {
+  const img = new Image();
+  img.src = "data:image/png;base64," + ${JSON.stringify(b64)};
+  await img.decode();
+  const cv = document.createElement("canvas");
+  cv.width = img.width; cv.height = img.height;
+  cv.getContext("2d").drawImage(img, 0, 0);
+  const px = cv.getContext("2d").getImageData(0, 0, cv.width, cv.height).data;
+  let sum = 0;
+  for (let i = 0; i < px.length; i += 4) sum += 0.299 * px[i] + 0.587 * px[i + 1] + 0.114 * px[i + 2];
+  return +(sum / (px.length / 4)).toFixed(3);
+})()`;
+
+const SHARPNESS = (b64) => `(async () => {
+  const img = new Image();
+  img.src = "data:image/png;base64," + ${JSON.stringify(b64)};
+  await img.decode();
+  const cv = document.createElement("canvas");
+  cv.width = img.width; cv.height = img.height;
+  cv.getContext("2d").drawImage(img, 0, 0);
+  const px = cv.getContext("2d").getImageData(0, 0, cv.width, cv.height).data;
+  const lum = (i) => 0.299 * px[i] + 0.587 * px[i + 1] + 0.114 * px[i + 2];
+  let sum = 0, n = 0;
+  for (let y = 0; y < cv.height; y++) {
+    for (let x = 0; x < cv.width - 1; x++) {
+      const i = (y * cv.width + x) * 4;
+      sum += Math.abs(lum(i) - lum(i + 4)); n++;
+    }
+  }
+  return n ? +(sum / n).toFixed(4) : 0;
+})()`;
+
+async function main() {
+  for (const p of [CDP_PORT, SERVER_PORT]) {
+    if (!(await portFree(p))) throw new Error(`port ${p} is in use — refusing to run`);
+  }
+
+  const wrapper = path.join(scratch, "wrapper.mjs");
+  fs.writeFileSync(wrapper, [
+    'import { app } from "electron";',
+    'app.setPath("userData", process.env.LIVE_USER_DATA);',
+    "await import(process.env.LIVE_MAIN);",
+  ].join("\n"));
+  const electronBin = process.platform === "darwin"
+    ? path.join(repoRoot, "node_modules/.pnpm/electron@37.10.3/node_modules/electron/dist/Electron.app/Contents/MacOS/Electron")
+    : path.join(repoRoot, "apps/desktop/node_modules/.bin/electron");
+  electron = spawn(electronBin, [wrapper], {
+    env: {
+      ...process.env,
+      REALM_HOME: path.join(scratch, "home"),
+      REALM_ENABLE_FAKE_AGENT: "1",
+      REALM_PORT: String(SERVER_PORT),
+      REALM_DEVTOOLS_PORT: String(CDP_PORT),
+      REALM_SERVER_ENTRY: path.join(repoRoot, "apps/server/dist/main.js"),
+      LIVE_USER_DATA: path.join(scratch, "userData"),
+      LIVE_MAIN: path.join(repoRoot, "apps/desktop/out/main/index.js"),
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  electron.stderr.on("data", () => {}); electron.stdout.on("data", () => {});
+
+  const targets = () => fetch(`http://127.0.0.1:${CDP_PORT}/json/list`).then((r) => r.json()).catch(() => []);
+  const rendererTarget = await until(async () => (await targets()).find((t) => t.type === "page" && t.url.startsWith("file://")), 30000, "renderer target");
+  const c = cdp(rendererTarget.webSocketDebuggerUrl);
+  await c.ready;
+  await c.send("Runtime.enable");
+  await c.send("Page.enable");
+
+  await until(() => evalIn(c, `!!document.querySelector('.onboarding input:not([type=radio])')`), 20000, "onboarding");
+  await evalIn(c, `(() => {
+    const input = document.querySelector('.onboarding input:not([type=radio])');
+    const set = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value').set;
+    set.call(input, 'Live'); input.dispatchEvent(new Event('input', { bubbles: true }));
+    input.closest('form').requestSubmit();
+    return true; })()`);
+  await until(() => evalIn(c, `!!document.querySelector('.composer')`), 20000, "composer");
+
+  // Short viewport on purpose: it takes fewer sessions to overflow the list, and the fade only has a
+  // job once the list scrolls.
+  await c.send("Emulation.setDeviceMetricsOverride", { width: 1100, height: 620, deviceScaleFactor: 1, mobile: false });
+  await sleep(400);
+
+  // "New session" opens into the focused leaf, so each click pushes the previous session out into the
+  // SPACE group — one click, one more row.
+  for (let i = 0; i < 10; i++) {
+    const want = i + 2;
+    await evalIn(c, `(() => { document.querySelector('.new-row').click(); return true; })()`);
+    await until(() => evalIn(c, `document.querySelectorAll('.space-body .item').length >= ${want}`), 15000, `session ${want}`);
+  }
+  await sleep(400);
+
+  const overflow = await evalIn(c, `(() => {
+    const b = document.querySelector('.space-body');
+    return { scrollH: b.scrollHeight, clientH: b.clientHeight, rows: b.querySelectorAll('.item').length };
+  })()`);
+  check("the list actually overflows, so the fade has something to do", overflow.scrollH > overflow.clientH + 40, overflow);
+
+  /* ── 1. Clearance: scrolled to the end, the last row is clear of the band ────────────────── */
+  const clearance = await evalIn(c, `(() => {
+    const b = document.querySelector('.space-body');
+    b.scrollTop = b.scrollHeight;
+    const rows = [...b.querySelectorAll('.item')];
+    const last = rows[rows.length - 1].getBoundingClientRect();
+    const fade = document.querySelector('.space-fade').getBoundingClientRect();
+    return { lastBottom: Math.round(last.bottom), lastTop: Math.round(last.top), fadeTop: Math.round(fade.top),
+             gap: Math.round(fade.top - last.bottom), fadeH: Math.round(fade.height) };
+  })()`);
+  await sleep(250);
+  check("scrolled to the end, the last session sits entirely above the fade band",
+    clearance.gap >= 0, clearance);
+
+  // The mutant: take the scroller's bottom padding away, which is the only thing buying that gap.
+  await evalIn(c, `(() => {
+    const st = document.createElement('style'); st.id = 'mutant-pad';
+    st.textContent = '.space-body { padding-bottom: 0 !important; }';
+    document.head.appendChild(st); return true; })()`);
+  await sleep(200);
+  const mutantClearance = await evalIn(c, `(() => {
+    const b = document.querySelector('.space-body');
+    b.scrollTop = b.scrollHeight;
+    const rows = [...b.querySelectorAll('.item')];
+    const last = rows[rows.length - 1].getBoundingClientRect();
+    const fade = document.querySelector('.space-fade').getBoundingClientRect();
+    return { gap: Math.round(fade.top - last.bottom) };
+  })()`);
+  check("the mutant reproduces the bug (no bottom padding ⇒ the last session ends under the blur)",
+    mutantClearance.gap < 0, { ...mutantClearance, withPadding: clearance.gap });
+  await evalIn(c, `(() => { document.getElementById('mutant-pad').remove(); return true; })()`);
+  await sleep(200);
+
+  /* ── 2. The blur composites over the vibrancy material ───────────────────────────────────── */
+  // Park the scroll mid-list so real rows are under the band, then measure the SAME pixels with the
+  // filter on and off. Same content, same offset — the only variable is the backdrop-filter.
+  const band = await evalIn(c, `(() => {
+    const b = document.querySelector('.space-body');
+    // Halfway down the SCROLLABLE range, not half the scroll height — the latter clamps to the end,
+    // where the bottom padding guarantees there are no rows under the band at all and the measurement
+    // below would be reading the empty gutter.
+    b.scrollTop = Math.round((b.scrollHeight - b.clientHeight) / 2);
+    const f = document.querySelector('.space-fade').getBoundingClientRect();
+    const s = b.getBoundingClientRect();
+    // The band's fully-blurred lower part, clipped to the scroller so the measurement never strays
+    // into the gutter below it.
+    const top = Math.round(f.top + f.height * 0.4), bottom = Math.round(Math.min(f.bottom, s.bottom));
+    const covered = [...b.querySelectorAll('.item')].filter((r) => {
+      const q = r.getBoundingClientRect(); return q.bottom > top && q.top < bottom;
+    }).length;
+    return { x: Math.round(s.left), y: top, width: Math.round(s.width), height: bottom - top, covered };
+  })()`);
+  check("real rows are under the measured strip, so the comparison is not vacuous", band.covered > 0, { covered: band.covered, h: band.height });
+
+  const clip = { x: band.x, y: band.y, width: band.width, height: band.height, scale: 1 };
+  await sleep(300);
+  const blurredShot = (await c.send("Page.captureScreenshot", { format: "png", clip })).data;
+  const blurred = await evalIn(c, SHARPNESS(blurredShot));
+
+  await evalIn(c, `(() => {
+    const st = document.createElement('style'); st.id = 'mutant-blur';
+    st.textContent = '.space-fade::before, .space-fade::after { backdrop-filter: none !important; -webkit-backdrop-filter: none !important; }';
+    document.head.appendChild(st); return true; })()`);
+  await sleep(350);
+  const sharpShot = (await c.send("Page.captureScreenshot", { format: "png", clip })).data;
+  const sharp = await evalIn(c, SHARPNESS(sharpShot));
+  await evalIn(c, `(() => { document.getElementById('mutant-blur').remove(); return true; })()`);
+
+  check("the band really blurs the rows under it — over macOS vibrancy, not just over an opaque panel",
+    blurred < sharp * 0.7, { blurred, sharp, ratio: +(blurred / sharp).toFixed(3) });
+
+  /* ── 3. The band is invisible where it has nothing to dissolve ──────────────────────────── */
+  // Scrolled to the end, the band sits over the bottom padding — empty column. If a blur over this
+  // material tints what it samples, that shows up here as a tonal stripe across the sidebar with no
+  // content under it, which is a seam rather than a dissolve.
+  const gutter = await evalIn(c, `(() => {
+    const b = document.querySelector('.space-body');
+    b.scrollTop = b.scrollHeight;
+    const f = document.querySelector('.space-fade').getBoundingClientRect();
+    const s = b.getBoundingClientRect();
+    const inBand = { x: Math.round(s.left), y: Math.round(f.top + 20), width: Math.round(s.width), height: 16 };
+    // An equal slab of untouched gutter directly above the band, between the last row and the ramp.
+    return { inBand, above: { ...inBand, y: Math.round(f.top - 18) } };
+  })()`);
+  await sleep(300);
+  const bandLum = await evalIn(c, MEANLUM((await c.send("Page.captureScreenshot", { format: "png", clip: { ...gutter.inBand, scale: 1 } })).data));
+  const aboveLum = await evalIn(c, MEANLUM((await c.send("Page.captureScreenshot", { format: "png", clip: { ...gutter.above, scale: 1 } })).data));
+  check("over empty gutter the band leaves no tonal seam — it dissolves content, it does not paint a stripe",
+    Math.abs(bandLum - aboveLum) < 2, { inBand: bandLum, above: aboveLum, delta: +(bandLum - aboveLum).toFixed(3) });
+
+  await sleep(300);
+  const sidebar = await c.send("Page.captureScreenshot", { format: "png", clip: { x: 0, y: 0, width: 280, height: 620, scale: 2 } });
+  for (const [tag, data] of [["band-blurred", blurredShot], ["band-sharp", sharpShot], ["sidebar", sidebar.data]]) {
+    const out = path.join(os.tmpdir(), `realm-sidebar-fade-${tag}.png`);
+    fs.writeFileSync(out, Buffer.from(data, "base64"));
+    console.log(`SCREENSHOT ${tag} ${out}`);
+  }
+
+  const errs = c.events.filter((e) => !e.includes("Autofill"));
+  check("no renderer console errors", errs.length === 0, errs.slice(0, 5));
+  c.close();
+}
+
+main()
+  .catch((e) => { console.error("ERROR", e.message); process.exitCode = 1; })
+  .finally(() => {
+    electron?.kill("SIGTERM");
+    setTimeout(() => { electron?.kill("SIGKILL"); fs.rmSync(scratch, { recursive: true, force: true }); process.exit(process.exitCode ?? 0); }, 1200);
+  });

--- a/apps/desktop/scripts/sidebar-marks-live.mjs
+++ b/apps/desktop/scripts/sidebar-marks-live.mjs
@@ -1,0 +1,319 @@
+/**
+ * Live check for the two marks a sidebar session row wears (run with: node apps/desktop/scripts/sidebar-marks-live.mjs)
+ *
+ * Boots the REAL app on a scratch REALM_HOME and proves three things jsdom cannot, because all three
+ * are about paint and layout rather than about markup:
+ *
+ *   1. The status ring is actually PAINTED. It is a `::after` over the macOS vibrancy material, drawn
+ *      with color-mix against a token — a jsdom test can only see that the rule exists.
+ *   2. It is still painted under prefers-reduced-motion. The global reduced-motion block uses `*`,
+ *      which does not match pseudo-elements, so that carve-out is easy to lose and impossible to
+ *      notice anywhere else; a running session that reads as idle is the whole failure.
+ *   3. The row's trailing marks stay a pair. The dot and the glyph both used to take
+ *      `margin-left: auto`, and two auto margins SHARE the free space — so the dot was pushed to the
+ *      middle of whatever the title left over while the glyph went on to the row's end, tearing the
+ *      two apart by an amount that depended on the title's length. Only real layout can see that.
+ *
+ * Each measurement is paired with a mutant that reproduces the bug it pins, so a check that has
+ * quietly stopped measuring anything fails instead of passing.
+ *
+ * Ports: env-overridable. Touches only a scratch dir; kills only the process it started.
+ */
+import { spawn } from "node:child_process";
+import { connect } from "node:net";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
+const CDP_PORT = Number(process.env.LIVE_CDP_PORT ?? 9338), SERVER_PORT = Number(process.env.LIVE_SERVER_PORT ?? 8904);
+const scratch = fs.mkdtempSync(path.join(os.tmpdir(), "realm-sidebar-marks-"));
+let electron = null;
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+async function portFree(port) {
+  return new Promise((resolve) => {
+    const s = connect({ port, host: "127.0.0.1" });
+    s.once("connect", () => { s.destroy(); resolve(false); });
+    s.once("error", () => resolve(true));
+  });
+}
+
+async function until(fn, ms, tag) {
+  const t0 = Date.now();
+  for (;;) {
+    const v = await fn();
+    if (v) return v;
+    if (Date.now() - t0 > ms) throw new Error(`timeout:${tag}`);
+    await sleep(150);
+  }
+}
+
+function cdp(wsUrl) {
+  const ws = new WebSocket(wsUrl);
+  let id = 0;
+  const pending = new Map();
+  const events = [];
+  const ready = new Promise((res) => ws.addEventListener("open", res));
+  ws.addEventListener("message", (m) => {
+    const msg = JSON.parse(m.data);
+    if (msg.id !== undefined) pending.get(msg.id)?.(msg);
+    else if (msg.method === "Runtime.consoleAPICalled" && msg.params.type === "error") {
+      events.push(msg.params.args.map((a) => a.value ?? a.description ?? "").join(" "));
+    }
+  });
+  return {
+    ready, events,
+    send: (method, params) => new Promise((res, rej) => {
+      const i = ++id;
+      pending.set(i, (msg) => (msg.error ? rej(new Error(msg.error.message)) : res(msg.result)));
+      ws.send(JSON.stringify({ id: i, method, params }));
+    }),
+    close: () => ws.close(),
+  };
+}
+
+async function evalIn(c, expr) {
+  const r = await c.send("Runtime.evaluate", { expression: expr, awaitPromise: true, returnByValue: true });
+  if (r.exceptionDetails) throw new Error(`page exception: ${r.exceptionDetails.exception?.description ?? r.exceptionDetails.text}`);
+  return r.result.value;
+}
+
+const check = (name, cond, detail) => {
+  if (!cond) process.exitCode = 1;
+  console.log(`${cond ? "PASS" : "FAIL"} ${name}${detail !== undefined ? " " + JSON.stringify(detail) : ""}`);
+};
+
+/** Pixels in a clip that differ from its own corner (the row ground) by more than a hair of
+ *  luminance — "how much mark is on screen here", which is what the ring adds and the mutant removes.
+ *  Counting ink rather than comparing hashes because a backdrop material dithers: two screenshots of
+ *  an unchanged vibrant surface are not bit-identical, and a hash would call that a difference. */
+const INK = (b64) => `(async () => {
+  const img = new Image();
+  img.src = "data:image/png;base64," + ${JSON.stringify(b64)};
+  await img.decode();
+  const cv = document.createElement("canvas");
+  cv.width = img.width; cv.height = img.height;
+  const ctx = cv.getContext("2d");
+  ctx.drawImage(img, 0, 0);
+  const px = ctx.getImageData(0, 0, cv.width, cv.height).data;
+  const lum = (i) => 0.299 * px[i] + 0.587 * px[i + 1] + 0.114 * px[i + 2];
+  const ground = lum(0);
+  let ink = 0;
+  for (let i = 0; i < px.length; i += 4) if (Math.abs(lum(i) - ground) > 6) ink++;
+  return ink;
+})()`;
+
+async function main() {
+  for (const p of [CDP_PORT, SERVER_PORT]) {
+    if (!(await portFree(p))) throw new Error(`port ${p} is in use — refusing to run`);
+  }
+
+  const wrapper = path.join(scratch, "wrapper.mjs");
+  fs.writeFileSync(wrapper, [
+    'import { app } from "electron";',
+    'app.setPath("userData", process.env.LIVE_USER_DATA);',
+    "await import(process.env.LIVE_MAIN);",
+  ].join("\n"));
+  const electronBin = process.platform === "darwin"
+    ? path.join(repoRoot, "node_modules/.pnpm/electron@37.10.3/node_modules/electron/dist/Electron.app/Contents/MacOS/Electron")
+    : path.join(repoRoot, "apps/desktop/node_modules/.bin/electron");
+  electron = spawn(electronBin, [wrapper], {
+    env: {
+      ...process.env,
+      REALM_HOME: path.join(scratch, "home"),
+      REALM_ENABLE_FAKE_AGENT: "1",
+      REALM_PORT: String(SERVER_PORT),
+      REALM_DEVTOOLS_PORT: String(CDP_PORT),
+      REALM_SERVER_ENTRY: path.join(repoRoot, "apps/server/dist/main.js"),
+      LIVE_USER_DATA: path.join(scratch, "userData"),
+      LIVE_MAIN: path.join(repoRoot, "apps/desktop/out/main/index.js"),
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  electron.stderr.on("data", () => {}); electron.stdout.on("data", () => {});
+
+  const targets = () => fetch(`http://127.0.0.1:${CDP_PORT}/json/list`).then((r) => r.json()).catch(() => []);
+  const rendererTarget = await until(async () => (await targets()).find((t) => t.type === "page" && t.url.startsWith("file://")), 30000, "renderer target");
+  const c = cdp(rendererTarget.webSocketDebuggerUrl);
+  await c.ready;
+  await c.send("Runtime.enable");
+  await c.send("Page.enable");
+
+  await until(() => evalIn(c, `!!document.querySelector('.onboarding input:not([type=radio])')`), 20000, "onboarding");
+  await evalIn(c, `(() => {
+    const input = document.querySelector('.onboarding input:not([type=radio])');
+    const set = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value').set;
+    set.call(input, 'Live'); input.dispatchEvent(new Event('input', { bubbles: true }));
+    input.closest('form').requestSubmit();
+    return true; })()`);
+  await until(() => evalIn(c, `!!document.querySelector('.composer')`), 20000, "composer");
+
+  // A window wide enough that the sidebar is at its full 280px and the panes split cleanly.
+  await c.send("Emulation.setDeviceMetricsOverride", { width: 1200, height: 820, deviceScaleFactor: 1, mobile: false });
+  await sleep(400);
+
+  /* ── A real two-pane split, made the way a user makes one ────────────────────────────────────
+     "New session" opens into the focused leaf, which pushes the first session out of the OPEN group;
+     splitting right then leaves an empty focused leaf, and clicking the first session's SPACE row
+     opens it there. The result is a two-way row split with two OPEN rows — the layout the glyph is
+     for, reached through the same gestures rather than by writing a layout into the store. */
+  await evalIn(c, `(() => { document.querySelector('.new-row').click(); return true; })()`);
+  await until(() => evalIn(c, `document.querySelectorAll('.item-list .item').length >= 2`), 15000, "a second session");
+  // Split right. The bar collapses its actions into a ⋯ menu below a threshold width and offers them
+  // inline above it, so take whichever this pane is showing rather than assuming one.
+  await evalIn(c, `(() => {
+    const inline = document.querySelector('.panel-bar button[aria-label^="Split"][aria-label$="right"]');
+    if (inline) { inline.click(); return true; }
+    document.querySelector('.panel-bar button[aria-label^="Pane menu"]').click();
+    return true; })()`);
+  await evalIn(c, `(() => {
+    const it = [...document.querySelectorAll('[role="menuitem"]')].find((m) => m.textContent.startsWith('Split right'));
+    if (it) it.click();
+    return true; })()`);
+  await until(() => evalIn(c, `document.querySelectorAll('.panehost .panel').length === 2`), 15000, "two panes");
+  // Sessions are auto-titled alike, so the first one is found by its ROLE in the sidebar — the only
+  // row in the SPACE group, i.e. the one row with no glyph — not by its text.
+  await evalIn(c, `(() => {
+    const row = [...document.querySelectorAll('.item-list .item-row')].find((r) => !r.querySelector('.item-glyph'));
+    row.click(); return true; })()`);
+  await until(() => evalIn(c, `document.querySelectorAll('.item-glyph').length === 2`), 15000, "two glyphs");
+  await sleep(300);
+
+  /* ── 1. The split glyph draws the split it is describing ─────────────────────────────────── */
+  const glyphs = await evalIn(c, `(() => {
+    return [...document.querySelectorAll('.item-glyph')].map((g) => {
+      const box = g.getBoundingClientRect();
+      const bars = [...g.querySelectorAll('span')].map((s) => {
+        const r = s.getBoundingClientRect();
+        return { w: +r.width.toFixed(2), h: +r.height.toFixed(2), on: s.hasAttribute('data-on') };
+      });
+      return { dir: g.dataset.dir, w: Math.round(box.width), h: Math.round(box.height), bars };
+    });
+  })()`);
+  check("both open rows draw a two-bar glyph on the split's own axis", glyphs.length === 2
+    && glyphs.every((g) => g.dir === "row" && g.bars.length === 2), glyphs.map((g) => ({ dir: g.dir, bars: g.bars.length })));
+  check("the two rows light different bars — the mark distinguishes the panes",
+    glyphs[0]?.bars.findIndex((b) => b.on) !== glyphs[1]?.bars.findIndex((b) => b.on),
+    glyphs.map((g) => g.bars.findIndex((b) => b.on)));
+  // Legibility, the reason the mark grew from 10px to 12px and dropped the second axis: a bar under
+  // ~4px reads as a speck. Two slots in the old 2x2 were 4.5px cells; these are 5.5px bars.
+  const thinnest = Math.min(...glyphs.flatMap((g) => g.bars.map((b) => b.w)));
+  check("every bar is at least 5px across", thinnest >= 5, { thinnest, box: glyphs[0]?.w });
+
+  /* ── 2. The trailing marks do not collide ────────────────────────────────────────────────── */
+  // A status has to exist for a dot to render, so drive one real turn through the scripted adapter.
+  await evalIn(c, `(() => {
+    const el = document.querySelector('.composer-input');
+    const set = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value').set;
+    set.call(el, 'hello'); el.dispatchEvent(new Event('input', { bubbles: true }));
+    document.querySelector('.composer-send').click(); return true; })()`);
+  const dotSel = `.item[data-active] .item-status, .item-status`;
+  await until(() => evalIn(c, `!!document.querySelector(${JSON.stringify(dotSel)})`), 20000, "a status dot");
+
+  const marks = await evalIn(c, `(() => {
+    const dot = document.querySelector('.item-row:has(.item-status):has(.item-glyph)');
+    if (!dot) return null;
+    const row = dot.getBoundingClientRect();
+    const s = dot.querySelector('.item-status').getBoundingClientRect();
+    const g = dot.querySelector('.item-glyph').getBoundingClientRect();
+    const t = dot.querySelector('.item-title').getBoundingClientRect();
+    return { gap: +(g.left - s.right).toFixed(2), titleToDot: +(s.left - t.right).toFixed(2),
+             glyphToRowEnd: +(row.right - g.right).toFixed(2), rowW: Math.round(row.width) };
+  })()`);
+  check("a row that is both running and open lays its dot and glyph out as a spaced pair at the row's end",
+    marks !== null && marks.gap > 6 && marks.gap < 14 && marks.titleToDot > 6 && marks.glyphToRowEnd < 12, marks);
+  // The mutant: put `margin-left: auto` back on both marks, exactly as it was. Two auto margins in one
+  // flex row SHARE the free space, so the dot is pushed to the middle of whatever the title left over
+  // and the glyph carries on to the end — the pair is torn across the row, and where the dot lands is
+  // a function of the title's length, so no two rows agree on it.
+  await evalIn(c, `(() => {
+    const st = document.createElement('style'); st.id = 'mutant-auto';
+    st.textContent = '.item-status, .item-glyph { margin-left: auto !important; } .item-title { flex: none !important; }';
+    document.head.appendChild(st); return true; })()`);
+  await sleep(150);
+  const mutantMarks = await evalIn(c, `(() => {
+    const dot = document.querySelector('.item-row:has(.item-status):has(.item-glyph)');
+    const s = dot.querySelector('.item-status').getBoundingClientRect();
+    const g = dot.querySelector('.item-glyph').getBoundingClientRect();
+    return { gap: +(g.left - s.right).toFixed(2) };
+  })()`);
+  check("the mutant reproduces the bug (both marks back on margin-left:auto ⇒ the dot floats off into the row)",
+    mutantMarks.gap > 20, { ...mutantMarks, fixed: marks.gap });
+  await evalIn(c, `(() => { document.getElementById('mutant-auto').remove(); return true; })()`);
+
+  /* ── 3. The status ring is painted, with and without motion ──────────────────────────────── */
+  const dotRect = await evalIn(c, `(() => {
+    const d = document.querySelector('.item-row:has(.item-glyph) .item-status');
+    d.setAttribute('data-status', 'idle');
+    const r = d.getBoundingClientRect();
+    // A clip wide enough for the 12px halo and no wider — the title's ellipsis sits 10px to the left.
+    return { x: Math.round(r.left) - 5, y: Math.round(r.top) - 5, width: Math.round(r.width) + 10, height: Math.round(r.height) + 10 };
+  })()`);
+  const inkOf = async (status) => {
+    await evalIn(c, `(() => { document.querySelector('.item-row:has(.item-glyph) .item-status').setAttribute('data-status', ${JSON.stringify(status)}); return true; })()`);
+    await sleep(250);
+    const shot = await c.send("Page.captureScreenshot", { format: "png", clip: { ...dotRect, scale: 1 } });
+    return { ink: await evalIn(c, INK(shot.data)), data: shot.data };
+  };
+
+  const idle = await inkOf("idle");
+  const running = await inkOf("running");
+  check("a running dot puts more mark on screen than an idle one — the ring is really painted over the vibrancy",
+    running.ink > idle.ink * 1.25, { idle: idle.ink, running: running.ink });
+
+  // The mutant: take the ring away and leave the core. This is the OLD indicator — a plain dot whose
+  // only difference from idle was its colour and a brightness throb. If ink does not collapse to
+  // idle's, the measurement above was reading something other than the ring.
+  await evalIn(c, `(() => {
+    const st = document.createElement('style'); st.id = 'mutant-ring';
+    st.textContent = '.status-dot::after { display: none !important; }';
+    document.head.appendChild(st); return true; })()`);
+  const ringless = await inkOf("running");
+  check("the mutant reproduces the old indicator (no ring ⇒ a running dot is the same mark as an idle one)",
+    ringless.ink < idle.ink * 1.25, { idle: idle.ink, ringless: ringless.ink });
+  await evalIn(c, `(() => { document.getElementById('mutant-ring').remove(); return true; })()`);
+
+  /* prefers-reduced-motion: the global block strips animation with `*`, which does not match
+     pseudo-elements. The ring must lose its ping and keep its halo — a running session that reads as
+     idle for anyone with the preference on is the failure this exists to catch. */
+  await c.send("Emulation.setEmulatedMedia", { features: [{ name: "prefers-reduced-motion", value: "reduce" }] });
+  await sleep(300);
+  const reducedIdle = await inkOf("idle");
+  const reducedRunning = await inkOf("running");
+  check("with prefers-reduced-motion the ring is still painted — running does not collapse to idle",
+    reducedRunning.ink > reducedIdle.ink * 1.25, { idle: reducedIdle.ink, running: reducedRunning.ink });
+  // …and nothing is moving: two frames half a second apart have to hold the same amount of ink.
+  const again = await c.send("Page.captureScreenshot", { format: "png", clip: { ...dotRect, scale: 1 } });
+  const againInk = await evalIn(c, INK(again.data));
+  check("and it is genuinely still — no ping survives the preference",
+    Math.abs(againInk - reducedRunning.ink) <= 2, { first: reducedRunning.ink, later: againInk });
+  await c.send("Emulation.setEmulatedMedia", { features: [] });
+
+  // The artifacts are captured again at 8x rather than reusing the measured frames: the ink counts
+  // above are in CSS pixels and the clip is 16 of them square, which is nothing to look at.
+  for (const status of ["idle", "running", "waiting_permission"]) {
+    await evalIn(c, `(() => { document.querySelector('.item-row:has(.item-glyph) .item-status').setAttribute('data-status', ${JSON.stringify(status)}); return true; })()`);
+    await sleep(200);
+    const big = await c.send("Page.captureScreenshot", { format: "png", clip: { ...dotRect, scale: 8 } });
+    const out = path.join(os.tmpdir(), `realm-sidebar-mark-${status}.png`);
+    fs.writeFileSync(out, Buffer.from(big.data, "base64"));
+    console.log(`SCREENSHOT ${status} ${out}`);
+  }
+  const sidebar = await c.send("Page.captureScreenshot", { format: "png", clip: { x: 0, y: 0, width: 280, height: 820, scale: 2 } });
+  const sidebarOut = path.join(os.tmpdir(), "realm-sidebar-marks.png");
+  fs.writeFileSync(sidebarOut, Buffer.from(sidebar.data, "base64"));
+  console.log(`SCREENSHOT sidebar ${sidebarOut}`);
+
+  const errs = c.events.filter((e) => !e.includes("Autofill"));
+  check("no renderer console errors", errs.length === 0, errs.slice(0, 5));
+  c.close();
+}
+
+main()
+  .catch((e) => { console.error("ERROR", e.message); process.exitCode = 1; })
+  .finally(() => {
+    electron?.kill("SIGTERM");
+    setTimeout(() => { electron?.kill("SIGKILL"); fs.rmSync(scratch, { recursive: true, force: true }); process.exit(process.exitCode ?? 0); }, 1200);
+  });

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -91,6 +91,11 @@ app.commandLine.appendSwitch("disable-backgrounding-occluded-windows");
 async function createWindow(info: { port: number; home: string }) {
   const win = new BrowserWindow({
     width: 1400, height: 900, minWidth: 900, minHeight: 600,
+    // y:14 centres the ~14px lights in a 40px strip, and the renderer keeps every strip they can land
+    // in at 40px for exactly that reason: .sb-head with the sidebar open, and with it collapsed the
+    // first pane's .panel-bar (or the group bar, which is raised to 40px in that one state). One
+    // placement serves both, so nothing here has to be moved at runtime when the sidebar collapses —
+    // but shortening any of those strips leaves the lights sitting off-centre in that state.
     titleBarStyle: "hiddenInset", trafficLightPosition: { x: 12, y: 14 },
     // Ara refresh §5: macOS gets sidebar vibrancy behind a fully transparent window paint; the
     // renderer keeps every surface EXCEPT the sidebar opaque, so only the sidebar column shows the

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -23,12 +23,18 @@ import "./panes";
 /**
  * The sidebar column and the content beside it — or, collapsed, a top rail and the content below it.
  *
- * The two states are one flex container that changes axis (`.app[data-sidebar-collapsed]` goes
- * column), not two layouts. Collapsed, the rail exists for exactly two reasons: it holds the toggle,
- * and it keeps the macOS traffic lights off the first pane's panel bar — with the 280px sidebar gone
- * there is nothing else between them and pane chrome, and they would land on top of a pane title.
- * That is why collapsing buys back 280px of width at the cost of 38px of height rather than being
- * free: the alternative is lights sitting on someone's content.
+ * The two states are one row, not two layouts: collapsed, the 280px column is gone and the
+ * content takes the whole window. What is left to place is the macOS traffic lights, which have no
+ * sidebar to sit in any more and would otherwise land on the first pane's title.
+ *
+ * They land on the first pane's BAR, and the corner that holds them is an overlay — absolutely
+ * positioned, no height of its own — so collapsing buys back 280px of width and costs nothing. It
+ * used to cost a 38px full-width rail whose only content was this one button, which is a strip of
+ * chrome across every pane forever in exchange for a corner. The strip beneath the lights reserves
+ * their width instead (see --corner-w in styles.css).
+ *
+ * The corner is rendered AFTER main and carries a z-index: panes are positioned elements, so DOM
+ * order alone would put the first pane's bar on top of it.
  *
  * Lives under the store provider so it can read `sidebarCollapsed`. Exported for the shell tests.
  */
@@ -36,8 +42,9 @@ export function AppShell() {
   const collapsed = useApp((s) => s.sidebarCollapsed);
   return (
     <div className="app" data-sidebar-collapsed={collapsed || undefined}>
-      {collapsed ? <div className="sb-rail"><SidebarToggle /></div> : <Sidebar />}
+      {!collapsed && <Sidebar />}
       <main className="main"><Main /></main>
+      {collapsed && <div className="sb-corner"><SidebarToggle /></div>}
     </div>
   );
 }

--- a/apps/desktop/src/renderer/src/components/PaneHost.tsx
+++ b/apps/desktop/src/renderer/src/components/PaneHost.tsx
@@ -1,6 +1,6 @@
 import { Fragment, useEffect, useRef, useState, type DragEvent as ReactDragEvent, type JSX } from "react";
 import { Panel, PanelGroup, PanelResizeHandle, type ImperativePanelGroupHandle } from "react-resizable-panels";
-import { findLeaf, type Item, type Layout, type LayoutSplit } from "@realm/contracts";
+import { findLeaf, firstLeaf, type Item, type Layout, type LayoutSplit } from "@realm/contracts";
 import type { DropEdge } from "../state/store";
 import { PanelBar } from "./PanelBar";
 import { PaneFor } from "../panes/registry";
@@ -111,13 +111,19 @@ export function PaneHost(p: PaneHostProps) {
   // A focused pane renders ALONE — not a `display:none` on its siblings, which would keep every other
   // pane mounted and (for terminals and browser views) fighting for size behind the one on screen.
   const zoomed = p.zoomedLeafId ? findLeaf(p.layout, p.zoomedLeafId) : null;
-  return <div className="panehost" data-zoomed={zoomed ? true : undefined}>{renderNode(zoomed ?? p.layout)}</div>;
+  const root = zoomed ?? p.layout;
+  // The leaf at the host's top-left, which is the first one depth-first for both split directions.
+  // With the sidebar collapsed its bar is what sits under the macOS traffic lights, and it is the
+  // only pane that has to leave room for them — a fact about where a pane IS, which CSS cannot ask.
+  const firstLeafId = firstLeaf(root).id;
+  return <div className="panehost" data-zoomed={zoomed ? true : undefined}>{renderNode(root)}</div>;
 
   function renderNode(n: Layout): JSX.Element {
     if (n.type === "leaf") {
       const item = n.itemId ? byId.get(n.itemId) ?? null : null;
       return (
         <div className="panel" data-leaf-id={n.id} data-focused={n.id === p.focusedLeafId || undefined}
+          data-first-leaf={n.id === firstLeafId || undefined}
           data-empty={!item || undefined} onPointerDownCapture={() => p.onFocus(n.id)}>
           {item && <PanelBar item={item} leafId={n.id} onSplit={(dir) => p.onSplit(n.id, dir)} onClose={() => p.onClose(item.id)}
             zoomed={n.id === p.zoomedLeafId} onZoom={p.onZoom ? () => p.onZoom!(n.id) : undefined} onUnzoom={p.onUnzoom} />}

--- a/apps/desktop/src/renderer/src/components/sidebar/ItemList.tsx
+++ b/apps/desktop/src/renderer/src/components/sidebar/ItemList.tsx
@@ -125,7 +125,7 @@ export function ItemList({ items, variant, layout: groupLayout }: {
                 <button className="item-shelf" aria-label={`${variant === "archived" ? "Unarchive" : "Archive"} ${it.title}`}
                   title={variant === "archived" ? "Unarchive" : "Archive"}
                   onClick={() => run(() => archiveItem(it.id, variant !== "archived"))}>
-                  <Icon name={variant === "archived" ? "unarchive" : "archive"} size={13} />
+                  <Icon name={variant === "archived" ? "unarchive" : "archive"} size={12} />
                 </button>
               )}
               {variant === "open" && (

--- a/apps/desktop/src/renderer/src/components/sidebar/ItemList.tsx
+++ b/apps/desktop/src/renderer/src/components/sidebar/ItemList.tsx
@@ -7,50 +7,44 @@ import { useItemContextMenu } from "./ItemContextMenu";
 
 const STATUS_LABEL = { idle: "idle", running: "running", waiting_permission: "needs permission", error: "error", ended: "ended" } as const;
 
-/** Depth-first leaves of a layout (including empty ones) — used only as a fallback when deriving the
- *  glyph's approximate quadrant on deep/irregular trees. */
-function leavesOf(l: Layout): Layout[] {
-  return l.type === "leaf" ? [l] : l.children.flatMap(leavesOf);
-}
+/** Past four the bars fall under a device pixel at the glyph's 12px and it reads as a smudge rather
+ *  than as slots. gridPreset's widest split is three, so nothing reachable is turned away today. */
+const MAX_GLYPH_SLOTS = 4;
 
 /**
- * A glanceable "which pane is this in" hint for the sidebar's 2x2 glyph — deliberately approximate, not a
- * faithful map of the layout. For the common case (the layout root is a two-way split), returns which side
- * of that split holds the item: 0 for the first child's subtree, 1 for the second. The caller pairs this
- * with the split's direction to light a whole column (row split) or row (col split) of the glyph.
- * For anything else — a single leaf (no split at all), or a root with more than two children — falls back
- * to the item's position in depth-first leaf order, modulo 4, so every layout still gets *some* cell lit.
- * Returns null only when there's no split at all, or the item isn't open anywhere in the tree.
+ * How many slots the layout's top-level split has, which one holds this item, and which way the
+ * split runs — the three facts the sidebar's glyph draws.
+ *
+ * Only the TOP level is read, and that is the design rather than a shortcut: the glyph is 12px wide,
+ * a nested tree drawn into it is mush, and "which half am I in" is the question a row in a split is
+ * actually asked. So a two-way root answers by which child's SUBTREE holds the item, never by
+ * depth-first leaf order — an item three levels down the first child is still in the first half.
+ *
+ * Returns null whenever there is nothing it can say truthfully: no split at all, the item is not
+ * open in this tree, or the root has more slots than the glyph can draw. What used to fill that gap
+ * was depth-first leaf index modulo 4, which was not an approximation but a wrong answer — under a
+ * three-column layout (gridPreset makes them, and the command palette offers them) a pane at the far
+ * right of a single row lit the bottom-left quadrant of a grid that had no bottom row. The glyph is
+ * read by someone who cannot otherwise tell two rows apart, so pointing them at the wrong pane costs
+ * more than saying nothing.
  */
-export function leafPositionOf(layout: Layout, itemId: string): 0 | 1 | 2 | 3 | null {
-  if (layout.type === "leaf") return null;
-  if (layout.children.length === 2) {
-    const idx = layout.children.findIndex((c) => allItems(c).includes(itemId));
-    if (idx === 0 || idx === 1) return idx;
-  }
-  const leaves = leavesOf(layout);
-  const idx = leaves.findIndex((l) => l.type === "leaf" && l.itemId === itemId);
-  return idx === -1 ? null : ((idx % 4) as 0 | 1 | 2 | 3);
+export function paneSlotOf(layout: Layout, itemId: string): { index: number; count: number; dir: "row" | "col" } | null {
+  if (layout.type !== "split") return null;
+  const count = layout.children.length;
+  if (count < 2 || count > MAX_GLYPH_SLOTS) return null;
+  const index = layout.children.findIndex((c) => allItems(c).includes(itemId));
+  return index === -1 ? null : { index, count, dir: layout.dir };
 }
 
-/** Which of the glyph's 4 cells (row-major: 0 top-left, 1 top-right, 2 bottom-left, 3 bottom-right) get
- *  data-on, given leafPositionOf's resolved position and the layout's shape. A two-way split root lights a
- *  whole column (row split) or row (col split); anything else lights just the single resolved cell. */
-function glyphCellsOn(layout: Layout, pos: 0 | 1 | 2 | 3): number[] {
-  if (layout.type === "split" && layout.children.length === 2) {
-    if (layout.dir === "row") return pos === 0 ? [0, 2] : [1, 3];
-    return pos === 0 ? [0, 1] : [2, 3];
-  }
-  return [pos];
-}
-
+/** One bar per slot of the top-level split, laid out along that split's own axis, with this item's
+ *  slot lit. The bar count and direction come from the layout, so the mark is a small picture of the
+ *  arrangement rather than a fixed grid the arrangement has to be squeezed into. */
 export function ItemGlyph({ layout, itemId }: { layout: Layout; itemId: string }) {
-  const pos = leafPositionOf(layout, itemId);
-  if (pos === null) return null;
-  const on = new Set(glyphCellsOn(layout, pos));
+  const slot = paneSlotOf(layout, itemId);
+  if (!slot) return null;
   return (
-    <span className="item-glyph" aria-hidden="true">
-      {[0, 1, 2, 3].map((i) => <span key={i} data-on={on.has(i) || undefined} />)}
+    <span className="item-glyph" data-dir={slot.dir} aria-hidden="true">
+      {Array.from({ length: slot.count }, (_, i) => <span key={i} data-on={i === slot.index || undefined} />)}
     </span>
   );
 }

--- a/apps/desktop/src/renderer/src/components/sidebar/SidebarToggle.tsx
+++ b/apps/desktop/src/renderer/src/components/sidebar/SidebarToggle.tsx
@@ -17,7 +17,7 @@ export function SidebarToggle() {
   return (
     <button className="sb-toggle" aria-label={collapsed ? "Show sidebar (⌘B)" : "Hide sidebar (⌘B)"}
       aria-expanded={!collapsed} onClick={() => run(() => toggleSidebar())}>
-      <Icon name="sidebar" size={16} />
+      <Icon name="sidebar" size={14} />
     </button>
   );
 }

--- a/apps/desktop/src/renderer/src/components/sidebar/SpaceHeader.tsx
+++ b/apps/desktop/src/renderer/src/components/sidebar/SpaceHeader.tsx
@@ -34,7 +34,7 @@ export function SpaceHeader({ space }: { space: Space }) {
             second door to the space page, which the title button beside it already is. */}
         {profile && <button className="pill" title="Open profile" onClick={() => run(() => openProfilePage())}>{profile.name}</button>}
         <button ref={btnRef} className="icon-btn" aria-label="Space menu" aria-haspopup="menu" aria-expanded={menu}
-          title="More" onClick={() => setMenu((o) => !o)}><Icon name="more" size={15} /></button>
+          title="More" onClick={() => setMenu((o) => !o)}><Icon name="more" size={14} /></button>
         {menu && (
           <Menu align="right" anchorRef={btnRef} label="Space menu" onClose={closeMenu} items={[
               { label: "Open space", onSelect: openPage },

--- a/apps/desktop/src/renderer/src/components/sidebar/SpaceOverview.tsx
+++ b/apps/desktop/src/renderer/src/components/sidebar/SpaceOverview.tsx
@@ -108,7 +108,7 @@ function OverviewBody() {
     <div className="spaces-backdrop" onMouseDown={(e) => { if (e.target === e.currentTarget) close(); }}>
       <div className="spaces-overview" role="dialog" aria-modal="true" aria-label="All spaces" style={style} onKeyDown={onKeyDown}>
         <div className="spaces-search">
-          <Icon name="search" size={15} />
+          <Icon name="search" size={14} />
           <input ref={inputRef} value={query} onChange={(e) => { setQuery(e.target.value); setCursor(0); }}
             placeholder="Filter spaces" aria-label="Filter spaces" spellCheck={false} />
           <kbd>esc</kbd>
@@ -144,7 +144,7 @@ function OverviewBody() {
         </div>
         <div className="spaces-foot">
           <button className="ghost-chip" onClick={() => openSheet({ kind: "new-space" })}>
-            <Icon name="add" size={13} /><span>New space</span>
+            <Icon name="add" size={12} /><span>New space</span>
           </button>
           <span className="spaces-foot-hint muted">↑↓←→ to move · ↵ to switch</span>
         </div>

--- a/apps/desktop/src/renderer/src/components/sidebar/SpaceStrip.tsx
+++ b/apps/desktop/src/renderer/src/components/sidebar/SpaceStrip.tsx
@@ -74,7 +74,7 @@ export function SpaceStrip() {
           );
         })}
       </div>
-      <button className="icon-btn strip-side" aria-label="New space" title="New space" onClick={() => openSheet({ kind: "new-space" })}><Icon name="add" size={16} /></button>
+      <button className="icon-btn strip-side" aria-label="New space" title="New space" onClick={() => openSheet({ kind: "new-space" })}><Icon name="add" size={14} /></button>
     </div>
   );
 }

--- a/apps/desktop/src/renderer/src/components/sidebar/SpaceSwiper.tsx
+++ b/apps/desktop/src/renderer/src/components/sidebar/SpaceSwiper.tsx
@@ -244,7 +244,7 @@ function ArchivedSection({ items }: { items: Item[] }) {
     <>
       <div className="group-label group-head archived-head">
         <button className="group-head-name archived-toggle" aria-expanded={open} onClick={() => setOpen((v) => !v)}>
-          <span className="archived-caret" data-open={open || undefined} aria-hidden="true"><Icon name="chevronRight" size={11} /></span>
+          <span className="archived-caret" data-open={open || undefined} aria-hidden="true"><Icon name="chevronRight" size={12} /></span>
           <span>Archived</span>
           <span className="archived-count">{items.length}</span>
         </button>

--- a/apps/desktop/src/renderer/src/components/sidebar/SpaceSwiper.tsx
+++ b/apps/desktop/src/renderer/src/components/sidebar/SpaceSwiper.tsx
@@ -226,6 +226,10 @@ const SpaceBody = memo(function SpaceBody({ items, groups }: { items: Item[]; gr
         <ItemList items={rest} variant="space" />
         {archived.length > 0 && <ArchivedSection items={archived} />}
       </div>
+      {/* A SIBLING of the scroller, never a child: a backdrop-filter inside the scrolling box would
+          scroll with the content it is meant to be blurring. .space-body's bottom padding is what
+          keeps the last row clear of the band — see --fade-h in styles.css. */}
+      <div className="space-fade" aria-hidden="true" />
     </>
   );
 });

--- a/apps/desktop/src/renderer/src/components/sidebar/sidebar-toggle.test.tsx
+++ b/apps/desktop/src/renderer/src/components/sidebar/sidebar-toggle.test.tsx
@@ -20,7 +20,7 @@ describe("sidebar collapse toggle", () => {
     const { store } = await mountShell();
     // Open: the sidebar is mounted and the button offers to hide it.
     expect(document.querySelector(".sidebar")).not.toBeNull();
-    expect(document.querySelector(".sb-rail")).toBeNull();
+    expect(document.querySelector(".sb-corner")).toBeNull();
     expect(toggle()).toHaveAccessibleName("Hide sidebar (⌘B)");
     expect(toggle()).toHaveAttribute("aria-expanded", "true");
     // Kills a mutation that renders the toggle only in the open branch: after collapsing, the
@@ -28,7 +28,7 @@ describe("sidebar collapse toggle", () => {
     fireEvent.click(toggle());
     await waitFor(() => expect(store.getState().sidebarCollapsed).toBe(true));
     expect(document.querySelector(".sidebar")).toBeNull();
-    expect(document.querySelector(".sb-rail")).not.toBeNull();
+    expect(document.querySelector(".sb-corner")).not.toBeNull();
     expect(screen.getAllByRole("button", { name: /(Hide|Show) sidebar/ })).toHaveLength(1);
     expect(toggle()).toHaveAccessibleName("Show sidebar (⌘B)");
     expect(toggle()).toHaveAttribute("aria-expanded", "false");
@@ -38,16 +38,23 @@ describe("sidebar collapse toggle", () => {
     expect(document.querySelector(".sidebar")).not.toBeNull();
   });
 
-  it("moves the toggle from the sidebar's head row into the top rail", async () => {
+  it("moves the toggle from the sidebar's head row into the window's corner", async () => {
     const { store } = await mountShell();
-    // Open: inside the sidebar, in its head row (the traffic-light band), NOT in a rail.
+    // Open: inside the sidebar, in its head row (the traffic-light band), NOT in the corner.
     expect(toggle().closest(".sb-head")).not.toBeNull();
     expect(toggle().closest(".sidebar")).not.toBeNull();
     await act(async () => { await store.getState().toggleSidebar(); });
-    // Collapsed: same button, now in the rail. Kills a mutation that leaves it parented to the
-    // sidebar subtree (where it would be unmounted with it) or drops the rail wrapper.
-    expect(toggle().closest(".sb-rail")).not.toBeNull();
+    // Collapsed: same button, now in the corner overlay. Kills a mutation that leaves it parented to
+    // the sidebar subtree (where it would be unmounted with it) or drops the corner wrapper.
+    const corner = toggle().closest(".sb-corner");
+    expect(corner).not.toBeNull();
     expect(toggle().closest(".sb-head")).toBeNull();
+    // After .main, not before it: panes are positioned, so a corner earlier in the DOM would be
+    // painted over by the first pane's bar however the z-index reads.
+    expect(corner!.previousElementSibling).toHaveClass("main");
+    // …and no rail: the whole point is that collapsing costs no height any more. Whether the lights
+    // actually clear the bar underneath is measured in sidebar-collapsed-live.mjs.
+    expect(document.querySelector(".sb-rail")).toBeNull();
     expect(document.querySelector(".app")).toHaveAttribute("data-sidebar-collapsed");
   });
 

--- a/apps/desktop/src/renderer/src/components/sidebar/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/components/sidebar/sidebar.test.tsx
@@ -6,7 +6,7 @@ import { StoreContext, createAppStore } from "../../state/store";
 import { fakeApi, iconAsset, item, session, space } from "../../state/store.test-fakes";
 import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
-import { leafPositionOf } from "./ItemList";
+import { paneSlotOf } from "./ItemList";
 
 /** The five rungs of Icon.tsx's ladder — card, tile, row, control, inline. */
 const RUNGS = new Set([20, 18, 16, 14, 12]);
@@ -450,7 +450,7 @@ describe("Arc sidebar", () => {
     expect(l.type === "leaf" && l.itemId).not.toBe("i1");
   });
 
-  it("during a row split, OPEN rows render the quadrant glyph lighting the correct column", async () => {
+  it("during a row split, OPEN rows draw one bar per slot along the split's axis, lighting their own", async () => {
     const layout: Layout = { type: "split", id: "root", dir: "row", sizes: [50, 50], children: [
       { type: "leaf", id: "L1", itemId: "i1" },
       { type: "leaf", id: "L2", itemId: "i2" },
@@ -460,11 +460,15 @@ describe("Arc sidebar", () => {
       items: { s1: [item("i1", "s1", { title: "Alpha" }), item("i2", "s1", { title: "Beta" })] },
     });
     await mount(api);
-    expect(onCells(glyphOf("Alpha"))).toEqual([0, 2]); // left child -> left column
-    expect(onCells(glyphOf("Beta"))).toEqual([1, 3]); // right child -> right column
+    // Two slots, two bars — not four cells with a column lit. The glyph draws the split it is
+    // describing, so the bar count is the pane count and `data-dir` is the axis CSS lays them along.
+    expect(glyphOf("Alpha")).toHaveAttribute("data-dir", "row");
+    expect(glyphOf("Alpha").querySelectorAll("span")).toHaveLength(2);
+    expect(onCells(glyphOf("Alpha"))).toEqual([0]);
+    expect(onCells(glyphOf("Beta"))).toEqual([1]);
   });
 
-  it("during a col split, OPEN rows render the quadrant glyph lighting the correct row", async () => {
+  it("during a col split, the same bars run down instead of across", async () => {
     const layout: Layout = { type: "split", id: "root", dir: "col", sizes: [50, 50], children: [
       { type: "leaf", id: "L1", itemId: "i1" },
       { type: "leaf", id: "L2", itemId: "i2" },
@@ -474,8 +478,26 @@ describe("Arc sidebar", () => {
       items: { s1: [item("i1", "s1", { title: "Alpha" }), item("i2", "s1", { title: "Beta" })] },
     });
     await mount(api);
-    expect(onCells(glyphOf("Alpha"))).toEqual([0, 1]); // top child -> top row
-    expect(onCells(glyphOf("Beta"))).toEqual([2, 3]); // bottom child -> bottom row
+    expect(glyphOf("Alpha")).toHaveAttribute("data-dir", "col");
+    expect(onCells(glyphOf("Alpha"))).toEqual([0]);
+    expect(onCells(glyphOf("Beta"))).toEqual([1]);
+  });
+
+  it("a three-column layout gets three bars — the case the old 2x2 could only answer wrongly", async () => {
+    // gridPreset("three-col") builds exactly this, and the command palette offers it. The old glyph
+    // had no third column to light, so it lit the bottom-left quadrant of a grid with no bottom row.
+    const layout: Layout = { type: "split", id: "root", dir: "row", sizes: [34, 33, 33], children: [
+      { type: "leaf", id: "L1", itemId: "i1" },
+      { type: "leaf", id: "L2", itemId: "i2" },
+      { type: "leaf", id: "L3", itemId: "i3" },
+    ] };
+    const api = fakeApi({
+      spaces: [space("s1", "p1", "Versed", { layout })],
+      items: { s1: [item("i1", "s1", { title: "Alpha" }), item("i2", "s1", { title: "Beta" }), item("i3", "s1", { title: "Gamma" })] },
+    });
+    await mount(api);
+    expect(glyphOf("Gamma").querySelectorAll("span")).toHaveLength(3);
+    expect(onCells(glyphOf("Gamma"))).toEqual([2]);
   });
 
   it("in a split, data-active marks only the focused leaf's row, not every open row; clicking the other OPEN row moves the highlight", async () => {
@@ -556,45 +578,46 @@ function onCells(glyph: Element): number[] {
     .filter((x): x is number => x !== null);
 }
 
-describe("leafPositionOf", () => {
+describe("paneSlotOf", () => {
   const leaf = (id: string, itemId: string | null): Layout => ({ type: "leaf", id, itemId });
   const split = (dir: "row" | "col", children: Layout[]): Layout =>
     ({ type: "split", id: "root", dir, sizes: children.map(() => 100 / children.length), children });
 
-  it("returns null for a single-leaf layout (no split at all)", () => {
-    expect(leafPositionOf(leaf("L1", "i1"), "i1")).toBeNull();
+  it("returns null for a single-leaf layout — there is no split to describe", () => {
+    expect(paneSlotOf(leaf("L1", "i1"), "i1")).toBeNull();
   });
 
   it("returns null when the item isn't open anywhere in the tree", () => {
-    expect(leafPositionOf(split("row", [leaf("L1", "i1"), leaf("L2", "i2")]), "i3")).toBeNull();
+    expect(paneSlotOf(split("row", [leaf("L1", "i1"), leaf("L2", "i2")]), "i3")).toBeNull();
   });
 
-  it("returns the child index (0/1) for a two-way split root", () => {
+  it("reports the slot, the slot count and the axis of the top-level split", () => {
     const l = split("row", [leaf("L1", "i1"), leaf("L2", "i2")]);
-    expect(leafPositionOf(l, "i1")).toBe(0);
-    expect(leafPositionOf(l, "i2")).toBe(1);
+    expect(paneSlotOf(l, "i1")).toEqual({ index: 0, count: 2, dir: "row" });
+    expect(paneSlotOf(l, "i2")).toEqual({ index: 1, count: 2, dir: "row" });
   });
 
-  it("falls back to depth-first leaf index modulo 4 for a root with more than two children", () => {
+  it("counts every slot of a three-way root, so the third pane is the third bar", () => {
+    // The behaviour this replaces: depth-first index modulo 4, which answered 2 here and drew that as
+    // the bottom-left of a 2x2 — a quadrant of a layout that has one row. The count travels with the
+    // index now, so the mark cannot claim a shape the layout does not have.
     const l = split("row", [leaf("L1", "i1"), leaf("L2", "i2"), leaf("L3", "i3")]);
-    expect(leafPositionOf(l, "i1")).toBe(0);
-    expect(leafPositionOf(l, "i2")).toBe(1);
-    expect(leafPositionOf(l, "i3")).toBe(2);
+    expect(paneSlotOf(l, "i3")).toEqual({ index: 2, count: 3, dir: "row" });
   });
 
-  it("a >2-child root with a nested split still takes the DF fallback, not the two-way branch", () => {
-    // root has 3 children (not two-way), so the two-way branch never applies here even though one of
-    // those children is itself a two-way split. DF leaf order is a, b, c, d — "c" is index 2.
-    const l = split("row", [leaf("L1", "a"), split("col", [leaf("L2", "b"), leaf("L3", "c")]), leaf("L4", "d")]);
-    expect(leafPositionOf(l, "c")).toBe(2);
+  it("says nothing at all once the root has more slots than the glyph can draw", () => {
+    // Five 2px bars inside 12px is a smudge, and a smudge that looks like a reading is worse than a
+    // row with no mark on it. Nothing gridPreset builds reaches this, but a future preset could.
+    const l = split("row", Array.from({ length: 5 }, (_, i) => leaf(`L${i}`, `i${i}`)));
+    expect(paneSlotOf(l, "i0")).toBeNull();
   });
 
-  it("a two-way root resolves by which top-level child's subtree holds the item, not DF order (the documented contract)", () => {
-    // The root IS two-way, so the two-way branch applies: "b" lives inside child 0's subtree -> 0.
-    // A DF-fallback implementation would instead see leaves [a, b, d] and answer 1 for "b" — wrong.
+  it("resolves by which top-level child's SUBTREE holds the item, not by leaf order", () => {
+    // "b" lives three levels down the first child, and is still in the first half. A depth-first
+    // implementation would see leaves [a, b, d] and answer 1 for "b" — the wrong half.
     const inner = split("col", [leaf("L1", "a"), leaf("L2", "b")]);
     const l = split("row", [inner, leaf("L3", "d")]);
-    expect(leafPositionOf(l, "b")).toBe(0);
+    expect(paneSlotOf(l, "b")).toEqual({ index: 0, count: 2, dir: "row" });
   });
 });
 

--- a/apps/desktop/src/renderer/src/components/sidebar/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/components/sidebar/sidebar.test.tsx
@@ -4,19 +4,15 @@ import { allItems, findLeafOfItem, type Layout } from "@realm/contracts";
 import { Sidebar } from "./Sidebar";
 import { StoreContext, createAppStore } from "../../state/store";
 import { fakeApi, iconAsset, item, session, space } from "../../state/store.test-fakes";
-import { existsSync, readdirSync, readFileSync } from "node:fs";
-import { dirname, join } from "node:path";
 import { paneSlotOf } from "./ItemList";
 
 /** The five rungs of Icon.tsx's ladder — card, tile, row, control, inline. */
 const RUNGS = new Set([20, 18, 16, 14, 12]);
-/* Vite rewrites `import.meta.url` to a non-file scheme under jsdom, so walk up from the cwd instead
-   (vitest may be invoked from the repo root or from apps/desktop). */
-function repoDir(rel: string): string {
-  let dir = process.cwd();
-  for (let i = 0; i < 6; i++) { const p = join(dir, rel); if (existsSync(p)) return p; dir = dirname(dir); }
-  throw new Error(`cannot locate ${rel} from ${process.cwd()}`);
-}
+/* Every component in this directory, as source text. Read through Vite rather than off disk: the
+   paths resolve against this module, so the scan below does not care whether vitest was invoked from
+   the repo root or from apps/desktop, and `import.meta.url` (which Vite rewrites to a non-file scheme
+   under jsdom) never comes into it. */
+const SIDEBAR_SOURCES = import.meta.glob("./*.tsx", { query: "?raw", import: "default", eager: true }) as Record<string, string>;
 
 async function mount(api = fakeApi()) {
   const store = createAppStore(api); await store.getState().boot();
@@ -861,14 +857,13 @@ describe("archiving a session", () => {
  *  happens to mount, and the drift this pins is in the ones nobody mounts. */
 describe("sidebar icon sizes", () => {
   it("every call site sits on a rung of the ladder", () => {
-    const dir = repoDir("apps/desktop/src/renderer/src/components/sidebar");
-    const files = readdirSync(dir).filter((f) => f.endsWith(".tsx") && !f.includes(".test."));
+    const files = Object.entries(SIDEBAR_SOURCES).filter(([name]) => !name.includes(".test."));
+    expect(files.length, "the source glob found nothing — the scan would pass vacuously").toBeGreaterThan(5);
     const offenders: string[] = [];
-    for (const file of files) {
-      const src = readFileSync(join(dir, file), "utf8");
+    for (const [name, src] of files) {
       for (const m of src.matchAll(/size=\{(\d+)\}/g)) {
         const size = Number(m[1]);
-        if (!RUNGS.has(size)) offenders.push(`${file}: size={${size}}`);
+        if (!RUNGS.has(size)) offenders.push(`${name.replace("./", "")}: size={${size}}`);
       }
     }
     expect(offenders, "off-ladder icon sizes — pick a rung or move the ladder, do not add a value").toEqual([]);

--- a/apps/desktop/src/renderer/src/components/sidebar/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/components/sidebar/sidebar.test.tsx
@@ -4,7 +4,19 @@ import { allItems, findLeafOfItem, type Layout } from "@realm/contracts";
 import { Sidebar } from "./Sidebar";
 import { StoreContext, createAppStore } from "../../state/store";
 import { fakeApi, iconAsset, item, session, space } from "../../state/store.test-fakes";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
 import { leafPositionOf } from "./ItemList";
+
+/** The five rungs of Icon.tsx's ladder — card, tile, row, control, inline. */
+const RUNGS = new Set([20, 18, 16, 14, 12]);
+/* Vite rewrites `import.meta.url` to a non-file scheme under jsdom, so walk up from the cwd instead
+   (vitest may be invoked from the repo root or from apps/desktop). */
+function repoDir(rel: string): string {
+  let dir = process.cwd();
+  for (let i = 0; i < 6; i++) { const p = join(dir, rel); if (existsSync(p)) return p; dir = dirname(dir); }
+  throw new Error(`cannot locate ${rel} from ${process.cwd()}`);
+}
 
 async function mount(api = fakeApi()) {
   const store = createAppStore(api); await store.getState().boot();
@@ -803,5 +815,25 @@ describe("archiving a session", () => {
     expect(screen.queryByRole("menuitem", { name: "Archive" })).not.toBeInTheDocument();
     fireEvent.click(screen.getByRole("menuitem", { name: "Unarchive" }));
     await waitFor(() => expect(store.getState().items.find((i) => i.id === "i2")?.archived).toBe(false));
+  });
+});
+
+/** The ladder is documented on `Icon` (packages/ui/src/Icon.tsx) and enforceable only here: `size`
+ *  is a plain number, so nothing in a type or a render can notice a call site quietly picking 15.
+ *  Scanning the source is the whole point — a rendered assertion would only cover the rows a test
+ *  happens to mount, and the drift this pins is in the ones nobody mounts. */
+describe("sidebar icon sizes", () => {
+  it("every call site sits on a rung of the ladder", () => {
+    const dir = repoDir("apps/desktop/src/renderer/src/components/sidebar");
+    const files = readdirSync(dir).filter((f) => f.endsWith(".tsx") && !f.includes(".test."));
+    const offenders: string[] = [];
+    for (const file of files) {
+      const src = readFileSync(join(dir, file), "utf8");
+      for (const m of src.matchAll(/size=\{(\d+)\}/g)) {
+        const size = Number(m[1]);
+        if (!RUNGS.has(size)) offenders.push(`${file}: size={${size}}`);
+      }
+    }
+    expect(offenders, "off-ladder icon sizes — pick a rung or move the ladder, do not add a value").toEqual([]);
   });
 });

--- a/apps/desktop/src/renderer/src/components/sidebar/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/components/sidebar/sidebar.test.tsx
@@ -569,6 +569,20 @@ describe("Arc sidebar", () => {
   });
 });
 
+describe("the list's bottom fade", () => {
+  it("is a SIBLING of the scroller, not a child of it", async () => {
+    // The one structural fact the stylesheet cannot state: a backdrop-filter nested inside the
+    // scrolling box scrolls with the content it is supposed to be blurring, which looks correct at
+    // scrollTop 0 and wrong everywhere else. Its height and the padding that clears it are pinned in
+    // styles.test.ts; how much it actually blurs, in sidebar-fade-live.mjs.
+    await mount();
+    const fade = document.querySelector(".space-fade")!;
+    expect(fade).not.toBeNull();
+    expect(fade.closest(".space-body")).toBeNull();
+    expect(fade.previousElementSibling).toHaveClass("space-body");
+  });
+});
+
 function glyphOf(title: string): Element {
   return screen.getByRole("button", { name: title }).querySelector(".item-glyph")!;
 }

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -203,11 +203,25 @@ kbd { font: 11px var(--font-mono); }
 .item[data-active] .item-row { color: var(--rl-text-bright); }
 .item-row { display: flex; align-items: center; gap: 10px; flex: 1; min-width: 0; text-align: left; padding: 5px 8px; font-weight: var(--fw-medium); color: var(--rl-text-dim); border-radius: var(--r-ctl); }
 .item:hover .item-row { color: var(--rl-text-bright); }
-.item-title { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.item-status { margin-left: auto; width: 6px; height: 6px; }
-.item-glyph { margin-left: auto; width: 10px; height: 10px; flex: none; display: grid; grid-template-columns: 1fr 1fr; grid-template-rows: 1fr 1fr; gap: 1px; opacity: .7; }
+/* One elastic column, and it is the title. The status dot and the glyph both used to carry
+   `margin-left: auto`, which splits the free space BETWEEN them: a session that was both running and
+   open parked its dot near the row's middle with the glyph jammed against it, and no two rows agreed
+   where either mark sat. The page rows had the same bug and this is the same fix — the title grows,
+   and nothing after it may claim free space. */
+.item-title { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.item-row > svg { flex: none; } /* …and the leading kind glyph is not a shrinkable column either */
+.item-status { width: 6px; height: 6px; }
+/* A small picture of the layout's top-level split with this row's pane lit: one bar per slot, laid
+   out along the split's own axis. Not a fixed 2x2 — that could only draw halves and quarters, so a
+   three-column layout had no truthful cell to light and lit a wrong one instead. Bars also buy back
+   width: two slots are 5.5px across here against 4.5px in the old grid, at 12px instead of 10px.
+   No blanket opacity: the contrast between a lit bar and an unlit one IS the message, and dimming
+   the whole mark flattened precisely that. */
+.item-glyph { width: 12px; height: 12px; flex: none; display: grid; gap: 1px; }
+.item-glyph[data-dir="row"] { grid-auto-flow: column; grid-auto-columns: 1fr; }
+.item-glyph[data-dir="col"] { grid-auto-flow: row; grid-auto-rows: 1fr; }
 .item-glyph span { background: var(--rl-line-strong); border-radius: 1px; }
-/* Glyph cells are neutral; the focused pane's row lifts them to ink (accent = ink now, V-C1 kept). */
+/* Glyph bars are neutral; the focused pane's row lifts them to ink (accent = ink now, V-C1 kept). */
 .item-glyph span[data-on] { background: var(--rl-text-dim); }
 .item[data-active] .item-glyph span[data-on] { background: var(--rl-text-bright); } /* W3: BUI active icons are ink, not accent */
 .item-close, .item-shelf { opacity: 0; display: grid; place-items: center; width: 22px; height: 22px; margin-right: 3px; border-radius: var(--r-chip); color: var(--rl-text-dim); }

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -251,6 +251,12 @@ kbd { font: 11px var(--font-mono); }
 .strip-space[data-active] { color: var(--rl-space); background: var(--rl-active); }
 .strip-space[data-drag-over] { box-shadow: inset 2px 0 0 var(--rl-accent); }
 /* Cross-space agent status (U-H3): waiting > error > running, resolved in spaceBadge. */
+/* This badge does NOT take the .status-dot ping, and the divergence is the point. A status dot says
+   what one session on screen is doing; this says whether anything is happening in a space you are
+   not looking at, and the only answer that asks you to go there is "waiting on you". Running
+   elsewhere needs nothing from anyone, so it is presence and gets colour alone. The geometry agrees:
+   the badge is notched into the corner of a 30px square in a rail of them, and a ring expanding from
+   it would have to cross the square's edge into its neighbour. So waiting alone keeps the blink. */
 .strip-badge { position: absolute; top: 2px; right: 2px; width: 7px; height: 7px; border-radius: 50%; border: 1.5px solid var(--rl-frame); }
 .strip-badge[data-status="running"] { background: var(--rl-success); }
 .strip-badge[data-status="waiting_permission"] { background: var(--rl-warning); animation: rl-pulse 0.9s ease-in-out infinite; }
@@ -732,21 +738,60 @@ button.panel-title:hover { background: var(--rl-hover); }
    Deliberately not animated: opening it is a resize, and §6 does not animate those. */
 .session-split { flex: 1; min-width: 0; min-height: 0; display: flex; }
 .session-split > [data-panel] { display: flex; min-width: 0; }
-.status-dot { display: inline-block; width: 7px; height: 7px; border-radius: 50%; background: var(--rl-text-faint); flex: none; }
+/* position: relative so the in-flight ring below has something to hang off; the dot itself is the
+   only box in the row's trailing column, and the ring is absolute, so nothing here changes layout. */
+.status-dot { position: relative; display: inline-block; width: 7px; height: 7px; border-radius: 50%; background: var(--rl-text-faint); flex: none; }
 /* §3 session status: colour = state, never chrome. Running is success (nothing running-related uses accent). */
-.status-dot[data-status="running"] { background: var(--rl-success); animation: rl-pulse 1.4s ease-in-out infinite; }
-.status-dot[data-status="waiting_permission"] { background: var(--rl-warning); animation: rl-pulse 0.9s ease-in-out infinite; }
+.status-dot[data-status="running"] { background: var(--rl-success); }
+.status-dot[data-status="waiting_permission"] { background: var(--rl-warning); }
 .status-dot[data-status="error"] { background: var(--rl-danger); }
 .status-dot[data-status="idle"] { background: var(--rl-line-strong); } /* idle is a state, not a verdict (V-C5) */
 .status-dot[data-status="ended"] { background: var(--rl-text-faint); opacity: .6; }
 /* W4: an agent act is in flight on a browser. Accent, not success — this is "Realm is acting here,
    watch", a pointer to activity, not a session verdict. */
-.status-dot[data-status="driving"] { background: var(--rl-accent); animation: rl-pulse 0.9s ease-in-out infinite; }
+.status-dot[data-status="driving"] { background: var(--rl-accent); }
 /* MCP server status (W6) shares the same dot — "connected"/"circuit_open" are this domain's own words
-   for "running"/"waiting on the user", so they get the same success/danger treatment. */
+   for "running"/"waiting on the user", so they get the same success/danger treatment. Connected is
+   RESTING, though — the server is up, nothing is in flight — so it stays a plain dot. */
 .status-dot[data-status="connected"] { background: var(--rl-success); }
 .status-dot[data-status="circuit_open"] { background: var(--rl-danger); animation: rl-pulse 0.9s ease-in-out infinite; }
 @keyframes rl-pulse { 0%, 100% { opacity: 1; } 50% { opacity: .55; } }
+
+/* The three states that mean "something is in flight" — a session running, a session waiting on the
+   user, an agent driving a browser — share one idiom: a solid core inside a ring that pings outward
+   from it. Only the ring moves; the core is untouched, so the row's dot column never jitters.
+   Replaces a whole-dot opacity throb that was doing no work. Frozen it was an ordinary dot, and
+   running it was a 6px circle changing brightness by a third — nothing an eye finds without being
+   told where to look, which is the opposite of what a live indicator is for.
+   The ring is authored at full strength with NO transform, so its un-animated form is a steady halo,
+   not a half-scaled ghost: the state still reads as hot when the animation is taken away.
+   `circuit_open` is deliberately not in this family. A tripped breaker is a fault that is PERSISTING,
+   not an act in progress, and the alarm idiom for that is a blink. */
+.status-dot[data-status="running"]::after,
+.status-dot[data-status="waiting_permission"]::after,
+.status-dot[data-status="driving"]::after {
+  content: ""; position: absolute; inset: -3px; border-radius: 50%;
+  border: 1px solid color-mix(in srgb, var(--ring) 60%, transparent);
+  animation: rl-ping var(--ring-rate) var(--ease-out-strong) infinite;
+}
+/* Told apart by colour AND rate, never by rate alone — 1.8s against 0.9s of the same motion is not a
+   distinction anyone makes at a glance, but success-slow against warning-fast is. waiting_permission
+   is the one that needs a human, so it is the loudest in BOTH motion modes: fastest ping with motion,
+   and without it the warning-toned halo still outranks the success-toned one. */
+.status-dot[data-status="running"]::after { --ring: var(--rl-success); --ring-rate: 1.8s; }
+.status-dot[data-status="waiting_permission"]::after { --ring: var(--rl-warning); --ring-rate: 0.9s; }
+.status-dot[data-status="driving"]::after { --ring: var(--rl-accent); --ring-rate: 0.9s; }
+/* Ends at scale(1) rather than growing past the authored box: the halo the reduced-motion reader
+   sees is the same 13px circle the ping resolves to, so the two forms are the same shape. */
+@keyframes rl-ping { from { transform: scale(.45); opacity: .85; } 70%, to { transform: scale(1); opacity: 0; } }
+/* The global reduced-motion block uses `*`, which does NOT match pseudo-elements — without this the
+   ping would be the one animation on the page that survives the preference. Only the motion goes;
+   the halo stays painted, because that is what carries the state with no motion left to carry it. */
+@media (prefers-reduced-motion: reduce) {
+  .status-dot[data-status="running"]::after,
+  .status-dot[data-status="waiting_permission"]::after,
+  .status-dot[data-status="driving"]::after { animation: none; }
+}
 /* The one loading spinner — the G5 "Idling" orb (components/Spinner.tsx builds the dots and their
    nine poses). Nothing here rotates: each dot walks its own pre-projected pose table, so the whole
    animation is transform + opacity. `--orb-k` scales the 28px stage geometry to the caller's size,

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -131,7 +131,9 @@ kbd { font: 11px var(--font-mono); }
 .panel ::selection { background: color-mix(in srgb, var(--rl-accent) 18%, transparent); }
 
 /* ── Sidebar (one step darker than the content ground, behind a 1px divider) ── */
-.app { display: flex; height: 100%; background: transparent; }
+/* position: relative for the collapsed corner below, which is the only thing in the shell that is
+   placed against the WINDOW rather than flowed. */
+.app { position: relative; display: flex; height: 100%; background: transparent; }
 /* §5 + Plan 9 W1: the sidebar paints the BUI window ground (--page) at ~0.82 so the macOS
    vibrancy material shows through; --page flips with data-mode, so one rule serves both themes. */
 .sidebar { width: var(--sidebar-w); flex: none; display: flex; flex-direction: column; min-height: 0;
@@ -142,14 +144,33 @@ kbd { font: 11px var(--font-mono); }
    the 48px of head room the sidebar had before, so nothing below it moves. */
 .sb-head { flex: none; height: 40px; display: flex; align-items: center; justify-content: flex-end; padding: 0 10px 0 16px; }
 .sb-top { padding: 0 16px 8px; display: flex; flex-direction: column; gap: 8px; }
-/* Collapsed: the app stacks, so the rail spans the window above the content. padding-left clears the
-   traffic lights (main sets them at x:12 and they run ~52px wide), which puts the toggle immediately
-   right of them — the same vertical band it occupies inside .sb-head, so collapsing reads as the
-   button moving rather than as one control being swapped for another. */
-.app[data-sidebar-collapsed] { flex-direction: column; }
-.sb-rail { flex: none; height: 38px; display: flex; align-items: center; padding-left: 76px;
-  background: color-mix(in srgb, var(--page) 82%, transparent); -webkit-app-region: drag; }
-.sb-rail button { -webkit-app-region: no-drag; }
+/* Collapsed: the 280px column goes and nothing takes its place. The rail that used to stand in for it
+   spent 38px of window HEIGHT, full width, for a strip whose entire content was one button — a
+   permanent tax on every pane, paid so the traffic lights would not land on pane chrome. The lights
+   land on pane chrome now, on purpose: the corner is an overlay, so it costs no height, and the strip
+   underneath reserves the width they need. Still a drag region, so the window is still draggable by
+   its own top-left corner.
+   padding-left clears the lights — main places them at x:12 and the three run to about 66px — which
+   leaves the toggle immediately right of them, the same vertical band it occupies inside .sb-head, so
+   collapsing reads as the button moving rather than as one control being swapped for another. */
+/* 76 to clear the lights, 26 for the toggle, then 16 so the first pane's leading control is not
+   touching it — .panel-nav opens with a -8px margin, so the gap has to be budgeted at 16 to land
+   as 8 on screen. */
+.app[data-sidebar-collapsed] { --corner-w: 118px; }
+.sb-corner { position: absolute; top: 0; left: 0; z-index: 5; height: 40px; display: flex; align-items: center;
+  padding-left: 76px; -webkit-app-region: drag; }
+.sb-corner button { -webkit-app-region: no-drag; }
+/* Whichever strip is first in the main column is the one under the lights, so it is the one that
+   reserves them. `:first-child` on each candidate keeps the three mutually exclusive — an error bar
+   pushes the others down, and only the bar actually at the top should be indented.
+   The lights themselves never move: main places them once at y:14, which centres a ~14px control in a
+   40px strip, and .sb-head, .panel-bar and the collapsed group bar are all 40px. Changing any of
+   those heights leaves the lights off-centre in that one state. */
+.app[data-sidebar-collapsed] .main > .error-bar:first-child,
+.app[data-sidebar-collapsed] .main > .group-bar:first-child,
+.app[data-sidebar-collapsed] .main > .panehost:first-child .panel[data-first-leaf] > .panel-bar { padding-left: var(--corner-w); }
+/* The group bar is 34px at rest and takes the panel bar's 40px when it is the strip under the lights. */
+.app[data-sidebar-collapsed] .main > .group-bar:first-child { min-height: 40px; }
 /* ink-3 → ink-2 on hover, matching .search: the glyph itself IS the state, no fill change. */
 .sb-toggle { display: flex; align-items: center; justify-content: center; width: 26px; height: 26px;
   border-radius: var(--r-ctl); color: var(--rl-text-faint); }

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -164,8 +164,45 @@ kbd { font: 11px var(--font-mono); }
 
 .swiper { flex: 1; min-height: 0; overflow: clip; position: relative; }
 .swiper-track { display: flex; height: 100%; width: 100%; will-change: transform; }
-.space-page { flex: 0 0 100%; min-width: 0; height: 100%; display: flex; flex-direction: column; padding: 4px 16px 8px; overflow: hidden; }
-.space-body { flex: 1; min-height: 0; overflow-y: auto; overflow-x: hidden; /* hit-target ::afters poke 3px past the rail */ display: flex; flex-direction: column; gap: 2px; }
+/* position: relative so the bottom fade below hangs off the PAGE rather than off the scroller — a
+   backdrop-filter nested inside the scrolling box would ride along with the content it blurs. */
+.space-page { position: relative; flex: 0 0 100%; min-width: 0; height: 100%; display: flex; flex-direction: column; padding: 4px 16px 8px; overflow: hidden;
+  --fade-h: 44px; }
+/* A full band of bottom padding, not a fraction of one, for the reason the diff list needs the same:
+   these are 32px rows of dense text, so a row that ends inside the ramp is a session you scrolled
+   down to read and then cannot. Scrolled to the end, the last row sits entirely clear of the band and
+   the blur has only empty gutter under it. The scroller and the ramp read the one --fade-h so they
+   cannot drift apart. */
+.space-body { flex: 1; min-height: 0; overflow-y: auto; overflow-x: hidden; /* hit-target ::afters poke 3px past the rail */ display: flex; flex-direction: column; gap: 2px;
+  padding-bottom: var(--fade-h); }
+/* The same progressive blur the transcript uses (two backdrop layers behind masks that start at
+   different heights, so the blur RAMPS rather than stepping — one flat band shows its own top edge),
+   with one deliberate difference: no colour wash. The transcript washes to --rl-panel because it
+   docks a card at its bottom and the gap above that card has to be solid pane. Nothing docks here —
+   below is the space strip, its own row — and this column is macOS vibrancy, not an opaque panel, so
+   a wash to any fixed colour would paint a band the material shows straight through as a tonal seam.
+   The blur alone is the dissolve; the masks live on the blurring layers, never on the parent, since a
+   masked ancestor becomes a backdrop root and its children would blur an empty backdrop.
+   It spans the page's full width, past the rows' 16px rails: a band that stopped where the text does
+   would draw two vertical edges of its own. */
+.space-fade { position: absolute; inset: auto 0 0 0; height: var(--fade-h); pointer-events: none; z-index: 1; }
+.space-fade::before, .space-fade::after { content: ""; position: absolute; inset: 0; }
+.space-fade::before { backdrop-filter: blur(3px); -webkit-backdrop-filter: blur(3px);
+  mask-image: linear-gradient(to bottom, transparent 0, #000 60%);
+  -webkit-mask-image: linear-gradient(to bottom, transparent 0, #000 60%); }
+.space-fade::after { backdrop-filter: blur(11px); -webkit-backdrop-filter: blur(11px);
+  mask-image: linear-gradient(to bottom, transparent 30%, #000 78%);
+  -webkit-mask-image: linear-gradient(to bottom, transparent 30%, #000 78%); }
+/* Asked for less translucency. Dropping the blur the way the transcript does would leave this fade
+   with nothing at all — it has no wash to fall back on — and the hard cut it exists to prevent would
+   come straight back. So the dissolve changes medium instead of going away: macOS renders the
+   vibrancy material opaque under this preference, which is the one condition where a ramp to a fixed
+   tone composites cleanly over this column. */
+@media (prefers-reduced-transparency: reduce) {
+  .space-fade::before { backdrop-filter: none; -webkit-backdrop-filter: none; }
+  .space-fade::after { backdrop-filter: none; -webkit-backdrop-filter: none;
+    background: linear-gradient(to bottom, transparent 0, var(--page) 88%); }
+}
 
 .space-header { display: flex; align-items: center; justify-content: space-between; gap: 6px; padding: 6px 0 8px; }
 .space-header h2 { display: flex; align-items: center; gap: 8px; margin: 0; font-size: 15px; font-weight: var(--fw-title); min-width: 0; letter-spacing: -0.01em; }

--- a/apps/desktop/src/renderer/src/styles.test.ts
+++ b/apps/desktop/src/renderer/src/styles.test.ts
@@ -129,8 +129,40 @@ describe("§6 motion table", () => {
     expect(blockAfter("@keyframes rl-chip-in")).toContain("translateY(8px)");
   });
 
-  it("the waiting status dot keeps the 0.9s pulse — §6's only looping motion at rest", () => {
-    expect(bodiesFor('.status-dot[data-status="waiting_permission"]').join(" ")).toContain("rl-pulse 0.9s ease-in-out infinite");
+  it("the three in-flight states share one ping, and its ring survives prefers-reduced-motion", () => {
+    // Only the ring moves; the core is untouched, so the row's dot column cannot jitter.
+    const ring = bodiesFor('.status-dot[data-status="running"]::after').join(" ");
+    expect(ring).toContain("animation: rl-ping var(--ring-rate)");
+    // Authored at full strength with NO transform: the un-animated form has to be a steady halo, not
+    // a half-scaled ghost. This one line is the whole reason the state is still legible when the
+    // preference takes the motion away — a `transform: scale(...)` here silently breaks that.
+    expect(ring).not.toContain("transform");
+    expect(ring).toContain("inset: -3px");
+    // …and the keyframe resolves to that same authored box, so the moving and still forms are one shape.
+    expect(blockAfter("@keyframes rl-ping")).toContain("scale(1)");
+    // Colour AND rate, never rate alone. waiting_permission is the one that needs a human, so it is
+    // the loudest in BOTH modes: fastest ping with motion, warning tone against success without it.
+    const waiting = bodiesFor('.status-dot[data-status="waiting_permission"]::after').join(" ");
+    expect(ring).toContain("--ring-rate: 1.8s");
+    expect(waiting).toContain("--ring-rate: 0.9s");
+    expect(ring).toContain("--ring: var(--rl-success)"); // never accent — that is reserved for `driving`
+    expect(waiting).toContain("--ring: var(--rl-warning)");
+    // `*` does not match pseudo-elements, so without a rule naming these three the ping would be the
+    // one animation on the page that ignores the preference.
+    const reduced = blockAfter("@media (prefers-reduced-motion: reduce)").replace(/\s+/g, " ");
+    for (const s of ["running", "waiting_permission", "driving"])
+      expect(reduced, s).toContain(`.status-dot[data-status="${s}"]::after`);
+    // The whole-dot opacity throb is gone from every state that now pings: two idioms for one thing
+    // is how these drifted apart in the first place.
+    for (const s of ["running", "waiting_permission", "driving"])
+      expect(bodiesFor(`.status-dot[data-status="${s}"]`).join(" "), s).not.toContain("rl-pulse");
+  });
+
+  it("the space strip's badge stays still — presence, not a summons", () => {
+    // Deliberately NOT the status dot's ping: this is a rollup for a space nobody is looking at, and
+    // only "waiting on you" asks anyone to go there. A running agent elsewhere needs no attention.
+    expect(bodiesFor('.strip-badge[data-status="running"]').join(" ")).not.toContain("animation");
+    expect(bodiesFor('.strip-badge[data-status="waiting_permission"]').join(" ")).toContain("rl-pulse 0.9s ease-in-out infinite");
   });
 
   it("`will-change` is reserved for the swiper track (§6 performance note)", () => {

--- a/apps/desktop/src/renderer/src/styles.test.ts
+++ b/apps/desktop/src/renderer/src/styles.test.ts
@@ -352,6 +352,42 @@ describe("Plan 9 W1 — the BUI bridge", () => {
     expect([...used].filter((n) => !defined.has(n) && !n.startsWith("--dsg-")).sort()).toEqual([]);
   });
 
+  it("collapsing costs no height: no rail, and a corner overlay that clears the lights", () => {
+    // The rail spent 38px of window HEIGHT, full width, to hold one button — a permanent strip across
+    // every pane bought so the traffic lights would not land on pane chrome. Its return is the
+    // regression this pins; sidebar-collapsed-live.mjs measures that the panes really start at y=0.
+    expect(RULES.some((r) => r.selectors.some((s) => s.includes(".sb-rail")))).toBe(false);
+    // …and the shell no longer changes axis: collapsed is the same row with the column taken out.
+    expect(bodiesFor(".app[data-sidebar-collapsed]").join(" ")).not.toContain("flex-direction");
+    const corner = bodiesFor(".sb-corner").join(" ");
+    expect(corner).toContain("position: absolute");
+    expect(corner).toContain("height: 40px");      // the band trafficLightPosition y:14 centres in
+    expect(corner).toContain("padding-left: 76px"); // clears the lights before the toggle starts
+    // The window must still be draggable by its own top-left, and the toggle still clickable inside it.
+    expect(corner).toContain("-webkit-app-region: drag");
+    expect(bodiesFor(".sb-corner button").join(" ")).toContain("-webkit-app-region: no-drag");
+    // An absolutely positioned corner is only in the window's corner if the shell is its containing block.
+    expect(bodiesFor(".app").join(" ")).toContain("position: relative");
+  });
+
+  it("exactly one strip reserves the lights — whichever is at the top of the main column", () => {
+    // :first-child on each candidate is what keeps the three mutually exclusive: an error bar pushes
+    // the others down, and only the strip actually under the lights may be indented.
+    const owners = RULES.filter((r) => r.body.includes("padding-left: var(--corner-w)")).flatMap((r) => r.selectors);
+    expect(owners).toEqual([
+      ".app[data-sidebar-collapsed] .main > .error-bar:first-child",
+      ".app[data-sidebar-collapsed] .main > .group-bar:first-child",
+      ".app[data-sidebar-collapsed] .main > .panehost:first-child .panel[data-first-leaf] > .panel-bar",
+    ]);
+    // One declaration of the width, or the corner and the space reserved for it drift apart.
+    expect(RULES.filter((r) => r.body.includes("--corner-w:")).flatMap((r) => r.selectors)).toEqual([".app[data-sidebar-collapsed]"]);
+    // Every strip the lights can land in is 40px. main places them once at y:14 and never moves them,
+    // which only works while that is true of all of them (see the comment on trafficLightPosition).
+    expect(bodiesFor(".sb-head").join(" ")).toContain("height: 40px");
+    expect(bodiesFor(".panel-bar").join(" ")).toContain("height: 40px");
+    expect(bodiesFor(".app[data-sidebar-collapsed] .main > .group-bar:first-child").join(" ")).toContain("min-height: 40px");
+  });
+
   it("the sidebar keeps its vibrancy: BUI --page at 82%, one mode-agnostic rule", () => {
     expect(bodiesFor(".sidebar").join(" ")).toContain("color-mix(in srgb, var(--page) 82%, transparent)");
     // The old per-mode rgba override is gone — --page flips with data-mode on its own.

--- a/apps/desktop/src/renderer/src/styles.test.ts
+++ b/apps/desktop/src/renderer/src/styles.test.ts
@@ -469,6 +469,37 @@ describe("Plan 9 W3 — composer + chrome in BUI language", () => {
     expect(RULES.filter((r) => r.selectors.includes(".diff-fade")).map((r) => r.body).join(" ")).not.toContain("--fade-h:");
   });
 
+  it("the sidebar list clears its own fade the same way, and dissolves with blur alone", () => {
+    // Same invariant as the changes list: a full band of padding, and ONE declaration of the number,
+    // so the ramp and the clearance that keeps the last session out of it cannot drift apart.
+    expect(bodiesFor(".space-body").join(" ")).toContain("padding-bottom: var(--fade-h)");
+    expect(bodiesFor(".space-page").join(" ")).toContain("--fade-h: 44px");
+    expect(RULES.filter((r) => r.selectors.includes(".space-fade")).map((r) => r.body).join(" ")).not.toContain("--fade-h:");
+    expect(bodiesFor(".space-fade").join(" ")).toContain("height: var(--fade-h)");
+    // No colour wash, unlike the transcript's: that one washes to --rl-panel because it docks a card
+    // and needs solid pane above it. This column is macOS vibrancy, so a ramp to any fixed tone would
+    // paint a stripe the material shows through. Verified on screen — sidebar-fade-live.mjs measures
+    // the band over empty gutter and holds it to the surrounding column's luminance.
+    // RULES flattens @media, so the two layers are identified by what they declare rather than by
+    // where they sit: the blurring rule is the one carrying the blur, and it must carry no colour.
+    const blurring = bodiesFor(".space-fade::after").filter((b) => b.includes("backdrop-filter: blur("));
+    expect(blurring, "the heavy blur layer").toHaveLength(1);
+    expect(blurring[0], "a colour wash on the blurring layer would stripe the material").not.toContain("background:");
+    expect(bodiesFor(".space-fade::before").filter((b) => b.includes("backdrop-filter: blur("))).toHaveLength(1);
+    // …and the wash exists exactly once in the whole sheet: the reduced-transparency fallback below.
+    expect(bodiesFor(".space-fade::after").filter((b) => b.includes("background:"))).toHaveLength(1);
+  });
+
+  it("reduced transparency swaps the sidebar fade's medium rather than removing it", () => {
+    // The transcript can drop its blur and keep its wash. This fade has no wash to fall back on, so
+    // dropping the blur alone would hand back the hard cut it exists to prevent — it gains the ramp
+    // in the same breath, in the one condition where a fixed tone composites cleanly here (macOS
+    // renders the vibrancy material opaque under this preference).
+    const reduced = blockAfter("@media (prefers-reduced-transparency: reduce)").replace(/\s+/g, " ");
+    expect(reduced).toContain(".space-fade::before");
+    expect(reduced).toContain("linear-gradient(to bottom, transparent 0, var(--page) 88%)");
+  });
+
   it("a disabled quiet button stays dark under the cursor — the hover fill is guarded like .btn's", () => {
     // Unguarded, "Commit only" with nothing staged still lit up on hover: a control that answers
     // the pointer while refusing the click.

--- a/packages/ui/src/Icon.tsx
+++ b/packages/ui/src/Icon.tsx
@@ -73,6 +73,21 @@ export function isIconName(x: string): x is IconName {
   return Object.prototype.hasOwnProperty.call(icons, x) || isBrandName(x);
 }
 
+/**
+ * The size ladder. `size` is a free number, so the only thing stopping 21 call sites from drifting
+ * to 21 values is this list — pick the rung whose ROLE matches, never the one that happens to look
+ * right in one place. Rungs are 2px apart because 1px apart is not a difference a reader can see:
+ * two controls in one 22px box at 12 and 13 read as a mistake, not as a distinction.
+ *
+ *   20  card     the glyph IS the card's subject, at card scale (.space-card)
+ *   18  tile     the glyph IS the tile's subject (.pinned-grid .tile)
+ *   16  row      what a row or a strip square IS — item kind, destination, space, profile
+ *   14  control  a button's verb (.icon-btn, .sb-toggle, .panel-bar) and a field's leading glyph
+ *   12  inline   inside a box of 22px or less (.item-close, .item-shelf), or leading text at 12.5px
+ *
+ * Role, not local font size: the overview's filter field sets 15px text and the sidebar's search
+ * 13px, and both take the 14 rung, because in both the glyph is the affordance and not the content.
+ */
 export function Icon({ name, size = 16, className, colored = false }: { name: IconName | (string & {}); size?: number; className?: string;
   /** Render a brand mark in its vendor's declared colour instead of `currentColor`. Only marks that
    *  declare one change (Claude, Gemini); the rest — and every non-brand glyph — ignore the flag. */


### PR DESCRIPTION
Five sidebar changes. Stacked on #20.

**An icon ladder.** Sidebar glyphs were drawn at 11, 12, 13, 14, 15, 16, 18 and 20 with no rule — `search` at 14 in one place and 15 in another, `add` at three different sizes, two buttons in the same 22×22 box differing by a pixel. There are now five rungs keyed to what the glyph *is* (card / tile / row / control / inline), documented on `Icon` itself, and a test that scans the call sites and names any that drift off it.

**A running indicator that survives losing its motion.** The green dot's only signal was a 1.4s opacity throb, and `prefers-reduced-motion` kills every animation app-wide — so for anyone with that preference a running session looked exactly like an idle one. Running now carries a painted ring that reads without motion at all; `waiting_permission` stays faster and warmer, because it is the one that needs a human.

**A split mark that draws the split.** The old 2×2 glyph fell back to depth-first leaf index modulo 4 for anything that was not a two-way root. Under a three-column layout — `gridPreset` makes them and the command palette offers them — the pane at the far right lit the bottom-left quadrant of a grid with no bottom row. That is read by precisely the person who cannot otherwise tell two rows apart, so it sent them to the wrong pane. It is now one bar per slot of the top-level split along that split's own axis, and it renders nothing rather than guess. Dropping the second axis bought back legibility: 5.5px bars against 4.5px cells.

Also fixes the two `margin-left: auto` marks fighting: they shared the free space, so a running-and-open row put its dot somewhere in the middle of whatever the title left over, at a distance that changed with title length.

**A dissolved list bottom.** The `.space-body` scroller ends in the same two-layer progressive-blur band the transcript uses, over enough bottom padding that the last session sits clear of it — measured at 8px above the band, where removing the padding ends it 35px inside.

**The lights inline with the panes.** Collapsing the sidebar used to swap it for a full-width 38px rail whose only job was keeping the macOS traffic lights off the first pane's bar. The rail is gone and those 38px come back: the leftmost pane's bar (or the group bar, when it is on top) reserves the corner instead, and the ⌘B toggle sits in the same 40px band it occupied inside the sidebar.

Verified by three live Electron checks — `sidebar-marks-live.mjs`, `sidebar-fade-live.mjs`, `sidebar-collapsed-live.mjs`, 31 assertions — each with a mutant confirmed to fail it. The ring is proven painted over the sidebar's vibrancy and proven static under reduced motion; the blur is proven to composite over the material without a tonal seam; the collapsed layout is measured rather than assumed.

One known limit: the traffic lights themselves are drawn by the window server above the web view, so a screenshot cannot contain them. Their geometry is asserted from the documented AppKit contract, and that constant carries the caveat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)