### PR TITLE
Design foundations: a drawn squircle, one motion ladder, trackless scrollbars, fewer rules, light-mode colour

### DIFF
--- a/apps/desktop/scripts/squircle-live.mjs
+++ b/apps/desktop/scripts/squircle-live.mjs
@@ -1,0 +1,334 @@
+/**
+ * Live check for the prompter's squircle corners (run with: node apps/desktop/scripts/squircle-live.mjs)
+ *
+ * Boots the REAL built app on a scratch REALM_HOME and measures the shape of the corner that
+ * actually reaches the screen. Nothing in the vitest suite can do this: jsdom has no layout, no
+ * compositor and no CSS Painting API, so to it `background: paint(rl-squircle)` and
+ * `border-radius: 20px` are the same declaration.
+ *
+ * The claim is geometric and falsifiable. Inside the R×R square at a card's corner, the fraction of
+ * area the card's own fill covers is fixed by the curve:
+ *   - a circular arc, which is all `border-radius` can draw   → π/4 ≈ 0.785
+ *   - the superellipse |x/R|⁴ + |y/R|⁴ = 1 the worklet draws  → ≈ 0.874
+ * The corner is therefore classified by COUNTING pixels rather than by reading one of them, and the
+ * two answers are 11% of the corner square apart.
+ *
+ * Its mutant is the gate: strip `data-squircle` and the same measurement has to fall back to π/4,
+ * because the stylesheet's fallback is a plain `border-radius`. If it does not, this is measuring
+ * something other than the corner.
+ *
+ * It also pins the two regressions the technique invites, since a mask or a filter — the obvious
+ * ways to get a superellipse — would have taken the card's box-shadow and its focus ring with it:
+ *   - the lift still darkens the ground beside the card (mutated by setting box-shadow: none)
+ *   - focus still draws a ring, and draws it ON the curve rather than as a box-shadow around the
+ *     now-radius-0 box, which would square the corner off and send the fraction towards 1.0
+ *
+ * REBUILD FIRST (`pnpm build`): this boots apps/desktop/out, not the sources.
+ * Ports: env-overridable. Touches only a scratch dir; kills only the process it started.
+ */
+import { spawn } from "node:child_process";
+import { connect } from "node:net";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
+const CDP_PORT = Number(process.env.LIVE_CDP_PORT ?? 9338), SERVER_PORT = Number(process.env.LIVE_SERVER_PORT ?? 8904);
+const scratch = fs.mkdtempSync(path.join(os.tmpdir(), "realm-squircle-live-"));
+let electron = null;
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+/** Area of a quadrant of |x|ⁿ + |y|ⁿ = 1 as a fraction of the unit square: n = 2 is the circle a
+ *  border-radius draws, n = 4 the squircle the worklet draws. */
+const CIRCLE = Math.PI / 4, SQUIRCLE = 0.874;
+/** Half the gap between them. Anything nearer one than the other is that curve. */
+const TOL = (SQUIRCLE - CIRCLE) / 2;
+
+async function portFree(port) {
+  return new Promise((resolve) => {
+    const s = connect({ port, host: "127.0.0.1" });
+    s.once("connect", () => { s.destroy(); resolve(false); });
+    s.once("error", () => resolve(true));
+  });
+}
+
+async function until(fn, ms, tag) {
+  const t0 = Date.now();
+  for (;;) {
+    const v = await fn();
+    if (v) return v;
+    if (Date.now() - t0 > ms) throw new Error(`timeout:${tag}`);
+    await sleep(150);
+  }
+}
+
+function cdp(wsUrl) {
+  const ws = new WebSocket(wsUrl);
+  let id = 0;
+  const pending = new Map();
+  const events = [];
+  const ready = new Promise((res) => ws.addEventListener("open", res));
+  ws.addEventListener("message", (m) => {
+    const msg = JSON.parse(m.data);
+    if (msg.id !== undefined) pending.get(msg.id)?.(msg);
+    else if (msg.method === "Runtime.consoleAPICalled" && msg.params.type === "error") {
+      events.push(msg.params.args.map((a) => a.value ?? a.description ?? "").join(" "));
+    }
+  });
+  return {
+    ready, events,
+    send: (method, params) => new Promise((res, rej) => {
+      const i = ++id;
+      pending.set(i, (msg) => (msg.error ? rej(new Error(msg.error.message)) : res(msg.result)));
+      ws.send(JSON.stringify({ id: i, method, params }));
+    }),
+    close: () => ws.close(),
+  };
+}
+
+/** Sampling helpers, installed in the page once. They read a screenshot back through a canvas so the
+ *  numbers come from what was COMPOSITED, not from what the CSSOM claims. */
+const HELPERS = `
+window.__live = window.__live ?? {
+  setInput(el, value) {
+    const proto = el instanceof HTMLTextAreaElement ? HTMLTextAreaElement.prototype : HTMLInputElement.prototype;
+    Object.getOwnPropertyDescriptor(proto, "value").set.call(el, value);
+    el.dispatchEvent(new Event("input", { bubbles: true }));
+  },
+  async sampler(b64) {
+    const img = new Image();
+    img.src = "data:image/png;base64," + b64;
+    await img.decode();
+    const cv = document.createElement("canvas");
+    cv.width = img.width; cv.height = img.height;
+    const g = cv.getContext("2d");
+    g.drawImage(img, 0, 0);
+    const px = g.getImageData(0, 0, cv.width, cv.height).data;
+    const dpr = img.width / window.innerWidth;
+    /* floor, not round: coordinates arrive as pixel CENTRES (x + 0.5), so rounding lands on the next
+       pixel along and slides the whole sampling window one pixel inward on each axis. Over a corner
+       square that is worth 2/R of its area — 10% at the prompter's radius, which is most of the gap
+       between the two curves this script exists to tell apart. */
+    const lum = (x, y) => {
+      const i = ((Math.floor(y * dpr) * cv.width) + Math.floor(x * dpr)) * 4;
+      return 0.299 * px[i] + 0.587 * px[i + 1] + 0.114 * px[i + 2];
+    };
+    const median = (xs) => xs.slice().sort((a, b) => a - b)[xs.length >> 1];
+    /* Median, not mean: a reference tone read off a live card lands on a glyph or an icon sooner or
+       later, and one stray dark pixel would drag a mean far enough to move the threshold. */
+    const tone = (x0, y0, x1, y1) => {
+      const xs = [];
+      for (let i = 0; i < 7; i++) for (let j = 0; j < 7; j++) {
+        xs.push(lum(x0 + ((x1 - x0) * i) / 6, y0 + ((y1 - y0) * j) / 6));
+      }
+      return median(xs);
+    };
+    const band = (x0, y0, x1, y1) => {
+      let total = 0, n = 0;
+      for (let y = y0; y < y1; y += 0.5) for (let x = x0; x < x1; x += 0.5) { total += lum(x, y); n++; }
+      return total / n;
+    };
+    return { lum, tone, band, dpr };
+  },
+  /** Fraction of an element's R×R corner square that the element's own fill covers. */
+  async cornerFill(b64, sel, corner) {
+    const s = await this.sampler(b64);
+    const el = document.querySelector(sel);
+    const box = el.getBoundingClientRect();
+    const cs = getComputedStyle(el);
+    /* Under the gate the radius is the painter's input; on the fallback it is border-radius. */
+    const key = corner === "bl" ? "--sq-radius-bottom" : "--sq-radius-top";
+    const fallback = corner === "bl" ? cs.borderBottomLeftRadius : cs.borderTopLeftRadius;
+    const R = Math.round(parseFloat(cs.getPropertyValue(key)) || parseFloat(fallback) || 0);
+    if (R < 8) return { error: "radius too small to measure", R };
+    /* Reference tones sampled from THIS screenshot rather than from a token value, so the test holds
+       in either mode and survives a repaint of the palette. */
+    const inset = R + 8;
+    const inside = s.tone(box.left + inset, box.top + inset, box.right - inset, box.bottom - inset);
+    /* Diagonally outside the corner under test. For a bottom corner that is BELOW the element — read
+       above it and the sample lands on whatever the element is tucked under, which for the
+       under-strip is the prompter's own fill. */
+    const gy = corner === "bl" ? box.bottom + 8 : box.top - 30;
+    const outside = s.tone(box.left - 30, gy, box.left - 8, gy + 22);
+    if (Math.abs(inside - outside) < 3) return { error: "fill and ground are indistinguishable", inside, outside };
+    /* Midway between the two tones: the antialiased boundary pixels split evenly either side of it,
+       which leaves the area estimate unbiased. */
+    const mid = (inside + outside) / 2;
+    const isFill = (x, y) => (inside > outside ? s.lum(x, y) > mid : s.lum(x, y) < mid);
+    /* Anchored to the first device pixel the card actually touches — a laid-out box lands on a
+       fractional coordinate often enough that taking box.left/top raw walks the window off by one. */
+    const x0 = Math.floor(box.left);
+    const y0 = Math.floor(corner === "bl" ? box.bottom - R : box.top);
+    let filled = 0;
+    for (let dy = 0; dy < R; dy++) for (let dx = 0; dx < R; dx++) {
+      if (isFill(x0 + dx + 0.5, y0 + dy + 0.5)) filled++;
+    }
+    return { fraction: +(filled / (R * R)).toFixed(3), R, inside: Math.round(inside), outside: Math.round(outside) };
+  },
+};
+void 0`;
+
+async function evalIn(c, expr) {
+  const r = await c.send("Runtime.evaluate", { expression: HELPERS + ";\n" + expr, awaitPromise: true, returnByValue: true });
+  if (r.exceptionDetails) throw new Error(`page exception: ${r.exceptionDetails.exception?.description ?? r.exceptionDetails.text}`);
+  return r.result.value;
+}
+
+const check = (name, cond, detail) => {
+  if (!cond) process.exitCode = 1;
+  console.log(`${cond ? "PASS" : "FAIL"} ${name}${detail !== undefined ? " " + JSON.stringify(detail) : ""}`);
+};
+const near = (v, target) => typeof v === "number" && Math.abs(v - target) < TOL;
+const shotOf = async (c) => (await c.send("Page.captureScreenshot", { format: "png" })).data;
+
+async function main() {
+  for (const p of [CDP_PORT, SERVER_PORT]) {
+    if (!(await portFree(p))) throw new Error(`port ${p} is in use — refusing to run`);
+  }
+  const mainEntry = path.join(repoRoot, "apps/desktop/out/main/index.js");
+  if (!fs.existsSync(mainEntry)) throw new Error("apps/desktop/out is missing — run `pnpm build` first");
+
+  const wrapper = path.join(scratch, "wrapper.mjs");
+  fs.writeFileSync(wrapper, [
+    'import { app } from "electron";',
+    'app.setPath("userData", process.env.LIVE_USER_DATA);',
+    "await import(process.env.LIVE_MAIN);",
+  ].join("\n"));
+  const electronBin = process.platform === "darwin"
+    ? path.join(repoRoot, "node_modules/.pnpm/electron@37.10.3/node_modules/electron/dist/Electron.app/Contents/MacOS/Electron")
+    : path.join(repoRoot, "apps/desktop/node_modules/.bin/electron");
+  electron = spawn(electronBin, [wrapper], {
+    env: {
+      ...process.env,
+      REALM_HOME: path.join(scratch, "home"),
+      REALM_PORT: String(SERVER_PORT),
+      REALM_DEVTOOLS_PORT: String(CDP_PORT),
+      REALM_SERVER_ENTRY: path.join(repoRoot, "apps/server/dist/main.js"),
+      LIVE_USER_DATA: path.join(scratch, "userData"),
+      LIVE_MAIN: mainEntry,
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  electron.stderr.on("data", () => {}); electron.stdout.on("data", () => {});
+
+  const targets = () => fetch(`http://127.0.0.1:${CDP_PORT}/json/list`).then((r) => r.json()).catch(() => []);
+  const rendererTarget = await until(async () => (await targets()).find((t) => t.type === "page" && t.url.startsWith("file://")), 30000, "renderer target");
+  const c = cdp(rendererTarget.webSocketDebuggerUrl);
+  await c.ready;
+  await c.send("Runtime.enable");
+  await c.send("Page.enable");
+
+  await until(() => evalIn(c, `!!document.querySelector('.onboarding input:not([type=radio])')`), 20000, "onboarding");
+  await evalIn(c, `(() => {
+    const input = document.querySelector('.onboarding input:not([type=radio])');
+    __live.setInput(input, "Live");
+    input.closest("form").requestSubmit();
+    return true; })()`);
+  await until(() => evalIn(c, `!!document.querySelector('.composer')`), 20000, "composer");
+  await c.send("Emulation.setDeviceMetricsOverride", { width: 1200, height: 820, deviceScaleFactor: 1, mobile: false });
+  await sleep(600);
+
+  console.log("runtime:", await evalIn(c, `JSON.stringify({
+    chromium: navigator.userAgent.match(/Chrome\\/[0-9.]+/)?.[0],
+    cornerShape: CSS.supports("corner-shape", "squircle"),
+  })`));
+
+  check("the painter loaded in the real bundle, so the cards are off their fallback",
+    await evalIn(c, `document.documentElement.hasAttribute("data-squircle")`));
+  check("the prompter's fill is the worklet's, and its border-radius is out of the way",
+    await evalIn(c, `(() => { const cs = getComputedStyle(document.querySelector(".composer"));
+      return cs.backgroundImage.includes("paint(rl-squircle)") && parseFloat(cs.borderTopLeftRadius) === 0; })()`));
+
+  // ── the lift the technique could have eaten ─────────────────────────────
+  // A mask (the obvious way to get a superellipse) clips box-shadow away entirely. Painting the fill
+  // instead leaves it, and the mutant here is the shadow itself: remove it and the same strip of
+  // ground beside the card has to get lighter.
+  const restShot = await shotOf(c);
+  const leftOfCard = (b64) => `(async () => {
+    const s = await __live.sampler(${JSON.stringify(b64)});
+    const b = document.querySelector(".composer").getBoundingClientRect();
+    return s.band(b.left - 6, b.top + 30, b.left - 1, b.bottom - 30);
+  })()`;
+  const lift = await evalIn(c, leftOfCard(restShot));
+  await evalIn(c, `(() => { document.querySelector(".composer").style.boxShadow = "none"; return true; })()`);
+  await sleep(250);
+  const flat = await evalIn(c, leftOfCard(await shotOf(c)));
+  check("the card still casts its lift — the ground beside it is darker than with box-shadow removed",
+    lift < flat - 0.3, { withShadow: +lift.toFixed(2), withoutShadow: +flat.toFixed(2) });
+  await evalIn(c, `(() => { document.querySelector(".composer").style.boxShadow = ""; return true; })()`);
+  await sleep(250);
+
+  // ── the focus ring the technique could also have eaten ───────────────────
+  const topEdge = (b64) => `(async () => {
+    const s = await __live.sampler(${JSON.stringify(b64)});
+    const b = document.querySelector(".composer").getBoundingClientRect();
+    return s.band(b.left + 60, b.top - 0.5, b.right - 60, b.top + 1.5);
+  })()`;
+  const edgeRest = await evalIn(c, topEdge(await shotOf(c)));
+  const cornerRest = await evalIn(c, `__live.cornerFill(${JSON.stringify(restShot)}, ".composer", "tl")`);
+  await evalIn(c, `(() => { document.querySelector(".composer-input").focus(); return true; })()`);
+  await sleep(300);
+  const focusShot = await shotOf(c);
+  check("focus still brightens the card's edge — the ring survived moving into the painter",
+    (await evalIn(c, topEdge(focusShot))) > edgeRest + 0.5,
+    { rest: +edgeRest.toFixed(2), focused: +(await evalIn(c, topEdge(focusShot))).toFixed(2) });
+  // The regression this catches: leave focus on a box-shadow and it rings the element's BOX, which
+  // under the gate has border-radius 0 — the corner squares off and the fraction runs to 1.
+  const cornerFocus = await evalIn(c, `__live.cornerFill(${JSON.stringify(focusShot)}, ".composer", "tl")`);
+  check("the focus ring is drawn ON the curve — a box-shadow ring would square the corner off",
+    cornerFocus.fraction < 0.96 && Math.abs(cornerFocus.fraction - cornerRest.fraction) < 0.03,
+    { rest: cornerRest.fraction, focused: cornerFocus.fraction });
+  await evalIn(c, `(() => { document.querySelector(".composer-input").blur(); return true; })()`);
+  await sleep(300);
+
+  // ── the corner itself ────────────────────────────────────────────────────
+  /* The silhouette is the claim, so the edge stroke comes off first: a 0.5px ring lands precisely on
+     the boundary pixels the count is deciding and brightens enough of them past the threshold to add
+     ~0.04 to either curve. `--card-ring` is the single lever for it — the painter reads it as
+     --sq-ring and --shadow-card composes it — so suppressing it drops the stroke from the worklet
+     path and the fallback path symmetrically, leaving nothing but shape. */
+  await evalIn(c, `(() => { document.documentElement.style.setProperty("--card-ring", "transparent"); return true; })()`);
+  await sleep(250);
+  const silhouette = await shotOf(c);
+  const painted = await evalIn(c, `__live.cornerFill(${JSON.stringify(silhouette)}, ".composer", "tl")`);
+  check(`the prompter's corner is a superellipse (${SQUIRCLE}), not a circular arc (${CIRCLE.toFixed(3)})`,
+    near(painted.fraction, SQUIRCLE), painted);
+  const stripOn = await evalIn(c, `__live.cornerFill(${JSON.stringify(silhouette)}, ".composer-understrip", "bl")`);
+
+  // ── the mutant: without the gate the same measurement must find a circle ──
+  await evalIn(c, `(() => { document.documentElement.removeAttribute("data-squircle"); return true; })()`);
+  await sleep(300);
+  const fallbackShot = await shotOf(c);
+  const fallback = await evalIn(c, `__live.cornerFill(${JSON.stringify(fallbackShot)}, ".composer", "tl")`);
+  check("the mutant reproduces the old corner (gate off ⇒ the fallback's circular arc)",
+    near(fallback.fraction, CIRCLE), fallback);
+  /* The under-strip's corner is 12px across a 5-level luminance step, which is too coarse to pin an
+     absolute area against. Its gate-on/gate-off difference is not: the strip has to move the same
+     way the prompter does, or the worklet is not shaping it. */
+  const stripOff = await evalIn(c, `__live.cornerFill(${JSON.stringify(fallbackShot)}, ".composer-understrip", "bl")`);
+  check("the under-strip's bottom corners are painted too — they fill more than the fallback's arc",
+    stripOn.fraction > stripOff.fraction + 0.03, { gateOn: stripOn.fraction, gateOff: stripOff.fraction, R: stripOn.R });
+
+  await evalIn(c, `(() => {
+    document.documentElement.setAttribute("data-squircle", "");
+    document.documentElement.style.removeProperty("--card-ring");
+    return true; })()`);
+
+  for (const [tag, data] of [["squircle", restShot], ["focused", focusShot], ["fallback", fallbackShot]]) {
+    const out = path.join(os.tmpdir(), `realm-squircle-${tag}.png`);
+    fs.writeFileSync(out, Buffer.from(data, "base64"));
+    console.log(`SCREENSHOT ${tag} ${out}`);
+  }
+
+  const errs = c.events.filter((e) => !e.includes("Autofill"));
+  check("no renderer console errors", errs.length === 0, errs.slice(0, 5));
+  c.close();
+}
+
+main()
+  .catch((e) => { console.error("ERROR", e.message); process.exitCode = 1; })
+  .finally(() => {
+    electron?.kill("SIGTERM");
+    setTimeout(() => { electron?.kill("SIGKILL"); fs.rmSync(scratch, { recursive: true, force: true }); process.exit(process.exitCode ?? 0); }, 1200);
+  });

--- a/apps/desktop/src/renderer/public/squircle-paint.js
+++ b/apps/desktop/src/renderer/public/squircle-paint.js
@@ -1,0 +1,89 @@
+/* Paint worklet: the continuous superellipse corner Realm's floating cards are drawn with.
+ *
+ * `corner-shape: squircle` is the declarative form of this and lands in Chromium 139; Electron
+ * 37.10.3 ships 138, where the property is not even recognised (`CSS.supports('corner-shape',
+ * 'squircle')` is false), so the stylesheet keeps that declaration as the path forward and this
+ * worklet is what actually draws the shape today.
+ *
+ * It paints the FILL and the RING, because both have to trace the same curve. A `box-shadow` ring is
+ * always drawn on the `border-radius` rounded rect, so leaving the edge to box-shadow puts a hairline
+ * across a corner the fill has already bulged past — a superellipse sits further into the corner than
+ * the circular arc of the same radius does. The soft lift layers stay on box-shadow: they are blurred
+ * far wider than the two curves ever diverge.
+ *
+ * Lives in `public/` rather than the module graph on purpose. The renderer's CSP is
+ * `script-src 'self'`, which rejects a worklet module fetched from a blob: or data: URL — measured,
+ * not assumed — so this has to be a real file at the document's own origin.
+ */
+
+/* Exponent of the superellipse |x/r|^n + |y/r|^n = 1. n = 2 is the circle a plain border-radius
+ * already draws; 4 is the ratio Figma and iOS settled on for a corner that reads as smooth rather
+ * than as a shape of its own. */
+const N = 4;
+/* Segments per corner. At the 20px radius the prompter uses this puts a vertex every ~1.3px, which
+ * is under the point a retina display can resolve a facet at. */
+const STEPS = 24;
+
+const px = (v) => (typeof v?.value === "number" ? v.value : parseFloat(String(v)) || 0);
+
+/** One corner, swept as a superellipse quadrant from `t0` to `t1` about (cx, cy). */
+function sweep(ctx, cx, cy, r, t0, t1) {
+  for (let i = 0; i <= STEPS; i++) {
+    const t = t0 + ((t1 - t0) * i) / STEPS;
+    const c = Math.cos(t), s = Math.sin(t);
+    ctx.lineTo(cx + r * Math.sign(c) * Math.abs(c) ** (2 / N), cy + r * Math.sign(s) * Math.abs(s) ** (2 / N));
+  }
+}
+
+function trace(ctx, w, h, rTop, rBot) {
+  ctx.beginPath();
+  ctx.moveTo(rTop, 0);
+  ctx.lineTo(w - rTop, 0);
+  sweep(ctx, w - rTop, rTop, rTop, -Math.PI / 2, 0);
+  ctx.lineTo(w, h - rBot);
+  sweep(ctx, w - rBot, h - rBot, rBot, 0, Math.PI / 2);
+  ctx.lineTo(rBot, h);
+  sweep(ctx, rBot, h - rBot, rBot, Math.PI / 2, Math.PI);
+  ctx.lineTo(0, rTop);
+  sweep(ctx, rTop, rTop, rTop, Math.PI, (3 * Math.PI) / 2);
+  ctx.closePath();
+}
+
+registerPaint(
+  "rl-squircle",
+  class {
+    static get inputProperties() {
+      return ["--sq-fill", "--sq-ring", "--sq-ring-w", "--sq-radius-top", "--sq-radius-bottom"];
+    }
+
+    paint(ctx, size, props) {
+      const { width: w, height: h } = size;
+      if (w <= 0 || h <= 0) return;
+      /* A radius past half the box turns the superellipse inside out at the midpoint. */
+      const cap = Math.min(w, h) / 2;
+      const rTop = Math.min(px(props.get("--sq-radius-top")), cap);
+      const rBot = Math.min(px(props.get("--sq-radius-bottom")), cap);
+      trace(ctx, w, h, rTop, rBot);
+
+      const fill = String(props.get("--sq-fill")).trim();
+      if (fill) {
+        ctx.fillStyle = fill;
+        ctx.fill();
+      }
+
+      const ringW = px(props.get("--sq-ring-w"));
+      const ring = String(props.get("--sq-ring")).trim();
+      if (ringW > 0 && ring) {
+        /* Clip first, then stroke at double width: a stroke straddles its path, and the outer half
+         * would be cut off by the background painting area anyway. This lands the whole ring just
+         * inside the curve, at the width asked for, with no second edge. */
+        ctx.save();
+        ctx.clip();
+        ctx.lineWidth = ringW * 2;
+        ctx.strokeStyle = ring;
+        ctx.stroke();
+        ctx.restore();
+      }
+    }
+  },
+);

--- a/apps/desktop/src/renderer/src/main.tsx
+++ b/apps/desktop/src/renderer/src/main.tsx
@@ -10,4 +10,8 @@ import "katex/dist/katex.min.css";
 // BUI foundation first (Tailwind layers + tokens); styles.css is unlayered and so wins conflicts.
 import "./theme/tokens.css";
 import "./styles.css";
+import { enableSquircles } from "./theme/squircle";
+// Fire and forget: the cards render on their circular-corner fallback until the painter is ready,
+// and stay there if it never loads. Nothing waits on a corner shape.
+void enableSquircles();
 createRoot(document.getElementById("root")!).render(<React.StrictMode><App /></React.StrictMode>);

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -359,7 +359,7 @@ kbd { font: 11px var(--font-mono); }
 .mention-picker { z-index: 100; width: min(380px, 80vw); max-height: min(40vh, 280px); overflow-y: auto; padding: 6px;
   background: var(--surface); color: var(--rl-text-bright); border-radius: var(--r-panel); box-shadow: var(--shadow-raised); }
 .mention-row { display: flex; align-items: baseline; gap: 8px; padding: 6px 8px; border-radius: var(--r-ctl); cursor: pointer;
-  transition: background-color 100ms ease; }
+  transition: background-color var(--dur-hover) ease; }
 .mention-row[data-active] { background: var(--hover); }
 .mention-row-id { flex: none; font-family: var(--font-mono); font-size: 12px; font-weight: var(--fw-label); color: var(--rl-text-bright); }
 .mention-row-desc { flex: 1; min-width: 0; font-size: 11.5px; color: var(--rl-text-dim); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
@@ -382,7 +382,7 @@ kbd { font: 11px var(--font-mono); }
 .skill-picker-group-label { padding: 5px 8px 3px; font-size: 10.5px; font-weight: var(--fw-title); letter-spacing: .04em;
   text-transform: uppercase; color: var(--rl-text-faint); }
 .skill-picker-row { display: flex; align-items: center; gap: 10px; padding: 6px 8px; border-radius: var(--r-ctl); cursor: pointer;
-  transition: background-color 100ms ease; }
+  transition: background-color var(--dur-hover) ease; }
 .skill-picker-row[data-active] { background: var(--hover); }
 .skill-picker-row-main { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 1px; }
 .skill-picker-row-id { font-family: var(--font-mono); font-size: 12px; font-weight: var(--fw-label); color: var(--rl-text-bright);
@@ -390,7 +390,7 @@ kbd { font: 11px var(--font-mono); }
 .skill-picker-row-desc { font-size: 11.5px; color: var(--rl-text-dim); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .skill-picker-empty { padding: 14px 10px; text-align: center; font-size: 12px; color: var(--rl-text-dim); }
 .skill-picker-manage { padding: 8px 11px; border-top: 1px solid var(--rl-hairline); text-align: left;
-  font-size: 12px; color: var(--rl-text-dim); transition: color 100ms ease; }
+  font-size: 12px; color: var(--rl-text-dim); transition: color var(--dur-hover) ease; }
 .skill-picker-manage:hover { color: var(--rl-text-bright); }
 
 /* ── Skills settings: search/filter bar and the per-source groups ── */
@@ -427,7 +427,7 @@ kbd { font: 11px var(--font-mono); }
 .mp-group-label { padding: 5px 8px 3px; font-size: 10px; font-weight: var(--fw-title); letter-spacing: .06em;
   text-transform: uppercase; color: var(--rl-text-faint); }
 .mp-row { display: flex; align-items: center; gap: 9px; padding: 6px 8px; border-radius: var(--r-ctl); cursor: pointer;
-  transition: background-color 100ms ease, color 100ms ease; }
+  transition: background-color var(--dur-hover) ease, color var(--dur-hover) ease; }
 .mp-row[data-active] { background: var(--hover); }
 /* Unavailable, not hidden: dimmed and non-interactive, but still readable and still explaining
    itself in the detail pane beside it. */
@@ -449,7 +449,7 @@ kbd { font: 11px var(--font-mono); }
 /* The star holds its column on every row — hollow when unstarred, so the list keeps one alignment
    instead of shifting text as rows are favourited. It only brightens on hover or when it is on. */
 .mp-star { flex: none; display: grid; place-items: center; width: 22px; height: 22px; border-radius: var(--r-chip);
-  color: var(--rl-text-faint); opacity: .5; transition: opacity 100ms ease, color 100ms ease, background-color 100ms ease; }
+  color: var(--rl-text-faint); opacity: .5; transition: opacity var(--dur-hover) ease, color var(--dur-hover) ease, background-color var(--dur-hover) ease; }
 .mp-row:hover .mp-star, .mp-row[data-active] .mp-star { opacity: 1; }
 .mp-star:hover { background: var(--hover-2); color: var(--rl-text-bright); }
 .mp-star[aria-pressed="true"] { opacity: 1; color: var(--rl-accent); }
@@ -477,7 +477,7 @@ kbd { font: 11px var(--font-mono); }
    a segmented control: the set is 1…3 wide and grows with the harnesses that can run this model. */
 .mp-route { display: flex; align-items: center; gap: 6px; padding: 4px 9px; border-radius: 999px;
   border: 1px solid var(--rl-line); background: none; color: var(--rl-text-dim); font: inherit; font-size: 11.5px;
-  cursor: pointer; transition: border-color 100ms ease, background-color 100ms ease, color 100ms ease; }
+  cursor: pointer; transition: border-color var(--dur-hover) ease, background-color var(--dur-hover) ease, color var(--dur-hover) ease; }
 .mp-route:hover:not(:disabled) { color: var(--rl-text-bright); background: var(--hover); }
 .mp-route[aria-pressed="true"] { color: var(--rl-text-bright); border-color: color-mix(in oklab, var(--rl-accent) 60%, transparent);
   background: color-mix(in oklab, var(--rl-accent) 14%, transparent); }
@@ -497,7 +497,7 @@ kbd { font: 11px var(--font-mono); }
 .mp-seg { flex: 1; min-width: 0; display: grid; grid-auto-flow: column; grid-auto-columns: 1fr; gap: 2px;
   padding: 2px; border-radius: var(--r-ctl); background: var(--hover); }
 .mp-seg-opt { padding: 3px 4px; border-radius: calc(var(--r-ctl) - 2px); border: 0; background: none; font: inherit;
-  font-size: 11px; color: var(--rl-text-dim); cursor: pointer; transition: background-color 100ms ease, color 100ms ease; }
+  font-size: 11px; color: var(--rl-text-dim); cursor: pointer; transition: background-color var(--dur-hover) ease, color var(--dur-hover) ease; }
 .mp-seg-opt:hover { color: var(--rl-text-bright); }
 .mp-seg-opt[aria-pressed="true"] { background: var(--surface); color: var(--rl-text-bright); box-shadow: var(--rl-edge); }
 .mp-use { align-self: flex-end; margin-top: 3px; padding: 6px 13px; border: 0; border-radius: var(--r-ctl);
@@ -509,7 +509,7 @@ kbd { font: 11px var(--font-mono); }
   border: 1px solid var(--rl-line); background: var(--rl-panel); color: var(--rl-text-dim); align-self: flex-start; }
 .icon-picker-trigger:hover { color: var(--rl-text-bright); }
 .icon-picker { z-index: 100; width: 320px; display: flex; flex-direction: column; overflow: hidden;
-  background: var(--surface); color: var(--rl-text-bright); border-radius: var(--r-panel); box-shadow: var(--shadow-raised); animation: rl-menu-in 140ms var(--ease-out-strong); }
+  background: var(--surface); color: var(--rl-text-bright); border-radius: var(--r-panel); box-shadow: var(--shadow-raised); animation: rl-menu-in var(--dur-pop) var(--ease-out-strong); }
 .ip-tabs { display: flex; border-bottom: 1px solid var(--rl-hairline); }
 /* Radius on the top corners only: the tab meets the header's bottom hairline flush, so rounding
    all four would float the selected underline off its own tab. */
@@ -572,7 +572,7 @@ kbd { font: 11px var(--font-mono); }
 .archived-head { padding-top: 14px; }
 .archived-toggle { display: flex; align-items: center; gap: 6px; }
 .archived-toggle:hover { color: var(--rl-text-dim); }
-.archived-caret { display: grid; place-items: center; transition: transform 140ms var(--ease-out-strong); }
+.archived-caret { display: grid; place-items: center; transition: transform var(--dur-pop) var(--ease-out-strong); }
 .archived-caret[data-open] { transform: rotate(90deg); }
 .archived-count { color: var(--rl-text-faint); font-variant-numeric: tabular-nums; }
 .group-new { display: flex; align-items: center; gap: 6px; margin: 6px 0 0; padding: 4px 8px; border-radius: var(--r-ctl);
@@ -651,7 +651,7 @@ button.panel-title:hover { background: var(--rl-hover); }
 /* Empty-terminal hint (V-F3): floats centered until the first output, then fades out. Fixed light
    colours, not text tokens — the terminal interior stays dark in both app modes. */
 .terminal-hint { position: absolute; inset: 0; z-index: 1; display: grid; place-content: center; justify-items: center; gap: 4px;
-  text-align: center; pointer-events: none; user-select: none; opacity: 1; transition: opacity .25s var(--ease); }
+  text-align: center; pointer-events: none; user-select: none; opacity: 1; transition: opacity var(--dur-slow) var(--ease); }
 .terminal-hint[data-hidden] { opacity: 0; }
 .terminal-hint-path { font: 12px var(--font-mono); color: rgba(255,255,255,.55); }
 .terminal-hint-keys { font-size: 11px; color: rgba(255,255,255,.32); }
@@ -1020,7 +1020,7 @@ button.panel-title:hover { background: var(--rl-hover); }
    corners and squares off against the body's divider. Rounding all four corners left the hover
    fill curving away from the hairline at both ends — two dark notches sitting on the divider. */
 .tool-card[data-open] .tool-row { border-radius: var(--r-ctl) var(--r-ctl) 0 0; }
-.tool-chevron { color: var(--rl-text-faint); transition: transform 200ms var(--ease-in-out-strong); flex: none; margin-left: auto; }
+.tool-chevron { color: var(--rl-text-faint); transition: transform var(--dur-base) var(--ease-in-out-strong); flex: none; margin-left: auto; }
 .tool-card[data-open] .tool-chevron, .tool-group[data-open] .tool-chevron { transform: rotate(90deg); }
 .tool-name { font-size: 12.5px; font-weight: var(--fw-label); flex: none; }
 /* Measured counts (editStat): green adds, red deletes, mono tabular — BUI's `+74 −41`. */
@@ -1030,7 +1030,7 @@ button.panel-title:hover { background: var(--rl-hover); }
 
 /* §6 tool-row expand: height animates via grid-template-rows 0fr→1fr over 200ms, content fades at
    120ms. .tool-body-clip is the overflow container the 0fr row needs to clip against. */
-.tool-body-wrap { display: grid; grid-template-rows: 0fr; transition: grid-template-rows 200ms var(--ease-in-out-strong); }
+.tool-body-wrap { display: grid; grid-template-rows: 0fr; transition: grid-template-rows var(--dur-base) var(--ease-in-out-strong); }
 .tool-card[data-open] .tool-body-wrap { grid-template-rows: 1fr; }
 .tool-body-clip { overflow: hidden; min-height: 0; }
 .tool-card[data-open] .tool-body { opacity: 1; }
@@ -1059,11 +1059,11 @@ button.panel-title:hover { background: var(--rl-hover); }
 .tool-card[data-state="error"] .tool-status { color: var(--rl-danger); }
 .tool-card[data-state="running"] .tool-status { color: var(--ink-2); } /* §3: nothing running-related uses accent */
 .tool-body { border-top: 1px solid var(--rl-hairline); padding: 10px 12px; display: flex; flex-direction: column; gap: 8px;
-  opacity: 0; transition: opacity 120ms ease; }
+  opacity: 0; transition: opacity var(--dur-press) ease; }
 .tool-section { display: flex; flex-direction: column; }
 /* Copy ✓ (§6 icon swap): both glyphs stacked in one grid cell, cross-fading with scale + blur. */
 .tool-copy .copy-icon, .tool-copy .copied-icon { grid-area: 1 / 1;
-  transition: opacity 160ms var(--ease-out-strong), transform 160ms var(--ease-out-strong), filter 160ms var(--ease-out-strong); }
+  transition: opacity var(--dur-swap) var(--ease-out-strong), transform var(--dur-swap) var(--ease-out-strong), filter var(--dur-swap) var(--ease-out-strong); }
 .tool-copy .copied-icon { color: var(--rl-success); }
 .tool-copy:not([data-copied]) .copied-icon, .tool-copy[data-copied] .copy-icon { opacity: 0; transform: scale(.25); filter: blur(4px); }
 .tool-label { display: flex; align-items: center; font-size: 10.5px; text-transform: uppercase; letter-spacing: .06em; color: var(--rl-text-dim); margin-bottom: 4px; }
@@ -1181,7 +1181,7 @@ button.panel-title:hover { background: var(--rl-hover); }
 .todo-track { height: 3px; border-radius: 2px; background: var(--rl-line); overflow: hidden; }
 /* The one bar in the app that fills with the accent: it is progress, not state — §3 reserves colour
    for state, and reserves the accent for "the thing that is happening". */
-.todo-fill { height: 100%; border-radius: 2px; background: var(--rl-accent); transition: width 240ms var(--ease-out-strong); }
+.todo-fill { height: 100%; border-radius: 2px; background: var(--rl-accent); transition: width var(--dur-slow) var(--ease-out-strong); }
 .todo-list { display: flex; flex-direction: column; gap: 3px; margin: 2px 0 0; padding: 0; list-style: none; }
 .todo-list li { display: flex; align-items: baseline; gap: 8px; font-size: 12.5px; line-height: 1.5; color: var(--rl-text-dim); }
 .todo-dot { flex: none; display: grid; place-items: center; width: 13px; height: 13px; border-radius: 50%;
@@ -1348,7 +1348,7 @@ button.panel-title:hover { background: var(--rl-hover); }
    transcript passes UNDER the prompter, never over it. */
 .composer-dock { position: relative; z-index: 2; flex: none; width: min(var(--prompter-w), 100% - 48px);
   margin: 8px auto max(12px, env(safe-area-inset-bottom));
-  transition: transform 320ms var(--ease-in-out-strong); }
+  transition: transform var(--dur-move) var(--ease-in-out-strong); }
 /* Hero (§4): card centered at ~38% pane height. It stays bottom-anchored in flow and is lifted by
    transform only — translateY % is own-height, cqh is pane height. The max() keeps the card from
    crossing ~60px below the pane top in short panes. */
@@ -1377,7 +1377,7 @@ button.panel-title:hover { background: var(--rl-hover); }
 .suggestion-chip:hover .suggestion-title { color: var(--rl-text-bright); }
 /* Stagger-in (§6): 220ms ease-out, 8px rise, 40ms steps — first render of a session's hero only
    (the data-animate guard is set from a module-level seen-set, so tab-backs never replay). */
-.suggestions[data-animate] .suggestion-chip { animation: rl-chip-in 220ms var(--ease-out-strong) backwards; animation-delay: calc(var(--i) * 40ms); }
+.suggestions[data-animate] .suggestion-chip { animation: rl-chip-in var(--dur-rise) var(--ease-out-strong) backwards; animation-delay: calc(var(--i) * 40ms); }
 @keyframes rl-chip-in { from { opacity: 0; transform: translateY(8px); } }
 
 /* The card (Plan 9 W3 — BUI PromptBar): a surface field on shadow-card (the hairline ring is part
@@ -1439,7 +1439,7 @@ button.panel-title:hover { background: var(--rl-hover); }
    file, not a control. It stays for keyboard focus, which has no hover to trade on. */
 .attach-remove { position: absolute; top: 2px; right: 2px; display: grid; place-items: center;
   width: 16px; height: 16px; border-radius: 50%; color: #fff; background: rgb(0 0 0 / .62);
-  box-shadow: var(--shadow-btn); opacity: 0; transition: opacity 100ms ease; }
+  box-shadow: var(--shadow-btn); opacity: 0; transition: opacity var(--dur-hover) ease; }
 .attach-tile:hover .attach-remove, .attach-remove:focus-visible { opacity: 1; }
 .attach-remove:hover { background: rgb(0 0 0 / .82); }
 /* The honesty row: what THIS agent does with these files, named before the message goes. */
@@ -1552,7 +1552,7 @@ button.panel-title:hover { background: var(--rl-hover); }
 .composer-send:hover:not(:disabled) { background: var(--accent-ink); }
 .composer-send:disabled { background: var(--line-strong); color: var(--ink-2); box-shadow: none; opacity: 1; }
 .composer-send svg { grid-area: 1 / 1;
-  transition: opacity 160ms var(--ease-out-strong), transform 160ms var(--ease-out-strong), filter 160ms var(--ease-out-strong); }
+  transition: opacity var(--dur-swap) var(--ease-out-strong), transform var(--dur-swap) var(--ease-out-strong), filter var(--dur-swap) var(--ease-out-strong); }
 .composer-send[data-state="send"] .stop-icon, .composer-send[data-state="stop"] .send-icon { opacity: 0; transform: scale(.25); filter: blur(4px); }
 /* ── Under-strip (§4 + Plan 12 W1): machine label + workspace selector, one size quieter than the
    control row (11px on faint vs 12px on dim), on a frame fill sliding out from beneath the card
@@ -1693,26 +1693,26 @@ button.panel-title:hover { background: var(--rl-hover); }
 /* ── Motion (§6): the whole easing/duration table, applied app-wide ───────── */
 /* A leaf's item changing IS content entering, not the "pane focus switching" §6 keeps instant — the
    animation is keyed to item.id in PaneHost, so moving focus between panes never replays it. */
-.panel-body .pane-slot { animation: rl-settle 150ms var(--ease-out-strong); }
+.panel-body .pane-slot { animation: rl-settle var(--dur-fast) var(--ease-out-strong); }
 @keyframes rl-settle { from { opacity: 0; transform: translateY(4px); } to { opacity: 1; transform: none; } }
 
 /* Menus / popovers (§6): 140ms, opacity + scale .97→1, origin-aware — Menu.tsx sets
    transform-origin to the corner the menu grew from, so it appears to unfold out of its trigger. */
-.menu, .model-picker { animation: rl-menu-in 140ms var(--ease-out-strong); }
+.menu, .model-picker { animation: rl-menu-in var(--dur-pop) var(--ease-out-strong); }
 @keyframes rl-menu-in { from { opacity: 0; transform: scale(.97); } to { opacity: 1; transform: none; } }
 
 /* Sheets (§6): enter 240ms, scale .96 + fade, origin center; the scrim fades on its own at 160ms.
    One rule for every sheet — W4b's `.sheet.onboarding` carve-out is gone. */
-.sheet { animation: rl-sheet-in 240ms var(--ease-out-strong); }
+.sheet { animation: rl-sheet-in var(--dur-slow) var(--ease-out-strong); }
 @keyframes rl-sheet-in { from { opacity: 0; transform: scale(.96); } to { opacity: 1; transform: none; } }
-.sheet-backdrop { animation: rl-fade-in 160ms var(--ease-out-strong); }
+.sheet-backdrop { animation: rl-fade-in var(--dur-swap) var(--ease-out-strong); }
 @keyframes rl-fade-in { from { opacity: 0; } to { opacity: 1; } }
 
 /* Transcript items (§6): 180ms, translateY 6px + fade, NEW items only. Transcript.tsx marks a block
    with data-enter the first time it is seen after mount and never takes the mark away — so a
    re-render, a scroll, or coming back to the session cannot replay (or abort) an entrance, and a
    restored history animates nothing at all. */
-.transcript-col > [data-enter], .tool-group-steps > [data-enter] { animation: rl-msg-in 180ms var(--ease-out-strong); }
+.transcript-col > [data-enter], .tool-group-steps > [data-enter] { animation: rl-msg-in var(--dur-enter) var(--ease-out-strong); }
 @keyframes rl-msg-in { from { opacity: 0; transform: translateY(6px); } to { opacity: 1; transform: none; } }
 
 /* §6 "do NOT animate": the command palette is a 100×/day action (Raycast rule) — it appears and
@@ -1722,25 +1722,25 @@ button.panel-title:hover { background: var(--rl-hover); }
 
 /* The overview is the opposite case to the palette above: an occasional, deliberate "show me
    everything" that covers the window, so it enters on the sheet's own timings rather than snapping. */
-.spaces-overview { animation: rl-sheet-in 240ms var(--ease-out-strong); }
-.spaces-backdrop { animation: rl-fade-in 160ms var(--ease-out-strong); }
+.spaces-overview { animation: rl-sheet-in var(--dur-slow) var(--ease-out-strong); }
+.spaces-backdrop { animation: rl-fade-in var(--dur-swap) var(--ease-out-strong); }
 
 /* Hover fills (§6): 100ms `ease`, background (and the text colour riding along with it) only —
    never `all`, never geometry. */
 .item-row, .item-close, .item-shelf, .icon-btn, .btn, .ghost-chip, .tool-row, .tool-group-row, .tool-copy,
 .strip-space, .strip-profile, .space-card, .suggestion-chip, .palette-opt, .permission-option, .menu [role^="menuitem"],
 .question-option, .question-skip {
-  transition: background-color 100ms ease, color 100ms ease;
+  transition: background-color var(--dur-hover) ease, color var(--dur-hover) ease;
 }
 /* Press (§6): 120ms to scale .97 on every pressable — buttons, chips, send, permission options.
    Full-width rows (.tool-row, .item-row) are left out: a wide surface shrinking reads as a glitch. */
 .btn, .icon-btn, .ghost-chip, .suggestion-chip, .composer-send, .permission-option, .tool-copy {
-  transition: background-color 100ms ease, color 100ms ease, transform 120ms var(--ease-out-strong);
+  transition: background-color var(--dur-hover) ease, color var(--dur-hover) ease, transform var(--dur-press) var(--ease-out-strong);
 }
 .btn:active:not(:disabled), .icon-btn:active:not(:disabled), .ghost-chip:active:not(:disabled),
 .suggestion-chip:active:not(:disabled), .composer-send:active:not(:disabled),
 .permission-option:active:not(:disabled), .tool-copy:active:not(:disabled) { transform: scale(.97); }
-.drop-zone { transition: opacity 80ms linear; }
+.drop-zone { transition: opacity var(--dur-drag) linear; }
 
 /* §6 "do NOT animate: theme/mode switching". useTheme sets this for a beat around a palette rewrite;
    without it the surfaces carrying a hover transition would tween to the new theme while the rest of
@@ -2016,8 +2016,8 @@ button.panel-title:hover { background: var(--rl-hover); }
 .settings-agent-note code { font: 10.5px var(--font-mono); }
 
 /* One switch idiom for every per-space toggle: a native checkbox drawn as a 30×17 pill. */
-.switch { appearance: none; flex: none; width: 30px; height: 17px; margin: 2px 0 0; border-radius: 999px; background: var(--rl-line-strong); position: relative; cursor: pointer; transition: background 120ms var(--ease-out-strong); }
-.switch::after { content: ""; position: absolute; top: 2px; left: 2px; width: 13px; height: 13px; border-radius: 50%; background: var(--surface); transition: translate 120ms var(--ease-out-strong); }
+.switch { appearance: none; flex: none; width: 30px; height: 17px; margin: 2px 0 0; border-radius: 999px; background: var(--rl-line-strong); position: relative; cursor: pointer; transition: background var(--dur-press) var(--ease-out-strong); }
+.switch::after { content: ""; position: absolute; top: 2px; left: 2px; width: 13px; height: 13px; border-radius: 50%; background: var(--surface); transition: translate var(--dur-press) var(--ease-out-strong); }
 .switch:checked { background: var(--rl-accent); }
 .switch:checked::after { translate: 13px 0; }
 .switch:focus-visible { outline: 1.5px solid var(--rl-accent); outline-offset: 2px; }
@@ -2353,7 +2353,7 @@ button.panel-title:hover { background: var(--rl-hover); }
   border-bottom: 1px solid var(--rl-line); flex: 0 0 auto; scrollbar-width: thin; overflow-y: hidden;
 }
 .documents-tab { display: flex; align-items: center; border-radius: var(--r-ctl); flex: 0 0 auto;
-  transition: background-color 100ms ease, color 100ms ease; }
+  transition: background-color var(--dur-hover) ease, color var(--dur-hover) ease; }
 .documents-tab:hover { background: var(--rl-hover); }
 .documents-tab[data-active] { background: var(--rl-active); }
 .documents-tab-label {
@@ -2385,7 +2385,7 @@ button.panel-title:hover { background: var(--rl-hover); }
   min-width: 0; max-width: 340px; padding: 2px 6px; margin-left: -6px; border-radius: var(--r-chip);
   font-size: 13px; font-weight: var(--fw-label); color: var(--rl-text-bright);
   overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
-  transition: background-color 100ms ease, color 100ms ease;
+  transition: background-color var(--dur-hover) ease, color var(--dur-hover) ease;
 }
 .documents-name:hover { background: var(--rl-hover); }
 .documents-name-input {
@@ -2401,7 +2401,7 @@ button.panel-title:hover { background: var(--rl-hover); }
   border-radius: var(--r-ctl); background: var(--field); box-shadow: var(--shadow-hairline); }
 .documents-modes button {
   padding: 3px 9px; border-radius: var(--r-chip); font-size: 11.5px; color: var(--rl-text-dim);
-  transition: background-color 100ms ease, color 100ms ease;
+  transition: background-color var(--dur-hover) ease, color var(--dur-hover) ease;
 }
 .documents-modes button:hover { color: var(--rl-text-bright); }
 .documents-modes button[aria-pressed="true"] { background: var(--rl-raised); color: var(--rl-text-bright); box-shadow: var(--shadow-btn); }
@@ -2429,7 +2429,7 @@ button.panel-title:hover { background: var(--rl-hover); }
 .documents-picker {
   position: absolute; z-index: 30; top: calc(100% + 4px); left: 12px; right: 12px; max-height: 60vh;
   overflow: auto; padding: 4px; border-radius: var(--r-panel); background: var(--surface);
-  box-shadow: var(--shadow-overlay); animation: rl-menu-in 140ms var(--ease-out-strong);
+  box-shadow: var(--shadow-overlay); animation: rl-menu-in var(--dur-pop) var(--ease-out-strong);
 }
 .documents-picker-head { display: flex; align-items: center; justify-content: space-between; gap: 8px;
   padding: 4px 6px 6px 10px; font-family: var(--font-mono); }
@@ -2437,7 +2437,7 @@ button.panel-title:hover { background: var(--rl-hover); }
 .documents-picker-list button {
   display: flex; align-items: center; gap: 8px; width: 100%; padding: 6px 10px; text-align: left;
   border-radius: var(--r-chip); color: var(--rl-text-bright); font-size: 12.5px;
-  transition: background-color 100ms ease, color 100ms ease;
+  transition: background-color var(--dur-hover) ease, color var(--dur-hover) ease;
 }
 .documents-picker-list button > svg { flex: none; color: var(--rl-text-faint); }
 .documents-picker-list button:hover:not(:disabled) { background: var(--hover); }
@@ -2525,7 +2525,7 @@ button.panel-title:hover { background: var(--rl-hover); }
 .lecture-row {
   display: flex; align-items: center; gap: 8px; width: 100%; padding: 7px 10px; border-radius: var(--r-ctl);
   background: none; color: var(--rl-text-bright); font: inherit; text-align: left;
-  transition: background-color 100ms ease, color 100ms ease;
+  transition: background-color var(--dur-hover) ease, color var(--dur-hover) ease;
 }
 .lecture-row:hover:not(:disabled) { background: var(--rl-hover); }
 .lecture-row:disabled { opacity: 0.6; cursor: default; }
@@ -2568,7 +2568,7 @@ button.panel-title:hover { background: var(--rl-hover); }
   position: absolute; inset: 0; margin: auto; width: 52px; height: 52px; display: grid; place-items: center;
   border: none; border-radius: var(--r-pill); color: #fff; background: rgb(0 0 0 / .55);
   backdrop-filter: blur(8px); cursor: pointer;
-  transition: transform 160ms var(--ease-out-strong), background-color 160ms var(--ease-out-strong);
+  transition: transform var(--dur-swap) var(--ease-out-strong), background-color var(--dur-swap) var(--ease-out-strong);
 }
 .media-play:hover { transform: scale(1.06); background: rgb(0 0 0 / .7); }
 
@@ -2578,7 +2578,7 @@ button.panel-title:hover { background: var(--rl-hover); }
   position: absolute; left: 0; right: 0; bottom: 0; display: flex; align-items: center; gap: 7px;
   padding: 8px 10px; color: #fff;
   background: linear-gradient(to top, rgb(0 0 0 / .72), rgb(0 0 0 / 0));
-  opacity: 0; transition: opacity 160ms var(--ease-out-strong);
+  opacity: 0; transition: opacity var(--dur-swap) var(--ease-out-strong);
 }
 .media-video:not([data-playing]) .media-controls,
 .media-video:hover .media-controls,
@@ -2586,7 +2586,7 @@ button.panel-title:hover { background: var(--rl-hover); }
 .media-btn {
   display: grid; place-items: center; width: 22px; height: 22px; flex: none;
   border: none; border-radius: var(--r-chip); background: none; color: inherit; cursor: pointer;
-  transition: background-color 100ms ease;
+  transition: background-color var(--dur-hover) ease;
 }
 .media-btn:hover { background: rgb(255 255 255 / .18); }
 .media-time { font: 11px var(--font-mono); font-variant-numeric: tabular-nums; flex: none; opacity: .85; }
@@ -2601,7 +2601,7 @@ button.panel-title:hover { background: var(--rl-hover); }
 }
 .media-scrub::-webkit-slider-thumb {
   appearance: none; width: 11px; height: 11px; border-radius: var(--r-pill); background: #fff; border: none;
-  transition: transform 120ms var(--ease-out-strong);
+  transition: transform var(--dur-press) var(--ease-out-strong);
 }
 .media-scrub:hover::-webkit-slider-thumb { transform: scale(1.2); }
 .media-scrub:disabled { cursor: default; }
@@ -2619,7 +2619,7 @@ button.panel-title:hover { background: var(--rl-hover); }
   flex: none; display: inline-flex; align-items: center; gap: 4px; margin-left: auto;
   padding: 2px 5px; border: none; border-radius: var(--r-chip); background: none;
   color: var(--rl-text-faint); font: inherit; font-size: 11px; cursor: pointer;
-  transition: background-color 100ms ease, color 100ms ease;
+  transition: background-color var(--dur-hover) ease, color var(--dur-hover) ease;
 }
 .media-action + .media-action { margin-left: 0; }
 .media-action:hover { background: var(--rl-hover); color: var(--rl-text-bright); }
@@ -2634,7 +2634,7 @@ button.panel-title:hover { background: var(--rl-hover); }
      in the stacking order and wins hit-testing — so a transcript video showed straight through the
      dim. Verified by sampling the composited screenshot, not by eye (scripts/media-live.mjs). */
   background: oklch(0.13 0 0 / 0.97);
-  animation: rl-fade-in 160ms var(--ease-out-strong);
+  animation: rl-fade-in var(--dur-swap) var(--ease-out-strong);
 }
 .media-stage { max-width: min(1200px, 100%); max-height: calc(100vh - 120px); display: flex; }
 .media-stage .media-video, .media-stage .media-image { box-shadow: var(--rl-shadow); background: transparent; }
@@ -2725,7 +2725,7 @@ body[data-media-lightbox] .transcript .media-el { visibility: hidden; }
 .seg-opt {
   padding: 3px 9px; font-size: 12px; line-height: 16px; color: var(--rl-text-dim);
   border-radius: var(--r-chip); cursor: pointer; white-space: nowrap;
-  transition: background-color 100ms ease, color 100ms ease;
+  transition: background-color var(--dur-hover) ease, color var(--dur-hover) ease;
 }
 .seg-opt input { position: absolute; opacity: 0; pointer-events: none; }
 .seg-opt:hover { color: var(--rl-text-bright); }
@@ -2768,7 +2768,7 @@ body[data-media-lightbox] .transcript .media-el { visibility: hidden; }
 /* The bar carries the series colour and nothing else: no stroke. Separation between touching
    segments is the 2px surface gap `stackSegments` subtracts, not a border — a border adds ink that
    is not data. */
-.chart-bar { transition: opacity 100ms ease; }
+.chart-bar { transition: opacity var(--dur-hover) ease; }
 .chart-crosshair { fill: var(--rl-hover); }
 [data-active] .chart-bar { opacity: 1; }
 .chart-empty { margin: 0; padding: 28px 0; text-align: center; font-size: 12px; color: var(--rl-text-faint); }
@@ -2848,7 +2848,7 @@ body[data-media-lightbox] .transcript .media-el { visibility: hidden; }
 .budget-thresholds legend { float: left; margin-right: 8px; padding: 0; font-size: 11.5px; color: var(--rl-text-dim); }
 .budget-threshold { display: inline-flex; align-items: center; gap: 4px; padding: 3px 8px; font-size: 11.5px;
   color: var(--rl-text-dim); border: 1px solid var(--rl-line); border-radius: var(--r-pill); cursor: pointer;
-  transition: background-color 100ms ease, color 100ms ease; }
+  transition: background-color var(--dur-hover) ease, color var(--dur-hover) ease; }
 .budget-threshold input { position: absolute; opacity: 0; pointer-events: none; }
 .budget-threshold[data-selected] { background: var(--rl-hover); color: var(--rl-text-bright); }
 .budget-threshold:has(input:focus-visible) { outline: 2px solid var(--rl-accent); outline-offset: 1px; }

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -75,6 +75,14 @@
   /* terminals stay dark in both modes, one step below BUI's dark --page (cool-tinted,
      oklch(.17 .004 264) ≈ #0e0f11). Hex literal: xterm parses it once at hub creation. */
   --rl-terminal-bg: #1c1d1f; /* the session pane's dark ground (BUI dark --canvas), so the drawer no longer reads as a darker well */
+  /* ...and the ink drawn ON it, which is white in both app modes for the same reason the ground is
+     dark in both. Named rather than written as a literal because a bare rgba(255,255,255,.55) in a
+     stylesheet reads as a light-mode bug to anyone sweeping for them — it has been mistaken for one. */
+  --rl-terminal-ink: oklch(1 0 0 / 0.55);
+  --rl-terminal-ink-dim: oklch(1 0 0 / 0.32);
+  /* Chrome drawn over an attached PICTURE rather than over the theme: it has to stay legible on
+     whatever the user attached, so it does not flip either. */
+  --rl-on-media: oklch(1 0 0);
   /* floating surfaces compose `var(--rl-edge), var(--rl-shadow)` — together they equal BUI's
      --shadow-overlay: the hairline ring half and the layered-shadow half, split so the few
      places using --rl-edge alone still get the BUI hairline ring. Light override below. */
@@ -651,8 +659,8 @@ button.panel-title:hover { background: var(--rl-hover); }
 .terminal-hint { position: absolute; inset: 0; z-index: 1; display: grid; place-content: center; justify-items: center; gap: 4px;
   text-align: center; pointer-events: none; user-select: none; opacity: 1; transition: opacity var(--dur-slow) var(--ease); }
 .terminal-hint[data-hidden] { opacity: 0; }
-.terminal-hint-path { font: 12px var(--font-mono); color: rgba(255,255,255,.55); }
-.terminal-hint-keys { font-size: 11px; color: rgba(255,255,255,.32); }
+.terminal-hint-path { font: 12px var(--font-mono); color: var(--rl-terminal-ink); }
+.terminal-hint-keys { font-size: 11px; color: var(--rl-terminal-ink-dim); }
 /* ── Browser pane (Plan 11 W1) ─────────────────────────────────────────────
    Chrome sits ABOVE the native WebContentsView; the view's bounds start below it. Every control is
    an inline toolbar button — no dropdowns, no menus (W2's no-overlay invariant starts here). */
@@ -701,7 +709,7 @@ button.panel-title:hover { background: var(--rl-hover); }
 .conn-banner button:hover { background: var(--rl-hover); }
 
 /* ── Sheets / palette (raised) ─────────────────────────────────────────── */
-.sheet-backdrop { position: fixed; inset: 0; z-index: 40; display: grid; place-items: center; background: rgba(0,0,0,.45); }
+.sheet-backdrop { position: fixed; inset: 0; z-index: 40; display: grid; place-items: center; background: var(--scrim); }
 .sheet { max-width: calc(100vw - 32px); max-height: calc(100vh - 32px); overflow: auto; border-radius: var(--r-float); background: var(--surface); color: var(--rl-text-bright);
   box-shadow: var(--shadow-overlay); outline: none; }
 .sheet-head { display: flex; align-items: center; justify-content: space-between; padding: 16px 18px 6px; }
@@ -732,7 +740,7 @@ button.panel-title:hover { background: var(--rl-hover); }
   background: var(--surface); box-shadow: var(--shadow-btn); }
 .btn > svg { flex: none; }
 .btn:hover:not(:disabled) { background: var(--inset); }
-.btn.primary { background: var(--rl-accent); color: var(--rl-accent-contrast); box-shadow: inset 0 1px 0 rgba(255,255,255,0.14); }
+.btn.primary { background: var(--rl-accent); color: var(--rl-accent-contrast); box-shadow: var(--fill-bevel); }
 .btn.primary:hover:not(:disabled) { background: var(--accent-ink); }
 .btn.danger { background: none; color: var(--rl-danger); box-shadow: none; }
 .btn.danger:hover:not(:disabled) { background: var(--hover); }
@@ -746,7 +754,7 @@ button.panel-title:hover { background: var(--rl-hover); }
 .danger-zone { justify-content: flex-start; align-items: center; border-top: 1px solid var(--rl-hairline); padding-top: 12px; }
 .danger-zone .muted { flex: 1; }
 
-.palette-backdrop { position: fixed; inset: 0; z-index: 50; display: flex; justify-content: center; align-items: flex-start; padding-top: 12vh; background: rgba(0,0,0,.35); }
+.palette-backdrop { position: fixed; inset: 0; z-index: 50; display: flex; justify-content: center; align-items: flex-start; padding-top: 12vh; background: var(--scrim-soft); }
 .palette { width: min(560px, calc(100vw - 32px)); border-radius: var(--r-float); overflow: hidden; background: var(--surface); color: var(--rl-text-bright); box-shadow: var(--shadow-overlay); }
 .palette-input { display: flex; align-items: center; gap: 10px; padding: 12px 14px; border-bottom: 1px solid var(--rl-hairline); color: var(--rl-text-dim); }
 .palette-input input { flex: 1; border: none; outline: none; background: transparent; font-size: 15px; color: var(--rl-text-bright); }
@@ -772,7 +780,7 @@ button.panel-title:hover { background: var(--rl-hover); }
    The strip is scoped to one profile, so this is where the whole home is legible: every space,
    sectioned by profile, with its NAME — the thing a 16px glyph in a rail can never give you. Sits on
    the sheet scrim rather than the palette's lighter one: it covers the window on purpose. */
-.spaces-backdrop { position: fixed; inset: 0; z-index: 50; display: flex; justify-content: center; align-items: flex-start; padding-top: 10vh; background: rgba(0,0,0,.45); }
+.spaces-backdrop { position: fixed; inset: 0; z-index: 50; display: flex; justify-content: center; align-items: flex-start; padding-top: 10vh; background: var(--scrim); }
 .spaces-overview { display: flex; flex-direction: column; width: min(620px, calc(100vw - 32px)); max-height: 72vh; border-radius: var(--r-float); overflow: hidden;
   background: var(--surface); color: var(--rl-text-bright); box-shadow: var(--shadow-overlay); }
 .spaces-search { flex: none; display: flex; align-items: center; gap: 10px; padding: 12px 14px; border-bottom: 1px solid var(--rl-hairline); color: var(--rl-text-dim); }
@@ -1413,7 +1421,7 @@ button.panel-title:hover { background: var(--rl-hover); }
 .attach-ext { position: absolute; left: 0; right: 0; bottom: 0; padding: 1px 2px; text-align: center;
   font-size: 8px; line-height: 1.25; font-weight: var(--fw-title); letter-spacing: .02em; text-transform: uppercase;
   color: var(--ink-2); background: color-mix(in srgb, var(--surface) 78%, transparent); }
-.attach-tile[data-image] .attach-ext { color: #fff; background: rgb(0 0 0 / .55); }
+.attach-tile[data-image] .attach-ext { color: var(--rl-on-media); background: rgb(0 0 0 / .55); }
 /* A file the agent will simply discard must not look like one it will read (§2.4: colour = state). */
 .attach-tile[data-disposition="ignored"] .attach-art { color: var(--orange); background: var(--orange-tint);
   box-shadow: 0 0 0 var(--hairline-w) var(--orange); }
@@ -1436,7 +1444,7 @@ button.panel-title:hover { background: var(--rl-hover); }
 /* Remove rides the corner and only exists while the pointer is on the tile — at rest the tile is the
    file, not a control. It stays for keyboard focus, which has no hover to trade on. */
 .attach-remove { position: absolute; top: 2px; right: 2px; display: grid; place-items: center;
-  width: 16px; height: 16px; border-radius: 50%; color: #fff; background: rgb(0 0 0 / .62);
+  width: 16px; height: 16px; border-radius: 50%; color: var(--rl-on-media); background: rgb(0 0 0 / .62);
   box-shadow: var(--shadow-btn); opacity: 0; transition: opacity var(--dur-hover) ease; }
 .attach-tile:hover .attach-remove, .attach-remove:focus-visible { opacity: 1; }
 .attach-remove:hover { background: rgb(0 0 0 / .82); }
@@ -1545,7 +1553,7 @@ button.panel-title:hover { background: var(--rl-hover); }
    Plan 9 W3: the circle wears BUI Button's accent treatment — inset top highlight, accent-ink on
    hover — and PromptBar's disabled send (line-strong fill, ink-2 glyph) replaces the bare fade. */
 .composer-send { position: relative; display: grid; place-items: center; width: 32px; height: 32px; border-radius: 50%;
-  background: var(--rl-accent); color: var(--rl-accent-contrast); box-shadow: inset 0 1px 0 rgba(255,255,255,0.14); flex: none; }
+  background: var(--rl-accent); color: var(--rl-accent-contrast); box-shadow: var(--fill-bevel); flex: none; }
 .composer-send:hover:not(:disabled) { background: var(--accent-ink); }
 .composer-send:disabled { background: var(--line-strong); color: var(--ink-2); box-shadow: none; opacity: 1; }
 .composer-send svg { grid-area: 1 / 1;
@@ -1925,7 +1933,7 @@ button.panel-title:hover { background: var(--rl-hover); }
 .cp-stale, .cp-blocked { margin: 0; font-size: 12px; color: var(--rl-warning); }
 .sheet-actions { display: flex; justify-content: flex-end; gap: 8px; margin-top: 4px; }
 /* §3: destructive confirms are the ONE place a red-filled button is allowed. */
-.btn.destructive { background: var(--rl-danger); color: #ffffff; box-shadow: inset 0 1px 0 rgba(255,255,255,0.14); }
+.btn.destructive { background: var(--rl-danger); color: #ffffff; box-shadow: var(--fill-bevel); }
 .btn.destructive:hover:not(:disabled) { background: var(--rl-danger); filter: brightness(0.95); } /* BUI's filled-hover for tones with no -ink step */
 .btn:disabled { opacity: .45; }
 /* A disabled primary must not wear the accent — 45% opacity on a filled blue button still reads as

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -1297,7 +1297,8 @@ button.panel-title:hover { background: var(--rl-hover); }
 /* AskUserQuestion (QuestionCard): the same card shell as a permission, but read as a QUESTION — the
    question itself is the heading rather than "Allow <Tool>?", and the options are the agent's own
    labels rather than Allow/Deny. Rows are taller than a permission's because each may carry a
-   description line, and they are separated by hairlines (the reference's list rhythm). */
+   description line, and they separate themselves the way .permission-options' do — a hover fill on a
+   rounded row, with a hairline between them as well saying the same thing twice. */
 .question-card { border-radius: var(--r-panel); padding: 16px; background: var(--surface); box-shadow: var(--shadow-card);
   display: flex; flex-direction: column; gap: 10px; }
 .question-head { display: flex; align-items: flex-start; gap: 10px; }
@@ -1306,10 +1307,9 @@ button.panel-title:hover { background: var(--rl-hover); }
 .question-pager .icon-btn:disabled { opacity: .35; }
 .question-close { flex: none; }
 
-.question-options { display: flex; flex-direction: column; }
+.question-options { display: flex; flex-direction: column; gap: 1px; }
 .question-option { display: flex; align-items: center; gap: 10px; width: 100%; padding: 9px 8px; border-radius: var(--r-ctl);
   text-align: left; font-size: 13px; color: var(--ink-2); }
-.question-option + .question-option { box-shadow: inset 0 1px 0 var(--line); }
 .question-option:hover { background: var(--hover); color: var(--ink); }
 .question-option[data-selected] { background: var(--hover-2); color: var(--ink); }
 .question-option[data-picked] { color: var(--ink); }
@@ -1806,8 +1806,11 @@ button.panel-title:hover { background: var(--rl-hover); }
 .diff-empty { padding: 32px 16px; text-align: center; font-size: 12.5px; color: var(--rl-text-faint); }
 .diff-note { padding: 8px 12px; font-size: 11.5px; color: var(--rl-text-faint); }
 .diff-loading { padding: 8px 12px; font-size: 11.5px; color: var(--rl-text-faint); }
-/* Table-style rows (§5): one hairline between, no vertical rules, no card chrome. */
-.diff-file + .diff-file { border-top: 1px solid var(--rl-hairline); }
+/* Table-style rows (§5): no vertical rules, no card chrome, and no rule between two COLLAPSED files
+   — 30px rows that light up under the pointer separate themselves, the way the sidebar's list does.
+   The seam is drawn in the one place it is still doing work: under an OPEN file, whose patch panel
+   would otherwise run straight into the next filename. */
+.diff-file[data-open] + .diff-file { border-top: 1px solid var(--rl-hairline); }
 .diff-row { display: flex; align-items: center; gap: 6px; padding: 0 8px 0 4px; min-height: 30px; }
 .diff-row:hover { background: var(--rl-hover); }
 .diff-expand { flex: 1; display: flex; align-items: center; gap: 8px; min-width: 0; padding: 5px 6px; text-align: left; border-radius: var(--r-chip); }
@@ -1907,7 +1910,6 @@ button.panel-title:hover { background: var(--rl-hover); }
    destructive act, and two different-looking confirms would teach the user to stop reading. */
 .cp-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; max-height: 320px; overflow-y: auto; }
 .cp-row { display: flex; align-items: center; gap: 10px; padding: 7px 8px; border-radius: var(--r-ctl); }
-.cp-row + .cp-row { border-top: 1px solid var(--rl-hairline); }
 .cp-row:hover { background: var(--rl-hover); }
 /* The undo point is the one row whose meaning differs from its neighbours, so it is the one row that
    is allowed a colour. */
@@ -1939,8 +1941,7 @@ button.panel-title:hover { background: var(--rl-hover); }
 /* ── Space settings: the space's checkouts (W1/W2 made visible in W3) ───── */
 .env-empty { margin: 0; font-size: 11.5px; color: var(--rl-text-faint); }
 .env-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; }
-.env-row { display: grid; grid-template-columns: 1fr auto; gap: 2px 8px; padding: 8px 0; }
-.env-row + .env-row { border-top: 1px solid var(--rl-hairline); }
+.env-row { display: grid; grid-template-columns: 1fr auto; gap: 2px 8px; padding: 10px 0; }
 .env-main { display: flex; align-items: center; gap: 6px; min-width: 0; color: var(--rl-text-dim); }
 .env-name { font-size: 12.5px; color: var(--rl-text-bright); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .env-kind { font-size: 10.5px; letter-spacing: .08em; text-transform: uppercase; color: var(--rl-text-faint); }
@@ -1993,7 +1994,6 @@ button.panel-title:hover { background: var(--rl-hover); }
    adds the toggled-on look, echoing `.icon-choice[data-selected]`'s accent-ring treatment. */
 .chip-filter[aria-pressed="true"] { color: var(--rl-accent); background: var(--rl-active); box-shadow: inset 0 0 0 1px var(--rl-accent); }
 .activity-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; max-height: 420px; overflow-y: auto; }
-.activity-row + .activity-row { border-top: 1px solid var(--rl-hairline); }
 /* `.activity-row-main` layers onto `.tool-row` (full-width pressable row, no press-scale — see the §6
    comment above `.tool-row` in the transitions block) with its own column grid. */
 .activity-row-main { display: grid; grid-template-columns: 56px 1fr auto 52px 18px; gap: 10px; }
@@ -2033,8 +2033,7 @@ button.panel-title:hover { background: var(--rl-hover); }
 .settings-hint[data-tone="danger"] { color: var(--rl-danger); }
 
 .settings-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; }
-.settings-row { display: flex; align-items: flex-start; gap: 10px; padding: 8px 0; }
-.settings-row + .settings-row, .settings-source-row + .settings-source-row { border-top: 1px solid var(--rl-hairline); }
+.settings-row { display: flex; align-items: flex-start; gap: 10px; padding: 10px 0; }
 .settings-row-main { flex: 1; min-width: 0; display: flex; flex-wrap: wrap; align-items: baseline; gap: 4px 8px; }
 .settings-row-name { font-size: 12.5px; font-weight: var(--fw-label); color: var(--rl-text-bright); }
 .settings-row-desc { flex-basis: 100%; font-size: 11.5px; line-height: 1.45; color: var(--rl-text-dim); }
@@ -2058,7 +2057,7 @@ button.panel-title:hover { background: var(--rl-hover); }
 .memory-doc:focus { border-color: var(--rl-accent); }
 .memory-meta { display: flex; align-items: center; justify-content: space-between; gap: 8px; }
 .settings-inline-toggle { display: flex; align-items: flex-start; gap: 10px; cursor: pointer; }
-.settings-source-row { display: flex; flex-wrap: wrap; align-items: baseline; gap: 4px 8px; padding: 5px 0; }
+.settings-source-row { display: flex; flex-wrap: wrap; align-items: baseline; gap: 4px 8px; padding: 6px 0; }
 .settings-source-row[data-missing] .env-path { color: var(--rl-text-faint); }
 
 /* ——— Page panes (Plan 12 W3). The space page is the first full "page" pane; Library, Notifications
@@ -2297,7 +2296,6 @@ button.panel-title:hover { background: var(--rl-hover); }
 @container (max-width: 640px) { .engines-head .page-lede { flex-basis: 100%; } }
 .engines-list { gap: 4px; }
 .engine-row { display: flex; gap: 10px; padding: 9px 10px; border-radius: var(--r-ctl); }
-.engine-row + .engine-row { border-top: 1px solid var(--rl-hairline); }
 .engine-mark { flex: none; display: inline-flex; margin-top: 1px; }
 .engine-main { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 5px; }
 .engine-line { display: flex; align-items: baseline; gap: 10px; min-width: 0; }

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -1383,10 +1383,11 @@ button.panel-title:hover { background: var(--rl-hover); }
 /* The card (Plan 9 W3 — BUI PromptBar): a surface field on shadow-card (the hairline ring is part
    of the stack), --r-float, borderless. Focus is BUI's border-brighten — the ring steps to
    line-strong — replacing the old 30% accent glow (PromptBar's focus-within:border-line-strong). */
-/* Squircle prompter: `corner-shape: squircle` turns the corners into a continuous superellipse
-   curve (Chromium 139+; a no-op on the current runtime, where the bumped radius alone already
-   reads softer). The radius steps past --r-float because a squircle at the same radius reads
-   visually smaller than a circular corner. */
+/* Squircle prompter. What is written here is the FALLBACK — a circular corner one radius step past
+   --r-float, because a squircle at the same radius reads visually smaller — plus `corner-shape`,
+   which states the shape declaratively and takes over once Electron ships Chromium 139. On the
+   runtime this app actually has (Chromium 138) `corner-shape` is not a recognised property at all,
+   so the curve is drawn by the paint worklet instead; see the squircle block further down. */
 .composer { width: 100%; border-radius: calc(var(--r-float) + 4px); corner-shape: squircle; background: var(--surface);
   box-shadow: var(--shadow-card); display: flex; flex-direction: column; position: relative; z-index: 1; }
 .composer:focus-within {
@@ -1560,7 +1561,7 @@ button.panel-title:hover { background: var(--rl-hover); }
    transform carries it and the absolutely-hung suggestions land below it. ── */
 .composer-understrip { display: flex; align-items: center; gap: 2px; min-width: 0;
   margin: -10px 10px 0; padding: 12px 6px 6px; background: var(--rl-frame);
-  border-radius: 0 0 var(--r-panel) var(--r-panel); }
+  border-radius: 0 0 var(--r-panel) var(--r-panel); corner-shape: squircle; }
 .composer-understrip .ghost-chip { height: 24px; font-size: 11px; gap: 5px; color: var(--rl-text-faint); max-width: 260px; }
 .composer-understrip .ghost-chip:hover:not([data-static]) { color: var(--rl-text-dim); }
 /* "Thinking…" hangs off the strip's far end, so arriving mid-stream costs the chips no motion. */
@@ -1591,6 +1592,59 @@ button.panel-title:hover { background: var(--rl-hover); }
 .install-cmd code { display: block; flex: 1; min-width: 0; font: 12px var(--font-mono); color: var(--rl-text-bright); overflow-x: auto; white-space: pre; user-select: text; }
 .install-actions { display: flex; justify-content: flex-end; gap: 8px; }
 .install-note { margin: 0; font-size: 11px; color: var(--rl-text-faint); }
+
+/* ── Squircle surfaces ─────────────────────────────────────────────────────
+   The prompter, its under-strip, its drop hint, the install card that stands in for it and the
+   commit dock all wear a continuous superellipse corner rather than the circular arc a plain
+   `border-radius` draws. `corner-shape: squircle` is the declarative form of exactly this and it
+   stays on every rule above — but it lands in Chromium 139 and Electron 37.10.3 ships 138, where
+   the property is not recognised, so today the curve comes from a paint worklet
+   (public/squircle-paint.js). theme/squircle.ts sets `data-squircle` only after the worklet module
+   has loaded, so a failed load leaves every surface below on its `border-radius` fallback rather
+   than on `paint()` with no painter — which resolves to nothing and would render an invisible card.
+
+   Three things the painter, not CSS, has to own:
+   - `border-radius` goes to 0. A superellipse sits FURTHER into the corner than the circular arc of
+     the same radius, and the background painting area is clipped by the radius — left in place it
+     would shave the painted corner straight back into the rounded rect this replaces.
+   - The RING. A box-shadow ring is drawn on the rounded rect whatever the fill does, so it would
+     cross a corner the fill has already bulged past; --sq-ring/--sq-ring-w hand it to the painter,
+     and focus and the drop target become a change of those two rather than a second box-shadow.
+   - Nothing else. The soft LIFT stays on box-shadow (--shadow-card-lift, --rl-shadow): it is blurred
+     several times wider than the two curves ever diverge, and a mask — the obvious alternative to
+     painting the fill — would have clipped it away entirely. */
+:root[data-squircle] .composer,
+:root[data-squircle] .composer-drop-hint,
+:root[data-squircle] .composer-understrip,
+:root[data-squircle] .install-card,
+:root[data-squircle] .commit-card {
+  border-radius: 0;
+  background: paint(rl-squircle);
+  --sq-radius-top: calc(var(--r-float) + 4px);
+  --sq-radius-bottom: calc(var(--r-float) + 4px);
+}
+:root[data-squircle] .composer, :root[data-squircle] .commit-card {
+  --sq-fill: var(--surface); --sq-ring: var(--card-ring); --sq-ring-w: var(--hairline-w);
+  box-shadow: var(--shadow-card-lift);
+}
+/* Focus is still PromptBar's border-brighten, now traced on the curve instead of around it. */
+:root[data-squircle] .composer:focus-within, :root[data-squircle] .commit-card:focus-within {
+  --sq-ring: var(--line-strong); --sq-ring-w: 1px;
+  box-shadow: var(--shadow-card-lift);
+}
+:root[data-squircle] .composer[data-dropping] {
+  --sq-ring: var(--rl-accent); --sq-ring-w: 2px;
+  box-shadow: var(--shadow-card-lift);
+}
+/* The hint lies inset:0 over the card, so it takes the card's own radius or it would square off
+   inside a rounded corner. No ring: the card underneath is already wearing the drop target's. */
+:root[data-squircle] .composer-drop-hint { --sq-fill: color-mix(in srgb, var(--rl-raised) 82%, transparent); }
+/* The under-strip's top edge is hidden beneath the card, so only its bottom corners are drawn. */
+:root[data-squircle] .composer-understrip { --sq-fill: var(--rl-frame); --sq-radius-top: 0px; --sq-radius-bottom: var(--r-panel); }
+:root[data-squircle] .install-card {
+  --sq-fill: var(--rl-raised); --sq-ring: var(--line); --sq-ring-w: var(--hairline-w);
+  box-shadow: var(--rl-shadow);
+}
 
 /* ── First-run onboarding (W4): the whole pane, one centered sheet, nothing behind it ── */
 .onboarding-stage { flex: 1; display: grid; place-items: center; padding: 24px; overflow: auto; }

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -309,7 +309,6 @@ kbd { font: 11px var(--font-mono); }
    where there is something under it, so a strip that fits reads as untouched. */
 .strip-spaces { flex: 1; display: flex; align-items: center; justify-content: safe center; gap: 2px; min-width: 0; overflow-x: auto; overscroll-behavior-x: contain; scrollbar-width: none;
   mask-image: linear-gradient(90deg, transparent 0, #000 14px, #000 calc(100% - 14px), transparent 100%); }
-.strip-spaces::-webkit-scrollbar { display: none; }
 .strip-side { flex: none; }
 /* The profile chip: which profile the strip below is scoped to, and the door to the others. One
    square the size of a space button, wearing the profile's own icon and colour — spelling the name
@@ -540,7 +539,6 @@ kbd { font: 11px var(--font-mono); }
   border-bottom: 1px solid var(--rl-hairline); background: var(--rl-panel); -webkit-app-region: drag; }
 .group-bar button, .group-bar input { -webkit-app-region: no-drag; }
 .group-tabs { display: flex; align-items: center; gap: 2px; min-width: 0; overflow-x: auto; scrollbar-width: none; }
-.group-tabs::-webkit-scrollbar { display: none; }
 .group-tab { display: flex; align-items: center; gap: 6px; padding: 5px 12px; border-radius: var(--r-ctl);
   font-size: 12.5px; color: var(--rl-text-dim); white-space: nowrap; }
 .group-tab:hover { background: var(--rl-hover); }
@@ -1482,7 +1480,6 @@ button.panel-title:hover { background: var(--rl-hover); }
    text box and NOT from the mirror's, which would misalign every wrapped line under it. Scrolling
    itself is untouched — wheel, drag-select and the caret's own scroll-into-view all still work. */
 .composer-input { scrollbar-width: none; }
-.composer-input::-webkit-scrollbar { display: none; }
 /* The palette (§4). Links wear the transcript's own link treatment, so a URL looks the same being
    typed as it will once sent. A resolving @mention is filled, not just tinted — it is the one run
    here that is a THING (a skill that will be handed over) rather than formatting. */
@@ -1684,11 +1681,46 @@ button.panel-title:hover { background: var(--rl-hover); }
 .agent-hint-text { font-size: 11px; color: var(--rl-text-dim); } .agent-hint-text code { font: 11px var(--font-mono); }
 .agent-name { font-weight: var(--fw-label); } .agent-hint { margin-left: auto; font-size: 11px; color: var(--rl-text-dim); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 60%; }
 
-/* ── Scrollbars: thin + on-theme in the few containers that actually scroll ───── */
-.transcript, .diff-list, .commit-message, .space-body, .palette-list, .menu, .tool-well, .sheet, .terminal-pane .xterm-viewport { scrollbar-width: thin; scrollbar-color: var(--rl-line-strong) transparent; }
-.transcript::-webkit-scrollbar, .diff-list::-webkit-scrollbar, .commit-message::-webkit-scrollbar, .space-body::-webkit-scrollbar, .palette-list::-webkit-scrollbar, .menu::-webkit-scrollbar, .tool-well::-webkit-scrollbar, .sheet::-webkit-scrollbar, .terminal-pane .xterm-viewport::-webkit-scrollbar { width: 10px; }
-.transcript::-webkit-scrollbar-thumb, .diff-list::-webkit-scrollbar-thumb, .commit-message::-webkit-scrollbar-thumb, .space-body::-webkit-scrollbar-thumb, .palette-list::-webkit-scrollbar-thumb, .menu::-webkit-scrollbar-thumb, .tool-well::-webkit-scrollbar-thumb, .sheet::-webkit-scrollbar-thumb, .terminal-pane .xterm-viewport::-webkit-scrollbar-thumb { background: var(--rl-line-strong); border-radius: 5px; }
-.transcript::-webkit-scrollbar-track, .diff-list::-webkit-scrollbar-track, .commit-message::-webkit-scrollbar-track, .space-body::-webkit-scrollbar-track, .palette-list::-webkit-scrollbar-track, .menu::-webkit-scrollbar-track, .tool-well::-webkit-scrollbar-track, .sheet::-webkit-scrollbar-track, .terminal-pane .xterm-viewport::-webkit-scrollbar-track { background: transparent; }
+/* ── Scrollbars: one thumb, no track, everywhere ──────────────────────────────
+   The ask was to stop drawing tracks — in the model picker, the skill picker and everywhere else.
+   The mechanism that makes "everywhere" true rather than a list to keep up with is inheritance:
+   `scrollbar-color` is an inherited property, so stating it once on the root hides the track in every
+   scroller in the app, including ones added after this line is written. `scrollbar-width` does NOT
+   inherit, so the scrollers that should be thin rather than default-width are named below.
+
+   The thumb is quiet at rest and steps up under the pointer. `:hover` is deliberately bare: hover
+   matches up the ancestor chain, so a scroller lights its own thumb the moment the pointer is inside
+   it, with no second copy of the list. `:focus-within` cannot join it for the same reason in reverse
+   — it would match <body> whenever anything in the app had focus, which is always.
+
+   What this replaces was four rules, and three of them had been dead since Chromium 121: setting
+   either standard property makes the browser ignore `::-webkit-scrollbar` entirely, and every
+   selector those rules targeted also set `scrollbar-width: thin`. Measured on this runtime — a
+   scroller with only the pseudo-element rules reserves the 24px they ask for, one with both reserves
+   the 11px the standard property asks for. The 10px width, the thumb colour and the transparent
+   track were all already coming from the line above them. */
+:root { scrollbar-color: var(--rl-line) transparent; }
+:hover { scrollbar-color: var(--rl-line-strong) transparent; }
+:where(
+  /* chrome and navigation */
+  .space-body, .menu, .mention-picker, .skill-picker-list, .mp-list, .mp-detail-body, .ip-grid,
+  .palette-list, .spaces-list, .sheet, .onboarding-stage, .page-content,
+  /* the transcript and everything it draws inside itself */
+  .transcript, .md pre, .msg-error pre, .tool-well, .tool-body pre, .permission-details pre,
+  .code-block, .code-body, .fd-file, .fd-body, .term-out, .md-scroll, .math-display,
+  /* the diff pane */
+  .diff-list, .diff-hunks, .diff-review-body, .commit-message,
+  /* page panes */
+  .cp-list, .activity-list, .task-detail-result, .notif-list, .notif-detail, .notif-split,
+  .lecture-list, .install-cmd code,
+  /* documents */
+  .documents-tabs, .documents-picker, .documents-rich-surface, .documents-rich .tiptap, .documents-raw
+) { scrollbar-width: thin; }
+/* xterm keeps an explicit treatment rather than inheriting the app's. It owns this element: it
+   measures the viewport to decide the terminal's column count, and its interior is a dark world in
+   both app modes (`color-scheme: dark` on .terminal-pane), so the thumb here answers to the terminal
+   rather than to whatever the rule above becomes next. */
+.terminal-pane .xterm-viewport { scrollbar-width: thin; scrollbar-color: var(--rl-line-strong) transparent; }
 
 /* ── Motion (§6): the whole easing/duration table, applied app-wide ───────── */
 /* A leaf's item changing IS content entering, not the "pane focus switching" §6 keeps instant — the
@@ -2084,7 +2116,6 @@ button.panel-title:hover { background: var(--rl-hover); }
      refuses to shrink under the width of all its tabs laid out in a row, and scrolls nothing. */
   .page-rail { flex-direction: row; width: auto; min-width: 0; align-self: stretch; gap: 4px;
     overflow-x: auto; overscroll-behavior-x: contain; scrollbar-width: none; }
-  .page-rail::-webkit-scrollbar { display: none; }
   .page-rail .settings-tab { white-space: nowrap; }
   .page-content { max-width: none; padding-right: 0; }
   /* The `1fr auto` row grid, stood up: the actions keep their own width and the path/name column
@@ -2350,7 +2381,7 @@ button.panel-title:hover { background: var(--rl-hover); }
 
 .documents-tabs {
   display: flex; align-items: center; gap: 2px; padding: 6px 8px; overflow-x: auto;
-  border-bottom: 1px solid var(--rl-line); flex: 0 0 auto; scrollbar-width: thin; overflow-y: hidden;
+  border-bottom: 1px solid var(--rl-line); flex: 0 0 auto; overflow-y: hidden;
 }
 .documents-tab { display: flex; align-items: center; border-radius: var(--r-ctl); flex: 0 0 auto;
   transition: background-color var(--dur-hover) ease, color var(--dur-hover) ease; }

--- a/apps/desktop/src/renderer/src/styles.test.ts
+++ b/apps/desktop/src/renderer/src/styles.test.ts
@@ -533,7 +533,9 @@ describe("Plan 9 W3 — composer + chrome in BUI language", () => {
     // Inheriting the composer's `scrollbar-width: none` hid the only sign a message runs on.
     expect(bodiesFor(".commit-message").join(" ")).not.toContain("scrollbar-width: none");
     expect(bodiesFor(".commit-message").join(" ")).not.toContain("max-height");
-    expect(bodiesFor(".commit-message").some((b) => b.includes("scrollbar-width: thin"))).toBe(true);
+    // It takes its bar from the shared scroller list rather than a rule of its own now, so
+    // membership of that list is what the guarantee rests on.
+    expect(SCROLLERS).toContain(".commit-message");
   });
 
   it("the changes list clears the whole fade, and reads its height from the same --fade-h the ramp does", () => {
@@ -690,6 +692,46 @@ describe("Plan 9 W3 — composer + chrome in BUI language", () => {
  *  checkable here is everything around the shape: that the fallback survives, that the two halves of
  *  the card shadow cannot drift apart, and that the three files involved still agree on the names
  *  they pass between them. */
+/** The shared scroller list, read out of the `:where(...)` block it is written in. */
+const SCROLLERS = (css.match(/:where\(([^)]*)\)\s*\{\s*scrollbar-width: thin/)?.[1] ?? "")
+  .split(",").map((s) => s.replace(/\s+/g, " ").trim()).filter(Boolean);
+/** The element that actually scrolls is the last compound of the selector: `.permission-preview
+ *  .fd-file` is `.fd-file` doing the scrolling, in a place that gives it a height to overflow. */
+const leaf = (sel: string): string => sel.split(" ").pop()!;
+
+describe("scrollbars", () => {
+  it("the track is hidden by INHERITANCE, so a scroller written tomorrow is covered too", () => {
+    // The whole point of putting it on :root: `scrollbar-color` inherits, and a list is a thing to
+    // keep up with. The transparent second value is the track.
+    expect(bodiesFor(":root").join(" ")).toContain("scrollbar-color: var(--rl-line) transparent");
+    expect(bodiesFor(":hover").join(" ")).toContain("scrollbar-color: var(--rl-line-strong) transparent");
+  });
+
+  it("the legacy ::-webkit-scrollbar rules are gone, not merely overridden", () => {
+    // They had been inert since Chromium 121 — setting either standard property makes the browser
+    // ignore the pseudo-elements outright, and every selector they targeted also set
+    // `scrollbar-width: thin`. Re-adding one would read as styling that does nothing.
+    expect(css).not.toContain("::-webkit-scrollbar");
+  });
+
+  it("every scroller in the stylesheet has had a deliberate decision made about its bar", () => {
+    // The regression this closes is how the app got here: nine containers were styled by hand and
+    // every scroller added afterwards shipped with the default bar and a visible track.
+    const covered = new Set(SCROLLERS.map(leaf));
+    // Left out on purpose. The horizontal strips hide their bar entirely (they fade at the edges or
+    // are short tab rows, and a bar under them would be the tallest thing in the row) and say so with
+    // `scrollbar-width: none` in their own rule, which is why they are filtered rather than listed.
+    // xterm is the one exception that keeps an explicit treatment: it measures this element to decide
+    // the terminal's column count, and its interior is dark in both app modes.
+    const exempt = new Set([".xterm-viewport"]);
+    const uncovered = RULES
+      .filter((r) => /overflow(-[xy])?:\s*(auto|scroll)/.test(r.body) && !/scrollbar-width:\s*none/.test(r.body))
+      .flatMap((r) => r.selectors)
+      .filter((sel) => !covered.has(leaf(sel)) && !exempt.has(leaf(sel)));
+    expect([...new Set(uncovered)].sort()).toEqual([]);
+  });
+});
+
 describe("squircle surfaces", () => {
   const tokens = readFileSync(repoFile("apps/desktop/src/renderer/src/theme/tokens.css"), "utf8");
   const worklet = readFileSync(repoFile("apps/desktop/src/renderer/public/squircle-paint.js"), "utf8");

--- a/apps/desktop/src/renderer/src/styles.test.ts
+++ b/apps/desktop/src/renderer/src/styles.test.ts
@@ -618,7 +618,7 @@ describe("Plan 9 W3 — composer + chrome in BUI language", () => {
   });
 
   it("the send circle carries BUI Button's accent treatment: inset top highlight, accent-ink hover, PromptBar's line-strong disabled fill", () => {
-    expect(bodiesFor(".composer-send").join(" ")).toContain("inset 0 1px 0 rgba(255,255,255,0.14)");
+    expect(bodiesFor(".composer-send").join(" ")).toContain("box-shadow: var(--fill-bevel)");
     expect(bodiesFor(".composer-send:hover:not(:disabled)").join(" ")).toContain("background: var(--accent-ink)");
     const off = bodiesFor(".composer-send:disabled").join(" ");
     expect(off).toContain("background: var(--line-strong)");
@@ -681,7 +681,7 @@ describe("Plan 9 W3 — composer + chrome in BUI language", () => {
     expect(btn).toContain("box-shadow: var(--shadow-btn)");
     expect(bodiesFor(".btn:hover:not(:disabled)").join(" ")).toContain("background: var(--inset)");
     const primary = bodiesFor(".btn.primary").join(" ");
-    expect(primary).toContain("inset 0 1px 0 rgba(255,255,255,0.14)");
+    expect(primary).toContain("box-shadow: var(--fill-bevel)");
     expect(bodiesFor(".btn.primary:hover:not(:disabled)").join(" ")).toContain("background: var(--accent-ink)");
   });
 });
@@ -847,6 +847,85 @@ describe("squircle surfaces", () => {
     const used = new Set([...css.matchAll(/(--sq-[a-z-]+)\s*:/g)].map((m) => m[1]!));
     expect([...used].filter((n) => !declared.has(n)).sort(), "set in styles.css, not read by the worklet").toEqual([]);
     expect([...used].filter((n) => !registered.has(n)).sort(), "set in styles.css, never registered").toEqual([]);
+  });
+});
+
+/** Light mode is a real mode, not a filter over the dark one. These pin the colours that were being
+ *  written as dark-tuned literals in `styles.css` — one layer below the token ramps, where a sweep of
+ *  tokens.css cannot see them — and, just as importantly, the ones that deliberately do NOT flip. */
+describe("light mode", () => {
+  const tokens = readFileSync(repoFile("apps/desktop/src/renderer/src/theme/tokens.css"), "utf8");
+  const lightBlocks = [...tokens.matchAll(/:root\[data-mode="light"\]\s*\{([^}]*)\}/g)].map((m) => m[1]!).join("\n");
+
+  /** Black or white written literally, in either the comma or the space syntax. */
+  const RAW_INK = /rgba?\(\s*(?:0[\s,]+0[\s,]+0|255[\s,]+255[\s,]+255)[\s,/)]|(?<![\w-])#(?:fff|ffffff)(?![\w-])/i;
+  /** Every rule allowed to write one, and the reason it is not the theme's to flip. */
+  const NOT_THE_THEMES_TO_FLIP = new Map([
+    // Drawn on a video frame or a photo the user supplied. The picture is the same picture in both
+    // modes, so chrome over it answers to the picture.
+    [".media-play", "on a video frame"], [".media-play:hover", "on a video frame"],
+    [".media-controls", "on a video frame"], [".media-btn:hover", "on a video frame"],
+    [".media-scrub", "on a video frame"], [".media-scrub::-webkit-slider-thumb", "on a video frame"],
+    [".media-lightbox-bar", "on a video frame"],
+    [".media-lightbox-bar .media-name", "on a video frame"], [".media-lightbox-bar .media-detail", "on a video frame"],
+    [".media-lightbox-bar .media-action", "on a video frame"], [".media-lightbox-bar .media-action:hover", "on a video frame"],
+    [".attach-tile[data-image] .attach-ext", "on the attached picture"],
+    [".attach-remove", "on the attached picture"], [".attach-remove:hover", "on the attached picture"],
+    // Matching the native WebContentsView's own opaque white, so the sliver it trails during a
+    // resize cannot flash the panel tone through the gap.
+    [".browser-view-host", "the browser view's own ground"],
+    // White on a red fill, the same as white on the accent fill (--rl-accent-contrast), which is
+    // deliberately one value for both modes.
+    [".btn.destructive", "ink on a filled control"],
+    // The base half of a pair: the rule immediately below it flips the outline for light mode.
+    [".md img", "paired with a light override"],
+  ]);
+
+  it("no rule paints a raw black or white that the mode cannot reach", () => {
+    // The failure is invisible from tokens.css: every ramp there flips correctly, and then a
+    // component writes `rgba(0,0,0,.45)` one layer below it and never changes. Anything that
+    // genuinely must not flip is either a named token now or listed above with its reason.
+    const offenders = RULES
+      .filter((r) => RAW_INK.test(r.body))
+      .flatMap((r) => r.selectors)
+      .filter((sel) => !sel.startsWith(':root[data-mode="light"]') && !NOT_THE_THEMES_TO_FLIP.has(sel));
+    expect(offenders.sort()).toEqual([]);
+  });
+
+  it("the one literal that is half a pair really does have its other half", () => {
+    expect(bodiesFor(".md img").join(" ")).toContain("outline: 1px solid rgba(255, 255, 255, 0.1)");
+    expect(bodiesFor(':root[data-mode="light"] .md img').join(" ")).toContain("outline-color: rgba(0, 0, 0, 0.1)");
+  });
+
+  it("the scrims are the one colour that has to differ per mode", () => {
+    // A veil subtracts from what is behind it, so the same alpha over a near-white window is a much
+    // heavier dim than over a dark one. Everything else here can be one value for both modes.
+    for (const sel of [".sheet-backdrop", ".spaces-backdrop"]) expect(bodiesFor(sel).join(" "), sel).toContain("background: var(--scrim)");
+    expect(bodiesFor(".palette-backdrop").join(" ")).toContain("background: var(--scrim-soft)");
+    expect(lightBlocks).toContain("--scrim:");
+    expect(lightBlocks).toContain("--scrim-soft:");
+  });
+
+  it("the colours that answer to something other than the theme are named, and stay put", () => {
+    // Each of these is drawn ON something that is the same in both modes — the terminal's own dark
+    // interior, or a picture the user attached — so a light override would be the bug. They are
+    // tokens rather than literals precisely so that reading is available to the next sweep.
+    for (const token of ["--rl-terminal-ink", "--rl-terminal-ink-dim", "--rl-on-media"])
+      expect(lightBlocks, token).not.toContain(token);
+    expect(bodiesFor(".terminal-hint-path").join(" ")).toContain("color: var(--rl-terminal-ink)");
+    expect(bodiesFor(".attach-remove").join(" ")).toContain("color: var(--rl-on-media)");
+    // Same case, one level up: a filled control's lit top edge. The fill under it is a saturated
+    // accent in both modes and the light still comes from above.
+    expect(lightBlocks).not.toContain("--fill-bevel");
+    for (const sel of [".btn.primary", ".composer-send", ".btn.destructive"])
+      expect(bodiesFor(sel).join(" "), sel).toContain("box-shadow: var(--fill-bevel)");
+  });
+
+  it("a token defined for one mode only is a token that would carry a dark value into light", () => {
+    // --grid-line and --shadow-glass-inset were both declared in the dark block alone and referenced
+    // nowhere. That is worse than unused: the first thing to reach for one would have got a dark
+    // value in light mode with nothing reporting it.
+    for (const gone of ["--grid-line", "--shadow-glass-inset"]) expect(tokens, gone).not.toContain(gone);
   });
 });
 

--- a/apps/desktop/src/renderer/src/styles.test.ts
+++ b/apps/desktop/src/renderer/src/styles.test.ts
@@ -644,6 +644,83 @@ describe("Plan 9 W3 — composer + chrome in BUI language", () => {
   });
 });
 
+/** The squircle surfaces. What the CORNER looks like is settled by scripts/squircle-live.mjs, which
+ *  measures the composited pixels — jsdom has no layout and no CSS Painting API, so to it
+ *  `background: paint(rl-squircle)` and `border-radius: 20px` are the same declaration. What is
+ *  checkable here is everything around the shape: that the fallback survives, that the two halves of
+ *  the card shadow cannot drift apart, and that the three files involved still agree on the names
+ *  they pass between them. */
+describe("squircle surfaces", () => {
+  const tokens = readFileSync(repoFile("apps/desktop/src/renderer/src/theme/tokens.css"), "utf8");
+  const worklet = readFileSync(repoFile("apps/desktop/src/renderer/public/squircle-paint.js"), "utf8");
+  const registrar = readFileSync(repoFile("apps/desktop/src/renderer/src/theme/squircle.ts"), "utf8");
+  const SURFACES = [".composer", ".composer-drop-hint", ".composer-understrip", ".install-card", ".commit-card"];
+
+  it("every squircle surface keeps a circular-corner fallback AND the declarative form", () => {
+    // `corner-shape` is a no-op on Chromium 138 (measured in squircle-live.mjs) and takes over at
+    // 139. Dropping either half strands the app: without `border-radius` a failed worklet load
+    // renders a square card, without `corner-shape` the upgrade brings nothing.
+    for (const sel of SURFACES) {
+      const body = bodiesFor(sel).join(" ");
+      expect(body, sel).toContain("corner-shape: squircle");
+      expect(body, sel).toMatch(/border-radius:/);
+    }
+  });
+
+  it("the painted treatment is gated on the mark theme/squircle.ts only sets once the worklet loaded", () => {
+    // `paint()` with no registered painter resolves to nothing, so a card that opted in before the
+    // module arrived would render as an invisible box. The gate is what makes that unreachable.
+    for (const sel of SURFACES) {
+      const body = bodiesFor(`:root[data-squircle] ${sel}`).join(" ");
+      expect(body, sel).toContain("background: paint(rl-squircle)");
+      // The background painting area is clipped by the radius, and a superellipse sits FURTHER into
+      // the corner than the arc of the same radius — left in place it shaves the painted corner
+      // straight back into the rounded rect this replaces.
+      expect(body, sel).toContain("border-radius: 0");
+    }
+    expect(registrar).toContain('root.setAttribute("data-squircle", "")');
+  });
+
+  it("the ring moves to the painter and the lift stays on box-shadow", () => {
+    // A box-shadow ring is drawn on the rounded rect whatever the fill does, so under the gate —
+    // where the radius is 0 — a focus ring left on box-shadow would square the corner off. The lift
+    // is the opposite case: blurred far wider than the two curves diverge, so it stays put, and
+    // keeping it there is what a mask would have cost.
+    for (const sel of [".composer", ".commit-card"]) {
+      expect(bodiesFor(`:root[data-squircle] ${sel}`).join(" "), sel).toContain("box-shadow: var(--shadow-card-lift)");
+      const focus = bodiesFor(`:root[data-squircle] ${sel}:focus-within`).join(" ");
+      expect(focus, sel).toContain("--sq-ring: var(--line-strong)");
+      expect(focus, sel).not.toContain("0 0 0 1px");
+    }
+    expect(bodiesFor(":root[data-squircle] .composer[data-dropping]").join(" ")).toContain("--sq-ring: var(--rl-accent)");
+  });
+
+  it("--shadow-card is composed from the ring and the lift, in both modes", () => {
+    // The squircle surfaces need the two halves apart; every other card wants the whole stack. One
+    // definition of each half, and the composite built from them, is what stops the two drifting.
+    // Twice: once per mode. (A third `--shadow-card:` exists in `@theme inline`, which only re-exports
+    // the token to Tailwind and states no value of its own.)
+    const composed = /--shadow-card: 0 0 0 var\(--hairline-w\) var\(--card-ring\), var\(--shadow-card-lift\)/g;
+    expect(tokens.match(composed) ?? []).toHaveLength(2);
+    for (const half of ["--card-ring", "--shadow-card-lift"]) {
+      expect(tokens.match(new RegExp(`${half}:`, "g")) ?? [], half).toHaveLength(2);
+    }
+  });
+
+  it("the stylesheet, the painter and the registrar agree on every name they pass between them", () => {
+    // All three failures here are silent. A renamed painter leaves `paint()` resolving to nothing; an
+    // input the worklet does not declare is never read, so the corner quietly keeps its last value;
+    // an unregistered property arrives as its raw token stream — `calc(16px + 4px)` — which canvas
+    // cannot parse into a length.
+    expect(worklet).toContain('registerPaint(\n  "rl-squircle"');
+    const declared = new Set([...worklet.matchAll(/"(--sq-[a-z-]+)"/g)].map((m) => m[1]!));
+    const registered = new Set([...registrar.matchAll(/name: "(--sq-[a-z-]+)"/g)].map((m) => m[1]!));
+    const used = new Set([...css.matchAll(/(--sq-[a-z-]+)\s*:/g)].map((m) => m[1]!));
+    expect([...used].filter((n) => !declared.has(n)).sort(), "set in styles.css, not read by the worklet").toEqual([]);
+    expect([...used].filter((n) => !registered.has(n)).sort(), "set in styles.css, never registered").toEqual([]);
+  });
+});
+
 describe("§6 do-NOT-animate list", () => {
   it("never uses `transition: all` anywhere", () => {
     expect(css).not.toMatch(/transition:\s*all\b/);

--- a/apps/desktop/src/renderer/src/styles.test.ts
+++ b/apps/desktop/src/renderer/src/styles.test.ts
@@ -732,6 +732,53 @@ describe("scrollbars", () => {
   });
 });
 
+describe("dividers", () => {
+  /** The table-list idiom: a rule drawn between every pair of adjacent rows. */
+  const ADJACENT = /^(\.[a-z-]+) \+ \1$/;
+  const drawsALine = (body: string): boolean =>
+    /border(-top|-bottom)?:\s*1px/.test(body) || /box-shadow:\s*inset 0 1px 0 var\(--line/.test(body);
+
+  it("no list draws an unconditional rule between its rows", () => {
+    // Six of these carried the app's divider weight — the diff files, checkpoints, checkouts, the
+    // activity log, the settings rows and the engines — and every one of them sat on rows that
+    // already separated themselves with a hover fill, a rounded row or plain spacing. A hairline on
+    // top of that says the same thing twice, which is most of what made the app read as ruled.
+    const offenders = RULES
+      .filter((r) => drawsALine(r.body))
+      .flatMap((r) => r.selectors)
+      .filter((sel) => ADJACENT.test(sel));
+    expect(offenders.sort()).toEqual([]);
+  });
+
+  it("the diff list draws a seam only under an OPEN file", () => {
+    // The exception that proves the rule, and the reason the check above says "unconditional": an
+    // expanded file's patch panel really would run into the next filename, so a seam there is doing
+    // work rather than decorating. Between two collapsed rows it is not.
+    expect(bodiesFor(".diff-file[data-open] + .diff-file").join(" ")).toContain("border-top: 1px solid");
+  });
+
+  it("the seams where content passes under a fixed edge are kept", () => {
+    // These are the ones that stop being decoration the moment anything scrolls: a pane's own bar, a
+    // sticky head over a list, a card's head over its body, a popover's search field over its rows.
+    for (const sel of [".panel-bar", ".diff-head", ".fd-head", ".md-code-head", ".mp-search", ".palette-input", ".spaces-search"])
+      expect(bodiesFor(sel).join(" "), sel).toMatch(/border-bottom: 1px solid/);
+    // Footers hold their place while the body scrolls past them.
+    for (const sel of [".permission-footer", ".question-footer", ".spaces-foot", ".mp-detail-foot"])
+      expect(bodiesFor(sel).join(" "), sel).toMatch(/border-top: 1px solid/);
+    // A table's rules ARE its structure, and the sidebar's edge is the app's one column boundary.
+    expect(bodiesFor(".md th").join(" ")).toContain("border-bottom: 1px solid");
+    expect(bodiesFor(".usage-table th").join(" ")).toContain("border-bottom: 1px solid");
+    expect(bodiesFor(".sidebar").join(" ")).toContain("border-right: 1px solid");
+  });
+
+  it("the two option lists in the transcript separate their rows the same way", () => {
+    // A permission and a question are the same card asking a different question; one of them used to
+    // rule its rows and the other did not.
+    for (const sel of [".permission-options", ".question-options"])
+      expect(bodiesFor(sel).join(" "), sel).toContain("gap: 1px");
+  });
+});
+
 describe("squircle surfaces", () => {
   const tokens = readFileSync(repoFile("apps/desktop/src/renderer/src/theme/tokens.css"), "utf8");
   const worklet = readFileSync(repoFile("apps/desktop/src/renderer/public/squircle-paint.js"), "utf8");

--- a/apps/desktop/src/renderer/src/styles.test.ts
+++ b/apps/desktop/src/renderer/src/styles.test.ts
@@ -48,9 +48,46 @@ function blocksAfter(prelude: string): string[] {
 }
 const blockAfter = (prelude: string): string => blocksAfter(prelude).join("\n");
 
+/** The motion ladder, read straight out of tokens.css: rung → milliseconds. §6's table is pinned
+ *  through it rather than against literals, so each timing below is now two facts — the rule reaches
+ *  for the right RUNG, and that rung is still the millisecond value §6 specified. Either one can
+ *  break on its own, and they fail with different messages. */
+const LADDER: Record<string, number> = Object.fromEntries(
+  [...readFileSync(repoFile("apps/desktop/src/renderer/src/theme/tokens.css"), "utf8")
+    .matchAll(/(--dur-[a-z]+):\s*(\d+)ms/g)].map((m) => [m[1]!, Number(m[2])]),
+);
+/** `var(--dur-x)`, and a hard failure if the rung does not exist — a typo'd token in an assertion
+ *  would otherwise quietly pin a string nothing in the stylesheet can ever match. */
+const dur = (rung: string): string => {
+  expect(LADDER[rung], `${rung} is not a rung of the ladder in tokens.css`).toBeGreaterThan(0);
+  return `var(${rung})`;
+};
+
+describe("§6 motion ladder", () => {
+  it("is the one place a duration is written, and these are its rungs", () => {
+    expect(LADDER).toEqual({
+      "--dur-drag": 80, "--dur-hover": 100, "--dur-press": 120, "--dur-pop": 140, "--dur-fast": 150,
+      "--dur-swap": 160, "--dur-enter": 180, "--dur-base": 200, "--dur-rise": 220, "--dur-slow": 240,
+      "--dur-move": 320,
+    });
+  });
+
+  it("no component writes a duration of its own", () => {
+    // The failure mode this closes is the one the ladder was built to end: four tokens existed, two
+    // of them with no users at all, while 41 `transition:` declarations wrote their own literals —
+    // so the ladder documented a system the stylesheet was not on.
+    const bare = new Set([...css.replace(/\/\*[\s\S]*?\*\//g, "")
+      .matchAll(/(?:transition|animation)[^;{}]*?(?<![\d.])([\d.]+m?s)\b/g)].map((m) => m[1]!));
+    // Loop PERIODS are a tempo, not the duration of a change, and the stagger step is a delay
+    // between siblings rather than a duration at all. Neither belongs on the ladder.
+    for (const period of ["0.9s", "1.4s", "3.6s", "5s", "40ms"]) bare.delete(period);
+    expect([...bare].sort()).toEqual([]);
+  });
+});
+
 describe("§6 motion table", () => {
   it("sheets enter at 240ms ease-out-strong with a .96 scale — one rule for every sheet, no per-sheet carve-out", () => {
-    expect(bodiesFor(".sheet").join(" ")).toContain("animation: rl-sheet-in 240ms var(--ease-out-strong)");
+    expect(bodiesFor(".sheet").join(" ")).toContain(`animation: rl-sheet-in ${dur("--dur-slow")} var(--ease-out-strong)`);
     expect(blockAfter("@keyframes rl-sheet-in")).toContain("scale(.96)");
     // W4b scoped 240ms to onboarding alone; W5's whole job was to hoist it. If the override comes
     // back, the shared sheet has silently regressed to something else.
@@ -58,73 +95,76 @@ describe("§6 motion table", () => {
   });
 
   it("the sheet scrim fades on its own at 160ms", () => {
-    expect(bodiesFor(".sheet-backdrop").join(" ")).toContain("animation: rl-fade-in 160ms");
+    expect(bodiesFor(".sheet-backdrop").join(" ")).toContain(`animation: rl-fade-in ${dur("--dur-swap")}`);
   });
 
   it("menus enter at 140ms ease-out-strong, scale .97→1, from an origin the component supplies", () => {
-    expect(bodiesFor(".menu").join(" ")).toContain("animation: rl-menu-in 140ms var(--ease-out-strong)");
+    expect(bodiesFor(".menu").join(" ")).toContain(`animation: rl-menu-in ${dur("--dur-pop")} var(--ease-out-strong)`);
     expect(blockAfter("@keyframes rl-menu-in")).toContain("scale(.97)");
   });
 
   it("the model picker is a popover and enters on the same rule as menus, not one of its own", () => {
     // It shares `.menu`'s declaration rather than carrying a copy: §6 gives every popover one timing,
     // and a second animation here is how the prompter's picker drifts away from every other surface.
-    expect(bodiesFor(".model-picker").join(" ")).toContain("animation: rl-menu-in 140ms var(--ease-out-strong)");
+    expect(bodiesFor(".model-picker").join(" ")).toContain(`animation: rl-menu-in ${dur("--dur-pop")} var(--ease-out-strong)`);
     // Its interactive rows honour the hover rule — background/colour only, never geometry.
+    const hover = `transition: background-color ${dur("--dur-hover")} ease, color ${dur("--dur-hover")} ease`;
     for (const sel of [".mp-row", ".mp-seg-opt"]) {
-      expect(bodiesFor(sel).join(" "), sel).toContain("transition: background-color 100ms ease, color 100ms ease");
+      expect(bodiesFor(sel).join(" "), sel).toContain(hover);
       expect(bodiesFor(sel).join(" "), sel).not.toContain("transform");
     }
     // The route pills animate their border too — they carry the selected state on the outline rather
     // than on a fill — but still nothing geometric.
-    expect(bodiesFor(".mp-route").join(" ")).toContain("transition: border-color 100ms ease, background-color 100ms ease, color 100ms ease");
+    expect(bodiesFor(".mp-route").join(" ")).toContain(
+      `transition: border-color ${dur("--dur-hover")} ease, background-color ${dur("--dur-hover")} ease, color ${dur("--dur-hover")} ease`);
     expect(bodiesFor(".mp-route").join(" ")).not.toContain("transform");
   });
 
   it("transcript items enter at 180ms with a 6px rise, gated on the data-enter mark Transcript.tsx sets", () => {
-    expect(bodiesFor(".transcript-col > [data-enter]").join(" ")).toContain("animation: rl-msg-in 180ms var(--ease-out-strong)");
+    expect(bodiesFor(".transcript-col > [data-enter]").join(" ")).toContain(`animation: rl-msg-in ${dur("--dur-enter")} var(--ease-out-strong)`);
     expect(blockAfter("@keyframes rl-msg-in")).toContain("translateY(6px)");
   });
 
   it("hover fills run 100ms on plain `ease` and touch background/colour only — never geometry", () => {
     const hover = bodiesFor(".item-row").join(" ");
-    expect(hover).toContain("transition: background-color 100ms ease, color 100ms ease");
+    expect(hover).toContain(`transition: background-color ${dur("--dur-hover")} ease, color ${dur("--dur-hover")} ease`);
     expect(hover).not.toContain("transform");
   });
 
   it("pressables scale to .97 over 120ms", () => {
     const press = bodiesFor(".ghost-chip").join(" ");
-    expect(press).toContain("transform 120ms var(--ease-out-strong)");
+    expect(press).toContain(`transform ${dur("--dur-press")} var(--ease-out-strong)`);
     for (const sel of [".btn:active:not(:disabled)", ".icon-btn:active:not(:disabled)", ".composer-send:active:not(:disabled)"])
       expect(bodiesFor(sel).join(" "), sel).toContain("transform: scale(.97)");
   });
 
   it("the send↔stop icon swap cross-fades over 160ms with opacity, scale and blur", () => {
     const swap = bodiesFor(".composer-send svg").join(" ");
-    for (const prop of ["opacity 160ms", "transform 160ms", "filter 160ms"]) expect(swap, prop).toContain(prop);
+    for (const prop of ["opacity", "transform", "filter"]) expect(swap, prop).toContain(`${prop} ${dur("--dur-swap")}`);
     expect(bodiesFor('.composer-send[data-state="send"] .stop-icon').join(" ")).toContain("blur(4px)");
   });
 
   it("the tool row expands by animating grid-template-rows over 200ms, with the content fading at 120ms", () => {
-    expect(bodiesFor(".tool-body-wrap").join(" ")).toContain("transition: grid-template-rows 200ms var(--ease-in-out-strong)");
+    expect(bodiesFor(".tool-body-wrap").join(" ")).toContain(`transition: grid-template-rows ${dur("--dur-base")} var(--ease-in-out-strong)`);
     expect(bodiesFor(".tool-body-wrap").join(" ")).toContain("grid-template-rows: 0fr");
     expect(bodiesFor(".tool-card[data-open] .tool-body-wrap").join(" ")).toContain("grid-template-rows: 1fr");
-    expect(bodiesFor(".tool-body").join(" ")).toContain("transition: opacity 120ms ease");
+    expect(bodiesFor(".tool-body").join(" ")).toContain(`transition: opacity ${dur("--dur-press")} ease`);
   });
 
   it("the copy ✓ swap uses the same 160ms opacity/scale/blur cross-fade as send↔stop", () => {
     const swap = bodiesFor(".tool-copy .copy-icon").join(" ");
-    for (const prop of ["opacity 160ms", "transform 160ms", "filter 160ms"]) expect(swap, prop).toContain(prop);
+    for (const prop of ["opacity", "transform", "filter"]) expect(swap, prop).toContain(`${prop} ${dur("--dur-swap")}`);
     expect(bodiesFor(".tool-copy:not([data-copied]) .copied-icon").join(" ")).toContain("blur(4px)");
   });
 
   it("W2's prompter hero→docked move keeps its 320ms ease-in-out-strong (§6 assigns that easing to on-screen movement)", () => {
-    expect(bodiesFor(".composer-dock").join(" ")).toContain("transition: transform 320ms var(--ease-in-out-strong)");
+    expect(bodiesFor(".composer-dock").join(" ")).toContain(`transition: transform ${dur("--dur-move")} var(--ease-in-out-strong)`);
   });
 
   it("W2's suggestion-chip stagger keeps §6's 220ms / 40ms steps / 8px rise", () => {
     const stagger = bodiesFor(".suggestions[data-animate] .suggestion-chip").join(" ");
-    expect(stagger).toContain("rl-chip-in 220ms var(--ease-out-strong)");
+    expect(stagger).toContain(`rl-chip-in ${dur("--dur-rise")} var(--ease-out-strong)`);
+    // The step stays a literal: it is a delay BETWEEN siblings, not the duration of one of them.
     expect(stagger).toContain("calc(var(--i) * 40ms)");
     expect(blockAfter("@keyframes rl-chip-in")).toContain("translateY(8px)");
   });

--- a/apps/desktop/src/renderer/src/theme/squircle.ts
+++ b/apps/desktop/src/renderer/src/theme/squircle.ts
@@ -1,0 +1,46 @@
+/** Switches on the superellipse corners the floating cards wear (styles.css's `:root[data-squircle]`
+ *  block, drawn by public/squircle-paint.js).
+ *
+ *  The gate is set only once the worklet module has actually loaded, and that ordering is the whole
+ *  point: `background: paint(rl-squircle)` with no registered painter resolves to nothing, so a card
+ *  that opted in before the module arrived would render as an invisible box. Everything outside the
+ *  gate is the fallback — `border-radius` plus `corner-shape: squircle`, which is a circular corner
+ *  today and the real thing once Electron ships Chromium 139. */
+
+/** The CSS Painting API is not in lib.dom. Only the one call this file makes is declared. */
+declare const CSS: {
+  registerProperty(definition: PropertyDefinition): void;
+  paintWorklet?: { addModule(url: string): Promise<void> };
+};
+
+/** The painter's inputs. They have to be REGISTERED rather than left as plain custom properties: the
+ *  computed value of an unregistered property is its substituted token stream, so the worklet would
+ *  receive the text `calc(16px + 4px)` and `color-mix(in srgb, …)` instead of a length and a colour,
+ *  and canvas can parse neither. */
+const PAINT_INPUTS: readonly PropertyDefinition[] = [
+  { name: "--sq-fill", syntax: "<color>", initialValue: "transparent", inherits: false },
+  { name: "--sq-ring", syntax: "<color>", initialValue: "transparent", inherits: false },
+  { name: "--sq-ring-w", syntax: "<length>", initialValue: "0px", inherits: false },
+  { name: "--sq-radius-top", syntax: "<length>", initialValue: "0px", inherits: false },
+  { name: "--sq-radius-bottom", syntax: "<length>", initialValue: "0px", inherits: false },
+];
+
+export async function enableSquircles(root: HTMLElement = document.documentElement): Promise<boolean> {
+  const worklet = CSS.paintWorklet;
+  if (!worklet) return false;
+  // Registering a name twice throws, and a second call means the properties are already there —
+  // which is a success, not a reason to leave the app on the fallback.
+  for (const definition of PAINT_INPUTS) {
+    try { CSS.registerProperty(definition); } catch { /* already registered */ }
+  }
+  try {
+    // Resolved against the document rather than this module: the painter is a `public/` file, so it
+    // sits beside index.html in the build and at the dev server's root. It cannot be an inline blob:
+    // or data: URL — the renderer's CSP is `script-src 'self'` and rejects both.
+    await worklet.addModule(new URL("squircle-paint.js", document.baseURI).href);
+  } catch {
+    return false;
+  }
+  root.setAttribute("data-squircle", "");
+  return true;
+}

--- a/apps/desktop/src/renderer/src/theme/tokens.css
+++ b/apps/desktop/src/renderer/src/theme/tokens.css
@@ -356,12 +356,34 @@ a {
   --line-strong: var(--overlay-lighten-400);
   --line-soft: var(--overlay-lighten-200);
 
-  /* Motion, tembo's four steps. `--dur-press` is deliberately shorter than
-   * `--dur-fast`: a press has to resolve inside the gesture that caused it. */
-  --dur-press: 0.14s;
-  --dur-fast: 0.15s;
-  --dur-base: 0.2s;
-  --dur-slow: 0.3s;
+  /* ── The motion ladder ───────────────────────────────────────────────────
+   * One rung per KIND of change, and the kind is the reason the number is
+   * what it is. Tembo's four steps are the spine; the rest are the durations
+   * §6's motion table already assigns, which used to be written out as
+   * literals at 41 call sites — a ladder nothing stands on is documentation,
+   * not a system, and `--dur-press` and `--dur-slow` had no users at all.
+   *
+   * A caveat worth knowing before adding to it: 140 / 150 / 160 are three
+   * rungs inside 20ms, which is finer than anyone can hold apart. They are
+   * three because §6 assigns those three numbers to three different kinds of
+   * change and the guardrail suite pins each one. Collapsing them is a
+   * RETUNE, not a rename — worth doing, but deliberately and on its own. */
+  --dur-drag: 80ms;   /* the drop target appearing mid-drag: fast enough not to read as motion */
+  --dur-hover: 100ms; /* a fill or an ink step answering the pointer */
+  --dur-press: 120ms; /* a control resolving inside the gesture that caused it — the .97 press, the switch throw */
+  --dur-pop: 140ms;   /* a popover unfolding out of its trigger */
+  --dur-fast: 150ms;  /* a fade with no gesture behind it: a tip arriving, a panel dimming to refetch */
+  --dur-swap: 160ms;  /* one thing replacing another, and the scrims that come and go with them */
+  --dur-enter: 180ms; /* an item arriving in a list that is already on screen */
+  --dur-base: 200ms;  /* a box changing SIZE */
+  --dur-rise: 220ms;  /* a staggered entrance */
+  --dur-slow: 240ms;  /* a surface arriving over the window, and the bars that fill at that pace */
+  --dur-move: 320ms;  /* something travelling across the pane */
+  /* Deliberately NOT on the ladder: the ambient loop periods (the 0.9s/1.4s
+   * pulses, the 3.6s orb, the shimmer, the generating canvas) and the 40ms
+   * stagger STEP. A loop period is a tempo and a step is a delay; neither is
+   * the duration of a change, and filing them here would invite picking one
+   * for a transition. */
   /* Drawers and sheets travel on their own curve — a long flat tail, so a panel
    * arrives rather than snaps. (The out-strong / in-out-strong pair above
    * already matches tembo's `--ease-out` / `--ease-in-out` exactly.) */

--- a/apps/desktop/src/renderer/src/theme/tokens.css
+++ b/apps/desktop/src/renderer/src/theme/tokens.css
@@ -49,7 +49,6 @@
 
   /* borders — the ramp itself now comes from the TEMBO ALIGNMENT block at the
    * foot of this file, which redraws it as alpha overlays. */
-  --grid-line: color-mix(in srgb, var(--line) 78%, transparent);
   --field: oklch(0.293 0.006 271.223);
   --stripe: oklch(1 0 0 / 0.055);
   --stripe-bg: oklch(0.226 0.004 264.485);
@@ -389,11 +388,22 @@ a {
    * already matches tembo's `--ease-out` / `--ease-in-out` exactly.) */
   --ease-drawer: cubic-bezier(0.32, 0.72, 0, 1);
 
+  /* Scrims. The one place "black at some alpha" cannot serve both modes: the veil subtracts from
+   * whatever is behind it, and a near-white window gives up far more light than a dark one does at
+   * the same alpha — 45% over light mode is a dim the dialog has to shout through. */
+  --scrim: oklch(0 0 0 / 0.45);      /* a surface that covers the window on purpose */
+  --scrim-soft: oklch(0 0 0 / 0.35); /* ⌘K, which is transient and does not */
+
   /* Shadow stacks: a RING plus a LIFT, the lift graduated across several soft
    * layers. Dark-mode rings lighten — a light edge over a dark ground reads as
    * the lit top face of a raised surface; light-mode rings darken. */
   --shadow-bevel: inset 0 1px 0.5px #ffffff14;
-  --shadow-glass-inset: inset 0 0 1.5px 0 #ffffff29;
+  /* The lit top edge of a FILLED control — primary, send, destructive. Deliberately does NOT flip
+   * with the mode, for the same reason --rl-accent-contrast does not: the fill under it is a
+   * saturated accent or red in both modes, and the light still comes from above. It is the ground
+   * that changes, not where the light is. (--shadow-bevel above is the other case — a bevel for a
+   * SURFACE, which does flip, because a white edge on a white card is nothing.) */
+  --fill-bevel: inset 0 1px 0 oklch(1 0 0 / 0.14);
   --shadow-pill: 0 2px 9px 0 #00000052;
   --shadow-btn: 0 0 0 var(--hairline-w) var(--overlay-lighten-400), 0 1px 2px #00000052;
   /* The card stack, stated as its two halves and then composed. The squircle surfaces need them
@@ -418,6 +428,9 @@ a {
   --line: var(--overlay-darken-200);
   --line-strong: var(--overlay-darken-300);
   --line-soft: var(--overlay-darken-100);
+
+  --scrim: oklch(0 0 0 / 0.32);
+  --scrim-soft: oklch(0 0 0 / 0.22);
 
   --shadow-bevel: inset 0 1px 0.5px #00000026;
   --shadow-pill: 0 2px 9px 0 #0000000f;

--- a/apps/desktop/src/renderer/src/theme/tokens.css
+++ b/apps/desktop/src/renderer/src/theme/tokens.css
@@ -374,9 +374,14 @@ a {
   --shadow-glass-inset: inset 0 0 1.5px 0 #ffffff29;
   --shadow-pill: 0 2px 9px 0 #00000052;
   --shadow-btn: 0 0 0 var(--hairline-w) var(--overlay-lighten-400), 0 1px 2px #00000052;
-  --shadow-card:
-    0 0 0 var(--hairline-w) var(--overlay-lighten-400),
-    0 1px 2px #00000033, 0 2px 6px #00000033;
+  /* The card stack, stated as its two halves and then composed. The squircle surfaces need them
+   * apart: a box-shadow ring is always drawn on the `border-radius` rounded rect, so on a card whose
+   * corner is a painted superellipse the ring cuts across the fill and the painter has to stroke the
+   * edge itself (--card-ring), leaving box-shadow only the lift. Every other card keeps the whole
+   * stack, and there is still one place either half is written. */
+  --card-ring: var(--overlay-lighten-400);
+  --shadow-card-lift: 0 1px 2px #00000033, 0 2px 6px #00000033;
+  --shadow-card: 0 0 0 var(--hairline-w) var(--card-ring), var(--shadow-card-lift);
   --shadow-raised:
     0 0 0 var(--hairline-w) var(--overlay-lighten-500),
     0 8px 16px #00000038, 0 24px 117px #0000003d;
@@ -395,7 +400,9 @@ a {
   --shadow-bevel: inset 0 1px 0.5px #00000026;
   --shadow-pill: 0 2px 9px 0 #0000000f;
   --shadow-btn: 0 0 0 var(--hairline-w) var(--overlay-darken-300), 0 1px 2px #03071214;
-  --shadow-card: 0 0 0 var(--hairline-w) #03071214, 0 2px 4px 0 #0307120a;
+  --card-ring: #03071214;
+  --shadow-card-lift: 0 2px 4px 0 #0307120a;
+  --shadow-card: 0 0 0 var(--hairline-w) var(--card-ring), var(--shadow-card-lift);
   --shadow-raised: 0 0 0 var(--hairline-w) #03071214, 0 8px 16px 0 #0307120a, 0 24px 117px 0 #1c284024;
   --shadow-overlay:
     0 0 0 var(--hairline-w) #0000000d,


### PR DESCRIPTION
Five foundation changes the rest of the visual work builds on. Stacked on #21.

**A squircle that is actually drawn.** `styles.css` has asked for `corner-shape: squircle` since the prompter was built, and it has never done anything: this runtime is Chromium 138 and the property landed in 139 — `CSS.supports('corner-shape','squircle')` is `false`. The corners are now painted by a CSS Painting API worklet, with `border-radius` + `corner-shape` left in place as the fallback and as the path that takes over for free once Electron ships 139.

Two things about that were not obvious. The renderer's CSP is `script-src 'self'`, which rejects `addModule()` from a `blob:` *or* a `data:` URL — so the painter has to be a real same-origin file, which is why it lives in `public/`. And its inputs have to go through `CSS.registerProperty`: the computed value of an unregistered custom property is its substituted token stream, so the worklet would have received the literal text `calc(16px + 4px)` and `color-mix(in srgb, …)`, neither of which canvas can parse. The `data-squircle` gate is set only after the module resolves, because `background: paint(…)` with no registered painter resolves to nothing and would render an invisible card.

The card's ring and lift moved onto the curve rather than around it, so focus still brightens the edge without a box-shadow squaring the corner back off.

**One motion ladder.** The duration tokens existed and 37 of 41 transitions ignored them; `--dur-press` and `--dur-slow` had zero users. Every timing now names a rung. No rendered timing changed except the terminal hint's `.25s` fade, which was the last orphan in the file and 10ms off the nearest rung.

**Trackless scrollbars, everywhere.** `scrollbar-color` is an inherited property, so stating it once on `:root` hides the track in every scroller in the app — including ones added after this line. That is what makes "everywhere" structural instead of a list to keep up with. `scrollbar-width` does not inherit, so the scrollers that should be thin are still named.

This also deletes three rules that had been dead since Chromium 121: setting either standard property makes the browser ignore `::-webkit-scrollbar` outright, and every selector those rules targeted also set `scrollbar-width: thin`. Measured on this runtime — a scroller with only the pseudo-element rules reserves the 24px they ask for, one with both reserves 11px.

**Fewer rules.** Six `X + X { border-top }` list rules are gone; the bright-name/dim-description luminance step and the existing gaps already separate those rows. Two-pane split boundaries stay, same category as the sidebar's own edge.

**Light-mode colour.** Two zero-referenced dark-only tokens deleted. The scrims, which were dark-tuned literals, now flip.

Verified by `apps/desktop/scripts/squircle-live.mjs` (9 assertions) against the built app. The corner is proved geometrically rather than by eye: inside a corner's R×R square the filled fraction is fixed by the curve — π/4 ≈ 0.785 for a circular arc, ≈ 0.874 for the superellipse — and it is measured by counting pixels against two reference tones sampled from the same screenshot. Prompter 0.885; with the gate stripped, 0.752. Both modes were checked on screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)