### PR TITLE
A plan gets its own place in the transcript, and Ask becomes a mode each backend enforces

### DIFF
--- a/apps/desktop/src/renderer/src/panes/session/Composer.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/Composer.tsx
@@ -1,5 +1,5 @@
-import { AGENT_META, AGENT_SUPPORTS_PERMISSION_MODES, DEFAULT_MODEL_LABEL, SELECTABLE_AGENT_KINDS, AGENT_SUPPORTS_PLAN_MODE, EFFORT_LEVELS, PERMISSION_MODES, PLAN_PERMISSION_MODE, SESSION_MODES, acpPlanMode, attachmentDisposition, attachmentNote, attachmentSummary, formatAttachmentSize, type AcpSessionMode, type AgentKind, type Environment, type GitInfo, type McpServer, type ModelInfo, type Session, type SessionMode, type SessionStatus, type Skill } from "@realm/contracts";
-import { Icon } from "@realm/ui";
+import { AGENT_META, AGENT_SUPPORTS_ASK_MODE, AGENT_SUPPORTS_PERMISSION_MODES, DEFAULT_MODEL_LABEL, SELECTABLE_AGENT_KINDS, AGENT_SUPPORTS_PLAN_MODE, EFFORT_LEVELS, PERMISSION_MODES, SESSION_MODES, acpAskMode, acpPlanMode, sessionModeOf, attachmentDisposition, attachmentNote, attachmentSummary, formatAttachmentSize, type AcpSessionMode, type AgentKind, type Environment, type GitInfo, type McpServer, type ModelInfo, type Session, type SessionMode, type SessionStatus, type Skill } from "@realm/contracts";
+import { Icon, type IconName } from "@realm/ui";
 import { Fragment, useEffect, useLayoutEffect, useMemo, useRef, useState, type ClipboardEvent, type DragEvent, type KeyboardEvent, type ReactNode, type RefObject } from "react";
 import { Menu, type MenuItem } from "../../components/Menu";
 import type { AgentProbe, PickedAttachment, SessionOptions, SubmitKey } from "../../state/store";
@@ -106,6 +106,10 @@ function AttachmentRow({ kind, attachments, onRemove }: { kind: AgentKind; attac
 }
 
 const permissionLabel = (id: string) => PERMISSION_MODES.find((m) => m.id === id)?.label ?? id;
+const MODE_LABEL: Record<SessionMode, string> = { build: "Build", plan: "Plan", ask: "Ask" };
+/** `search` for Ask, not the session bubble: the mode is reading and searching, and the bubble is
+ *  already what a session row is. */
+const MODE_ICON: Record<SessionMode, IconName> = { build: "tool", plan: "plan", ask: "search" };
 
 /** An environment's display name (under-strip selector, Plan 12 W1): the space's own name for the
  *  primary (the folder IS the space), the branch for a worktree, the folder's basename otherwise. */
@@ -223,14 +227,24 @@ function PlusMenu({ onAttachPick, onAddFolder, onSkills, canSkills, connectors, 
  *  session id, A-M9) so a suggestion chip can fill it without sending — and layout reshapes never
  *  lose it. */
 /**
- * What Plan MEANS for this agent — the chip title's honesty clause (Plan 14 W3). Claude and Codex have
- * Realm-transmitted plan semantics; an ACP agent's Plan is its OWN mode, described in its own words
- * where it offered any.
+ * What the current mode MEANS for this agent — the chip title's honesty clause (Plan 14 W3).
+ *
+ * Claude and Codex have Realm-transmitted semantics and each is described in its OWN terms, because
+ * they are not the same guarantee: Codex's Plan can be talked out of the sandbox by approving a
+ * prompt, and its Ask cannot. An ACP agent's Plan or Ask is its own mode, described in its own words
+ * where it offered any — Realm does not paraphrase an agent's mode into Realm's vocabulary.
  */
-function planMeaning(kind: AgentKind, acpPlan: AcpSessionMode | null): string {
-  if (acpPlan) {
-    const label = AGENT_META[kind].label;
-    return acpPlan.description ? `Plan is ${label}'s own ${acpPlan.name} mode: ${acpPlan.description}` : `Plan is ${label}'s own ${acpPlan.name} mode`;
+function modeMeaning(mode: Exclude<SessionMode, "build">, kind: AgentKind, acpMode: AcpSessionMode | null): string {
+  const label = AGENT_META[kind].label;
+  const name = MODE_LABEL[mode];
+  if (acpMode) {
+    return acpMode.description
+      ? `${name} is ${label}'s own ${acpMode.name} mode: ${acpMode.description}`
+      : `${name} is ${label}'s own ${acpMode.name} mode`;
+  }
+  if (mode === "ask") {
+    if (kind === "codex") return "Ask runs the turn read-only with approvals disabled — there is no prompt through which to escalate, and a mid-session switch applies when the session next starts";
+    return "Ask is read-only: the agent may read and search, and every edit or command is refused before it runs";
   }
   if (kind === "codex") return "Plan runs the turn read-only under an untrusted approval policy — the agent proposes, but does not edit";
   return "Plan means the agent researches and proposes, but does not edit";
@@ -326,9 +340,16 @@ export function Composer({ session, status, gitInfo, onOpenDiff, draft, onDraftC
   // than promising a mapping that may not exist. A fresh session shows nothing at all.
   const isAcpKind = kind.startsWith("acp:");
   const acpPlan = isAcpKind ? acpPlanMode(acpModes) : null;
+  const acpAsk = isAcpKind ? acpAskMode(acpModes) : null;
   const canPlan = isAcpKind ? acpPlan !== null : AGENT_SUPPORTS_PLAN_MODE[kind];
+  // Asked separately from Plan and answered separately: Cursor advertises both, opencode neither, and
+  // an agent offering one is not offering the other.
+  const canAsk = isAcpKind ? acpAsk !== null : AGENT_SUPPORTS_ASK_MODE[kind];
   const acpModesPending = isAcpKind && acpModes === null && !canSwitchAgent && status !== "error" && status !== "ended";
-  const inPlan = session.permissionMode === PLAN_PERMISSION_MODE;
+  const mode = sessionModeOf(session.permissionMode);
+  // Both Plan and Ask replace the permission axis rather than sitting beside it, so both turn the
+  // permission control into a label naming what Build will restore.
+  const inReadOnly = mode !== "build";
   // bypassPermissions must never be a one-click slip (U-M7): selecting it arms an inline confirm chip
   // for 5s while the chip simply stays on the current mode; only the explicit confirm applies it.
   const [confirmBypass, setConfirmBypass] = useState(false);
@@ -546,9 +567,19 @@ export function Composer({ session, status, gitInfo, onOpenDiff, draft, onDraftC
   // chip's gray suffix names the level, and this list is the picker's permanent Effort section.
   // Deliberately narrow (no `MenuItem[]`): OverflowGroup's item shape, which has no separator arm.
   const effortItems = EFFORT_LEVELS.map((l) => ({ label: formatEffort(l), checked: session.effort === l, onSelect: () => onOptions({ effort: l }) }));
-  const modeItems: MenuItem[] = SESSION_MODES.map((m) => ({
-    label: m.label, checked: (m.id === "plan") === inPlan, onSelect: () => onMode(m.id),
-  }));
+  // Only the modes this agent can actually be put INTO. Build is always offered — it is the absence
+  // of the other two, not a capability — and a menu row for a mode nothing would enforce is the lie
+  // the per-kind tables exist to prevent.
+  const modeItems: MenuItem[] = SESSION_MODES
+    .filter((m) => (m.id === "plan" ? canPlan : m.id === "ask" ? canAsk : true))
+    .map((m) => ({ label: m.label, checked: m.id === mode, onSelect: () => onMode(m.id) }));
+
+  // While IN a read-only mode the title says what that mode is doing; from Build it says what each
+  // offered mode WOULD do, because Build is where the choice is made and the per-agent guarantee is
+  // exactly what the user needs before making it.
+  const modeTitle = `Mode: ${MODE_LABEL[mode]}. ` + (mode === "build"
+    ? [canPlan ? modeMeaning("plan", kind, acpPlan) : null, canAsk ? modeMeaning("ask", kind, acpAsk) : null].filter(Boolean).join(". ")
+    : modeMeaning(mode, kind, mode === "ask" ? acpAsk : acpPlan));
 
   // Built HERE rather than inside ModelPicker so the harness chip and the model list are the same
   // rows: the chip resolves a switch through `modelIdOn`, and two independent `modelRows` calls
@@ -588,7 +619,7 @@ export function Composer({ session, status, gitInfo, onOpenDiff, draft, onDraftC
   });
   // In Plan the permission control is a read-only label (see below) and stays on the row — only
   // the MENU collapses.
-  const overflow: OverflowGroup[] | undefined = collapsed && canSetPermissionMode && !inPlan
+  const overflow: OverflowGroup[] | undefined = collapsed && canSetPermissionMode && !inReadOnly
     ? [{ label: "Permissions", items: permissionItems }]
     : undefined;
 
@@ -664,27 +695,27 @@ export function Composer({ session, status, gitInfo, onOpenDiff, draft, onDraftC
               onManageConnections={() => onManageConnections?.()} btnRef={plusRef} />
             {/* Left group order (prompter rework): "+" · permission · mode · branch. The permission
                 and mode chips sit against the attach button; the git chip trails them. */}
-            {/* In Plan the permission mode is not in effect — Claude's `plan` replaces it outright and
-                Codex forces read-only — so the control becomes a LABEL naming what Build will restore.
+            {/* In Plan and in Ask the permission mode is not in effect — Claude's `plan` replaces it
+                outright, Realm's own gate refuses in Ask, and Codex forces read-only either way — so
+                the control becomes a LABEL naming what Build will restore.
                 Offering a picker whose selection changes nothing is the lie this split exists to end;
                 hiding it instead would lose the answer to "what happens when I go back?". */}
             {canSetPermissionMode && (
-              inPlan
+              inReadOnly
                 ? <ChipMenu ariaLabel="Permission mode" items={[]}
-                    title={`Plan is read-only — returning to Build restores ${permissionLabel(planReturn ?? "default")}`}
+                    title={`${MODE_LABEL[mode]} is read-only — returning to Build restores ${permissionLabel(planReturn ?? "default")}`}
                     label={permissionLabel(planReturn ?? "default")} />
                 : !collapsed && <ChipMenu ariaLabel="Permission mode" warning={session.permissionMode === "bypassPermissions"}
                     label={permissionLabel(session.permissionMode)} items={permissionItems} />
             )}
-            {canPlan && (
-              <ChipMenu ariaLabel="Mode" title={`Mode: ${inPlan ? "Plan" : "Build"}. ${planMeaning(kind, acpPlan)}`}
-                icon={inPlan ? "plan" : "tool"} label={inPlan ? "Plan" : "Build"} items={modeItems} />
+            {(canPlan || canAsk) && (
+              <ChipMenu ariaLabel="Mode" title={modeTitle} icon={MODE_ICON[mode]} label={MODE_LABEL[mode]} items={modeItems} />
             )}
             {/* The materialize-honestly window: the session is live but the agent has not named its
                 modes yet. Disabled (a static label, out of the tab order) rather than absent, so the
                 chip does not pop into a row the user is already aiming at — and rather than enabled,
                 because offering Plan before the agent has said it exists would be a guess. */}
-            {!canPlan && acpModesPending && (
+            {!canPlan && !canAsk && acpModesPending && (
               <ChipMenu ariaLabel="Mode" title="Waiting for the agent's modes" icon="tool" label="Build" items={[]} />
             )}
             <GitChip gitInfo={gitInfo} onOpenDiff={onOpenDiff} />

--- a/apps/desktop/src/renderer/src/panes/session/Composer.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/Composer.tsx
@@ -347,8 +347,7 @@ export function Composer({ session, status, gitInfo, onOpenDiff, draft, onDraftC
   const canAsk = isAcpKind ? acpAsk !== null : AGENT_SUPPORTS_ASK_MODE[kind];
   const acpModesPending = isAcpKind && acpModes === null && !canSwitchAgent && status !== "error" && status !== "ended";
   const mode = sessionModeOf(session.permissionMode);
-  // Both Plan and Ask replace the permission axis rather than sitting beside it, so both turn the
-  // permission control into a label naming what Build will restore.
+  // Plan and Ask both REPLACE the permission axis rather than sitting beside it.
   const inReadOnly = mode !== "build";
   // bypassPermissions must never be a one-click slip (U-M7): selecting it arms an inline confirm chip
   // for 5s while the chip simply stays on the current mode; only the explicit confirm applies it.

--- a/apps/desktop/src/renderer/src/panes/session/PlanCard.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/PlanCard.tsx
@@ -1,0 +1,52 @@
+import { Icon } from "@realm/ui";
+import type { PermissionDecision } from "../../state/store";
+import { Markdown } from "./Markdown";
+import { TodoList } from "./rich/ToolViews";
+import type { PendingPermission, PlanStep } from "./transcript-model";
+
+/**
+ * The plan the agent proposed, drawn as a plan.
+ *
+ * Two bodies rather than one, because the protocols send two different artifacts and neither can be
+ * derived from the other (see the `plan` session event): prose renders as the markdown it is, a
+ * checklist reuses `TodoList` — the same drawing TodoWrite already gets, and for the same reason,
+ * since a plan with per-step status IS a to-do list. A plan carrying both draws both.
+ */
+export function PlanCard({ text, steps, enter = false }: { text?: string; steps?: PlanStep[]; enter?: boolean }) {
+  return (
+    <div className="plan-card" role="group" aria-label="Plan" data-enter={enter || undefined}>
+      <div className="plan-head"><Icon name="plan" size={14} /><span>Plan</span></div>
+      {steps && steps.length > 0 && <TodoList todos={steps.map((s) => ({ content: s.text, status: s.status, activeForm: null }))} />}
+      {text && <Markdown text={text} className="plan-body" />}
+    </div>
+  );
+}
+
+/**
+ * The decision on a plan, when the agent is waiting for one.
+ *
+ * `ExitPlanMode` reaches Realm on the permission channel like any other tool, and that channel is
+ * load-bearing: answering it is how the session leaves Plan. What it is NOT is a permission —
+ * "Allow / Allow always / Deny" on a plan asks the wrong question, and the generic card buried the
+ * plan itself in a clipped one-line summary.
+ *
+ * So the plan is a block of its own (mapped off the same tool call, and it stays in the scrollback
+ * after the decision), and this is only the answer to it: approve, or keep planning. There is no
+ * "always" — a standing grant to leave Plan unasked is not a thing a user can mean.
+ */
+export const isPlanDecision = (p: PendingPermission): boolean => p.toolName === "ExitPlanMode";
+
+export function PlanDecision({ onDecide, autoFocus = false, enter = false }: {
+  onDecide: (d: PermissionDecision) => void; autoFocus?: boolean; enter?: boolean;
+}) {
+  return (
+    <div className="plan-decision" role="group" aria-label="Plan approval" data-enter={enter || undefined}
+      onKeyDown={(e) => { if (e.key === "Escape") { e.preventDefault(); e.stopPropagation(); onDecide("deny"); } }}>
+      <span className="plan-decision-ask">Ready to build this?</span>
+      <div className="plan-decision-actions">
+        <button type="button" className="plan-approve" autoFocus={autoFocus} onClick={() => onDecide("allow")}>Approve plan</button>
+        <button type="button" className="plan-reject" onClick={() => onDecide("deny")}>Keep planning</button>
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/src/panes/session/Transcript.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/Transcript.tsx
@@ -5,6 +5,7 @@ import { AttachmentTile } from "./AttachmentTile";
 import type { PermissionDecision } from "../../state/store";
 import { Markdown } from "./Markdown";
 import { PermissionCard } from "./PermissionCard";
+import { PlanCard, PlanDecision, isPlanDecision } from "./PlanCard";
 import { QuestionCard, questionCardFor } from "./QuestionCard";
 import { ToolCard, ToolGroup } from "./ToolCard";
 import { formatDuration, groupTranscript } from "./tool-group";
@@ -104,7 +105,8 @@ export function Transcript({ transcript, sessionStatus, onDecide, visible = true
   const [pill, setPill] = useState(false);
   const count = transcript.blocks.length;
   const lastText = transcript.blocks.at(-1);
-  const lastLen = lastText && "text" in lastText ? lastText.text.length : 0;
+  // `?? 0` because not every text-bearing block has text: a checklist-only plan carries none.
+  const lastLen = lastText && "text" in lastText ? lastText.text?.length ?? 0 : 0;
   // Permission cards only make sense while the adapter is actually waiting; stale requests (crash, restart) are closed server-side.
   const permissions = sessionStatus === "waiting_permission" ? transcript.pendingPermissions : [];
   // §6: 180ms enter, new items only. Everything on screen at mount is seeded as already-seen, so
@@ -176,6 +178,7 @@ export function Transcript({ transcript, sessionStatus, onDecide, visible = true
             case "assistant": return <AssistantMessage key={key} text={b.text} streaming={b.streaming} enter={enter} cwd={cwd} />;
             case "thinking": return <Thinking key={key} text={b.text} enter={enter} />;
             case "tool": return <ToolCard key={key} block={b} sessionStatus={sessionStatus} enter={enter} />;
+            case "plan": return <PlanCard key={key} text={b.text} steps={b.steps} enter={enter} />;
             case "error": return <div key={key} className="msg-error" role="alert" data-enter={enter || undefined}><Icon name="alert" size={14} /><pre>{b.message}</pre></div>;
             // The shimmer the reader was watching, settled: same verb, past tense, with the wait it
             // cost them. It stays in the scrollback rather than vanishing with the spinner — "how
@@ -184,12 +187,17 @@ export function Transcript({ transcript, sessionStatus, onDecide, visible = true
           }
         })}
         {permissions.map((p, i) => {
-          // A question-shaped tool call gets the question card; everything else is a permission and
-          // keeps the Allow / Allow always / Deny gate.
+          // A question-shaped tool call gets the question card and a plan gets its approve/reject
+          // row; everything else really is a permission and keeps the Allow / Allow always / Deny gate.
           const questions = questionCardFor(p);
           if (questions) return <QuestionCard key={p.requestId} questions={questions} autoFocus={focused && i === 0}
             enter={isEntering(permKey(p.requestId))}
             onAnswer={(answers) => onDecide(p.requestId, "allow", answers)} onSkip={() => onDecide(p.requestId, "deny")} />;
+          // A plan is not a permission. The plan itself is already a block above (mapped off the same
+          // tool call), so this is only the answer to it — repeating the markdown here would print the
+          // plan twice.
+          if (isPlanDecision(p)) return <PlanDecision key={p.requestId} autoFocus={focused && i === 0}
+            enter={isEntering(permKey(p.requestId))} onDecide={(d) => onDecide(p.requestId, d)} />;
           return <PermissionCard key={p.requestId} permission={p} autoFocus={focused && i === 0}
             enter={isEntering(permKey(p.requestId))} onDecide={(d) => onDecide(p.requestId, d)} />;
         })}

--- a/apps/desktop/src/renderer/src/panes/session/Transcript.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/Transcript.tsx
@@ -187,8 +187,7 @@ export function Transcript({ transcript, sessionStatus, onDecide, visible = true
           }
         })}
         {permissions.map((p, i) => {
-          // A question-shaped tool call gets the question card and a plan gets its approve/reject
-          // row; everything else really is a permission and keeps the Allow / Allow always / Deny gate.
+          // Only what really is a permission keeps the Allow / Allow always / Deny gate.
           const questions = questionCardFor(p);
           if (questions) return <QuestionCard key={p.requestId} questions={questions} autoFocus={focused && i === 0}
             enter={isEntering(permKey(p.requestId))}

--- a/apps/desktop/src/renderer/src/panes/session/plan-card.test.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/plan-card.test.tsx
@@ -1,0 +1,75 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
+import { Transcript } from "./Transcript";
+import type { Block, PendingPermission, Transcript as TranscriptModel } from "./transcript-model";
+
+afterEach(() => cleanup());
+
+const model = (blocks: Block[], pendingPermissions: PendingPermission[] = []): TranscriptModel =>
+  ({ blocks, run: null, pendingPermissions, usage: { costUsd: 0, inputTokens: 0, outputTokens: 0, numTurns: 0 }, init: null });
+
+const perm = (over: Partial<PendingPermission> = {}): PendingPermission =>
+  ({ requestId: "r1", toolName: "ExitPlanMode", title: "Exit plan mode?", input: { plan: "# Ship it" }, ...over });
+
+describe("the plan card", () => {
+  it("renders prose as the markdown it is, not as a clipped one-line tool summary", () => {
+    render(<Transcript sessionStatus="idle" onDecide={() => {}} transcript={model([
+      { kind: "plan", planId: "p1", text: "# Ship it\n\nRewrite `foo` first.", ts: 1 },
+    ])} />);
+    const card = document.querySelector(".plan-card")!;
+    expect(within(card as HTMLElement).getByRole("heading", { level: 1 })).toHaveTextContent("Ship it");
+    expect(card.querySelector("code")).toHaveTextContent("foo");
+    // The mutant: leaving ExitPlanMode on the tool path. The plan would come back as a `.tool-card`
+    // whose summary is the first 90 characters of the document.
+    expect(document.querySelector(".tool-card")).toBeNull();
+  });
+
+  it("draws a checklist plan with its per-step status", () => {
+    render(<Transcript sessionStatus="idle" onDecide={() => {}} transcript={model([
+      { kind: "plan", planId: "p1", steps: [{ text: "Read the spec", status: "completed" }, { text: "Write it", status: "in_progress" }], ts: 1 },
+    ])} />);
+    const items = document.querySelectorAll(".plan-card .todo-list li");
+    expect([...items].map((li) => li.getAttribute("data-status"))).toEqual(["completed", "in_progress"]);
+    expect(screen.getByText("1 of 2")).toBeTruthy();
+  });
+
+  it("draws both halves when a plan carries both, and neither when it carries neither", () => {
+    render(<Transcript sessionStatus="idle" onDecide={() => {}} transcript={model([
+      { kind: "plan", planId: "p1", text: "why", steps: [{ text: "how", status: "pending" }], ts: 1 },
+    ])} />);
+    expect(document.querySelector(".plan-card .todo-list")).toBeTruthy();
+    expect(document.querySelector(".plan-card .plan-body")).toBeTruthy();
+  });
+});
+
+describe("the decision on a plan", () => {
+  it("is the plan's own approve/keep-planning row, never the generic Allow / Allow always / Deny card", () => {
+    render(<Transcript sessionStatus="waiting_permission" onDecide={() => {}} transcript={model(
+      [{ kind: "plan", planId: "toolu_p", text: "# Ship it", ts: 1 }], [perm()])} />);
+    // The mutant: dropping the isPlanDecision branch. "Allow always" on a plan is a standing grant to
+    // leave Plan unasked, which is not a thing a user can mean — and the card would print the plan a
+    // second time under the one already on screen.
+    expect(document.querySelector(".permission-card")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Allow always" })).toBeNull();
+    expect(document.querySelectorAll(".plan-card")).toHaveLength(1);
+    expect(screen.getByRole("button", { name: "Approve plan" })).toBeTruthy();
+  });
+
+  it("answers on the permission channel, because that is how the session leaves Plan", () => {
+    const onDecide = vi.fn();
+    const view = render(<Transcript sessionStatus="waiting_permission" onDecide={onDecide} transcript={model([], [perm()])} />);
+    fireEvent.click(screen.getByRole("button", { name: "Approve plan" }));
+    expect(onDecide).toHaveBeenCalledWith("r1", "allow");
+    view.rerender(<Transcript sessionStatus="waiting_permission" onDecide={onDecide} transcript={model([], [perm()])} />);
+    fireEvent.click(screen.getByRole("button", { name: "Keep planning" }));
+    expect(onDecide).toHaveBeenLastCalledWith("r1", "deny");
+  });
+
+  it("leaves every other tool on the permission card", () => {
+    render(<Transcript sessionStatus="waiting_permission" onDecide={() => {}} transcript={model([], [
+      perm({ toolName: "Bash", input: { command: "rm -rf /" }, title: "Run rm?" }),
+    ])} />);
+    expect(document.querySelector(".permission-card")).toBeTruthy();
+    expect(document.querySelector(".plan-decision")).toBeNull();
+  });
+});

--- a/apps/desktop/src/renderer/src/panes/session/prompt-hint.test.ts
+++ b/apps/desktop/src/renderer/src/panes/session/prompt-hint.test.ts
@@ -18,6 +18,8 @@ const assistant = (text: string): Block => ({ kind: "assistant", messageId: "m1"
 const tool = (name: string, input: Record<string, unknown> = {}, result: { content: string; isError: boolean } | null = null): Block =>
   ({ kind: "tool", toolUseId: `t-${name}`, name, input, result, ts: 2 });
 
+const plan = (): Block => ({ kind: "plan", planId: "p1", text: "# The plan", ts: 2 });
+
 const hint = (o: Partial<Parameters<typeof promptHint>[0]> = {}) =>
   promptHint({ blocks: [], gitInfo: null, status: "idle", inPlan: false, ...o });
 
@@ -75,11 +77,17 @@ describe("the session's suggested prompt", () => {
     });
 
     it("says go when a plan is on screen and the agent cannot act on it", () => {
-      const blocks = [user("plan it"), assistant("Here is the plan.")];
+      const blocks = [user("plan it"), plan()];
       expect(hint({ blocks, inPlan: true }))
         .toBe("Implement the plan, then verify its riskiest assumption.");
       // Out of Plan, it still continues the actual subject rather than falling back to repo state.
       expect(hint({ blocks, inPlan: false })).toBeNull();
+    });
+
+    it("waits for a real plan rather than reading one into any finished sentence", () => {
+      // The mutant: gating on `assistant && !streaming` again. An agent that asked a clarifying
+      // question and stopped would be answered with "Implement the plan" — there is no plan.
+      expect(hint({ blocks: [user("plan it"), assistant("Which files should I look at first?")], inPlan: true })).toBeNull();
     });
 
     it("suggests the tests once the agent has written to a file", () => {

--- a/apps/desktop/src/renderer/src/panes/session/prompt-hint.ts
+++ b/apps/desktop/src/renderer/src/panes/session/prompt-hint.ts
@@ -65,7 +65,11 @@ export function promptHint(ctx: {
   // Plan mode: retain the subject that caused the plan and ask for the valuable second half of the
   // work too — testing its riskiest assumption. This reads like a continuation of this conversation,
   // not a stock button label.
-  if (inPlan && turn.some((b) => b.kind === "assistant" && !b.streaming)) {
+  //
+  // Gated on an actual plan block, not on the agent merely having finished speaking. "Which files
+  // should I look at first?" is a completed assistant message too, and offering to implement the
+  // plan under it promised a plan that did not exist. A `plan` event is the agent saying it has one.
+  if (inPlan && turn.some((b) => b.kind === "plan")) {
     return request
       ? `Turn the plan for ${request} into working code, then verify its riskiest assumption.`
       : "Implement the plan, then verify its riskiest assumption.";

--- a/apps/desktop/src/renderer/src/panes/session/session-pane.test.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/session-pane.test.tsx
@@ -1013,15 +1013,32 @@ describe("ACP mode chip — per-session modes (Plan 14 W3)", () => {
     expect(chip).toHaveTextContent("Build");
     expect(chip.title).toContain("Cursor's own Plan mode");
     expect(chip.title).toContain("Read-only mode for planning and designing before implementation");
+    // Cursor advertises `ask` in the same handshake, so the chip describes that too — from Build the
+    // title is what the user reads before choosing.
+    expect(chip.title).toContain("Cursor's own Ask mode");
     expect(document.querySelector('.ghost-chip[data-static][title="Waiting for the agent\'s modes"]')).toBeNull();
   });
 
-  it("shows NO chip for a session whose modes lack a plan-equivalent", async () => {
+  it("shows NO chip for a session whose modes carry neither a plan- nor an ask-equivalent", async () => {
     // The named mutant: a chip here would drive session/set_mode toward a mode that does not exist.
     await mountCursor([sessionEvent("user_message", { text: "go", attachments: [] }),
-      initEvent([{ id: "agent", name: "Agent", description: "d" }, { id: "ask", name: "Ask", description: "d" }])]);
+      initEvent([{ id: "agent", name: "Agent", description: "d" }, { id: "review", name: "Review", description: "d" }])]);
     expect(screen.queryByRole("button", { name: "Mode" })).toBeNull();
     expect(document.querySelector('.ghost-chip[data-static][title="Waiting for the agent\'s modes"]')).toBeNull();
+  });
+
+  it("offers Ask alone when the agent advertises `ask` but no plan-equivalent", async () => {
+    await mountCursor([sessionEvent("user_message", { text: "go", attachments: [] }),
+      initEvent([{ id: "agent", name: "Agent", description: "d" }, { id: "ask", name: "Ask", description: "Q&A mode - no edits or command execution" }])]);
+    const chip = screen.getByRole("button", { name: "Mode" });
+    // The mutant: gating the whole chip on `canPlan`. An agent that offers only Ask would show no
+    // mode control at all, and its one read-only mode would be unreachable.
+    expect(chip).toHaveTextContent("Build");
+    expect(chip.title).toContain("Cursor's own Ask mode");
+    expect(chip.title).toContain("no edits or command execution");
+    fireEvent.click(chip);
+    // …and the menu offers exactly Build and Ask: Plan has nothing to map onto here.
+    expect(screen.getAllByRole("menuitemcheckbox").map((r) => r.textContent)).toEqual(["Build", "Ask"]);
   });
 
   it("shows NO chip when the agent named no modes at all", async () => {

--- a/apps/desktop/src/renderer/src/panes/session/transcript-model.test.ts
+++ b/apps/desktop/src/renderer/src/panes/session/transcript-model.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { sessionEvent } from "@realm/contracts";
-import { emptyTranscript, reduceAll, reduceTranscript } from "./transcript-model";
+import { blockKey, emptyTranscript, reduceAll, reduceTranscript } from "./transcript-model";
 
 describe("a message another session delivered (Plan 20)", () => {
   it("carries `from` onto the user block, and leaves it undefined for a message the user typed", () => {
@@ -13,6 +13,58 @@ describe("a message another session delivered (Plan 20)", () => {
     // Kills the reducer dropping the field, which silently un-labels every injected message: the pane
     // would then render another agent's words as something the user typed.
     expect(t.blocks.at(-1)).toMatchObject({ kind: "user", text: "an agent asked this", from: { sessionId: "s1", title: "Refactor the parser" } });
+  });
+});
+
+describe("a plan the agent proposed", () => {
+  const plan = (planId: string, payload: { text?: string; steps?: { text: string; status: "pending" | "in_progress" | "completed" }[] }, ts: number) =>
+    sessionEvent("plan", { planId, ...payload }, ts);
+
+  it("carries prose and checklist independently — neither is derived from the other", () => {
+    let t = emptyTranscript();
+    t = reduceTranscript(t, plan("p1", { text: "# Do it" }, 10));
+    expect(t.blocks.at(-1)).toEqual({ kind: "plan", planId: "p1", text: "# Do it", ts: 10 });
+    // A checklist-only plan must not grow an empty `text`: Claude sends no steps and Codex's
+    // turn/plan/updated sends no prose, and inventing the missing half is the whole failure mode.
+    t = reduceTranscript(t, plan("p2", { steps: [{ text: "Read the spec", status: "completed" }] }, 20));
+    expect(t.blocks.at(-1)).toEqual({ kind: "plan", planId: "p2", steps: [{ text: "Read the spec", status: "completed" }], ts: 20 });
+    expect(t.blocks.at(-1)).not.toHaveProperty("text");
+  });
+
+  it("replaces a revised plan in place instead of stacking a second card", () => {
+    // The mutant: `blocks.push(block)` unconditionally. Codex re-sends the whole plan on every
+    // turn/plan/updated and ACP's plan is explicitly "not incremental", so an agent that revises
+    // three times would leave four cards saying almost the same thing.
+    let t = emptyTranscript();
+    t = reduceTranscript(t, plan("p1", { steps: [{ text: "A", status: "pending" }] }, 10));
+    t = reduceTranscript(t, sessionEvent("assistant_text", { messageId: "m1", text: "working" }, 15));
+    t = reduceTranscript(t, plan("p1", { steps: [{ text: "A", status: "completed" }, { text: "B", status: "in_progress" }] }, 30));
+    expect(t.blocks.filter((b) => b.kind === "plan")).toHaveLength(1);
+    expect(t.blocks[0]).toMatchObject({ kind: "plan", steps: [{ text: "A", status: "completed" }, { text: "B", status: "in_progress" }] });
+    // In its original place, and dated from when it first appeared: the card the reader has been
+    // watching must not jump ahead of the message that was written after it.
+    expect(t.blocks.map((b) => b.kind)).toEqual(["plan", "assistant"]);
+    expect(t.blocks[0]).toMatchObject({ ts: 10 });
+  });
+
+  it("keeps a different plan id as its own card", () => {
+    let t = emptyTranscript();
+    t = reduceTranscript(t, plan("p1", { text: "first" }, 10));
+    t = reduceTranscript(t, plan("p2", { text: "second" }, 20));
+    expect(t.blocks.filter((b) => b.kind === "plan")).toHaveLength(2);
+  });
+
+  it("keys the block on its plan id, so a revision never replays the entrance animation", () => {
+    // The mutant: letting plan fall through to the positional `${kind}:${i}` key. A plan whose index
+    // shifts (an interjected message landing before it) would then remount and animate in again.
+    const block = { kind: "plan" as const, planId: "p1", text: "x", ts: 1 };
+    expect(blockKey(block, 3)).toBe("plan:p1");
+    expect(blockKey(block, 7)).toBe("plan:p1");
+  });
+
+  it("survives a reload: the same events replayed rebuild the same single card", () => {
+    const events = [plan("p1", { steps: [{ text: "A", status: "pending" }] }, 10), plan("p1", { steps: [{ text: "A", status: "completed" }] }, 30)];
+    expect(reduceAll(events).blocks).toEqual([{ kind: "plan", planId: "p1", steps: [{ text: "A", status: "completed" }], ts: 10 }]);
   });
 });
 

--- a/apps/desktop/src/renderer/src/panes/session/transcript-model.ts
+++ b/apps/desktop/src/renderer/src/panes/session/transcript-model.ts
@@ -1,4 +1,7 @@
-import type { AcpSessionMode, SessionEvent } from "@realm/contracts";
+import type { AcpSessionMode, SessionEvent, SessionEventPayload } from "@realm/contracts";
+
+/** One step of a checklist-shaped plan, exactly as the `plan` event carries it. */
+export type PlanStep = NonNullable<SessionEventPayload<"plan">["steps"]>[number];
 
 export type Block =
   /** `attachments` present only when the message carried any — an attachment-only message (Plan 14
@@ -10,6 +13,12 @@ export type Block =
   | { kind: "thinking"; messageId: string; text: string; ts: number }
   | { kind: "tool"; toolUseId: string; name: string; input: Record<string, unknown>; result: { content: string; isError: boolean } | null; ts: number }
   | { kind: "error"; message: string; ts: number }
+  /** A plan the agent proposed. `text` is prose, `steps` a checklist, and at least one is present —
+   *  which of them depends on the protocol, not on the agent's mood (see the `plan` event). A revised
+   *  plan REPLACES this block rather than appending a second one, so `ts` stays the moment the plan
+   *  first appeared: the card keeps its place in the scrollback, and claiming the revision's time
+   *  would put it out of order with the messages around it. */
+  | { kind: "plan"; planId: string; text?: string; steps?: PlanStep[]; ts: number }
   /** A finished run, banked where it finished. `ms` is how long the agent actually worked — the time
    *  the run sat parked on a permission prompt is subtracted, because a run the user left waiting on
    *  an Allow button for twenty minutes did not work for twenty minutes. `startedAt` rides along as
@@ -35,7 +44,8 @@ export type Transcript = {
 /** Stable render identity for a block. Tool calls key on their own id so a card keeps its expanded
  *  state; everything else keys on position, which is stable because blocks are only ever appended or
  *  replaced in place (a streaming assistant block becomes its final self at the same index). */
-export const blockKey = (b: Block, i: number): string => (b.kind === "tool" ? `tool:${b.toolUseId}` : `${b.kind}:${i}`);
+export const blockKey = (b: Block, i: number): string =>
+  b.kind === "tool" ? `tool:${b.toolUseId}` : b.kind === "plan" ? `plan:${b.planId}` : `${b.kind}:${i}`;
 
 export const emptyTranscript = (): Transcript => ({ blocks: [], pendingPermissions: [], usage: { costUsd: 0, inputTokens: 0, outputTokens: 0, numTurns: 0 }, init: null, run: null });
 
@@ -75,6 +85,17 @@ export function reduceTranscript(t: Transcript, e: SessionEvent): Transcript {
       return { ...t, pendingPermissions: t.pendingPermissions.filter((p) => p.requestId !== e.payload.requestId) };
     }
     case "error": blocks.push({ kind: "error", message: e.payload.message, ts: e.ts }); return { ...t, blocks };
+    case "plan": {
+      const i = findLast(blocks, (b) => b.kind === "plan" && b.planId === e.payload.planId);
+      const block: Block = {
+        kind: "plan", planId: e.payload.planId,
+        ...(e.payload.text ? { text: e.payload.text } : {}),
+        ...(e.payload.steps ? { steps: e.payload.steps } : {}),
+        ts: i >= 0 ? blocks[i]!.ts : e.ts,
+      };
+      if (i >= 0) blocks[i] = block; else blocks.push(block);
+      return { ...t, blocks };
+    }
     case "usage": return { ...t, usage: e.payload };
     case "init": return { ...t, init: { model: e.payload.model, tools: e.payload.tools, providerSessionId: e.payload.providerSessionId, ...(e.payload.availableModes ? { availableModes: e.payload.availableModes } : {}) } };
     case "status": {

--- a/apps/desktop/src/renderer/src/panes/session/transcript-model.ts
+++ b/apps/desktop/src/renderer/src/panes/session/transcript-model.ts
@@ -1,6 +1,5 @@
 import type { AcpSessionMode, SessionEvent, SessionEventPayload } from "@realm/contracts";
 
-/** One step of a checklist-shaped plan, exactly as the `plan` event carries it. */
 export type PlanStep = NonNullable<SessionEventPayload<"plan">["steps"]>[number];
 
 export type Block =

--- a/apps/desktop/src/renderer/src/panes/settings/settings-page.test.tsx
+++ b/apps/desktop/src/renderer/src/panes/settings/settings-page.test.tsx
@@ -202,7 +202,7 @@ describe("App tab", () => {
   it("default permission mode: reads the stored key, and a plain choice (Accept edits) writes it immediately", async () => {
     const { api } = await openApp({ settings: { [DEFAULT_PERMISSION_MODE_KEY]: "acceptEdits" } });
     expect(await screen.findByRole("radio", { name: "Accept edits" })).toBeChecked();
-    fireEvent.click(screen.getByRole("radio", { name: "Ask" }));
+    fireEvent.click(screen.getByRole("radio", { name: "Ask each time" }));
     await waitFor(() => expect(api.data.settings[DEFAULT_PERMISSION_MODE_KEY]).toBe("default"));
   });
 
@@ -211,7 +211,7 @@ describe("App tab", () => {
     fireEvent.click(await screen.findByRole("radio", { name: "Full access" }));
     // Nothing written yet, and the control still shows the current mode.
     expect(api.data.settings[DEFAULT_PERMISSION_MODE_KEY]).toBeUndefined();
-    expect(screen.getByRole("radio", { name: "Ask" })).toBeChecked();
+    expect(screen.getByRole("radio", { name: "Ask each time" })).toBeChecked();
     const confirm = screen.getByRole("button", { name: /run tools and edit files without asking first/ });
     fireEvent.click(confirm);
     await waitFor(() => expect(api.data.settings[DEFAULT_PERMISSION_MODE_KEY]).toBe("bypassPermissions"));
@@ -230,11 +230,12 @@ describe("App tab", () => {
     expect(ignored.textContent).not.toContain("Claude,  Codex");
   });
 
-  it("junk under either key degrades safely: unknown categories dropped, an unlisted mode renders as Ask", async () => {
+  it("junk under either key degrades safely: unknown categories dropped, an unlisted mode renders as Ask each time", async () => {
     await openApp({ settings: { [NOTIFICATIONS_DISABLED_KEY]: ["nonsense", "permission"], [DEFAULT_PERMISSION_MODE_KEY]: "plan" } });
     expect(await screen.findByRole("switch", { name: "Permission requests" })).not.toBeChecked();
-    // "plan" is a mode axis, not a permission — the server would refuse it, so the page must not show it.
-    expect(screen.getByRole("radio", { name: "Ask" })).toBeChecked();
+    // "plan" is a mode axis, not a permission — the server would refuse it, so the page must not show
+    // it. "ask" is the same, and is why the `default` rung is no longer LABELLED "Ask".
+    expect(screen.getByRole("radio", { name: "Ask each time" })).toBeChecked();
   });
 });
 

--- a/apps/desktop/src/renderer/src/state/store.test.ts
+++ b/apps/desktop/src/renderer/src/state/store.test.ts
@@ -1055,6 +1055,52 @@ describe("app store", () => {
       return store;
     };
 
+    /** A Claude session on a chosen permission mode — the axis Plan and Ask have to preserve. */
+    const onFullAccess = async () => {
+      api = fakeApi({
+        items: { s1: [item("i2", "s1", { kind: "session", refId: "se1", title: "s" })] },
+        sessions: [session("se1", "s1", { agentKind: "claude", permissionMode: "bypassPermissions" })],
+      });
+      const store = createAppStore(api); await store.getState().boot();
+      return store;
+    };
+    const modeOf = (store: Awaited<ReturnType<typeof onFullAccess>>) => store.getState().sessions.se1?.permissionMode;
+
+    it("carries the chosen permission through a trip via Plan AND Ask, and back", async () => {
+      // The mutant: parking on every entry rather than only on the way in from Build. Plan → Ask would
+      // overwrite the parked "bypassPermissions" with "plan", and the user would come out of the round
+      // trip silently demoted to "Ask each time" — the exact failure the park exists to prevent.
+      const store = await onFullAccess();
+      await store.getState().setSessionMode("se1", "plan");
+      expect(modeOf(store)).toBe("plan");
+      expect(store.getState().planReturn.se1).toBe("bypassPermissions");
+      await store.getState().setSessionMode("se1", "ask");
+      expect(modeOf(store)).toBe("ask");
+      expect(store.getState().planReturn.se1).toBe("bypassPermissions");
+      await store.getState().setSessionMode("se1", "build");
+      expect(modeOf(store)).toBe("bypassPermissions");
+      expect(store.getState().planReturn.se1).toBeUndefined();
+    });
+
+    it("goes straight from Ask to Plan without passing through Build", async () => {
+      // The mutant: treating "not plan" as "leave", which would restore the permission mode on the way
+      // to Ask and leave the session building under bypassPermissions.
+      const store = await onFullAccess();
+      await store.getState().setSessionMode("se1", "ask");
+      await store.getState().setSessionMode("se1", "plan");
+      expect(modeOf(store)).toBe("plan");
+      expect(store.getState().planReturn.se1).toBe("bypassPermissions");
+    });
+
+    it("does nothing when the session is already in the mode asked for", async () => {
+      const store = await onFullAccess();
+      await store.getState().setSessionMode("se1", "ask");
+      const before = api.calls.length;
+      await store.getState().setSessionMode("se1", "ask");
+      expect(api.calls.length).toBe(before);
+      expect(store.getState().planReturn.se1).toBe("bypassPermissions");
+    });
+
     it("approving the plan leaves Plan and restores the permission mode it was holding", async () => {
       // The mutant: dropping the setSessionMode call from respondPermission. The agent acts on the
       // approval at once and Realm never hears about it, so the chip goes on claiming Plan over a

--- a/apps/desktop/src/renderer/src/state/store.test.ts
+++ b/apps/desktop/src/renderer/src/state/store.test.ts
@@ -1040,6 +1040,49 @@ describe("app store", () => {
       expect(store.getState().sessions.se1?.permissionMode).toBe("plan");
     });
 
+    /** A session parked in Plan with an open ExitPlanMode request — the state the plan card answers. */
+    const inPlan = async () => {
+      api = fakeApi({
+        items: { s1: [item("i2", "s1", { kind: "session", refId: "se1", title: "Fake agent session" })] },
+        sessions: [session("se1", "s1", { status: "waiting_permission", permissionMode: "plan" })],
+        sessionEvents: { se1: [
+          stored("se1", 1, sessionEvent("plan", { planId: "toolu_p", text: "# Ship it" })),
+          stored("se1", 2, sessionEvent("permission_request", { requestId: "r1", toolName: "ExitPlanMode", input: { plan: "# Ship it" }, title: "Exit plan mode?", suggestions: [] })),
+        ] },
+      });
+      const store = createAppStore(api); await store.getState().boot(); await store.getState().openSession("se1");
+      store.setState({ planReturn: { se1: "acceptEdits" } });
+      return store;
+    };
+
+    it("approving the plan leaves Plan and restores the permission mode it was holding", async () => {
+      // The mutant: dropping the setSessionMode call from respondPermission. The agent acts on the
+      // approval at once and Realm never hears about it, so the chip goes on claiming Plan over a
+      // session that is building — and the parked "Accept edits" is stranded forever.
+      const store = await inPlan();
+      await store.getState().respondPermission("se1", "r1", "allow");
+      expect(api.calls).toContain("respondPermission:se1:r1:allow");
+      expect(store.getState().sessions.se1?.permissionMode).toBe("acceptEdits");
+      expect(store.getState().planReturn.se1).toBeUndefined();
+    });
+
+    it("keeps the session in Plan when the plan is rejected — `keep planning` changes nothing", async () => {
+      const store = await inPlan();
+      await store.getState().respondPermission("se1", "r1", "deny");
+      expect(store.getState().sessions.se1?.permissionMode).toBe("plan");
+      expect(store.getState().planReturn.se1).toBe("acceptEdits");
+    });
+
+    it("leaves the mode alone when the approved tool is anything else", async () => {
+      const store = await inPlan();
+      // Allowing a Read inside Plan is an ordinary permission; it is not the user choosing Build.
+      store.setState({ transcripts: { ...store.getState().transcripts,
+        se1: { ...store.getState().transcripts.se1!, t: { ...store.getState().transcripts.se1!.t,
+          pendingPermissions: [{ requestId: "r2", toolName: "Read", input: {}, title: "Read?" }] } } } });
+      await store.getState().respondPermission("se1", "r2", "allow");
+      expect(store.getState().sessions.se1?.permissionMode).toBe("plan");
+    });
+
     it("probeAgents stores the probe; deleteItem on a session drops its transcript, status and session", async () => {
       api = seed(); const store = createAppStore(api); await store.getState().boot();
       await store.getState().probeAgents();

--- a/apps/desktop/src/renderer/src/state/store.ts
+++ b/apps/desktop/src/renderer/src/state/store.ts
@@ -2459,7 +2459,20 @@ export function createAppStore(api: Api): StoreApi<AppState> {
         await get().openItemBesideQuiet(itemId);
       },
       async interruptSession(id) { await api.interruptSession(id); },
-      async respondPermission(id, requestId, decision, answers) { await api.respondPermission(id, requestId, decision, answers); },
+      /**
+       * Answering a permission — plus the one case where the answer also settles the MODE axis.
+       *
+       * `ExitPlanMode` is how a Claude session leaves Plan, and the agent acts on the approval
+       * immediately. Realm's own row does not hear about that, so without this the session would go
+       * on building while its chip still said Plan, and the parked permission mode would never be
+       * restored. Approving the plan IS choosing Build; a denial is "keep planning" and changes
+       * nothing.
+       */
+      async respondPermission(id, requestId, decision, answers) {
+        const pending = get().transcripts[id]?.t.pendingPermissions.find((p) => p.requestId === requestId);
+        await api.respondPermission(id, requestId, decision, answers);
+        if (decision !== "deny" && pending?.toolName === "ExitPlanMode") await get().setSessionMode(id, "build");
+      },
       async setSessionOptions(id, o) { mergeSession(await api.setSessionOptions(id, o)); },
       /**
        * Build ⇄ Plan.

--- a/apps/desktop/src/renderer/src/state/store.ts
+++ b/apps/desktop/src/renderer/src/state/store.ts
@@ -1,6 +1,6 @@
 import { createStore, useStore, type StoreApi } from "zustand";
 import {
-  allItems, closeItem as layoutClose, emptyLayout, equalizeSplit as layoutEqualize, findLeafOfItem, firstLeaf, gridPreset, itemIdOfLeaf, openItem as layoutOpen, splitLeaf, updateSizes, AgentKindSchema, LayoutSchema, PLAN_PERMISSION_MODE,
+  allItems, closeItem as layoutClose, emptyLayout, equalizeSplit as layoutEqualize, findLeafOfItem, firstLeaf, gridPreset, itemIdOfLeaf, openItem as layoutOpen, splitLeaf, updateSizes, AgentKindSchema, LayoutSchema, modeWireValue, sessionModeOf,
   lectureWrapUpPrompt, localDateStamp, sessionEvent,
   activeGroup, activeLayout, addGroup as groupsAdd, reconcileGroups, allGroupItems, detachItemFrom, groupAtOffset, groupOfItem, groupsFromLayout, moveItemToGroup as groupsMoveItem, removeGroup as groupsRemove, renameGroup as groupsRename, setActiveGroup as groupsSetActive, setActiveLayout, SpaceGroupsSchema, toggleZoom as groupsToggleZoom, unzoom as groupsUnzoom, zoomLeaf as groupsZoom,
   canNav, forgetNavItems, navEntry, pushNav, reconcileNav, stepNav,
@@ -644,9 +644,11 @@ export type AppState = {
   iconAssets: Record<string, IconAsset[]>;
   /** `memory.sources` by session id — fetched when the memory panel asks about a session. */
   sessionMemorySources: Record<string, MemorySources>;
-  /** The permission mode a session was on when it entered Plan, by session id — see `setSessionMode`.
-   *  Not persisted: after a restart a session already in Plan returns to `default`, which is the safe
-   *  direction to be wrong in. */
+  /** The permission mode a session was on when it left Build for a read-only mode (Plan or Ask), by
+   *  session id — see `setSessionMode`. One entry per session, not one per mode: a trip through both
+   *  is still one absence from Build, and the permission to come back to is the same either way.
+   *  Not persisted: after a restart a session already in Plan or Ask returns to `default`, which is
+   *  the safe direction to be wrong in. */
   planReturn: Record<string, string>;
   /** Git working-tree summaries by cwd; null = known non-repo. Refreshed event-driven only (session
    *  status transitions to idle/error, space activation, session open) — never polled. */
@@ -2475,34 +2477,42 @@ export function createAppStore(api: Api): StoreApi<AppState> {
       },
       async setSessionOptions(id, o) { mergeSession(await api.setSessionOptions(id, o)); },
       /**
-       * Build ⇄ Plan.
+       * Build ⇄ Plan ⇄ Ask.
        *
-       * Build and Plan are their own axis in the prompter, but Plan still travels on the wire as
-       * `permissionMode: "plan"` (the only channel Claude and Codex read it on). So a session in Plan
-       * has nowhere left to hold the permission the user actually chose — entering Plan parks it here,
-       * and leaving Plan puts it back.
+       * The three are one axis in the prompter, but Plan and Ask still travel on the wire as
+       * `permissionMode` (the only channel the adapters read the axis on). So a session in either has
+       * nowhere left to hold the permission the user actually chose — entering one parks it here, and
+       * leaving puts it back.
        *
-       * Without the park, every round trip through Plan would quietly demote a session from
-       * "Full access" to "Ask", or strand it on a `permissionMode` the picker can no longer name.
-       * `default` is the fallback only when there is nothing parked (a session that was already in
-       * Plan when the app started).
+       * Written as "what is parked" rather than "am I in Plan", because with three modes the binary
+       * is wrong in both directions: Plan → Ask is not a return to Build, so it must NOT restore, and
+       * it must not overwrite the parked permission with `"plan"` either — the permission the user
+       * chose has to survive a trip through both modes and come back at the end of it. So the park is
+       * written only on the way IN from Build, and consumed only on the way OUT to Build.
+       *
+       * Without it, every round trip would quietly demote a session from "Full access" to "Ask each
+       * time", or strand it on a `permissionMode` the picker can no longer name. `default` is the
+       * fallback only when there is nothing parked (a session that was already in Plan or Ask when
+       * the app started).
        */
       async setSessionMode(id, mode) {
         const s = get().sessions[id];
         if (!s) return;
-        const inPlan = s.permissionMode === PLAN_PERMISSION_MODE;
-        // The park is for agents whose Plan REPLACES a real permission axis (Claude, Codex — the
-        // kinds Realm can set a permission mode on at all). An ACP agent's Plan is its own mode
-        // (Plan 14 W3): there is no chosen permission to preserve, so leaving Plan simply returns
-        // the row to its resting "default" — parking would fabricate Claude-shaped semantics on an
-        // agent that never had them.
+        const from = sessionModeOf(s.permissionMode);
+        if (from === mode) return;
+        // The park is for agents whose read-only modes REPLACE a real permission axis (Claude, Codex —
+        // the kinds Realm can set a permission mode on at all). An ACP agent's Plan and Ask are its
+        // own modes: there is no chosen permission to preserve, so leaving returns the row to its
+        // resting "default" — parking would fabricate Claude-shaped semantics on an agent that never
+        // had them.
         const parks = AGENT_SUPPORTS_PERMISSION_MODES[s.agentKind];
-        if (mode === "plan") {
-          if (inPlan) return;
-          if (parks) set({ planReturn: { ...get().planReturn, [id]: s.permissionMode } });
-          await get().setSessionOptions(id, { permissionMode: PLAN_PERMISSION_MODE });
+        const wire = modeWireValue(mode);
+        if (wire !== null) {
+          // Only from Build is `s.permissionMode` a permission; from the other read-only mode it is
+          // that mode's own wire value, and parking it would lose the real one.
+          if (parks && from === "build") set({ planReturn: { ...get().planReturn, [id]: s.permissionMode } });
+          await get().setSessionOptions(id, { permissionMode: wire });
         } else {
-          if (!inPlan) return;
           const back = parks ? get().planReturn[id] ?? "default" : "default";
           const { [id]: _used, ...planReturn } = get().planReturn;
           set({ planReturn });

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -2914,3 +2914,27 @@ body[data-media-lightbox] .transcript .media-el { visibility: hidden; }
   .bd-bar-row { grid-template-columns: minmax(70px, 1fr) minmax(60px, 2fr) auto; }
   .bd-bar-caption { display: none; }
 }
+
+/* ── The agent's plan, as a transcript block ──────────────────────────────────
+   A card on the permission card's bones (opaque --surface, --shadow-card) rather than the tool
+   card's, because a plan is addressed TO the reader: it is the one thing in a Plan-mode turn they
+   are meant to actually read, and the tool card's collapsed ledger row is built to be skipped.
+   The checklist inside reuses `.todo` wholesale — a plan with per-step status IS a to-do list. */
+.plan-card { border-radius: var(--r-panel); padding: 14px; background: var(--surface); box-shadow: var(--shadow-card);
+  display: flex; flex-direction: column; gap: 10px; }
+.plan-head { display: flex; align-items: center; gap: 8px; font-size: 14px; font-weight: var(--fw-label); color: var(--ink); }
+/* The prose body is the plan's own markdown and carries its own headings and lists; it only needs
+   its outer margins collapsed so the card's padding is the whole frame. */
+.plan-body > :first-child { margin-top: 0; }
+.plan-body > :last-child { margin-bottom: 0; }
+
+/* The answer to a plan, not a permission on one: two named outcomes, no "always". Sits directly
+   under the plan block it answers, so it carries no copy of the plan. */
+.plan-decision { display: flex; align-items: center; gap: 12px; flex-wrap: wrap;
+  padding: 10px 12px; border-radius: var(--r-panel); background: var(--surface); box-shadow: var(--shadow-card); }
+.plan-decision-ask { flex: 1; min-width: 0; font-size: 13px; color: var(--ink); }
+.plan-decision-actions { display: flex; gap: 6px; }
+.plan-decision button { padding: 6px 12px; border-radius: var(--r-ctl); font-size: 13px; }
+.plan-approve { background: var(--rl-accent); color: var(--rl-accent-contrast); font-weight: var(--fw-label); }
+.plan-reject { background: var(--hover); color: var(--ink-2); }
+.plan-reject:hover { background: var(--hover-2); color: var(--ink); }

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -170,7 +170,17 @@ export function defaultAdapters(): AdapterRegistry {
       loginHint: "Run `fx login` to sign in with Vercel, `fx setup` for an AI Gateway API key, or set AI_GATEWAY_API_KEY.",
     }),
   };
-  if (process.env.REALM_ENABLE_FAKE_AGENT === "1") reg.fake = new FakeAdapter({ script: [], delayMs: 15 });
+  // The offline-dev script: enough to reach the surfaces that only exist for one event type. A plan
+  // is here because it is drawn by a card of its own, and without a scripted one the fake agent —
+  // whose whole purpose is UI development — can never produce it. Revised in place, since a plan that
+  // updates is the behaviour worth looking at.
+  if (process.env.REALM_ENABLE_FAKE_AGENT === "1") reg.fake = new FakeAdapter({ delayMs: 15, script: [{ on: "plan", emit: [
+    { kind: "text", text: "Here is how I would go about it." },
+    { kind: "plan", planId: "fake-plan", text: "## Rework the mapper\n\n1. Carry the plan as its own event.\n2. Draw it as a plan.", steps: [
+      { text: "Carry the plan as its own event", status: "in_progress" }, { text: "Draw it as a plan", status: "pending" }] },
+    { kind: "plan", planId: "fake-plan", text: "## Rework the mapper\n\n1. Carry the plan as its own event.\n2. Draw it as a plan.", steps: [
+      { text: "Carry the plan as its own event", status: "completed" }, { text: "Draw it as a plan", status: "in_progress" }] },
+  ] }] });
   return reg;
 }
 

--- a/apps/server/src/browsers/permissions.test.ts
+++ b/apps/server/src/browsers/permissions.test.ts
@@ -33,6 +33,17 @@ describe("BrowserPermissionBroker.gate", () => {
     expect(events).toEqual([]);
   });
 
+  it("ask mode refuses the same way plan does, and says which mode it is", async () => {
+    // The mutant: leaving the gate on `mode === "plan"`. An Ask session would then drive the browser
+    // — clicking, typing, submitting — under a mode whose whole promise is that it changes nothing.
+    const { broker, events } = setup("ask");
+    const r = await broker.gate("s1", "browser_act", "Click X", {});
+    expect(r.allowed).toBe(false);
+    expect(!r.allowed && r.reason).toMatch(/read-only/);
+    expect(!r.allowed && r.reason).toContain("Ask");
+    expect(events).toEqual([]);
+  });
+
   it("default mode emits permission_request + waiting status, then resolves on allow", async () => {
     const { broker, events } = setup();
     const gate = broker.gate("s1", "browser_act", "Click *Submit* on example.com", { ref: 7 });
@@ -152,6 +163,13 @@ describe("BrowserPermissionBroker.gate — alwaysPrompt (credential fills)", () 
 
   it("still refuses in plan mode — a read-only session fills nothing", async () => {
     const { broker, events } = setup("plan");
+    const r = await broker.gate("s1", "browser_fill_credential", "Fill…", {}, "browser_fill_credential", opts);
+    expect(r.allowed).toBe(false);
+    expect(events).toEqual([]);
+  });
+
+  it("refuses a credential fill in ask mode too", async () => {
+    const { broker, events } = setup("ask");
     const r = await broker.gate("s1", "browser_fill_credential", "Fill…", {}, "browser_fill_credential", opts);
     expect(r.allowed).toBe(false);
     expect(events).toEqual([]);

--- a/apps/server/src/browsers/permissions.ts
+++ b/apps/server/src/browsers/permissions.ts
@@ -1,5 +1,5 @@
 import { randomBytes } from "node:crypto";
-import { sessionEvent, type SessionEvent } from "@realm/contracts";
+import { isReadOnlyMode, sessionEvent, type SessionEvent } from "@realm/contracts";
 import type { PermissionDecision } from "@realm/adapters";
 
 /** Distinguishes broker-owned requestIds from adapter-owned ones in `sessions.respondPermission` —
@@ -114,7 +114,7 @@ export class BrowserPermissionBroker {
    */
   async gate(sessionId: string, toolKey: string, title: string, input: Record<string, unknown>, toolName: string = toolKey, opts: GateOptions = {}): Promise<GateResult> {
     const mode = this.d.permissionMode(sessionId);
-    if (mode === "plan") return { allowed: false, reason: "this session is in Plan (read-only) mode — mutating tools are refused; switch modes to act" };
+    if (isReadOnlyMode(mode)) return { allowed: false, reason: `this session is in ${mode === "plan" ? "Plan" : "Ask"} (read-only) mode — mutating tools are refused; switch modes to act` };
     if (!opts.alwaysPrompt) {
       // `allow_always` is consulted BEFORE the mode, so a `promptUnderBypass` gate the user has
       // already answered "always" to stops asking. For every other caller the two orders agree:

--- a/apps/server/src/delegation/agent-run.test.ts
+++ b/apps/server/src/delegation/agent-run.test.ts
@@ -198,6 +198,21 @@ describe("permission cap — min(parent, requested), bypass never granted", () =
     const second = app.sessions.list(spaceId).find((s) => s.id !== parentId && s.id !== first.id)!;
     expect(second.permissionMode).toBe("plan");
   });
+
+  it("grants a requested `ask`, because ask is a TIGHTENING of the parent's default", async () => {
+    // The mutant: leaving `ask` out of MODE_RANK. It falls to the unknown-mode fallback and ranks as
+    // `default`, so it stops counting as tighter — the constraint is silently ignored and the child
+    // that asked to be read-only is handed a mode that writes.
+    const { spaceId, parentId } = await boot({ parentMode: "default", script: [...CHILD_SCRIPT] });
+    await app.agentRuns.run({ sessionId: parentId, spaceId }, { goal: "go", constraints: { permissionMode: "ask" } });
+    expect(childOf(spaceId, parentId).permissionMode).toBe("ask");
+  });
+
+  it("caps a child of an Ask parent at Ask, however much it asks for", async () => {
+    const { spaceId, parentId } = await boot({ parentMode: "ask", script: [...CHILD_SCRIPT] });
+    await app.agentRuns.run({ sessionId: parentId, spaceId }, { goal: "go", constraints: { permissionMode: "acceptEdits" } });
+    expect(childOf(spaceId, parentId).permissionMode).toBe("ask");
+  });
 });
 
 describe("the depth budget — a wall replaced by a countdown, enforced server-side", () => {

--- a/apps/server/src/delegation/agent-run.ts
+++ b/apps/server/src/delegation/agent-run.ts
@@ -74,8 +74,13 @@ type SettingsLike = { get(key: string): unknown; set(key: string, value: unknown
  *  effectively has, and `bypassPermissions` is unreachable through this table because a requested
  *  bypass is degraded to `default` before ranking and a bypass PARENT is capped to `default` first
  *  (the browser agent's rule, verbatim). An unranked mode (an adapter-specific string) ranks as
- *  `default` — capping math over an unknown mode should fail toward asking, not toward access. */
-const MODE_RANK: Record<string, number> = { plan: 0, default: 1, acceptEdits: 2, bypassPermissions: 3 };
+ *  `default` — capping math over an unknown mode should fail toward asking, not toward access.
+ *
+ *  `ask` TIES with `plan` rather than sitting beside it. They are two different read-only modes, not
+ *  two rungs of one ladder: neither lets the child change anything, so capping a child of one to the
+ *  other is safe in both directions, and giving either a lower number would claim an ordering between
+ *  them that does not exist. */
+const MODE_RANK: Record<string, number> = { plan: 0, ask: 0, default: 1, acceptEdits: 2, bypassPermissions: 3 };
 const rank = (mode: string): number => MODE_RANK[mode] ?? 1;
 
 /**
@@ -494,7 +499,7 @@ function spawnInputSchema(): Tool["inputSchema"] {
           agentKind: { type: "string", enum: [...AgentKindSchema.options], description: "Agent for the child. Omitted: the caller's own kind (with a claude fallback when that kind cannot take Realm's skills)." },
           environmentId: { type: "string", description: "Run in this EXISTING environment of the caller's space. Mutually exclusive with newWorktree." },
           newWorktree: { type: ["boolean", "string"], description: "Create a fresh git worktree for the child: true titles it from the goal, a string titles it verbatim. Mutually exclusive with environmentId. Give PARALLEL agents separate worktrees — several agents editing one checkout will clobber each other." },
-          permissionMode: { type: "string", enum: ["plan", "default", "acceptEdits", "bypassPermissions"], description: "Requested mode; granted = min(parent's, requested). bypassPermissions is NEVER granted (degrades to default)." },
+          permissionMode: { type: "string", enum: ["plan", "ask", "default", "acceptEdits", "bypassPermissions"], description: "Requested mode; granted = min(parent's, requested). `plan` and `ask` are both read-only. bypassPermissions is NEVER granted (degrades to default)." },
           maxTurns: { type: "number", description: "Scales the child's time budget (default 20; there is no per-turn counter — this is a time scale)." },
           timeoutMs: { type: "number", description: "Absolute time budget in ms (5s–1h); overrides maxTurns scaling." },
           skills: { type: "array", items: { type: "string" }, description: "Narrow the child to this SUBSET of the space's enabled skills. An id not enabled in the space refuses the call." },

--- a/apps/server/src/import/parsers.test.ts
+++ b/apps/server/src/import/parsers.test.ts
@@ -24,7 +24,7 @@ describe("isHarnessPreamble", () => {
 const NOW = 1_800_000_000_000;
 const jsonl = (rows: unknown[]): string => rows.map((r) => JSON.stringify(r)).join("\n");
 const texts = (events: SessionEvent[], type: SessionEvent["type"]): string[] =>
-  events.filter((e) => e.type === type).map((e) => ("text" in e.payload ? e.payload.text : ""));
+  events.filter((e) => e.type === type).map((e) => ("text" in e.payload ? e.payload.text ?? "" : ""));
 
 describe("parseClaudeTranscript", () => {
   const base = { sessionId: "s-1", cwd: "/Users/me/proj", isSidechain: false };

--- a/packages/adapters/src/acp/acp-adapter.test.ts
+++ b/packages/adapters/src/acp/acp-adapter.test.ts
@@ -702,6 +702,30 @@ describe("AcpAdapter", () => {
     await handle.dispose();
   });
 
+  it("translates Ask onto the agent's own `ask` id, and back out to `agent`", async () => {
+    const { handle, evs } = await booted();
+    await handle.setOptions({ permissionMode: "ask" });
+    await handle.setOptions({ permissionMode: "plan" });
+    // Plan → Ask → Build, all three on the agent's own ids. The mutant: routing anything that is not
+    // "plan" to acpBuildMode, which would send `agent` for Ask and leave the session building.
+    await handle.setOptions({ permissionMode: "ask" });
+    await handle.setOptions({ permissionMode: "acceptEdits" });
+    await turn(handle, evs, "REVEAL");
+    const journal = JSON.parse(texts(evs)[0]!) as { calls: { method: string; params: { modeId?: string } }[] };
+    expect(journal.calls.filter((c) => c.method === "session/set_mode").map((c) => c.params.modeId)).toEqual(["ask", "plan", "ask", "agent"]);
+    await handle.dispose();
+  });
+
+  it("boots straight into Ask when the session was persisted there", async () => {
+    // A row carrying `ask` must reach the agent's own mode at boot, not on the first setOptions —
+    // the first turn is the one most likely to want to edit something.
+    const { handle, evs } = await booted({ permissionMode: "ask" });
+    await turn(handle, evs, "REVEAL");
+    const journal = JSON.parse(texts(evs)[0]!) as { calls: { method: string; params: { modeId?: string } }[] };
+    expect(journal.calls.filter((c) => c.method === "session/set_mode").map((c) => c.params.modeId)).toEqual(["ask"]);
+    await handle.dispose();
+  });
+
   it("sends NOTHING to session/set_mode when the agent advertises no plan-equivalent", async () => {
     // The named mutant: forwarding Realm's id would collide with Cursor's `plan` by luck today and be
     // a foreign-id rejection (or an accidental match) on any other agent.

--- a/packages/adapters/src/acp/acp-adapter.test.ts
+++ b/packages/adapters/src/acp/acp-adapter.test.ts
@@ -64,6 +64,34 @@ const ALLOW_ONLY = [
 ];
 const FULL = [...ALLOW_ONLY, { optionId: "r1", name: "Reject", kind: "reject_once" }, { optionId: "r2", name: "Always reject", kind: "reject_always" }];
 
+describe("plans", () => {
+  it("keeps a full-replacement plan on ONE card for the whole turn, across the tool calls between revisions", async () => {
+    const { handle, evs } = await booted();
+    await handle.send({ text: "PLAN it", attachments: [] });
+    await waitFor(() => expect(statuses(evs).at(-1)).toBe("idle"));
+    const plans = of(evs, "plan");
+    // The mutant: `plan` back in the parsed-and-dropped list. ACP's plan is the only plan a Cursor or
+    // Gemini session ever produces, so dropping it means those agents can never show one at all.
+    expect(plans).toHaveLength(2);
+    expect(new Set(plans.map((e) => e.payload.planId)).size).toBe(1);
+    expect(plans.at(-1)!.payload.steps).toEqual([
+      { text: "Read the spec", status: "completed" }, { text: "Write the code", status: "in_progress" }]);
+    // Entries carry no prose, and none is invented for them.
+    expect(plans.every((e) => e.payload.text === undefined)).toBe(true);
+  });
+
+  it("gives the NEXT turn its own plan card rather than overwriting the last turn's", async () => {
+    const { handle, evs } = await booted();
+    await handle.send({ text: "PLAN one", attachments: [] });
+    await waitFor(() => expect(statuses(evs).at(-1)).toBe("idle"));
+    await handle.send({ text: "PLAN two", attachments: [] });
+    await waitFor(() => expect(of(evs, "plan")).toHaveLength(4));
+    // The mutant: never clearing the id on flush. The second turn's plan would land on the first
+    // turn's card and erase what the agent set out to do the first time.
+    expect(new Set(of(evs, "plan").map((e) => e.payload.planId)).size).toBe(2);
+  });
+});
+
 describe("pickAcpOption", () => {
   it("prefers allow_once for allow and falls back to allow_always", () => {
     expect(pickAcpOption("allow", FULL)).toBe("a1");

--- a/packages/adapters/src/acp/acp-adapter.ts
+++ b/packages/adapters/src/acp/acp-adapter.ts
@@ -1,7 +1,7 @@
 import { basename, dirname, join, resolve, sep } from "node:path";
 import { tmpdir } from "node:os";
 import { readFile, realpath, stat, writeFile } from "node:fs/promises";
-import { acpBuildMode, acpPlanMode, acpSessionConfig, PLAN_PERMISSION_MODE, sessionEvent, type AcpSessionMode, type AgentKind, type SessionEvent } from "@realm/contracts";
+import { acpAskMode, acpBuildMode, acpPlanMode, acpSessionConfig, ASK_PERMISSION_MODE, PLAN_PERMISSION_MODE, sessionEvent, type AcpSessionMode, type AgentKind, type SessionEvent } from "@realm/contracts";
 import { AsyncQueue } from "../event-queue";
 import { JsonRpcCallError, StdioJsonRpc, withTimeout, type JsonRpcId } from "../jsonrpc/stdio";
 import { createAcpMapper } from "./map-acp";
@@ -210,6 +210,19 @@ export function acpBootFailureMessage(e: unknown, spec: Pick<AcpAgentSpec, "labe
  * Unlike Codex's multiplexed app-server, an ACP session belongs to its connection, so this spawns **one child
  * per session** and `dispose()` takes that child down.
  */
+/**
+ * The agent's own mode for a Realm mode wire value, or null when it advertises none.
+ *
+ * The one place Realm's ids are turned into the agent's, so the boot path and the live path can never
+ * disagree about what Plan or Ask means on THIS session. Build is `acpBuildMode`, which needs the
+ * mode the session booted in to fall back to.
+ */
+function acpModeFor(permissionMode: string, modes: readonly AcpSessionMode[], bootModeId: string | null): AcpSessionMode | null {
+  if (permissionMode === PLAN_PERMISSION_MODE) return acpPlanMode(modes);
+  if (permissionMode === ASK_PERMISSION_MODE) return acpAskMode(modes);
+  return acpBuildMode(modes, bootModeId);
+}
+
 export class AcpAdapter implements AgentAdapter {
   readonly kind: AgentKind;
 
@@ -458,16 +471,18 @@ export class AcpAdapter implements AgentAdapter {
           ...(availableModes.length ? { availableModes } : {}),
         }));
         events.push(sessionEvent("status", { status: "idle" }));
-        // A session persisted in Plan resumes in Plan (the row's permissionMode carries the Realm-side
-        // record of the mode axis; see PLAN_PERMISSION_MODE). Only ever the AGENT'S OWN id, and only
-        // when it advertised one — with no plan-equivalent the session honestly stays in its default
-        // mode and the prompter shows no Plan chip either. Best-effort like setOptions: a refusal is
-        // a log line, not a boot failure.
-        const bootPlan = opts.permissionMode === PLAN_PERMISSION_MODE ? acpPlanMode(availableModes) : null;
-        if (bootPlan && bootPlan.id !== bootModeId) {
+        // A session persisted in Plan or Ask resumes there (the row's permissionMode carries the
+        // Realm-side record of the mode axis; see PLAN_PERMISSION_MODE). Only ever the AGENT'S OWN
+        // id, and only when it advertised one — with no equivalent the session honestly stays in its
+        // default mode and the prompter shows no chip for that mode either. Best-effort like
+        // setOptions: a refusal is a log line, not a boot failure.
+        const bootMode = opts.permissionMode === PLAN_PERMISSION_MODE || opts.permissionMode === ASK_PERMISSION_MODE
+          ? acpModeFor(opts.permissionMode, availableModes, bootModeId)
+          : null;
+        if (bootMode && bootMode.id !== bootModeId) {
           const [method, params] = modeConfigId
-            ? ["session/set_config_option", { sessionId: id, configId: modeConfigId, value: bootPlan.id }] as const
-            : ["session/set_mode", { sessionId: id, modeId: bootPlan.id }] as const;
+            ? ["session/set_config_option", { sessionId: id, configId: modeConfigId, value: bootMode.id }] as const
+            : ["session/set_mode", { sessionId: id, modeId: bootMode.id }] as const;
           try { await ask(method, params, INITIALIZE_TIMEOUT_MS); }
           catch (e) { log(`${method} at boot failed: ${message(e)}`); }
         }
@@ -539,13 +554,13 @@ export class AcpAdapter implements AgentAdapter {
         if (o.permissionMode !== undefined) {
           // The mode axis, translated (Plan 14 W3): Realm's plan wire value maps onto the agent's own
           // plan-equivalent, anything else onto its Build mode. NEVER `o.permissionMode` itself — ACP
-          // mode ids are agent-defined, and `session/set_mode` with a Realm id ("plan" happens to
-          // collide on Cursor today, "acceptEdits" never would) is a foreign-id rejection at best and
-          // an accidental match at worst. No equivalent advertised → nothing is sent at all.
-          const target = o.permissionMode === PLAN_PERMISSION_MODE ? acpPlanMode(availableModes) : acpBuildMode(availableModes, bootModeId);
+          // mode ids are agent-defined, and `session/set_mode` with a Realm id ("plan" and "ask"
+          // happen to collide on Cursor today, "acceptEdits" never would) is a foreign-id rejection
+          // at best and an accidental match at worst. No equivalent advertised → nothing is sent.
+          const target = acpModeFor(o.permissionMode, availableModes, bootModeId);
           if (target && modeConfigId) await attempt("session/set_config_option", { sessionId, configId: modeConfigId, value: target.id });
           else if (target) await attempt("session/set_mode", { sessionId, modeId: target.id });
-          else log(`no advertised mode maps onto ${o.permissionMode === PLAN_PERMISSION_MODE ? "Plan" : "Build"}; nothing sent`);
+          else log(`no advertised mode maps onto ${o.permissionMode === PLAN_PERMISSION_MODE ? "Plan" : o.permissionMode === ASK_PERMISSION_MODE ? "Ask" : "Build"}; nothing sent`);
         }
         if (o.model !== undefined) {
           if (modelConfigId) await attempt("session/set_config_option", { sessionId, configId: modelConfigId, value: o.model });

--- a/packages/adapters/src/acp/fixtures/fake-acp-agent.mjs
+++ b/packages/adapters/src/acp/fixtures/fake-acp-agent.mjs
@@ -172,6 +172,18 @@ async function runTurn(id, sessionId, prompt) {
   else if (text.includes("REVEAL")) message(sessionId, JSON.stringify(journal));
   else if (text.includes("PERMIT2")) await Promise.all([permitTurn(sessionId, 0), permitTurn(sessionId, 1)]);
   else if (text.includes("PERMIT")) await permitTurn(sessionId, 0);
+  else if (text.includes("PLAN")) {
+    // ACP's plan is a FULL replacement each time (§3.1), so the second send is a revision of the
+    // first and must land on the same card. A tool call between them is what a naive "reset the plan
+    // whenever anything else arrives" would trip over.
+    update(sessionId, { sessionUpdate: "plan", entries: [
+      { content: "Read the spec", priority: "high", status: "in_progress" },
+      { content: "Write the code", priority: "medium", status: "pending" }] });
+    update(sessionId, { sessionUpdate: "tool_call", toolCallId: `call_${nextCallN++}`, title: "Read spec", kind: "read", status: "completed" });
+    update(sessionId, { sessionUpdate: "plan", entries: [
+      { content: "Read the spec", priority: "high", status: "completed" },
+      { content: "Write the code", priority: "medium", status: "in_progress" }] });
+  }
   else if (text.includes("READFILE")) await readFileTurn(sessionId, text);
   else if (text.includes("WRITEFILE")) await writeFileTurn(sessionId, text);
   else if (text.includes("ODDBALL")) await oddballTurn(sessionId);

--- a/packages/adapters/src/acp/map-acp.ts
+++ b/packages/adapters/src/acp/map-acp.ts
@@ -32,6 +32,22 @@ function renderToolContent(content: unknown): string {
   }).filter(Boolean).join("\n");
 }
 
+
+/** ACP's `plan` entries — `{content, priority, status}` with status `pending | in_progress |
+ *  completed` (docs/dev/acp-protocol.md:182), which is already Realm's spelling. An unrecognised
+ *  status reads as `pending`: it must never render as work already done. `priority` is carried by
+ *  the protocol and deliberately not by Realm — the card is an ordered checklist, and a field only
+ *  one agent in ten ever sets would be blank everywhere else.
+ *
+ *  Entries with no content are dropped rather than drawn as blank rows. */
+function planSteps(raw: unknown): { text: string; status: "pending" | "in_progress" | "completed" }[] {
+  if (!Array.isArray(raw)) return [];
+  return raw.map((e) => {
+    const status = str(obj(e).status);
+    return { text: str(obj(e).content), status: status === "completed" ? "completed" as const : status === "in_progress" ? "in_progress" as const : "pending" as const };
+  }).filter((e) => e.text !== "");
+}
+
 /** The merged state of one ACP tool call. `input`/`kind` feed §4 permission-card rendering. */
 export type AcpCall = { title: string; kind: string; input: Record<string, unknown>; done: boolean };
 
@@ -51,6 +67,10 @@ export function createAcpMapper() {
   const calls = new Map<string, AcpCall>();
   let msg: { id: string; text: string } | null = null;
   let thought: { id: string; text: string } | null = null;
+  /** Identity for THIS turn's plan. ACP's plan "is not incremental: replace the whole list each
+   *  time", so every update inside a turn has to land on the same card; a new turn gets a new one,
+   *  because overwriting the last turn's plan would erase what the agent set out to do. */
+  let planId: string | null = null;
 
   // At most one of `msg`/`thought` is ever open: each chunk branch cross-flushes the other before opening its own
   // run, so the order of the two blocks below is unobservable — they never both fire in the same call.
@@ -113,12 +133,23 @@ export function createAcpMapper() {
         return out;
       }
 
-      // plan / available_commands_update / current_mode_update / user_message_chunk are parsed and dropped in v1.
+      if (kind === "plan") {
+        const steps = planSteps(u.entries);
+        if (!steps.length) return out;
+        planId ??= newId();
+        out.push(sessionEvent("plan", { planId, steps }));
+        return out;
+      }
+
+      // available_commands_update / current_mode_update / user_message_chunk are parsed and dropped.
       return out;
     },
 
-    /** Flush any open text runs — call on prompt resolution, cancellation, and dispose. */
-    flush(): SessionEvent[] { return flushRuns(); },
+    /** Flush any open text runs — call on prompt resolution, cancellation, and dispose.
+     *  Also ends the turn's plan: the NEXT turn's plan is a new card, not an overwrite of this one.
+     *  Deliberately not in `flushRuns`, which every non-chunk update calls — resetting there would
+     *  give a plan a fresh card for every tool call between its revisions. */
+    flush(): SessionEvent[] { const out = flushRuns(); planId = null; return out; },
 
     /** Close any tool call still open, e.g. when the child dies mid-turn. */
     closeOpenCalls(reason: string): SessionEvent[] {

--- a/packages/adapters/src/claude/claude-adapter.test.ts
+++ b/packages/adapters/src/claude/claude-adapter.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { ClaudeAdapter, claudeAllowedTools, claudeMcpServers } from "./claude-adapter";
+import { ClaudeAdapter, claudeAllowedTools, claudeAskTools, claudeMcpServers, claudeSdkPermissionMode } from "./claude-adapter";
 import type { SessionEvent } from "@realm/contracts";
 import type { StartOptions } from "../types";
 import { readFileSync, writeFileSync } from "node:fs"; import { tmpdir } from "node:os"; import { join, dirname } from "node:path"; import { fileURLToPath } from "node:url";
@@ -23,10 +23,13 @@ type FakeOpts = {
   abortable?: boolean;
   /** record each user message pulled off the prompt stream (content-shape assertions) */
   capture?: unknown[];
+  /** record the Options object the adapter handed `query` (start-time option assertions) */
+  captureOptions?: Record<string, unknown>[];
 };
 function fakeQuery(opts: FakeOpts, calls: string[] = []) {
   return ({ prompt, options }: { prompt: AsyncIterable<unknown>; options: Record<string, unknown> }) => {
     const gen = (async function* () {
+      opts.captureOptions?.push(options);
       for (const l of opts.stderr ?? []) (options.stderr as (d: string) => void)(l);
       const it = prompt[Symbol.asyncIterator](); const first = await it.next();
       if (first.done) return;
@@ -59,6 +62,71 @@ const collectUntil = (events: AsyncIterable<SessionEvent>, stop: (e: SessionEven
   (async () => { const all: SessionEvent[] = []; for await (const e of events) { all.push(e); onEach?.(e); if (stop(e, all)) break; } return all; })();
 const types = (evs: SessionEvent[]) => evs.map((e) => e.type);
 const statuses = (evs: SessionEvent[]) => evs.flatMap((e) => (e.type === "status" ? [e.payload.status] : []));
+
+describe("Ask — read-only, enforced by the adapter", () => {
+  const gateway = { name: "realm", transport: "http", url: "http://localhost:1/mcp", headers: {} } as const;
+
+  it("allows reading and searching, and nothing that changes anything", () => {
+    const allowed = claudeAskTools([]);
+    for (const t of ["Read", "Glob", "Grep", "NotebookRead", "WebFetch", "WebSearch", "TodoWrite", "AskUserQuestion"]) {
+      expect(allowed.has(t), t).toBe(true);
+    }
+    // Bash is the named mutant. Nothing can tell from a command string whether it mutates, and
+    // `git log` and `git reset --hard` are the same shape — admitting it makes the mode advisory.
+    for (const t of ["Bash", "Write", "Edit", "MultiEdit", "NotebookEdit", "Task", "Agent", "ExitPlanMode"]) {
+      expect(allowed.has(t), t).toBe(false);
+    }
+  });
+
+  it("admits the read-only browser tools by deriving them from the same list the adapter pre-allows", () => {
+    const allowed = claudeAskTools([gateway]);
+    // Not a second hand-written list: Ask and `allowedTools` cannot disagree about what is read-only.
+    for (const t of claudeAllowedTools([gateway])) expect(allowed.has(t), t).toBe(true);
+    expect(allowed.has("mcp__realm__realm-browser__browser_act")).toBe(false);
+  });
+
+  it("sends the SDK `default`, because that is the only mode under which its own gate runs", () => {
+    // The mutant: passing "ask" through. The SDK's PermissionMode union has no such member; passing
+    // acceptEdits or bypassPermissions instead would hand the gate its own bypass.
+    expect(claudeSdkPermissionMode("ask")).toBe("default");
+    expect(claudeSdkPermissionMode("plan")).toBe("plan");
+    expect(claudeSdkPermissionMode("bypassPermissions")).toBe("bypassPermissions");
+    expect(claudeSdkPermissionMode(undefined)).toBe("default");
+  });
+
+  it("refuses a mutating tool outright — no prompt the user could answer `allow` to", async () => {
+    const captureOptions: Record<string, unknown>[] = [];
+    const a = new ClaudeAdapter({ query: fakeQuery({ permissionOnTool: "Edit", captureOptions }) as never });
+    const h = a.start({ cwd: "/tmp", mcpServers: [], permissionMode: "ask" });
+    const c = collectUntil(h.events, () => false);
+    await h.send({ text: "hi", attachments: [] }); await h.dispose(); const got = await c;
+    // Denied before it ran, and never put to the user: a prompt here would make Ask advisory.
+    expect(types(got)).not.toContain("permission_request");
+    expect(statuses(got)).not.toContain("waiting_permission");
+    expect(captureOptions[0]!.permissionMode).toBe("default");
+  });
+
+  it("still routes a READ through the ordinary permission channel", async () => {
+    // Ask narrows what may run; it does not take over deciding the calls that are allowed to.
+    const a = new ClaudeAdapter({ query: fakeQuery({ permissionOnTool: "Read" }) as never });
+    const h = a.start({ cwd: "/tmp", mcpServers: [], permissionMode: "ask" });
+    const c = collectUntil(h.events, (e, all) => e.type === "status" && e.payload.status === "idle" && types(all).includes("permission_response"),
+      (e) => { if (e.type === "permission_request") h.respondPermission(e.payload.requestId, "allow"); });
+    await h.send({ text: "hi", attachments: [] }); const got = await c; await h.dispose();
+    expect(types(got)).toContain("permission_request");
+  });
+
+  it("holds on a session switched into Ask mid-flight, not only on one that started there", async () => {
+    // The mutant: reading the mode off `options` instead of tracking it. `Options` is consulted once
+    // at start, so a live switch would leave the gate open for the rest of the session.
+    const a = new ClaudeAdapter({ query: fakeQuery({ permissionOnTool: "Edit" }) as never });
+    const h = a.start({ cwd: "/tmp", mcpServers: [], permissionMode: "default" });
+    await h.setOptions({ permissionMode: "ask" });
+    const c = collectUntil(h.events, () => false);
+    await h.send({ text: "hi", attachments: [] }); await h.dispose(); const got = await c;
+    expect(types(got)).not.toContain("permission_request");
+  });
+});
 
 describe("ClaudeAdapter", () => {
   it("streams normalized events for a turn and marks idle at result", async () => {

--- a/packages/adapters/src/claude/claude-adapter.ts
+++ b/packages/adapters/src/claude/claude-adapter.ts
@@ -1,6 +1,6 @@
 import { readFile, stat } from "node:fs/promises";
 import { query as sdkQuery, type Options, type PermissionResult, type PermissionUpdate, type SDKUserMessage, type Query } from "@anthropic-ai/claude-agent-sdk";
-import { BROWSER_READ_ONLY_TOOLS, MAX_ATTACHMENT_BYTES, newId, sessionEvent, type SessionEvent } from "@realm/contracts";
+import { ASK_PERMISSION_MODE, BROWSER_READ_ONLY_TOOLS, MAX_ATTACHMENT_BYTES, newId, sessionEvent, type SessionEvent } from "@realm/contracts";
 import { AsyncQueue } from "../event-queue";
 import { createSdkMapper } from "./map-sdk-message";
 import { probeClaude } from "./probe";
@@ -44,6 +44,50 @@ export function claudeAllowedTools(servers: readonly McpServerConfig[]): string[
   return servers.flatMap((s) => BROWSER_READ_ONLY_TOOLS.map((t) => `mcp__${s.name}__realm-browser__${t}`));
 }
 
+/**
+ * The BUILT-IN tools an Ask session may run — read and search, and nothing that changes anything.
+ *
+ * An allow-list, never a deny-list. Ask's whole value is that it is enforced, and a deny-list fails
+ * open: the next tool the CLI ships, and every tool of every MCP server a space adds, would be
+ * allowed by default until somebody remembered to name it.
+ *
+ * `Bash` is absent and that is the point. Nothing can decide from a command string whether it
+ * mutates — `git log` and `git reset --hard` are the same shape, and a shell can write a file
+ * through a hundred spellings. Guessing is exactly the lie this mode exists to avoid, and Cursor's
+ * own `ask` mode draws the line in the same place: "no edits or command execution".
+ *
+ * `Task` is absent for the same fail-closed reason: whether the SDK routes a subagent's tool calls
+ * back through this `canUseTool` is not something Realm can assert from the published types, and a
+ * subagent that edits is an edit.
+ *
+ * `TodoWrite` and `AskUserQuestion` are in: one writes the agent's own checklist and the other asks
+ * the user a question. Neither touches the repo.
+ */
+const CLAUDE_ASK_BUILTINS = ["Read", "Glob", "Grep", "NotebookRead", "WebFetch", "WebSearch", "TodoWrite", "AskUserQuestion"] as const;
+
+/**
+ * Every tool name an Ask session may run, for a session with these MCP servers.
+ *
+ * The MCP half is `claudeAllowedTools` itself rather than a second list: those are the read-only
+ * `realm-browser` tools, they are already pre-allowed for every session, and deriving them here
+ * means Ask can never disagree with what the rest of the adapter calls read-only.
+ */
+export function claudeAskTools(servers: readonly McpServerConfig[]): Set<string> {
+  return new Set<string>([...CLAUDE_ASK_BUILTINS, ...claudeAllowedTools(servers)]);
+}
+
+/**
+ * Realm's mode onto the SDK's `PermissionMode`, whose union is
+ * `default | acceptEdits | bypassPermissions | plan | dontAsk | auto` and has no "ask".
+ *
+ * Ask becomes `default` because that is the mode under which `canUseTool` is consulted for every
+ * call, and `canUseTool` is where Ask is enforced. `acceptEdits` and `bypassPermissions` let calls
+ * through without asking, so sending either would hand the mode's one gate its own bypass.
+ */
+export function claudeSdkPermissionMode(mode: string | null | undefined): string {
+  return mode === ASK_PERMISSION_MODE || !mode ? "default" : mode;
+}
+
 const STDERR_TAIL_LINES = 50;
 const DISPOSE_TIMEOUT_MS = 3000;
 
@@ -63,6 +107,10 @@ export class ClaudeAdapter implements AgentAdapter {
     const mapper = createSdkMapper();
     const stderrTail: string[] = [];
     let q: Query | null = null;
+    // Tracked rather than read off `options`, because Ask has to hold on a LIVE session: the mode can
+    // change mid-turn and `Options` is only ever read at start.
+    let permissionMode = opts.permissionMode ?? "default";
+    const askTools = claudeAskTools(opts.mcpServers);
     let running = false;
     let sawResult = false;
     let disposed = false;
@@ -92,6 +140,12 @@ export class ClaudeAdapter implements AgentAdapter {
     // Several tools may ask at once (parallel tool calls): status flips to waiting_permission on the first open request
     // and back only when the last one is answered.
     const canUseTool: NonNullable<Options["canUseTool"]> = async (toolName, toolInput, o) => {
+      // Ask, enforced: refused here, before the tool runs, and never put to the user — a prompt the
+      // user could answer "allow" to would make the mode advisory. The message names what IS
+      // available, so the model re-plans within the mode instead of retrying the same call.
+      if (permissionMode === ASK_PERMISSION_MODE && !askTools.has(toolName)) {
+        return { behavior: "deny", message: `This session is in Ask mode: read-only. ${toolName} cannot run. Reading, searching (Grep, Glob) and web lookups are available; to change files or run commands, the user has to leave Ask.` };
+      }
       const requestId = newId();
       const suggestions = o.suggestions ?? [];
       if (pending.size === 0) events.push(sessionEvent("status", { status: "waiting_permission" }));
@@ -112,7 +166,7 @@ export class ClaudeAdapter implements AgentAdapter {
       cwd: opts.cwd,
       model: opts.model ?? undefined,
       effort: (opts.effort ?? undefined) as Options["effort"],
-      permissionMode: (opts.permissionMode ?? "default") as Options["permissionMode"],
+      permissionMode: claudeSdkPermissionMode(opts.permissionMode) as Options["permissionMode"],
       canUseTool,
       includePartialMessages: true,
       abortController: abort,
@@ -222,7 +276,12 @@ export class ClaudeAdapter implements AgentAdapter {
       },
       setOptions: async (o) => {
         if (o.model) await q?.setModel(o.model);
-        if (o.permissionMode) await q?.setPermissionMode(o.permissionMode as never);
+        if (o.permissionMode) {
+          // Realm's own record moves FIRST: it is what the gate above reads, and it must hold even
+          // if the SDK call throws.
+          permissionMode = o.permissionMode;
+          await q?.setPermissionMode(claudeSdkPermissionMode(o.permissionMode) as never);
+        }
       },
       dispose: async () => {
         if (disposed) return;

--- a/packages/adapters/src/claude/map-sdk-message.test.ts
+++ b/packages/adapters/src/claude/map-sdk-message.test.ts
@@ -54,6 +54,31 @@ describe("map-sdk-message", () => {
     expect(delta1.type === "assistant_delta" && delta1.payload.messageId).toBe(delta2.type === "assistant_delta" && delta2.payload.messageId);
     expect(delta1.type === "assistant_delta" && delta1.payload.messageId).toBe(text.type === "assistant_text" && text.payload.messageId);
   });
+  it("maps ExitPlanMode to a plan carrying the markdown, not to a tool call", () => {
+    const out = createSdkMapper().map(asst([{ type: "tool_use", id: "toolu_p", name: "ExitPlanMode", input: { plan: "# Ship it\n\n1. Do the thing", planFilePath: "/tmp/p.md" } }]) as never);
+    // The mutant: dropping the ExitPlanMode branch. The plan then reaches the transcript as a generic
+    // tool call whose summary clips the whole document to one line.
+    expect(out.map((e) => e.type)).toEqual(["plan"]);
+    expect(out[0]!.type === "plan" && out[0]!.payload).toEqual({ planId: "toolu_p", text: "# Ship it\n\n1. Do the thing" });
+  });
+  it("keys the plan on the tool use id, so a re-proposed plan is a second card and a resend is not", () => {
+    const m = createSdkMapper();
+    const first = m.map(asst([{ type: "tool_use", id: "toolu_a", name: "ExitPlanMode", input: { plan: "v1" } }]) as never);
+    const second = m.map(asst([{ type: "tool_use", id: "toolu_b", name: "ExitPlanMode", input: { plan: "v2" } }]) as never);
+    expect([first[0]!, second[0]!].map((e) => e.type === "plan" && e.payload.planId)).toEqual(["toolu_a", "toolu_b"]);
+  });
+  it.each([
+    ["no plan field", { planFilePath: "/tmp/p.md" }],
+    ["a non-string plan", { plan: { markdown: "nope" } }],
+    ["a blank plan", { plan: "   " }],
+  ])("falls back to the ordinary tool call when the call carries %s — a plan card with no plan is worse than the generic one", (_name, input) => {
+    const out = createSdkMapper().map(asst([{ type: "tool_use", id: "toolu_p", name: "ExitPlanMode", input }]) as never);
+    expect(out.map((e) => e.type)).toEqual(["tool_call"]);
+  });
+  it("leaves every other tool alone — a TodoWrite whose input happens to have a `plan` key is still a tool call", () => {
+    const out = createSdkMapper().map(asst([{ type: "tool_use", id: "t9", name: "TodoWrite", input: { plan: "not mine" } }]) as never);
+    expect(out.map((e) => e.type)).toEqual(["tool_call"]);
+  });
   it("result with is_error emits usage then error, and resets text dedupe", () => {
     const m = createSdkMapper();
     m.map(asst([{ type: "text", text: "same" }], null, "m1") as never);

--- a/packages/adapters/src/claude/map-sdk-message.ts
+++ b/packages/adapters/src/claude/map-sdk-message.ts
@@ -16,6 +16,24 @@ type Block = { type: string; [k: string]: unknown };
  * - `assistant_text` is de-duplicated per (messageId, text) because the SDK can re-emit the same assistant message;
  *   the dedupe set is cleared on `result`.
  */
+/**
+ * Claude's plan, which arrives as an ordinary `ExitPlanMode` tool call.
+ *
+ * The markdown is `input.plan` — verified against real SDK transcripts on disk, whose tool_use input
+ * is `{plan, planFilePath}`; the generated `ExitPlanModeInput` types only the deprecated
+ * `allowedPrompts` and leaves the rest to its index signature, so the schema cannot be read for it.
+ * Null when there is no plan string, and the call then maps as the plain tool call it is: a plan card
+ * with no plan in it would be worse than the generic one.
+ *
+ * The `canUseTool` permission this same call raises is deliberately untouched. Approving it is how
+ * the session leaves Plan, so it stays on the permission channel and keeps its decision.
+ */
+function exitPlanText(name: string, input: Record<string, unknown>): string | null {
+  if (name !== "ExitPlanMode") return null;
+  const plan = input["plan"];
+  return typeof plan === "string" && plan.trim() ? plan : null;
+}
+
 export function createSdkMapper() {
   const streamMsgIds = new Map<string | null, string>(); // parent_tool_use_id -> current streaming message id
   const emittedText = new Set<string>();
@@ -46,7 +64,11 @@ export function createSdkMapper() {
           const messageId = streamMsgIds.get(parent) ?? m.id;
           for (const b of m.content) {
             if (b.type === "tool_use") {
-              out.push(sessionEvent("tool_call", { toolUseId: String(b.id), name: String(b.name), input: (b.input as Record<string, unknown>) ?? {}, parentToolUseId: parent }));
+              const toolUseId = String(b.id), name = String(b.name), input = (b.input as Record<string, unknown>) ?? {};
+              const plan = exitPlanText(name, input);
+              out.push(plan
+                ? sessionEvent("plan", { planId: toolUseId, text: plan })
+                : sessionEvent("tool_call", { toolUseId, name, input, parentToolUseId: parent }));
             } else if (parent !== null) {
               continue; // subagent prose dropped in v1 (see header comment)
             } else if (b.type === "text") {

--- a/packages/adapters/src/codex/codex-adapter.test.ts
+++ b/packages/adapters/src/codex/codex-adapter.test.ts
@@ -44,6 +44,50 @@ async function booted(o: Partial<StartOptions> = {}) {
   return { adapter, handle, evs, done };
 }
 
+describe("plans", () => {
+  it("carries BOTH of Codex's plan shapes, each as its own card", async () => {
+    const { handle, evs } = await booted();
+    await handle.send({ text: "PLAN it", attachments: [] });
+    await waitFor(() => expect(statuses(evs).at(-1)).toBe("idle"));
+    const plans = of(evs, "plan");
+    // The mutant: reinstating `toolNameFor`'s `default: return null` for `plan` and the notification
+    // switch's `default: return []`. Both plans vanish and the turn reads as if nothing was proposed.
+    const prose = plans.filter((e) => e.payload.text !== undefined);
+    const steps = plans.filter((e) => e.payload.steps !== undefined);
+    expect(prose).toHaveLength(1);
+    expect(prose[0]!.payload.text).toBe("## Ship it\n\nRewrite the mapper first.");
+    // Prose carries no steps and the step list carries no prose: neither is synthesised from the other.
+    expect(prose[0]!.payload.steps).toBeUndefined();
+    expect(steps.every((e) => e.payload.text === undefined)).toBe(true);
+    expect(steps.at(-1)!.payload.steps).toEqual([
+      { text: "Read the spec", status: "completed" }, { text: "Write the code", status: "in_progress" }]);
+  });
+
+  it("keys every revision of the step list on the turn, so the card is replaced and not repeated", async () => {
+    const { handle, evs } = await booted();
+    await handle.send({ text: "PLAN it", attachments: [] });
+    await waitFor(() => expect(statuses(evs).at(-1)).toBe("idle"));
+    const stepPlans = of(evs, "plan").filter((e) => e.payload.steps !== undefined);
+    expect(stepPlans).toHaveLength(2);
+    // One id for both sends. The mutant — a fresh id per notification — leaves the reader with one
+    // card per step transition, all saying nearly the same thing.
+    expect(new Set(stepPlans.map((e) => e.payload.planId)).size).toBe(1);
+    expect(stepPlans[0]!.payload.steps![0]!.status).toBe("in_progress");
+  });
+
+  it("never emits the experimental plan deltas live, and salvages them only when the item never completes", async () => {
+    const { handle, evs } = await booted();
+    await handle.send({ text: "PLANOPEN now", attachments: [] });
+    await waitFor(() => expect(of(evs, "plan").some((e) => e.payload.steps !== undefined)).toBe(true));
+    // `item/plan/delta` is EXPERIMENTAL and its own doc comment forbids assuming the concatenation
+    // matches the completed item, so nothing prose-shaped may appear while the item is still open.
+    expect(of(evs, "plan").filter((e) => e.payload.text !== undefined)).toEqual([]);
+    await handle.interrupt();
+    // Now there is no completed content to differ from, and the concatenation is the only record.
+    await waitFor(() => expect(of(evs, "plan").filter((e) => e.payload.text !== undefined).map((e) => e.payload.text)).toEqual(["## Ship it"]));
+  });
+});
+
 describe("pickCodexDecision", () => {
   // The live capture offered ["accept", {acceptWithExecpolicyAmendment:…}, "cancel"] — no "decline" at all.
   const LIVE = ["accept", { acceptWithExecpolicyAmendment: { execpolicy_amendment: {} } }, "cancel"];

--- a/packages/adapters/src/codex/codex-adapter.test.ts
+++ b/packages/adapters/src/codex/codex-adapter.test.ts
@@ -128,6 +128,16 @@ describe("codexPolicyFor", () => {
   it("maps bypassPermissions to never/danger-full-access", () => {
     expect(codexPolicyFor("bypassPermissions")).toEqual({ approvalPolicy: "never", sandbox: "danger-full-access" });
   });
+  it("maps ask to read-only with approvals DISABLED — strictly tighter than plan", () => {
+    // The mutant: giving Ask plan's `untrusted`. A write the sandbox refuses would then raise an
+    // approval the user can answer "yes" to, and the escalation puts the write through — which is
+    // the one thing a mode advertised as read-only must not allow.
+    expect(codexPolicyFor("ask")).toEqual({ approvalPolicy: "never", sandbox: "read-only" });
+    expect(codexPolicyFor("ask").sandbox).toBe(codexPolicyFor("plan").sandbox);
+    expect(codexPolicyFor("ask").approvalPolicy).not.toBe(codexPolicyFor("plan").approvalPolicy);
+    // …and `never` is only ever paired with read-only here, never with the bypass sandbox by accident.
+    expect(codexPolicyFor("ask").sandbox).not.toBe("danger-full-access");
+  });
   it("maps everything else to on-request/workspace-write", () => {
     for (const m of ["default", "acceptEdits", undefined, "", "nonsense"]) {
       expect(codexPolicyFor(m)).toEqual({ approvalPolicy: "on-request", sandbox: "workspace-write" });
@@ -262,6 +272,7 @@ describe("CodexAdapter", () => {
     const cases = [
       ["plan", { approvalPolicy: "untrusted", sandbox: "read-only" }],
       ["bypassPermissions", { approvalPolicy: "never", sandbox: "danger-full-access" }],
+      ["ask", { approvalPolicy: "never", sandbox: "read-only" }],
       ["default", { approvalPolicy: "on-request", sandbox: "workspace-write" }],
     ] as const;
     for (const [permissionMode, expected] of cases) {

--- a/packages/adapters/src/codex/codex-adapter.ts
+++ b/packages/adapters/src/codex/codex-adapter.ts
@@ -1,4 +1,4 @@
-import { sessionEvent, type SessionEvent } from "@realm/contracts";
+import { ASK_PERMISSION_MODE, sessionEvent, type SessionEvent } from "@realm/contracts";
 import { AsyncQueue } from "../event-queue";
 import { JsonRpcCallError, type JsonRpcId } from "../jsonrpc/stdio";
 import { CodexConnection, type ThreadListener } from "./connection";
@@ -80,9 +80,19 @@ export function pickCodexDecision(decision: PermissionDecision, availableDecisio
   return prefs.find((p) => offered.has(p)) ?? prefs[prefs.length - 1]!;
 }
 
-/** Realm's permission modes onto Codex's two independent knobs. Both are `thread/start` params. */
+/**
+ * Realm's permission modes onto Codex's two independent knobs. Both are `thread/start` params.
+ *
+ * Ask and Plan are BOTH read-only and they are not the same rung. Plan keeps `untrusted`, so a write
+ * the sandbox refuses raises an approval the user can answer "yes" to — that escalation is what makes
+ * a plan revisable in place. Ask disables approvals outright, so there is no answer that lets a write
+ * through: Codex's own config validator describes exactly this pairing as "read-only permissions with
+ * approvals disabled". The sandbox does the refusing in the kernel — a write under
+ * `codex sandbox -c sandbox_mode='"read-only"'` fails with "Operation not permitted".
+ */
 export function codexPolicyFor(permissionMode: string | undefined): { approvalPolicy: string; sandbox: string } {
   if (permissionMode === "plan") return { approvalPolicy: "untrusted", sandbox: "read-only" };
+  if (permissionMode === ASK_PERMISSION_MODE) return { approvalPolicy: "never", sandbox: "read-only" };
   if (permissionMode === "bypassPermissions") return { approvalPolicy: "never", sandbox: "danger-full-access" };
   return { approvalPolicy: "on-request", sandbox: "workspace-write" };
 }

--- a/packages/adapters/src/codex/fixtures/fake-codex-server.mjs
+++ b/packages/adapters/src/codex/fixtures/fake-codex-server.mjs
@@ -14,6 +14,8 @@
  *
  *   HANG      opens a command item and never finishes the turn        (interrupt / steer tests)
  *   PARTIAL   streams message deltas and never finishes the item      (partial-text flush tests)
+ *   PLAN      sends both plan shapes, the step list twice (revised)    (plan mapping tests)
+ *   PLANOPEN  (modifier) leaves the prose plan item unfinished         (plan salvage on interrupt)
  *   SLOW      (modifier) delays the turn's notifications by 60ms      (turn-id-from-response tests)
  *   GHOST     opens a turn the server does not register as steerable  (turn/steer -> turn/start fallback)
  *   APPROVE   runs one command that needs an approval decision
@@ -84,6 +86,27 @@ function endTurn(threadId, turnId, status = "completed") {
   activeTurns.delete(threadId);
   notify("thread/status/changed", { threadId, status: { type: "idle" } });
   notify("turn/completed", { threadId, turn: { id: turnId, itemsView: "summary", items: [], status, error: null } });
+}
+
+/**
+ * Both of Codex's plan shapes in one turn: the prose `plan` ThreadItem (streamed as `item/plan/delta`,
+ * settled by `item/completed`) and the `turn/plan/updated` step list, sent twice so the second is a
+ * revision of the first. Shapes are `codex app-server generate-ts`'s: `TurnPlanStep {step, status}`
+ * with status `pending | inProgress | completed`.
+ */
+async function streamPlanTurn(threadId, turnId, text) {
+  await openTurn(threadId, turnId, text);
+  const itemId = `plan_${nextItemN++}`;
+  notify("item/started", { threadId, turnId, startedAtMs: Date.now(), item: { type: "plan", id: itemId, text: "" } });
+  notify("item/plan/delta", { threadId, turnId, itemId, delta: "## Ship " });
+  notify("item/plan/delta", { threadId, turnId, itemId, delta: "it" });
+  notify("turn/plan/updated", { threadId, turnId, explanation: null, plan: [
+    { step: "Read the spec", status: "inProgress" }, { step: "Write the code", status: "pending" }] });
+  if (text.includes("PLANOPEN")) return; // the item never completes: an interrupt has something to salvage
+  notify("item/completed", { threadId, turnId, completedAtMs: Date.now(), item: { type: "plan", id: itemId, text: "## Ship it\n\nRewrite the mapper first." } });
+  notify("turn/plan/updated", { threadId, turnId, explanation: "revised", plan: [
+    { step: "Read the spec", status: "completed" }, { step: "Write the code", status: "inProgress" }] });
+  endTurn(threadId, turnId);
 }
 
 function agentMessage(threadId, turnId, text) {
@@ -301,6 +324,7 @@ function handleRequest(id, method, params) {
       // Dies with a tool card still open, so the crash has something to force-close.
       if (text.includes("CRASH")) { void streamHangTurn(params.threadId, turnId, text); setTimeout(() => process.exit(9), 25); return; }
       if (text.includes("GHOST")) { void openTurn(params.threadId, turnId, text); return; }
+      if (text.includes("PLAN")) { void streamPlanTurn(params.threadId, turnId, text); return; }
       if (text.includes("PARTIAL")) { void streamPartialTurn(params.threadId, turnId, text); return; }
       if (text.includes("HANG")) { void streamHangTurn(params.threadId, turnId, text); return; }
       if (text.includes("APPROVE2")) { void streamTwoApprovalsTurn(params.threadId, turnId, text); return; }

--- a/packages/adapters/src/codex/map-codex.ts
+++ b/packages/adapters/src/codex/map-codex.ts
@@ -43,6 +43,19 @@ function toolOutputFor(item: Bag): string {
   }
 }
 
+/** Realm's plan-step status from Codex's `TurnPlanStepStatus` — `"pending" | "inProgress" |
+ *  "completed"` (`codex app-server generate-ts`, codex 0.146.0). Anything else reads as `pending`:
+ *  a status Realm does not recognise must never render as work already done. */
+const planStatus = (v: unknown): "pending" | "in_progress" | "completed" =>
+  v === "completed" ? "completed" : v === "inProgress" ? "in_progress" : "pending";
+
+/** `turn/plan/updated`'s `plan: TurnPlanStep[]`, each `{step, status}`. Steps with no text are
+ *  dropped rather than rendered as blank rows; an empty result means there is no plan to show. */
+function planSteps(raw: unknown): { text: string; status: "pending" | "in_progress" | "completed" }[] {
+  if (!Array.isArray(raw)) return [];
+  return raw.map((e) => ({ text: str(obj(e).step), status: planStatus(obj(e).status) })).filter((e) => e.text !== "");
+}
+
 /**
  * Pure, stateful mapper from `codex app-server` notifications to Realm SessionEvents.
  *
@@ -59,6 +72,8 @@ export function createCodexMapper() {
   /** Delta text accumulated for message and reasoning items still awaiting item/completed. */
   const openText = new Map<string, string>();
   const openThought = new Map<string, string>();
+  /** Delta text accumulated for `plan` items still awaiting item/completed — see flushOpenRuns. */
+  const openPlan = new Map<string, string>();
   let numTurns = 0;
 
   /**
@@ -72,8 +87,14 @@ export function createCodexMapper() {
     const out: SessionEvent[] = [];
     for (const [id, text] of openText) if (text) out.push(sessionEvent("assistant_text", { messageId: id, text }));
     for (const [id, text] of openThought) if (text) out.push(sessionEvent("thinking", { messageId: id, text }));
+    // The plan an interrupt cut short. `item/plan/delta` is flagged EXPERIMENTAL and its own doc
+    // comment says clients must not assume concatenated deltas match the completed item — but an
+    // item that never completes has no completed content to differ from, and the concatenation is
+    // the only record there will be. That is why these deltas are never emitted live.
+    for (const [id, text] of openPlan) if (text) out.push(sessionEvent("plan", { planId: id, text }));
     openText.clear();
     openThought.clear();
+    openPlan.clear();
     return out;
   };
 
@@ -90,6 +111,7 @@ export function createCodexMapper() {
           // No Realm event of their own, but the run has to be open before its first delta can be kept.
           if (type === "agentMessage") { openText.set(id, ""); return out; }
           if (type === "reasoning") { openThought.set(id, ""); return out; }
+          if (type === "plan") { openPlan.set(id, ""); return out; }
           const name = toolNameFor(item);
           if (name) { openTools.add(id); out.push(sessionEvent("tool_call", { toolUseId: id, name, input: toolInputFor(item), parentToolUseId: null })); }
           return out; // userMessage starts carry no Realm event
@@ -101,6 +123,14 @@ export function createCodexMapper() {
           const type = str(item.type);
           // Clearing the run is what keeps the flush from persisting a normal message a second time.
           if (type === "agentMessage") { openText.delete(id); out.push(sessionEvent("assistant_text", { messageId: id, text: str(item.text) })); return out; }
+          // The `plan` ThreadItem is `{id, text}` — prose, not the step list `turn/plan/updated`
+          // carries. Both are plans and neither is derived from the other, so each gets its own card.
+          if (type === "plan") {
+            openPlan.delete(id);
+            const text = str(item.text);
+            if (text) out.push(sessionEvent("plan", { planId: id, text }));
+            return out;
+          }
           if (type === "reasoning") {
             openThought.delete(id);
             const summary = Array.isArray(item.summary) ? (item.summary as unknown[]).map(str) : [];
@@ -130,6 +160,21 @@ export function createCodexMapper() {
           const id = str(p.itemId);
           openThought.set(id, (openThought.get(id) ?? "") + str(p.delta));
           return [];
+        }
+
+        case "item/plan/delta": {
+          // Accumulated, never emitted: see flushOpenRuns for why the completed item is the truth.
+          const id = str(p.itemId);
+          openPlan.set(id, (openPlan.get(id) ?? "") + str(p.delta));
+          return [];
+        }
+
+        case "turn/plan/updated": {
+          // Keyed on the TURN, not the notification: Codex re-sends the whole plan every time a step
+          // moves, so a revision has to replace the card already drawn. `plan:` keeps that id out of
+          // the item-id space the prose plans above use.
+          const steps = planSteps(p.plan);
+          return steps.length ? [sessionEvent("plan", { planId: `plan:${str(p.turnId)}`, steps })] : [];
         }
 
         case "item/commandExecution/outputDelta":

--- a/packages/adapters/src/fake/fake-adapter.test.ts
+++ b/packages/adapters/src/fake/fake-adapter.test.ts
@@ -12,6 +12,24 @@ describe("FakeAdapter", () => {
     expect(got.indexOf("permission_request")).toBeLessThan(got.indexOf("tool_result"));
     await h.dispose();
   });
+  it("scripts a plan and its revision on one id, so the dev prompter can reach the plan card", async () => {
+    // The `plan` event is drawn by a card of its own, and the scripted adapter is what UI development
+    // runs against — without this step that card is unreachable offline.
+    const a = new FakeAdapter({ script: [{ on: "plan", emit: [
+      { kind: "plan", planId: "p1", steps: [{ text: "A", status: "in_progress" }] },
+      { kind: "plan", planId: "p1", text: "## A", steps: [{ text: "A", status: "completed" }] },
+    ] }] });
+    const h = a.start({ cwd: "/tmp", mcpServers: [] });
+    const evs: { type: string; payload: unknown }[] = [];
+    const c = (async () => { for await (const e of h.events) { evs.push(e); if (e.type === "status" && e.payload.status === "idle" && evs.some((x) => x.type === "plan")) break; } })();
+    h.send({ text: "plan it", attachments: [] }); await c;
+    const plans = evs.filter((e) => e.type === "plan").map((e) => e.payload);
+    expect(plans).toEqual([
+      { planId: "p1", steps: [{ text: "A", status: "in_progress" }] },
+      { planId: "p1", text: "## A", steps: [{ text: "A", status: "completed" }] },
+    ]);
+    await h.dispose();
+  });
   it("deny skips tool result and reports error text", async () => {
     const a = new FakeAdapter({ script: [{ on: "x", emit: [{ kind: "tool", name: "Bash", input: {}, needsPermission: true, result: "never" }] }] });
     const h = a.start({ cwd: "/tmp", mcpServers: [] }); const types: string[] = [];

--- a/packages/adapters/src/fake/fake-adapter.ts
+++ b/packages/adapters/src/fake/fake-adapter.ts
@@ -5,6 +5,10 @@ import type { AgentAdapter, AgentHandle, PermissionDecision, ProbeResult, StartO
 export type FakeStep =
   | { kind: "text"; text: string }
   | { kind: "tool"; name: string; input: Record<string, unknown>; needsPermission?: boolean; result: string }
+  /** A plan, in either shape the `plan` event carries. Re-using a `planId` revises that plan in
+   *  place, which is what the real agents do and the one plan behaviour a script must be able to
+   *  reproduce. */
+  | { kind: "plan"; planId: string; text?: string; steps?: { text: string; status: "pending" | "in_progress" | "completed" }[] }
   | { kind: "throw"; message: string };
 export type FakeScript = { on: string; emit: FakeStep[] }[];
 
@@ -43,6 +47,7 @@ export class FakeAdapter implements AgentAdapter {
         if (interrupted) break; // like the real adapter: interrupt stops the turn; the turn's natural end still emits usage + idle
         await sleep();
         if (st.kind === "throw") throw new Error(st.message);
+        if (st.kind === "plan") { q.push(sessionEvent("plan", { planId: st.planId, ...(st.text ? { text: st.text } : {}), ...(st.steps ? { steps: st.steps } : {}) })); continue; }
         if (st.kind === "text") {
           const id = newId();
           for (const ch of st.text) q.push(sessionEvent("assistant_delta", { messageId: id, delta: ch }));

--- a/packages/contracts/src/delegation.ts
+++ b/packages/contracts/src/delegation.ts
@@ -25,7 +25,10 @@ export const AgentRunConstraintsSchema = z.object({
   agentKind: AgentKindSchema.optional(),
   environmentId: IdSchema.optional(),
   newWorktree: z.union([z.boolean(), z.string().min(1).max(80)]).optional(),
-  permissionMode: z.enum(["plan", "default", "acceptEdits", "bypassPermissions"]).optional(),
+  /** Both read-only modes are requestable: they are the two most restrictive things a parent can ask
+   *  a child to be, and leaving one out of the enum refuses the constraint outright rather than
+   *  tightening. `MODE_RANK` ranks them equal — see `agent-run.ts`. */
+  permissionMode: z.enum(["plan", "ask", "default", "acceptEdits", "bypassPermissions"]).optional(),
   maxTurns: z.number().int().min(1).max(200).optional(),
   timeoutMs: z.number().int().min(5_000).max(3_600_000).optional(),
   skills: z.array(SkillIdSchema).max(50).optional(),

--- a/packages/contracts/src/presets.test.ts
+++ b/packages/contracts/src/presets.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { SPACE_COLORS, SPACE_ICONS, pickSpaceColor, parseSpaceIcon, acpBuildMode, acpPlanMode, acpSessionConfig, acpWellKnownMode, parseAcpConfigOptions, AGENT_CLI_COMMANDS, AGENT_META, AGENT_MODELS, AGENT_LOGIN_HINTS, AGENT_SUPPORTS_PERMISSION_MODES, AGENT_SUPPORTS_PLAN_MODE, DEFAULT_MODEL_LABEL, PERMISSION_MODES, PLAN_PERMISSION_MODE, SELECTABLE_AGENT_KINDS, SESSION_MODES, type AcpSessionMode } from "./presets";
+import { SPACE_COLORS, SPACE_ICONS, pickSpaceColor, parseSpaceIcon, acpBuildMode, acpPlanMode, acpSessionConfig, acpWellKnownMode, parseAcpConfigOptions, AGENT_CLI_COMMANDS, AGENT_META, AGENT_MODELS, AGENT_LOGIN_HINTS, AGENT_SUPPORTS_ASK_MODE, AGENT_SUPPORTS_PERMISSION_MODES, AGENT_SUPPORTS_PLAN_MODE, ASK_PERMISSION_MODE, acpAskMode, isReadOnlyMode, sessionModeOf, modeWireValue, DEFAULT_MODEL_LABEL, PERMISSION_MODES, PLAN_PERMISSION_MODE, SELECTABLE_AGENT_KINDS, SESSION_MODES, type AcpSessionMode } from "./presets";
 import { AgentKindSchema } from "./entities";
 describe("presets", () => {
   it("has at least 8 colors and a lot more icons", () => { expect(SPACE_COLORS.length).toBeGreaterThanOrEqual(8); expect(SPACE_ICONS.length).toBeGreaterThanOrEqual(50); });
@@ -84,10 +84,20 @@ describe("PERMISSION_MODES", () => {
     expect(PERMISSION_MODES.map((m) => m.id)).toEqual(["default", "acceptEdits", "bypassPermissions"]);
     expect(PERMISSION_MODES.map((m) => m.id)).not.toContain(PLAN_PERMISSION_MODE);
   });
-  it("still names Plan's wire value, which the adapters read off `permissionMode`", () => {
+  it("still names Plan's and Ask's wire values, which the adapters read off `permissionMode`", () => {
     // Splitting the axes was a UI change; the transport did not move.
     expect(PLAN_PERMISSION_MODE).toBe("plan");
-    expect(SESSION_MODES.map((m) => m.id)).toEqual(["build", "plan"]);
+    expect(ASK_PERMISSION_MODE).toBe("ask");
+    expect(SESSION_MODES.map((m) => m.id)).toEqual(["build", "plan", "ask"]);
+    expect(PERMISSION_MODES.map((m) => m.id)).not.toContain(ASK_PERMISSION_MODE);
+  });
+  it("calls the `default` rung `Ask each time`, so it cannot be mistaken for the Ask MODE", () => {
+    // The mutant: relabelling it back to "Ask". Two controls in the same row would then both offer
+    // something called Ask, meaning two unrelated things — per-action prompting, and read-only Q&A.
+    const labels = PERMISSION_MODES.map((m) => m.label);
+    expect(labels).not.toContain("Ask");
+    expect(labels).toContain("Ask each time");
+    expect(SESSION_MODES.map((m) => m.label)).toContain("Ask");
   });
 });
 
@@ -151,7 +161,46 @@ describe("SELECTABLE_AGENT_KINDS", () => {
       // the generic AcpAdapter, so its permission/plan/skills/memory answers must match Cursor's.
       expect(AGENT_SUPPORTS_PERMISSION_MODES[k], k).toBe(false);
       expect(AGENT_SUPPORTS_PLAN_MODE[k], k).toBe(false);
+      expect(AGENT_SUPPORTS_ASK_MODE[k], k).toBe(false);
     }
+  });
+});
+
+describe("AGENT_SUPPORTS_ASK_MODE", () => {
+  it("has an entry for every agent kind, so a new kind cannot be silently offered Ask", () => {
+    expect(Object.keys(AGENT_SUPPORTS_ASK_MODE).sort()).toEqual(Object.keys(AGENT_META).sort());
+  });
+  it("claims Ask only where an adapter actually refuses the call", () => {
+    // Claude denies in canUseTool, Codex runs read-only with approvals disabled. Every ACP kind is
+    // false as the pre-handshake floor — acpAskMode answers per session.
+    expect(AGENT_SUPPORTS_ASK_MODE.claude).toBe(true);
+    expect(AGENT_SUPPORTS_ASK_MODE.codex).toBe(true);
+    for (const k of Object.keys(AGENT_SUPPORTS_ASK_MODE)) {
+      if (k.startsWith("acp:")) expect(AGENT_SUPPORTS_ASK_MODE[k as keyof typeof AGENT_SUPPORTS_ASK_MODE], k).toBe(false);
+    }
+  });
+});
+
+describe("the mode axis on the permissionMode wire", () => {
+  it("round-trips every mode through the field it travels on", () => {
+    for (const m of SESSION_MODES) {
+      const wire = modeWireValue(m.id);
+      // Build is the ABSENCE of a wire value; the other two are their own strings.
+      expect(sessionModeOf(wire ?? "default")).toBe(m.id);
+    }
+    expect(modeWireValue("build")).toBeNull();
+  });
+  it("reads a permission as Build, so a session on `acceptEdits` is not in some mode of its own", () => {
+    for (const p of PERMISSION_MODES) expect(sessionModeOf(p.id)).toBe("build");
+    expect(sessionModeOf("some-adapter-string")).toBe("build");
+  });
+  it("calls exactly Plan and Ask read-only", () => {
+    // The mutant: dropping `ask` from isReadOnlyMode. Every gate that refuses mutations in Plan —
+    // the browser broker above all — would let an Ask session through, which is the one failure a
+    // read-only mode cannot have.
+    expect(isReadOnlyMode(PLAN_PERMISSION_MODE)).toBe(true);
+    expect(isReadOnlyMode(ASK_PERMISSION_MODE)).toBe(true);
+    for (const p of PERMISSION_MODES) expect(isReadOnlyMode(p.id), p.id).toBe(false);
   });
 });
 
@@ -180,13 +229,34 @@ describe("acpPlanMode / acpBuildMode (Plan 14 W3)", () => {
     // …even when the session booted elsewhere: `agent` is the mode Build claims to be.
     expect(acpBuildMode(CURSOR, "ask")?.id).toBe("agent");
   });
-  it("falls back to the boot mode, but never to the plan mode itself", () => {
-    const noAgent: AcpSessionMode[] = [{ id: "chat", name: "Chat" }, { id: "plan", name: "Plan" }];
+  it("falls back to the boot mode, but never to a read-only mode itself", () => {
+    const noAgent: AcpSessionMode[] = [{ id: "chat", name: "Chat" }, { id: "plan", name: "Plan" }, { id: "ask", name: "Ask" }];
     expect(acpBuildMode(noAgent, "chat")?.id).toBe("chat");
     // Booted in plan with no `agent` id: leaving Plan has nowhere honest to go.
     expect(acpBuildMode(noAgent, "plan")).toBeNull();
+    // The mutant: excluding only plan. A session that booted in Ask would "leave" Ask by being sent
+    // straight back into it, and the chip would flip to Build over a session that never moved.
+    expect(acpBuildMode(noAgent, "ask")).toBeNull();
     expect(acpBuildMode(noAgent, null)).toBeNull();
     expect(acpBuildMode(null, "agent")).toBeNull();
+  });
+
+  it("finds Cursor's ask mode by the agent's own id, and refuses a name that merely sounds like it", () => {
+    expect(acpAskMode(CURSOR)?.id).toBe("ask");
+    expect(acpAskMode(CURSOR)?.description).toContain("no edits or command execution");
+    expect(acpAskMode([{ id: "chat", name: "Ask" }, { id: "agent", name: "Agent" }])).toBeNull();
+    expect(acpAskMode([{ id: "agent", name: "Agent" }, { id: "plan", name: "Plan" }])).toBeNull();
+    expect(acpAskMode(null)).toBeNull();
+  });
+
+  it("reads the spec URI form of ask, the way Copilot reports plan", () => {
+    const uri = "https://agentclientprotocol.com/protocol/session-modes#ask";
+    expect(acpWellKnownMode(uri, "ask")).toBe(true);
+    expect(acpAskMode([{ id: uri, name: "Ask" }])?.id).toBe(uri);
+    // Plan and Ask must never resolve to each other.
+    expect(acpWellKnownMode(uri, "plan")).toBe(false);
+    expect(acpAskMode([{ id: "plan", name: "Plan" }])).toBeNull();
+    expect(acpPlanMode([{ id: "ask", name: "Ask" }])).toBeNull();
   });
 });
 

--- a/packages/contracts/src/presets.ts
+++ b/packages/contracts/src/presets.ts
@@ -172,8 +172,13 @@ export const AGENT_CONVERSATION_REWIND = {
  * `plan` is deliberately NOT here. It used to sit in this list, which conflated two different axes:
  * "how freely may the agent act" and "is the agent building or thinking". Plan is now its own chip
  * (see `AGENT_SUPPORTS_PLAN_MODE`), and the two are chosen independently.
+ *
+ * `default` is labelled "Ask each time" rather than "Ask", which is what it used to say. Ask is now a
+ * MODE on the other chip — read-only Q&A — and two controls in one row both offering something called
+ * Ask, meaning two unrelated things, is a question the user cannot answer. The longer label is also
+ * the more accurate one: this rung is about being asked per action, not about a way of working.
  */
-export const PERMISSION_MODES = [{ id: "default", label: "Ask" }, { id: "acceptEdits", label: "Accept edits" }, { id: "bypassPermissions", label: "Full access" }] as const;
+export const PERMISSION_MODES = [{ id: "default", label: "Ask each time" }, { id: "acceptEdits", label: "Accept edits" }, { id: "bypassPermissions", label: "Full access" }] as const;
 
 /**
  * Settings key for the permission mode NEW sessions start in (Plan 12 W6) — consumed server-side by
@@ -195,9 +200,44 @@ export const DEFAULT_PERMISSION_MODE_KEY = "sessions.defaultPermissionMode";
  * chose, so leaving Plan has to put it back rather than resetting to `default`.
  */
 export const PLAN_PERMISSION_MODE = "plan";
-/** Build/Plan, the mode axis. Build is the absence of Plan, not a value Realm ever transmits. */
-export const SESSION_MODES = [{ id: "build", label: "Build" }, { id: "plan", label: "Plan" }] as const;
+
+/**
+ * The wire value for Ask: a read-only Q&A mode — the agent may read and search the repo, and may not
+ * edit a file or run a command.
+ *
+ * It rides the `permissionMode` field for the same reason Plan does, and like Plan it is a MODE and
+ * not a permission rung: a session in Ask is not storing the permission the user chose, so leaving
+ * Ask has to put it back.
+ *
+ * Unlike Plan, no backend has a mode of this name, so every adapter enforces it in its own terms and
+ * the string itself is never transmitted anywhere:
+ *
+ *  - **Claude** — the SDK's `PermissionMode` union has no "ask", so `ClaudeAdapter` sends `default`
+ *    and refuses everything outside `claudeAskTools` in `canUseTool` before the call runs.
+ *  - **Codex** — `codexPolicyFor` maps it onto `approvalPolicy: "never"` + `sandbox: "read-only"`:
+ *    read-only, with no approval to escalate through. Strictly tighter than Plan, whose `untrusted`
+ *    policy can be answered "yes" and let a write out of the sandbox.
+ *  - **ACP** — the agent's OWN `ask` mode when it advertises one (`acpAskMode`), and no chip at all
+ *    when it does not.
+ */
+export const ASK_PERMISSION_MODE = "ask";
+
+/** Build/Plan/Ask, the mode axis. Build is the absence of the other two, not a value Realm transmits. */
+export const SESSION_MODES = [{ id: "build", label: "Build" }, { id: "plan", label: "Plan" }, { id: "ask", label: "Ask" }] as const;
 export type SessionMode = (typeof SESSION_MODES)[number]["id"];
+
+/** The wire value a mode travels on, or null for Build — which is the absence of one. */
+export const modeWireValue = (mode: SessionMode): string | null =>
+  mode === "plan" ? PLAN_PERMISSION_MODE : mode === "ask" ? ASK_PERMISSION_MODE : null;
+
+/** The mode a session's stored `permissionMode` puts it in. Anything else is a permission, so Build. */
+export const sessionModeOf = (permissionMode: string): SessionMode =>
+  permissionMode === PLAN_PERMISSION_MODE ? "plan" : permissionMode === ASK_PERMISSION_MODE ? "ask" : "build";
+
+/** Modes in which the agent must not change anything — no edits, no commands, no page mutations.
+ *  The one predicate every read-only gate asks, so widening the axis can never leave one behind. */
+export const isReadOnlyMode = (permissionMode: string): boolean =>
+  permissionMode === PLAN_PERMISSION_MODE || permissionMode === ASK_PERMISSION_MODE;
 
 /**
  * Agent kinds that can actually be put into Plan.
@@ -269,6 +309,36 @@ export const AGENT_SUPPORTS_PLAN_MODE = {
   fake: true,
 } as const satisfies Record<import("./entities").AgentKind, boolean>;
 
+/**
+ * Agent kinds whose adapter can actually ENFORCE Ask.
+ *
+ * Read-only is the whole feature: a mode that says the agent cannot edit and then lets it edit is
+ * worse than no mode, so an entry is `true` only where the adapter refuses the call itself and never
+ * because the agent can be asked nicely to behave.
+ *
+ * - `claude` — `canUseTool` denies anything outside `claudeAskTools` before it runs. The SDK's own
+ *   `Options.tools` is deliberately NOT the lever: it restricts the base set of BUILT-IN tools, so
+ *   an MCP server's mutating tool would walk straight past it, and it cannot be changed on a live
+ *   query (`Query` exposes `setPermissionMode` and `setModel` and nothing else) — a session that
+ *   started in Ask would be left without its tools until a restart after leaving it.
+ * - `codex` — `sandbox: "read-only"` refuses writes in the kernel (verified: a write under
+ *   `codex sandbox -c sandbox_mode='"read-only"'` fails "Operation not permitted"), and
+ *   `approvalPolicy: "never"` means there is no prompt through which to escalate out of it.
+ * - `acp:*` — false as the pre-handshake floor, exactly as for Plan: the answer is per session, and
+ *   `acpAskMode` gives it once THIS session's `session/new` has named its modes. Cursor advertises
+ *   `ask` ("no edits or command execution"); an agent that advertises none is offered nothing.
+ * - `fake` — the scripted adapter, so the development prompter shows the same controls as a real one.
+ */
+export const AGENT_SUPPORTS_ASK_MODE = {
+  claude: true, codex: true, "acp:cursor": false, "acp:gemini": false,
+  "acp:opencode": false, "acp:copilot": false, "acp:goose": false,
+  "acp:qwen": false, "acp:grok": false, "acp:fx": false,
+  // dsh-acp advertises no modes and no config options, so the handshake has nothing to raise this
+  // with — the one ACP kind where `false` is the final answer rather than a floor.
+  "acp:deepseek": false,
+  fake: true,
+} as const satisfies Record<import("./entities").AgentKind, boolean>;
+
 /** One advertised ACP session mode, as `session/new`'s `modes.availableModes` carries it. */
 export type AcpSessionMode = { id: string; name: string; description?: string };
 
@@ -287,6 +357,20 @@ export function acpPlanMode(modes: readonly AcpSessionMode[] | null | undefined)
 }
 
 /**
+ * The advertised mode Realm treats as Ask-equivalent, or null when the agent offers none.
+ *
+ * Same standard as `acpPlanMode` and the same refusal of fuzzy name matching: the agent's own id has
+ * to BE the well-known `"ask"`. Verified live against cursor-agent 2026.07.25, whose modes are
+ * `agent` / `plan` / `ask` with `ask` described as "no edits or command execution" — which is Ask's
+ * definition, arrived at independently. An agent that advertises no `ask` gets no Ask chip; there is
+ * nothing to fall back to, because a read-only mode Realm cannot name is a read-only mode Realm
+ * cannot enforce.
+ */
+export function acpAskMode(modes: readonly AcpSessionMode[] | null | undefined): AcpSessionMode | null {
+  return modes?.find((m) => acpWellKnownMode(m.id, "ask")) ?? null;
+}
+
+/**
  * The advertised mode Build maps back onto: the agent's `agent` mode when it has one (Cursor's
  * default), else the mode the session BOOTED in — provided that is not the plan mode itself.
  * Null means leaving Plan has nowhere honest to go, and the adapter sends nothing.
@@ -296,7 +380,9 @@ export function acpBuildMode(modes: readonly AcpSessionMode[] | null | undefined
   const agent = modes.find((m) => acpWellKnownMode(m.id, "agent"));
   if (agent) return agent;
   const boot = modes.find((m) => m.id === bootModeId);
-  return boot && !acpWellKnownMode(boot.id, "plan") ? boot : null;
+  // Neither read-only mode can stand in for Build: a session that BOOTED in Plan or Ask would
+  // otherwise "leave" it by being sent straight back into it.
+  return boot && !acpWellKnownMode(boot.id, "plan") && !acpWellKnownMode(boot.id, "ask") ? boot : null;
 }
 
 /**
@@ -309,7 +395,7 @@ export function acpBuildMode(modes: readonly AcpSessionMode[] | null | undefined
  */
 const ACP_MODE_URI_PREFIX = "https://agentclientprotocol.com/protocol/session-modes#";
 /** True when `id` is the bare well-known id or its spec URI form. */
-export function acpWellKnownMode(id: string, wellKnown: "plan" | "agent"): boolean {
+export function acpWellKnownMode(id: string, wellKnown: "plan" | "agent" | "ask"): boolean {
   return id === wellKnown || id === `${ACP_MODE_URI_PREFIX}${wellKnown}`;
 }
 

--- a/packages/contracts/src/session-events.ts
+++ b/packages/contracts/src/session-events.ts
@@ -23,6 +23,31 @@ const P = {
   status: z.object({ status: z.enum(["idle", "running", "waiting_permission", "error", "ended"]) }),
   error: z.object({ message: z.string() }),
   usage: z.object({ costUsd: z.number(), inputTokens: z.number(), outputTokens: z.number(), numTurns: z.number() }),
+  /** A plan the agent proposed. Both shapes are carried because the three protocols send genuinely
+   *  different artifacts and neither derives from the other:
+   *
+   *   - **Claude** — `ExitPlanMode`'s `input.plan`, markdown prose. No structure at all.
+   *   - **Codex** — TWO things. The `plan` ThreadItem is `{id, text}`, prose again; `turn/plan/updated`
+   *     is `{step, status}[]`, a checklist. (`codex app-server generate-ts`, codex 0.146.0.)
+   *   - **ACP** — the `plan` update's `entries: {content, status}[]`, a checklist
+   *     (docs/dev/acp-protocol.md:182).
+   *
+   *  Collapsing the checklist to prose would throw away per-step status; synthesising steps out of
+   *  Claude's markdown would invent structure it never sent. So a plan carries whichever it was given
+   *  and at least one is always present — a mapper holding neither emits nothing rather than a card
+   *  with no plan in it.
+   *
+   *  `planId` is the identity a REVISION lands on. Codex re-sends the whole plan on every
+   *  `turn/plan/updated` and ACP says its `plan` is "not incremental: replace the whole list each
+   *  time", so a repeat has to replace the card already drawn rather than stack a second one.
+   *
+   *  Both payload fields optional, per this file's rule that a new field must not break rows already
+   *  on disk — transcripts are rebuilt from `session_events` at every relaunch. */
+  plan: z.object({
+    planId: z.string(),
+    text: z.string().optional(),
+    steps: z.array(z.object({ text: z.string(), status: z.enum(["pending", "in_progress", "completed"]) })).optional(),
+  }),
   init: z.object({
     providerSessionId: z.string(), model: z.string(), tools: z.array(z.string()), cwd: z.string(),
     /** The instruction files the agent says it loaded — Codex `thread/start` `instructionSources`, W3's
@@ -54,6 +79,7 @@ export const SessionEventSchema = z.discriminatedUnion("type", [
   variant("error"),
   variant("usage"),
   variant("init"),
+  variant("plan"),
 ]);
 
 export type SessionEvent = z.infer<typeof SessionEventSchema>;
@@ -65,7 +91,7 @@ export function sessionEvent<T extends SessionEventType>(type: T, payload: Sessi
 }
 
 /** Event types the server persists; the rest (assistant_delta) are ephemeral. */
-export const PERSISTED_EVENT_TYPES: SessionEventType[] = ["user_message", "assistant_text", "thinking", "tool_call", "tool_result", "permission_request", "permission_response", "status", "error", "usage", "init"];
+export const PERSISTED_EVENT_TYPES: SessionEventType[] = ["user_message", "assistant_text", "thinking", "tool_call", "tool_result", "permission_request", "permission_response", "status", "error", "usage", "init", "plan"];
 
 export const StoredSessionEventSchema = z.object({ seq: z.number().int(), sessionId: z.string(), event: SessionEventSchema });
 export type StoredSessionEvent = { seq: number; sessionId: string; event: SessionEvent };


### PR DESCRIPTION
Stacked on #23.

## Plans

Realm was throwing plans away from all three backends. Claude's `ExitPlanMode` arrived as an ordinary tool call and rendered as a generic permission card whose summary clipped the plan markdown to one line; Codex's `turn/plan/updated` and `item/plan/delta` were swallowed by `map-codex.ts`'s `default: return []`; ACP's `plan` update was parsed and dropped.

The payload is `{ planId, text?, steps?: {text, status}[] }` — prose and checklist carried **independently**, at least one present. The split is not Claude-vs-the-rest as it first appears. Codex straddles it: the `plan` ThreadItem is `{id, text}` (prose) while `turn/plan/updated` is `{step, status}[]` (a checklist), verified against `codex app-server generate-ts` on codex 0.146.0. Claude's `ExitPlanMode` input is `{plan: markdown, planFilePath?}`, confirmed from real transcripts on disk because the generated types leave it to an index signature. Collapsing the checklist into prose loses per-step status; synthesising steps from Claude's markdown invents structure it never sent.

`planId` is what lets a revision replace the card instead of stacking a second one — Codex re-sends the whole list per step transition, ACP's spec says its plan "is not incremental", Claude re-proposes under a new `toolUseId`.

`item/plan/delta` is accumulated but never emitted live: it is flagged experimental and its own doc comment tells clients not to assume concatenated deltas match the completed item. It is flushed only as interrupt salvage, where there is no completed content to disagree with.

ExitPlanMode keeps its permission — it is how you leave Plan — but stops being a *permission card*: the plan renders as a block with a two-outcome row beneath it. There is no "Allow always", because a standing grant to leave Plan unasked is not something a user can mean. This also fixes an adjacent bug: approving a plan left Realm's own row still saying Plan while the agent built on, stranding the parked permission mode.

## Ask

Read-only, and enforced per backend rather than requested politely.

**Claude** — `canUseTool` denies anything outside an allow-list, before the tool runs, never prompting. `Options.tools` is deliberately not the lever: it restricts built-ins only, so any MCP server's mutating tool walks straight past it, and `Query` exposes only `setPermissionMode`/`setModel`, so it cannot change on a live session. An allow-list rather than a deny-list because Ask's value is that it is enforced, and a deny-list fails open on the next tool the CLI ships. `Bash` is excluded: nothing can tell from a command string whether it mutates, and guessing is the lie this mode exists to avoid. `Task` is excluded fail-closed, since the published types do not let Realm assert that a subagent's calls re-enter the gate.

**Codex** — `{approvalPolicy: "never", sandbox: "read-only"}`, genuinely distinguishable from Plan rather than a relabel: Plan's `untrusted` turns a refused write into an approval the user can say yes to, and that escalation lands the write. Verified live — `codex sandbox -c sandbox_mode='"read-only"'` fails a write with "Operation not permitted".

**ACP** — the agent's own `ask` mode id, matched by the same well-known-id standard as Plan, never by fuzzy name. Not offered on `acp:deepseek`, which advertises no modes at all.

`PERMISSION_MODES`' `default` is relabelled "Ask each time" — two controls in one row both offering "Ask" for unrelated things is unanswerable, and the longer label is also the more accurate one for a rung that means "ask me per action".

## A bug the mutation testing found

The `MODE_RANK` mutant initially survived, because the first test used an Ask *parent*, where the ranks tie and the mutant is invisible. Rewriting it as a `default` parent whose child requests `ask` exposed both the mutant and a real bug: `AgentRunConstraintsSchema`'s enum rejected `"ask"` outright, so the most restrictive mode a parent could ask for was refused rather than granted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)