### PR TITLE
Sending goes to the bottom, the branch chip stops being sliced in half, and the model picker can be asked who made a model

### DIFF
--- a/apps/desktop/scripts/composer-bar-live.mjs
+++ b/apps/desktop/scripts/composer-bar-live.mjs
@@ -1,0 +1,319 @@
+/**
+ * Live check for the prompter's control row across pane widths
+ * (run with: node apps/desktop/scripts/composer-bar-live.mjs)
+ *
+ * The row's width depends on content nobody controls: a branch name is user data and can be any
+ * length, and the pane it sits in can be a quarter of the window. Whether that row degrades or simply
+ * gets cut in half is a question about BOXES, so it is asked here rather than in jsdom, where every
+ * rect is zero and a chip sliced down the middle measures exactly like one that fits.
+ *
+ * The session is put on a scratch repo with a long branch, real +/- counts and dirty files, because
+ * an all-clean repo with a branch called `main` is the one case the row was never going to fail on.
+ *
+ * Ports: env-overridable. Touches only a scratch dir; kills only the process it started.
+ */
+import { execFileSync, spawn } from "node:child_process";
+import { connect } from "node:net";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
+const CDP_PORT = Number(process.env.LIVE_CDP_PORT ?? 9345), SERVER_PORT = Number(process.env.LIVE_SERVER_PORT ?? 8912);
+const scratch = fs.mkdtempSync(path.join(os.tmpdir(), "realm-bar-live-"));
+/** Long, but not absurd — this is a branch name of the kind this repo's own worktrees carry. */
+const BRANCH = "feature/prompter-composer-bar-responsive-overflow";
+/** Window widths to sweep. The session pane is what the row answers to (and what its container
+ *  queries measure), so these are a proxy for it: each one is reported with the pane width it
+ *  produced, which is the same range a split reaches on a window that stays at its 900px minimum. */
+const WIDTHS = (process.env.LIVE_WIDTHS ?? "1280,1040,900,780,700,620,560,500,440,400,360").split(",").map(Number);
+/**
+ * The narrowest pane this row is claimed to work at.
+ *
+ * Below it the row is over-subscribed by its FIXED controls alone — the "+", the mode chip, the model
+ * chip and the send button come to ~220px before a branch name is mentioned — so nothing the branch
+ * chip does can rescue it. That is a different repair (the mode chip needs the same fold into the
+ * model menu the permission chip already has), and pretending otherwise here would hide it. Those
+ * widths are still swept and printed, just not asserted on.
+ */
+const MIN_PANE = 320;
+const results = {};
+let electron = null;
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+async function portFree(port) {
+  return new Promise((resolve) => {
+    const s = connect({ port, host: "127.0.0.1" });
+    s.once("connect", () => { s.destroy(); resolve(false); });
+    s.once("error", () => resolve(true));
+  });
+}
+
+async function until(fn, ms, tag) {
+  const t0 = Date.now();
+  for (;;) {
+    const v = await fn();
+    if (v) return v;
+    if (Date.now() - t0 > ms) throw new Error(`timeout:${tag}`);
+    await sleep(150);
+  }
+}
+
+function cdp(wsUrl) {
+  const ws = new WebSocket(wsUrl);
+  let id = 0;
+  const pending = new Map();
+  const events = [];
+  const ready = new Promise((res) => ws.addEventListener("open", res));
+  ws.addEventListener("message", (m) => {
+    const msg = JSON.parse(m.data);
+    if (msg.id !== undefined) pending.get(msg.id)?.(msg);
+    else if (msg.method === "Runtime.consoleAPICalled" && msg.params.type === "error") {
+      events.push(msg.params.args.map((a) => a.value ?? a.description ?? "").join(" "));
+    }
+  });
+  return {
+    ready, events,
+    send: (method, params) => new Promise((res, rej) => {
+      const i = ++id;
+      pending.set(i, (msg) => (msg.error ? rej(new Error(msg.error.message)) : res(msg.result)));
+      ws.send(JSON.stringify({ id: i, method, params }));
+    }),
+    close: () => ws.close(),
+  };
+}
+
+function rpc(port) {
+  const ws = new WebSocket(`ws://127.0.0.1:${port}`);
+  let id = 0;
+  const pending = new Map();
+  const ready = new Promise((res) => ws.addEventListener("open", res));
+  ws.addEventListener("message", (m) => {
+    const msg = JSON.parse(m.data);
+    if (msg.id !== undefined) pending.get(msg.id)?.(msg);
+  });
+  return {
+    ready,
+    call: (method, params) => new Promise((res, rej) => {
+      const i = String(++id);
+      pending.set(i, (msg) => (msg.ok ? res(msg.result) : rej(new Error(`${method}: ${msg.error?.message}`))));
+      ws.send(JSON.stringify({ id: i, method, params }));
+    }),
+    close: () => ws.close(),
+  };
+}
+
+const HELPERS = `
+window.__live = window.__live ?? {
+  setInput(el, value) {
+    const proto = el instanceof HTMLTextAreaElement ? HTMLTextAreaElement.prototype : HTMLInputElement.prototype;
+    const set = Object.getOwnPropertyDescriptor(proto, "value").set;
+    set.call(el, value); el.dispatchEvent(new Event("input", { bubbles: true }));
+  },
+  box: (n) => { const b = n.getBoundingClientRect(); return { l: Math.round(b.left), r: Math.round(b.right), w: Math.round(b.width) }; },
+  // Everything the row's fitness depends on, in one read: what each control got, what it wanted,
+  // and whether it ends inside the box that is allowed to draw it.
+  row() {
+    const bar = document.querySelector(".composer-bar");
+    const opts = document.querySelector(".composer-opts");
+    const acts = document.querySelector(".composer-actions");
+    if (!bar || !opts) return null;
+    const optsBox = __live.box(opts);
+    const chip = (n) => {
+      const label = n.querySelector(".chip-label");
+      return {
+        cls: n.className.replace("ghost-chip", "").trim() || n.className,
+        ...__live.box(n),
+        // A label whose text is wider than its box is ellipsized; one whose right edge is past the
+        // group's is amputated by overflow:hidden, which looks nothing like truncation.
+        cut: Math.round(__live.box(n).r) > optsBox.r + 1,
+        ellipsis: !!label && label.scrollWidth > label.clientWidth + 1,
+        text: (n.textContent || "").trim().slice(0, 40),
+      };
+    };
+    return {
+      pane: __live.box(document.querySelector(".session-pane")).w,
+      bar: __live.box(bar).w,
+      opts: { ...optsBox, need: Math.round(opts.scrollWidth), have: Math.round(opts.clientWidth), collapsed: opts.hasAttribute("data-collapsed") },
+      acts: acts ? __live.box(acts) : null,
+      // The git button's own children too: shrinking the BUTTON below its content's minimum spills
+      // the branch chip out through the group's clip, which reads identically to the button being
+      // sliced and is invisible if only the outer box is measured.
+      items: [...opts.children, ...(opts.querySelector(".composer-git")?.children ?? [])].map(chip),
+      // The two controls that must survive every width: you can always send, and you can always
+      // see which model you are sending to.
+      send: !!document.querySelector(".composer-send") && __live.box(document.querySelector(".composer-send")).r <= __live.box(bar).r + 1,
+      model: document.querySelector(".model-chip") ? __live.box(document.querySelector(".model-chip")) : null,
+      git: document.querySelector(".composer-git") ? { ...__live.box(document.querySelector(".composer-git")), text: document.querySelector(".composer-git").textContent.trim() } : null,
+      gitTitle: document.querySelector(".composer-git")?.title ?? null,
+    };
+  },
+};
+void 0`;
+
+async function evalIn(c, expr) {
+  const r = await c.send("Runtime.evaluate", { expression: HELPERS + ";\n" + expr, awaitPromise: true, returnByValue: true });
+  if (r.exceptionDetails) throw new Error(`page exception: ${r.exceptionDetails.exception?.description ?? r.exceptionDetails.text}`);
+  return r.result.value;
+}
+
+const check = (name, cond, detail) => {
+  results[name] = { pass: !!cond, ...(detail !== undefined ? { detail } : {}) };
+  if (!cond) process.exitCode = 1;
+  console.log(`${cond ? "PASS" : "FAIL"} ${name}${detail !== undefined ? " " + JSON.stringify(detail) : ""}`);
+};
+
+/** A repo the git chip has something to say about: long branch, real diff counts, dirty files. */
+function seedRepo(dir) {
+  const git = (...args) => execFileSync("git", args, { cwd: dir, stdio: "pipe" });
+  fs.mkdirSync(dir, { recursive: true });
+  git("init", "-q", "-b", BRANCH);
+  git("config", "user.email", "live@example.com");
+  git("config", "user.name", "Live");
+  fs.writeFileSync(path.join(dir, "a.txt"), Array.from({ length: 40 }, (_, i) => `line ${i}`).join("\n") + "\n");
+  fs.writeFileSync(path.join(dir, "b.txt"), "kept\n");
+  git("add", "-A");
+  git("commit", "-q", "-m", "seed");
+  fs.writeFileSync(path.join(dir, "a.txt"), Array.from({ length: 60 }, (_, i) => `changed ${i}`).join("\n") + "\n");
+  fs.writeFileSync(path.join(dir, "c.txt"), "new\n");
+}
+
+async function main() {
+  for (const p of [CDP_PORT, SERVER_PORT]) {
+    if (!(await portFree(p))) throw new Error(`port ${p} is in use — refusing to run`);
+  }
+
+  const wrapper = path.join(scratch, "wrapper.mjs");
+  fs.writeFileSync(wrapper, [
+    'import { app } from "electron";',
+    'app.setPath("userData", process.env.LIVE_USER_DATA);',
+    "await import(process.env.LIVE_MAIN);",
+  ].join("\n"));
+  const electronBin = process.platform === "darwin"
+    ? path.join(repoRoot, "node_modules/.pnpm/electron@37.10.3/node_modules/electron/dist/Electron.app/Contents/MacOS/Electron")
+    : path.join(repoRoot, "apps/desktop/node_modules/.bin/electron");
+  electron = spawn(electronBin, [wrapper], {
+    env: {
+      ...process.env,
+      REALM_HOME: path.join(scratch, "home"),
+      REALM_PORT: String(SERVER_PORT),
+      REALM_DEVTOOLS_PORT: String(CDP_PORT),
+      REALM_SERVER_ENTRY: path.join(repoRoot, "apps/server/dist/main.js"),
+      REALM_ENABLE_FAKE_AGENT: "1",
+      LIVE_USER_DATA: path.join(scratch, "userData"),
+      LIVE_MAIN: path.join(repoRoot, "apps/desktop/out/main/index.js"),
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  electron.stderr.on("data", () => {}); electron.stdout.on("data", () => {});
+
+  const targets = () => fetch(`http://127.0.0.1:${CDP_PORT}/json/list`).then((r) => r.json()).catch(() => []);
+  const rendererTarget = await until(async () => (await targets()).find((t) => t.type === "page" && t.url.startsWith("file://")), 30000, "renderer target");
+  const c = cdp(rendererTarget.webSocketDebuggerUrl);
+  await c.ready;
+  await c.send("Runtime.enable");
+  await c.send("Page.enable");
+
+  await until(() => evalIn(c, `!!document.querySelector('.onboarding input:not([type=radio])')`), 20000, "onboarding");
+  await evalIn(c, `(() => {
+    const input = document.querySelector('.onboarding input:not([type=radio])');
+    __live.setInput(input, "Live");
+    input.closest("form").requestSubmit();
+    return true; })()`);
+  await until(() => evalIn(c, `!!document.querySelector('.composer')`), 20000, "composer");
+
+  const api = rpc(SERVER_PORT);
+  await api.ready;
+  const sessions = await until(async () => {
+    const all = await api.call("sessions.listAll", {});
+    return all.length ? all : null;
+  }, 15000, "a session to drive");
+  const session = sessions[0];
+  // `fake` keeps the send from needing a login; the send itself is only here to make the store
+  // re-read git for this session's cwd, which is event-driven.
+  await api.call("sessions.setAgent", { id: session.id, agentKind: "fake" });
+  seedRepo(session.cwd);
+  // The chip can only be as good as what the server reads; separating the two makes a failure here
+  // say which half broke. Polled because opening the session already asked once, before the repo
+  // existed, and GitInfoService holds that `null` for its 3s TTL.
+  const serverGit = await until(async () => {
+    const g = await api.call("workspace.gitInfo", { cwd: session.cwd });
+    return g?.branch === BRANCH ? g : null;
+  }, 20000, "the server to see the scratch repo");
+  check("the server reads the scratch repo the session sits in",
+    serverGit.branch === BRANCH && serverGit.dirty > 0, { cwd: session.cwd, serverGit });
+  // A finished turn is what makes the store re-read git for this cwd (the refresh is event-driven).
+  await api.call("sessions.send", { id: session.id, text: "hello", attachments: [], mentions: [] });
+
+  const gitReady = await until(async () => {
+    const r = await evalIn(c, `__live.row()`);
+    return r?.git ? r : null;
+  }, 25000, "the branch chip");
+  check("the branch chip is showing a real repo's branch, diff and dirty count",
+    gitReady.git.text.includes("prompter") && /\d/.test(gitReady.git.text), { text: gitReady.git.text, title: gitReady.gitTitle });
+
+  const sweep = [];
+  for (const width of WIDTHS) {
+    await c.send("Emulation.setDeviceMetricsOverride", { width, height: 860, deviceScaleFactor: 2, mobile: false });
+    // Two frames: the ResizeObserver that decides the collapse runs after layout, and the row it
+    // then re-renders has to be laid out again before it can be measured.
+    await sleep(400);
+    const row = await evalIn(c, `__live.row()`);
+    sweep.push({ width, ...row });
+    const cutItems = row.items.filter((i) => i.cut).map((i) => i.cls);
+    console.log(`WIDTH ${String(width).padStart(4)} pane=${String(row.pane).padStart(4)} opts need=${String(row.opts.need).padStart(4)} have=${String(row.opts.have).padStart(4)} collapsed=${row.opts.collapsed ? "y" : "n"} cut=[${cutItems.join(" ")}] git=${row.git ? row.git.w : "-"} model=${row.model ? row.model.w : "-"}`);
+  }
+  fs.writeFileSync(path.join(os.tmpdir(), "realm-composer-bar.json"), JSON.stringify(sweep, null, 2));
+
+  // ── What the row must be true of at every width it is claimed at ─────────
+  const room = sweep.filter((s) => s.pane >= MIN_PANE);
+  for (const s of sweep.filter((s) => s.pane < MIN_PANE)) {
+    console.log(`INFO pane=${s.pane} is below the claimed floor (${MIN_PANE}px) — fixed controls alone do not fit`);
+  }
+  const amputated = room.filter((s) => s.items.some((i) => i.cut));
+  check("no control is ever sliced by the group's overflow — a chip either fits or is not on the row",
+    amputated.length === 0, amputated.map((s) => ({ width: s.width, cut: s.items.filter((i) => i.cut).map((i) => i.cls) })));
+
+  const branchless = room.filter((s) => !s.git);
+  check("the branch chip is present at every width it is offered at", branchless.length === 0, branchless.map((s) => s.width));
+
+  const truncated = room.filter((s) => s.git && s.items.some((i) => i.cls.includes("git-branch") && i.ellipsis));
+  check("a branch too long for the pane is ellipsized rather than dropped or clipped",
+    truncated.length > 0, { panes: truncated.map((s) => s.pane) });
+  // The point of capping against the pane rather than at a flat 160px: a wide pane spends its slack
+  // on the name, a narrow one takes it back.
+  const widest = room[0], narrowest = room[room.length - 1];
+  check("the branch chip uses the room it has — wider pane, more name",
+    widest.git.w > narrowest.git.w + 100, { widest: { pane: widest.pane, git: widest.git.w }, narrowest: { pane: narrowest.pane, git: narrowest.git.w } });
+
+  check("the full branch name is always one hover away", /prompter-composer-bar-responsive-overflow/.test(gitReady.gitTitle ?? ""), gitReady.gitTitle);
+
+  const sendLost = room.filter((s) => !s.send);
+  check("the send button is inside the card at every width", sendLost.length === 0, sendLost.map((s) => s.width));
+
+  const modelLost = room.filter((s) => !s.model || s.model.w < 40);
+  check("the model chip keeps a usable width at every pane size", modelLost.length === 0, modelLost.map((s) => ({ width: s.width, model: s.model })));
+
+  // Narrow but supported: the pane where the numbers have gone and the name is down to a few
+  // characters, which is the width the row used to be cut in half at.
+  await c.send("Emulation.setDeviceMetricsOverride", { width: 700, height: 860, deviceScaleFactor: 2, mobile: false });
+  await sleep(400);
+  const shot = await c.send("Page.captureScreenshot", { format: "png" });
+  const out = path.join(os.tmpdir(), "realm-composer-bar.png");
+  fs.writeFileSync(out, Buffer.from(shot.data, "base64"));
+  console.log(`SCREENSHOT ${out}`);
+  console.log(`SWEEP ${path.join(os.tmpdir(), "realm-composer-bar.json")}`);
+
+  const errs = c.events.filter((e) => !e.includes("Autofill"));
+  check("no renderer console errors", errs.length === 0, errs.slice(0, 5));
+  api.close();
+  c.close();
+}
+
+main()
+  .catch((e) => { console.error("ERROR", e.message); process.exitCode = 1; })
+  .finally(() => {
+    electron?.kill("SIGTERM");
+    setTimeout(() => { electron?.kill("SIGKILL"); fs.rmSync(scratch, { recursive: true, force: true }); process.exit(process.exitCode ?? 0); }, 1200);
+  });

--- a/apps/desktop/scripts/model-picker-live.mjs
+++ b/apps/desktop/scripts/model-picker-live.mjs
@@ -201,8 +201,66 @@ async function main() {
   check("the detail pane says what the harness is for and how it bills",
     !!harness.good && !!harness.billing, harness);
 
+  /* ── 6. The provider strip. Live because it is only real with a real catalog: the chips are the
+        MAKERS the catalog attributes the rows to, so offline there is no axis and no strip — a
+        state jsdom can stage but only this can confirm the app actually reaches. */
+  if (priced) {
+    const strip = await evalIn(c, `(() => {
+      const g = document.querySelector('.mp-vendors');
+      if (!g) return null;
+      const r = (n) => { const b = n.getBoundingClientRect(); return { top: Math.round(b.top), bottom: Math.round(b.bottom) }; };
+      const chips = [...g.querySelectorAll('[role="radio"]')];
+      return {
+        labels: chips.map((b) => b.textContent),
+        lit: chips.find((b) => b.getAttribute('aria-checked') === 'true')?.textContent ?? null,
+        rows: [...new Set(chips.map((b) => Math.round(b.getBoundingClientRect().top)))].length,
+        search: r(document.querySelector('.mp-search')), self: r(g), list: r(document.querySelector('.mp-list')),
+        // One tab stop for the strip, the roving-radio way.
+        tabbable: chips.filter((b) => b.tabIndex === 0).map((b) => b.textContent),
+      };
+    })()`);
+    check("a provider strip sits between the search field and the list",
+      strip && strip.self.top >= strip.search.bottom - 1 && strip.self.bottom <= strip.list.top + 1, strip);
+    check("it leads with the way back, on one line, as a single tab stop",
+      strip && strip.labels[0] === "All" && strip.lit === "All" && strip.rows === 1 && strip.tabbable.length === 1,
+      strip && { labels: strip.labels.slice(0, 6), rows: strip.rows, tabbable: strip.tabbable });
+
+    const narrowing = await evalIn(c, `(async () => {
+      const count = () => document.querySelectorAll('.mp-list [role="option"]').length;
+      const chips = [...document.querySelectorAll('.mp-vendors [role="radio"]')];
+      const all = count();
+      const vendor = chips[1];
+      vendor.click();
+      await new Promise((r) => setTimeout(r, 200));
+      const narrowed = count();
+      const lit = document.querySelector('.mp-vendors [aria-checked="true"]')?.textContent ?? null;
+      chips[0].click();
+      await new Promise((r) => setTimeout(r, 200));
+      return { all, narrowed, lit, vendor: vendor.textContent, restored: count() };
+    })()`);
+    check("choosing a provider narrows the list to it, and All brings the rest back",
+      narrowing.narrowed > 0 && narrowing.narrowed < narrowing.all && narrowing.lit === narrowing.vendor
+        && narrowing.restored === narrowing.all, narrowing);
+
+    // The collision the strip was easiest to get wrong: ←/→ already walk the highlighted model's
+    // ROUTES from the search field, and must go on meaning only that.
+    const arrows = await evalIn(c, `(async () => {
+      const input = document.querySelector('.mp-search input');
+      input.focus();
+      const before = document.querySelector('.mp-vendors [aria-checked="true"]')?.textContent ?? null;
+      for (const key of ["ArrowRight", "ArrowRight"]) {
+        input.dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true }));
+      }
+      await new Promise((r) => setTimeout(r, 200));
+      return { before, after: document.querySelector('.mp-vendors [aria-checked="true"]')?.textContent ?? null };
+    })()`);
+    check("←/→ in the search field leave the provider alone", arrows.before === arrows.after, arrows);
+  } else {
+    console.log("SKIP the provider strip — no catalog, so there is no vendor axis to draw (offline is a supported state)");
+  }
+
   // CDP's clip takes x/y/width/height only — the rect helper's edges would be rejected outright.
-  // 6. The fx mark actually PAINTS. Its path is lifted from a full lockup, so it starts 166 units
+  // 7. The fx mark actually PAINTS. Its path is lifted from a full lockup, so it starts 166 units
   //    from the origin: with the set's default `0 0 24 24` viewBox the glyph sits entirely
   //    off-canvas and the row renders a blank 15px hole — which no DOM assertion can see, because
   //    the <svg> and its <path> are both present and correct. Count ink instead.

--- a/apps/desktop/scripts/prompter-pin-live.mjs
+++ b/apps/desktop/scripts/prompter-pin-live.mjs
@@ -1,0 +1,270 @@
+/**
+ * Live check for the prompter's stick-to-bottom (run with: node apps/desktop/scripts/prompter-pin-live.mjs)
+ *
+ * The claim is that SENDING pins the transcript to the bottom, and jsdom cannot hold an opinion about
+ * it: with no layout, `scrollHeight` and `clientHeight` are both 0, `scrollHeight - scrollTop -
+ * clientHeight < 80` is true of every element on the page, and every scroller looks pinned already.
+ * A jsdom test can stage those numbers — and one does — but only a real window can say whether the
+ * transcript overflows in the first place, whether the composer's send reaches the scroller, and
+ * whether the pin is still in force when the `user_message` block gets back from the server.
+ *
+ * The scripted adapter is the lever. Messages pushed straight over RPC arrive in the transcript
+ * WITHOUT going through the prompter, which is both how the scrollback gets built and how the
+ * control case is staged: a block the reader did not send must still raise the pill, or "sending
+ * scrolls" would be indistinguishable from "everything scrolls".
+ *
+ * Ports: env-overridable. Touches only a scratch dir; kills only the process it started.
+ */
+import { spawn } from "node:child_process";
+import { connect } from "node:net";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
+const CDP_PORT = Number(process.env.LIVE_CDP_PORT ?? 9344), SERVER_PORT = Number(process.env.LIVE_SERVER_PORT ?? 8911);
+const scratch = fs.mkdtempSync(path.join(os.tmpdir(), "realm-pin-live-"));
+/** Transcript.tsx's NEAR_BOTTOM_PX — the slack "at the bottom" is allowed. */
+const NEAR_BOTTOM_PX = 80;
+const results = {};
+let electron = null;
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+async function portFree(port) {
+  return new Promise((resolve) => {
+    const s = connect({ port, host: "127.0.0.1" });
+    s.once("connect", () => { s.destroy(); resolve(false); });
+    s.once("error", () => resolve(true));
+  });
+}
+
+async function until(fn, ms, tag) {
+  const t0 = Date.now();
+  for (;;) {
+    const v = await fn();
+    if (v) return v;
+    if (Date.now() - t0 > ms) throw new Error(`timeout:${tag}`);
+    await sleep(150);
+  }
+}
+
+function cdp(wsUrl) {
+  const ws = new WebSocket(wsUrl);
+  let id = 0;
+  const pending = new Map();
+  const events = [];
+  const ready = new Promise((res) => ws.addEventListener("open", res));
+  ws.addEventListener("message", (m) => {
+    const msg = JSON.parse(m.data);
+    if (msg.id !== undefined) pending.get(msg.id)?.(msg);
+    else if (msg.method === "Runtime.consoleAPICalled" && msg.params.type === "error") {
+      events.push(msg.params.args.map((a) => a.value ?? a.description ?? "").join(" "));
+    }
+  });
+  return {
+    ready, events,
+    send: (method, params) => new Promise((res, rej) => {
+      const i = ++id;
+      pending.set(i, (msg) => (msg.error ? rej(new Error(msg.error.message)) : res(msg.result)));
+      ws.send(JSON.stringify({ id: i, method, params }));
+    }),
+    close: () => ws.close(),
+  };
+}
+
+function rpc(port) {
+  const ws = new WebSocket(`ws://127.0.0.1:${port}`);
+  let id = 0;
+  const pending = new Map();
+  const ready = new Promise((res) => ws.addEventListener("open", res));
+  ws.addEventListener("message", (m) => {
+    const msg = JSON.parse(m.data);
+    if (msg.id !== undefined) pending.get(msg.id)?.(msg);
+  });
+  return {
+    ready,
+    call: (method, params) => new Promise((res, rej) => {
+      const i = String(++id);
+      pending.set(i, (msg) => (msg.ok ? res(msg.result) : rej(new Error(`${method}: ${msg.error?.message}`))));
+      ws.send(JSON.stringify({ id: i, method, params }));
+    }),
+    close: () => ws.close(),
+  };
+}
+
+const HELPERS = `
+window.__live = window.__live ?? {
+  setInput(el, value) {
+    const proto = el instanceof HTMLTextAreaElement ? HTMLTextAreaElement.prototype : HTMLInputElement.prototype;
+    const set = Object.getOwnPropertyDescriptor(proto, "value").set;
+    set.call(el, value); el.dispatchEvent(new Event("input", { bubbles: true }));
+  },
+  scroller: () => document.querySelector(".transcript"),
+  // What the component itself computes, plus the two facts that explain it.
+  where() {
+    const el = window.__live.scroller();
+    if (!el) return null;
+    return {
+      top: Math.round(el.scrollTop),
+      slack: Math.round(el.scrollHeight - el.scrollTop - el.clientHeight),
+      overflow: Math.round(el.scrollHeight - el.clientHeight),
+      pill: !!document.querySelector(".new-msgs-pill"),
+    };
+  },
+  // The reader dragging the bar: move it, and let the component's own onScroll observe the move.
+  readerScrollsTo(v) {
+    const el = window.__live.scroller();
+    el.scrollTop = v;
+    el.dispatchEvent(new Event("scroll", { bubbles: false }));
+  },
+};
+void 0`;
+
+async function evalIn(c, expr) {
+  const r = await c.send("Runtime.evaluate", { expression: HELPERS + ";\n" + expr, awaitPromise: true, returnByValue: true });
+  if (r.exceptionDetails) throw new Error(`page exception: ${r.exceptionDetails.exception?.description ?? r.exceptionDetails.text}`);
+  return r.result.value;
+}
+
+const check = (name, cond, detail) => {
+  results[name] = { pass: !!cond, ...(detail !== undefined ? { detail } : {}) };
+  if (!cond) process.exitCode = 1;
+  console.log(`${cond ? "PASS" : "FAIL"} ${name}${detail !== undefined ? " " + JSON.stringify(detail) : ""}`);
+};
+
+async function main() {
+  for (const p of [CDP_PORT, SERVER_PORT]) {
+    if (!(await portFree(p))) throw new Error(`port ${p} is in use — refusing to run`);
+  }
+
+  const wrapper = path.join(scratch, "wrapper.mjs");
+  fs.writeFileSync(wrapper, [
+    'import { app } from "electron";',
+    'app.setPath("userData", process.env.LIVE_USER_DATA);',
+    "await import(process.env.LIVE_MAIN);",
+  ].join("\n"));
+  const electronBin = process.platform === "darwin"
+    ? path.join(repoRoot, "node_modules/.pnpm/electron@37.10.3/node_modules/electron/dist/Electron.app/Contents/MacOS/Electron")
+    : path.join(repoRoot, "apps/desktop/node_modules/.bin/electron");
+  electron = spawn(electronBin, [wrapper], {
+    env: {
+      ...process.env,
+      REALM_HOME: path.join(scratch, "home"),
+      REALM_PORT: String(SERVER_PORT),
+      REALM_DEVTOOLS_PORT: String(CDP_PORT),
+      REALM_SERVER_ENTRY: path.join(repoRoot, "apps/server/dist/main.js"),
+      REALM_ENABLE_FAKE_AGENT: "1",
+      LIVE_USER_DATA: path.join(scratch, "userData"),
+      LIVE_MAIN: path.join(repoRoot, "apps/desktop/out/main/index.js"),
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  electron.stderr.on("data", () => {}); electron.stdout.on("data", () => {});
+
+  const targets = () => fetch(`http://127.0.0.1:${CDP_PORT}/json/list`).then((r) => r.json()).catch(() => []);
+  const rendererTarget = await until(async () => (await targets()).find((t) => t.type === "page" && t.url.startsWith("file://")), 30000, "renderer target");
+  const c = cdp(rendererTarget.webSocketDebuggerUrl);
+  await c.ready;
+  await c.send("Runtime.enable");
+  await c.send("Page.enable");
+
+  await until(() => evalIn(c, `!!document.querySelector('.onboarding input:not([type=radio])')`), 20000, "onboarding");
+  await evalIn(c, `(() => {
+    const input = document.querySelector('.onboarding input:not([type=radio])');
+    __live.setInput(input, "Live");
+    input.closest("form").requestSubmit();
+    return true; })()`);
+  await until(() => evalIn(c, `!!document.querySelector('.composer')`), 20000, "composer");
+
+  // Short window on purpose: the transcript has to actually overflow, and a handful of echoed
+  // messages is a cheaper way to get there than fifty.
+  await c.send("Emulation.setDeviceMetricsOverride", { width: 1180, height: 620, deviceScaleFactor: 2, mobile: false });
+  await sleep(400);
+
+  // `fake` is deliberately not in SELECTABLE_AGENT_KINDS, so the switch goes over RPC rather than
+  // through the model chip — the same route media-live.mjs takes, for the same reason.
+  const api = rpc(SERVER_PORT);
+  await api.ready;
+  const sessions = await until(async () => {
+    const all = await api.call("sessions.listAll", {});
+    return all.length ? all : null;
+  }, 15000, "a session to drive");
+  const sessionId = sessions[0].id;
+  await api.call("sessions.setAgent", { id: sessionId, agentKind: "fake" });
+
+  // Scrollback, pushed straight at the server: these never touch the prompter, so nothing here can
+  // be confused for the gesture under test.
+  const filler = (n) => `Turn ${n}. ${"The transcript needs enough height to have a top and a bottom that differ. ".repeat(4)}`;
+  for (let i = 1; i <= 6; i++) await api.call("sessions.send", { id: sessionId, text: filler(i), attachments: [], mentions: [] });
+
+  const deep = await until(async () => {
+    const w = await evalIn(c, `__live.where()`);
+    return w && w.overflow > 400 ? w : null;
+  }, 25000, "a transcript with somewhere to scroll");
+  check("the transcript overflows, so 'the bottom' is a place you can be away from", deep.overflow > 400, deep);
+
+  // ── The control. A reader who has scrolled up gets the pill, not a yank ──
+  await evalIn(c, `__live.readerScrollsTo(0)`);
+  await sleep(150);
+  await api.call("sessions.send", { id: sessionId, text: filler(7), attachments: [], mentions: [] });
+  const control = await until(async () => {
+    const w = await evalIn(c, `__live.where()`);
+    return w && w.pill ? w : null;
+  }, 15000, "the new-messages pill");
+  check("a block the reader did not send raises the pill and leaves them where they were",
+    control.pill && control.top === 0, control);
+
+  // ── The gesture. Same reader, same place, but this time they send ──
+  await until(() => evalIn(c, `!!document.querySelector('.composer-send[data-state="send"]')`), 20000, "an idle prompter");
+  await evalIn(c, `__live.readerScrollsTo(0)`);
+  await sleep(150);
+  const before = await evalIn(c, `__live.where()`);
+  check("the reader is genuinely at the top before sending", before.top === 0 && before.slack > NEAR_BOTTOM_PX, before);
+
+  await evalIn(c, `(() => {
+    __live.setInput(document.querySelector(".composer-input"), "and what about the send path");
+    return true; })()`);
+  await sleep(120);
+  await evalIn(c, `(() => { document.querySelector('.composer-send').click(); return true; })()`);
+
+  // Measured BEFORE the round trip lands: the pin is the gesture's, not the arriving block's.
+  await sleep(120);
+  const onSend = await evalIn(c, `__live.where()`);
+  check("the send scrolls to the bottom immediately, before the server has answered",
+    onSend.slack <= NEAR_BOTTOM_PX && !onSend.pill, onSend);
+
+  // …and is still in force when the user's own message actually arrives, seconds later. The pill
+  // here would mean the reader was notified about the message they had just typed.
+  const landed = await until(async () => {
+    const seen = await evalIn(c, `(() => {
+      const last = [...document.querySelectorAll('.msg-user')].pop();
+      return last && last.textContent.includes("and what about the send path") ? __live.where() : null;
+    })()`);
+    return seen;
+  }, 20000, "the sent message in the transcript");
+  check("the pin survives the round trip: the user's own message lands at the bottom, no pill",
+    landed.slack <= NEAR_BOTTOM_PX && !landed.pill, landed);
+
+  // The echo is a THIRD arrival, after the pin was set and after the block landed — still bottom.
+  await sleep(1200);
+  const echoed = await evalIn(c, `__live.where()`);
+  check("the reply that follows keeps the reader at the bottom", echoed.slack <= NEAR_BOTTOM_PX && !echoed.pill, echoed);
+
+  const shot = await c.send("Page.captureScreenshot", { format: "png" });
+  const out = path.join(os.tmpdir(), "realm-prompter-pin.png");
+  fs.writeFileSync(out, Buffer.from(shot.data, "base64"));
+  console.log(`SCREENSHOT ${out}`);
+
+  const errs = c.events.filter((e) => !e.includes("Autofill"));
+  check("no renderer console errors", errs.length === 0, errs.slice(0, 5));
+  api.close();
+  c.close();
+}
+
+main()
+  .catch((e) => { console.error("ERROR", e.message); process.exitCode = 1; })
+  .finally(() => {
+    electron?.kill("SIGTERM");
+    setTimeout(() => { electron?.kill("SIGKILL"); fs.rmSync(scratch, { recursive: true, force: true }); process.exit(process.exitCode ?? 0); }, 1200);
+  });

--- a/apps/desktop/src/renderer/src/panes/session/ModelPicker.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/ModelPicker.tsx
@@ -1,9 +1,9 @@
 import { AGENT_META, AGENT_NOTES, DEFAULT_MODEL_LABEL, formatContext, formatPrice, type AgentKind, type ModelInfo } from "@realm/contracts";
 import { Icon } from "@realm/ui";
-import { useCallback, useEffect, useMemo, useRef, useState, type KeyboardEvent } from "react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, type KeyboardEvent } from "react";
 import { createPortal } from "react-dom";
 import { useAnchoredPopover } from "../../components/use-anchored-popover";
-import { filterRows, flatten, groupRows, modelDetail, modelIdOn, type ModelRow } from "./model-rows";
+import { filterRows, filterVendor, flatten, groupRows, modelDetail, modelIdOn, modelVendor, vendorsOf, type ModelRow } from "./model-rows";
 
 /** How many favourites get a ⌘-digit shortcut. Nine because ⌘0 is not a tenth — it is a different
  *  key users read as "zero", and a tenth badge nobody can press is worse than no badge. */
@@ -103,8 +103,43 @@ function ModelPopover({ rows, info, anchorRef, onClose, onPick, onToggleFavorite
    *  at — a route is a property of the choice being made, not a mode the picker is in. */
   const [routes, setRoutes] = useState<Record<string, AgentKind>>({});
 
-  const groups = useMemo(() => groupRows(filterRows(rows, query), { query }), [rows, query]);
+  /** The provider narrowing, or null for all of them. See `modelVendor` for why a provider here is
+   *  the model's VENDOR and not the harness that runs it. */
+  const [vendor, setVendor] = useState<string | null>(null);
+  const strip = useRef<HTMLDivElement>(null);
+  // The chips come from the UNFILTERED rows, so the strip is a fixed set that neither the query nor
+  // a previous pick can reflow out from under the pointer.
+  const vendors = useMemo(() => vendorsOf(rows, info), [rows, info]);
+  const queried = useMemo(() => filterRows(rows, query), [rows, query]);
+  const groups = useMemo(() => groupRows(filterVendor(queried, vendor, info), { query }), [queried, vendor, info, query]);
   const shown = useMemo(() => flatten(groups), [groups]);
+  // What each chip would leave, counted against the TEXT query alone — a chip has to be able to say
+  // "nothing of mine survives what you typed" without that answer depending on which chip is lit.
+  const vendorCounts = useMemo(() => {
+    const n = new Map<string, number>();
+    for (const r of queried) { const v = modelVendor(r, info); if (v) n.set(v, (n.get(v) ?? 0) + 1); }
+    return n;
+  }, [queried, info]);
+  /** `null` is "All", and it leads the strip — the way back is always the first thing in it. */
+  const chips = useMemo((): (string | null)[] => [null, ...vendors], [vendors]);
+  const chooseVendor = (v: string | null) => { setVendor(v); setActiveKey(null); };
+  // Roving focus, the radio-group way: the strip is ONE tab stop, so the arrows have to carry focus
+  // to whichever chip they just lit or the next press would come from a button nobody is on.
+  useLayoutEffect(() => {
+    const el = strip.current;
+    // Only when the strip already had focus: a mouse pick must not pull it out of the search field.
+    if (!el || !el.contains(document.activeElement)) return;
+    el.querySelector<HTMLElement>('[aria-checked="true"]')?.focus();
+  }, [vendor]);
+  // Bound on the strip and not on the popover, which is what lets these share a keystroke with the
+  // ←/→ that walks the highlighted model's routes: that handler is the search field's, and these keys
+  // mean "next provider" only while focus is in here.
+  const onVendorKey = (e: KeyboardEvent) => {
+    if (e.key !== "ArrowLeft" && e.key !== "ArrowRight") return;
+    e.preventDefault();
+    const at = chips.indexOf(vendor);
+    chooseVendor(chips[(at + (e.key === "ArrowRight" ? 1 : chips.length - 1)) % chips.length] ?? null);
+  };
   // Numbered by POSITION IN THE LIST, not by when they were starred: a badge column that reads
   // 1,2,3 down the page is legible, and one that reads 3,1,2 because that was the starring order is
   // not. The cost is that starring a model renumbers the ones below it, which is a rare thing the
@@ -174,6 +209,21 @@ function ModelPopover({ rows, info, anchorRef, onClose, onPick, onToggleFavorite
           role="combobox" aria-expanded aria-controls="mp-list" aria-activedescendant={activeRow ? `mp-${activeRow.key}` : undefined}
           onChange={(e) => { setQuery(e.target.value); setActiveKey(null); }} onKeyDown={onKeyDown} />
       </div>
+      {/* Under the search rather than beside the list, because it narrows what the search searches:
+          the two compose, and reading them top to bottom is the order the question is asked in. */}
+      {vendors.length > 0 && (
+        <div ref={strip} className="mp-vendors" role="radiogroup" aria-label="Provider" onKeyDown={onVendorKey}>
+          {chips.map((v) => (
+            <button key={v ?? "all"} type="button" role="radio" aria-checked={v === vendor} className="mp-vendor"
+              // Dimmed, never disabled: a provider the query has emptied is still worth being able to
+              // land on, and the list says so in words when you do.
+              data-empty={v !== null && (vendorCounts.get(v) ?? 0) === 0 ? "" : undefined}
+              tabIndex={v === vendor ? 0 : -1} onClick={() => chooseVendor(v)}>
+              {v ?? "All"}
+            </button>
+          ))}
+        </div>
+      )}
       <div className="mp-body">
         <div className="mp-list" id="mp-list" role="listbox" aria-label="Models">
           {groups.map((g) => (
@@ -218,7 +268,16 @@ function ModelPopover({ rows, info, anchorRef, onClose, onPick, onToggleFavorite
               })}
             </div>
           ))}
-          {shown.length === 0 && <div className="mp-empty">No models match “{query.trim()}”.</div>}
+          {shown.length === 0 && (
+            <div className="mp-empty">
+              {/* Both constraints get named. With a provider lit, an empty list is as likely to be the
+                  chip's doing as the query's, and "no models match" over a full catalog reads as a bug. */}
+              {query.trim() && vendor ? `No ${vendor} models match “${query.trim()}”.`
+                : vendor ? `Nothing from ${vendor} can run this session.`
+                : `No models match “${query.trim()}”.`}
+              {vendor && <button type="button" className="mp-empty-all" onClick={() => chooseVendor(null)}>Show every provider</button>}
+            </div>
+          )}
         </div>
         {activeRow && route && (
           <ModelDetail row={activeRow} route={route} info={info}

--- a/apps/desktop/src/renderer/src/panes/session/SessionPane.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/SessionPane.tsx
@@ -1,5 +1,5 @@
 import { Icon } from "@realm/ui";
-import { useCallback, useEffect, useMemo, useRef, type ReactNode } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { Panel, PanelGroup, PanelResizeHandle, type ImperativePanelGroupHandle } from "react-resizable-panels";
 import { AGENT_SKILL_SUPPORT, PLAN_PERMISSION_MODE, type Item, type Skill } from "@realm/contracts";
 import { TERMINAL_PANEL_WIDTH, useApp, type PickedAttachment } from "../../state/store";
@@ -247,6 +247,11 @@ export function SessionPane({ item, visible, focused = false }: PaneProps) {
   const submitKey = useApp((s) => s.submitKey);
   // Stable across renders: InstallCard registers it as a window "focus" listener.
   const reprobe = useCallback(() => { run(() => probeAgents(true)); }, [probeAgents, run]);
+  // Sends from THIS prompter, counted so the transcript can pin to the bottom on each one. Counted
+  // here rather than off the transcript's own growth because only the prompter's send carries the
+  // intent: ⌘⇧↩ dispatches the draft into a NEW session (store.dispatchDraft, bound in hotkeys.ts)
+  // and must leave this scroller exactly where the reader parked it.
+  const [sends, setSends] = useState(0);
 
   useEffect(() => { run(() => openSession(id)); }, [id, openSession, run]);
   // Cheap by construction: the store dedups concurrent calls and the server holds a TTL cache, so a
@@ -287,6 +292,7 @@ export function SessionPane({ item, visible, focused = false }: PaneProps) {
   const body = (
     <div className="session-pane" data-visible={visible || undefined} data-composer={hero ? "hero" : "docked"}>
       <Transcript transcript={transcript} sessionStatus={status} visible={visible} focused={focused} cwd={session.cwd}
+        sends={sends}
         onDecide={(requestId, d, answers) => run(() => respondPermission(id, requestId, d, answers))} />
       {blocked && isBlocked(availability)
         ? <InstallCard availability={availability} onRetry={reprobe}
@@ -297,7 +303,7 @@ export function SessionPane({ item, visible, focused = false }: PaneProps) {
             onAttachPick={() => run(() => attachFromPicker(id))}
             onAttachFiles={(files) => run(() => attachFiles(id, files))}
             onRemoveAttachment={(path) => removeAttachment(id, path)}
-            onSend={(text) => run(() => sendMessage(id, text))}
+            onSend={(text) => { setSends((n) => n + 1); run(() => sendMessage(id, text)); }}
             onStop={() => run(() => interruptSession(id))}
             onOptions={(o) => run(() => setSessionOptions(id, o))}
             onPickModel={(kind, modelId) => run(async () => {

--- a/apps/desktop/src/renderer/src/panes/session/Transcript.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/Transcript.tsx
@@ -1,5 +1,5 @@
 import { Icon } from "@realm/ui";
-import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { useLayoutEffect, useMemo, useRef, useState } from "react";
 import { basenameOf, isPlayablePath, mediaCandidatesIn, type MediaFile, type SessionStatus } from "@realm/contracts";
 import { AttachmentTile } from "./AttachmentTile";
 import type { PermissionDecision } from "../../state/store";
@@ -92,13 +92,18 @@ function AssistantMessage({ text, streaming, enter, cwd }: { text: string; strea
 /** Scrolling message list. Follows the bottom while the reader is near it; otherwise offers a "new messages" pill.
  *  Content lives in a centered 680px `.transcript-col` so messages share rails with the prompter (§4);
  *  the scrollbar stays at the pane edge because `.transcript` itself is the scroller. */
-export function Transcript({ transcript, sessionStatus, onDecide, visible = true, focused = false, cwd = null }: {
+export function Transcript({ transcript, sessionStatus, onDecide, visible = true, focused = false, cwd = null, sends = 0 }: {
   transcript: TranscriptModel; sessionStatus: SessionStatus; onDecide: (requestId: string, d: PermissionDecision, answers?: Record<string, string>) => void; visible?: boolean;
   /** The pane sits in the focused leaf: the first pending permission card autofocuses (U-H4). */
   focused?: boolean;
   /** The session's working directory — the base a message's bare filenames are joined against when
    *  it names no directory of its own. Null in tests and wherever the session is not yet known. */
   cwd?: string | null;
+  /** How many messages the prompter below has sent, counted by the pane. Sending is an unambiguous
+   *  statement that the bottom is where the reader wants to be, so it re-pins from wherever they had
+   *  scrolled to — and because the pin is `atBottom` itself, it holds across the RPC until the
+   *  `user_message` block lands, which is what stops a send answering itself with the pill. */
+  sends?: number;
 }) {
   const ref = useRef<HTMLDivElement>(null);
   const atBottom = useRef(true);
@@ -127,7 +132,8 @@ export function Transcript({ transcript, sessionStatus, onDecide, visible = true
     if (atBottom.current) { const el = ref.current; if (el) el.scrollTop = el.scrollHeight; }
     else if (count > 0) setPill(true);
   }, [count, lastLen, permissions.length, visible]);
-  useEffect(() => { scrollToBottom(); }, []); // first paint of a restored transcript starts at the end
+  // First paint of a restored transcript starts at the end, and so does every send.
+  useLayoutEffect(() => { scrollToBottom(); }, [sends]);
 
   /* Content that grows AFTER its block arrived. The effect above fires on new blocks and on the
      streaming message getting longer, and neither describes a media strip: it appears once main has

--- a/apps/desktop/src/renderer/src/panes/session/model-picker-vendors.test.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/model-picker-vendors.test.tsx
@@ -1,0 +1,154 @@
+import { describe, expect, it } from "vitest";
+import { render, screen, fireEvent, within } from "@testing-library/react";
+import { canonicalModelKey, type AgentKind, type ModelInfo } from "@realm/contracts";
+import { ModelPicker } from "./ModelPicker";
+import { filterVendor, modelRows, modelVendor, vendorsOf } from "./model-rows";
+import type { AgentProbe } from "../../state/store";
+
+const probe = (kind: AgentProbe["kind"], models: AgentProbe["models"]): AgentProbe =>
+  ({ kind, available: true, version: "1", loggedIn: true, reason: null, models });
+
+/** Claude's curated list plus a Codex catalog, so the rows carry two makers rather than one. */
+const rows = modelRows({
+  kind: "claude", model: null, canSwitchAgent: true,
+  agentProbe: [probe("codex", [{ id: "gpt-5.6-sol", label: "GPT-5.6-Sol" }, { id: "gpt-5.6-terra", label: "GPT-5.6-Terra" }])],
+});
+
+const entry = (label: string, vendor: string): [string, ModelInfo] => {
+  const key = canonicalModelKey(label);
+  return [key, { key, label, vendor, priceIn: null, priceOut: null, context: null, efforts: [], blurb: null }];
+};
+/** A partial catalog on purpose: the rows it says nothing about are the Default rows and anything
+ *  else no public catalog carries, which is the normal state rather than a broken one. */
+const info = Object.fromEntries([
+  entry("Claude Fable 5.1", "Anthropic"),
+  entry("Claude Opus 5", "Anthropic"),
+  entry("GPT-5.6-Sol", "OpenAI"),
+]);
+
+function mount(catalog: Record<string, ModelInfo> = info) {
+  const picked: [AgentKind, string | null][] = [];
+  const r = render(
+    <ModelPicker kind="claude" model={null} effort={null} rows={rows} info={catalog}
+      onToggleFavorite={() => {}} onPick={(k, m) => picked.push([k, m])} effortItems={[]} />,
+  );
+  fireEvent.click(screen.getByRole("button", { name: "Model" }));
+  return { picked, ...r };
+}
+
+const stripChips = () => within(screen.getByRole("radiogroup", { name: "Provider" }))
+  .getAllByRole("radio").map((b) => b.textContent);
+const chip = (name: string) => within(screen.getByRole("radiogroup", { name: "Provider" })).getByRole("radio", { name });
+const lit = () => within(screen.getByRole("radiogroup", { name: "Provider" }))
+  .getAllByRole("radio").find((b) => b.getAttribute("aria-checked") === "true")?.textContent;
+const listed = () => within(screen.getByRole("listbox", { name: "Models" })).getAllByRole("option").map((o) => o.textContent ?? "");
+const search = () => screen.getByRole("combobox", { name: "Search models" });
+
+describe("provider is the model's vendor, not the harness that runs it", () => {
+  it("reads the maker off the catalog, and says nothing for rows no catalog covers", () => {
+    const fable = rows.find((r) => r.label === "Claude Fable 5.1")!;
+    expect(modelVendor(fable, info)).toBe("Anthropic");
+    // Every harness's Default row is in no catalog at all — that is ordinary, and it is why there is
+    // no "Other" chip collecting them.
+    const fallback = rows.find((r) => r.key.startsWith("default:"))!;
+    expect(modelVendor(fallback, info)).toBeNull();
+  });
+
+  it("lists each vendor once, in the order the rows introduce them", () => {
+    expect(vendorsOf(rows, info)).toEqual(["Anthropic", "OpenAI"]);
+    expect(vendorsOf(rows, {})).toEqual([]); // no catalog, no axis to filter on
+  });
+
+  it("narrows to one maker across every harness that offers it", () => {
+    const anthropic = filterVendor(rows, "Anthropic", info);
+    expect(anthropic.map((r) => r.label)).toEqual(["Claude Fable 5.1", "Claude Opus 5"]);
+    expect(filterVendor(rows, null, info)).toBe(rows);
+  });
+});
+
+describe("the provider strip", () => {
+  it("leads with the way back and offers every vendor the rows carry", () => {
+    mount();
+    expect(stripChips()).toEqual(["All", "Anthropic", "OpenAI"]);
+    expect(lit()).toBe("All");
+  });
+
+  it("is absent when no catalog arrived — an axis with one value is not a control", () => {
+    mount({});
+    expect(screen.queryByRole("radiogroup", { name: "Provider" })).toBeNull();
+    expect(listed().length).toBeGreaterThan(0); // …and the picker still works
+  });
+
+  it("narrows the list, and the lit chip says which narrowing is in force", () => {
+    mount();
+    const before = listed();
+    fireEvent.click(chip("Anthropic"));
+    expect(lit()).toBe("Anthropic");
+    expect(listed().join(" ")).toContain("Claude Fable 5.1");
+    expect(listed().join(" ")).not.toContain("GPT-5.6-Sol");
+    fireEvent.click(chip("All"));
+    expect(listed()).toEqual(before);
+  });
+
+  it("composes with the text query instead of replacing it", () => {
+    mount();
+    fireEvent.click(chip("Anthropic"));
+    fireEvent.change(search(), { target: { value: "opus" } });
+    // The named mutant: have the chip REPLACE the query (or the query clear the chip) and one of
+    // these two lines goes — either GPT rows come back, or every Claude model does.
+    expect(listed().join(" ")).toContain("Claude Opus 5");
+    expect(listed().join(" ")).not.toContain("Claude Fable 5.1");
+    expect(listed().join(" ")).not.toContain("GPT");
+  });
+
+  it("a provider the query has emptied is dimmed, still reachable, and says how to get back", () => {
+    mount();
+    fireEvent.change(search(), { target: { value: "gpt" } });
+    expect(chip("Anthropic")).toHaveAttribute("data-empty");
+    expect(chip("OpenAI")).not.toHaveAttribute("data-empty");
+    fireEvent.click(chip("Anthropic"));
+    expect(screen.getByRole("listbox", { name: "Models" })).toHaveTextContent(/No Anthropic models match/);
+    fireEvent.click(screen.getByRole("button", { name: "Show every provider" }));
+    expect(lit()).toBe("All");
+    expect(listed().join(" ")).toContain("GPT");
+  });
+
+  it("still picks a model after a provider has narrowed the list", () => {
+    const { picked } = mount();
+    fireEvent.click(chip("OpenAI"));
+    fireEvent.click(within(screen.getByRole("listbox", { name: "Models" })).getByText("GPT-5.6-Sol"));
+    expect(picked).toEqual([["codex", "gpt-5.6-sol"]]);
+  });
+});
+
+describe("the strip's arrows and the search field's arrows are different keys", () => {
+  it("←/→ in the SEARCH field never move the provider — that pair walks the highlighted model's routes", () => {
+    // The named mutant: bind the strip's ←/→ at the popover level instead of on the strip. The
+    // route-walk and the provider filter then fire on the same keystroke, and a keyboard user
+    // re-routing a model silently re-filters the list underneath it.
+    mount();
+    fireEvent.keyDown(search(), { key: "ArrowRight" });
+    fireEvent.keyDown(search(), { key: "ArrowRight" });
+    expect(lit()).toBe("All");
+  });
+
+  it("←/→ inside the strip walk the providers, and wrap", () => {
+    mount();
+    const group = screen.getByRole("radiogroup", { name: "Provider" });
+    fireEvent.keyDown(group, { key: "ArrowRight" });
+    expect(lit()).toBe("Anthropic");
+    fireEvent.keyDown(group, { key: "ArrowRight" });
+    expect(lit()).toBe("OpenAI");
+    fireEvent.keyDown(group, { key: "ArrowRight" });
+    expect(lit()).toBe("All");
+    fireEvent.keyDown(group, { key: "ArrowLeft" });
+    expect(lit()).toBe("OpenAI");
+  });
+
+  it("the strip is one tab stop: only the chip in force is reachable by Tab", () => {
+    mount();
+    const tabbable = within(screen.getByRole("radiogroup", { name: "Provider" }))
+      .getAllByRole("radio").filter((b) => b.getAttribute("tabindex") === "0");
+    expect(tabbable.map((b) => b.textContent)).toEqual(["All"]);
+  });
+});

--- a/apps/desktop/src/renderer/src/panes/session/model-rows.ts
+++ b/apps/desktop/src/renderer/src/panes/session/model-rows.ts
@@ -219,6 +219,48 @@ export function filterRows(rows: ModelRow[], query: string): ModelRow[] {
     r.harnesses.some((h) => AGENT_META[h].label.toLowerCase().includes(q)));
 }
 
+/**
+ * Who MADE this model, as the catalog attributes it ("Anthropic"), or null where nothing does.
+ *
+ * The vendor and not the harness, deliberately, because the harness is already two of the things
+ * this list does: `groupRows` blocks the rows by it, and `filterRows` matches its name, so typing
+ * "cursor" already answers "what could I run through Cursor". The detail pane carries a horizontal
+ * strip of harnesses of its own, and those buttons mean "run it through this one" — a second
+ * horizontal strip of the same names meaning "show me only these" would be two controls that look
+ * alike and do different things, inches apart.
+ *
+ * A vendor is the axis nothing here could express. One row reached through the Claude CLI and through
+ * Cursor has two routes and exactly one maker, so "show me Anthropic's" is a question about the model
+ * rather than about the way in — the one question the list could not be asked.
+ *
+ * Null is ordinary rather than a failure: every harness's Default row and Cursor's Composer are in no
+ * catalog at all. They belong to no vendor, so choosing one hides them. There is deliberately no
+ * "Other" bucket — a chip collecting the models Realm happens to have no maker for would sort by an
+ * accident of the catalog and teach nobody anything.
+ */
+export function modelVendor(row: ModelRow, info: Record<string, ModelInfo>): string | null {
+  return info[row.key]?.vendor || null;
+}
+
+/** Every vendor present in `rows`, in first-appearance order — which is `modelRows`' order, so the
+ *  makers behind the session's own harness lead. Empty when the catalog never arrived (offline is a
+ *  supported state), which is what makes the strip absent rather than a single useless chip. */
+export function vendorsOf(rows: ModelRow[], info: Record<string, ModelInfo>): string[] {
+  const seen: string[] = [];
+  for (const r of rows) {
+    const v = modelVendor(r, info);
+    if (v && !seen.includes(v)) seen.push(v);
+  }
+  return seen;
+}
+
+/** Narrow to one vendor. Composes with `filterRows` rather than replacing it — the two answer
+ *  different questions, and someone who has picked Anthropic still wants to type "haiku". */
+export function filterVendor(rows: ModelRow[], vendor: string | null, info: Record<string, ModelInfo>): ModelRow[] {
+  if (vendor === null) return rows;
+  return rows.filter((r) => modelVendor(r, info) === vendor);
+}
+
 /** One labelled block of the picker's list. `label: ""` is a group with no heading — what a search
  *  produces, where a heading per harness would be three words of chrome per result. */
 export type RowGroup = { label: string; rows: ModelRow[] };

--- a/apps/desktop/src/renderer/src/panes/session/transcript-scroll.test.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/transcript-scroll.test.tsx
@@ -1,0 +1,113 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { sessionEvent } from "@realm/contracts";
+import { StoreContext, createAppStore } from "../../state/store";
+import { fakeApi, item, session } from "../../state/store.test-fakes";
+import { SessionPane } from "./SessionPane";
+import { reduceAll } from "./transcript-model";
+
+/**
+ * jsdom lays nothing out, so `scrollHeight` and `clientHeight` are 0 on every element and the
+ * near-bottom test (`scrollHeight - scrollTop - clientHeight < 80`) is true everywhere: without
+ * this, every scroller looks pinned to the bottom already and "the reader had scrolled up" is a
+ * state no test could be in. Stage a geometry on `.transcript`, including a `scrollTop` that
+ * actually stores what is written to it — jsdom's own is a permanent 0.
+ */
+function stageTranscript({ height, view }: { height: number; view: number }) {
+  let top = height;
+  const mine = (el: unknown) => el instanceof HTMLElement && el.classList.contains("transcript");
+  Object.defineProperty(HTMLElement.prototype, "scrollHeight", { configurable: true, get() { return mine(this) ? height : 0; } });
+  Object.defineProperty(HTMLElement.prototype, "clientHeight", { configurable: true, get() { return mine(this) ? view : 0; } });
+  Object.defineProperty(HTMLElement.prototype, "scrollTop", {
+    configurable: true,
+    get() { return mine(this) ? top : 0; },
+    set(v: number) { if (mine(this)) top = v; },
+  });
+  return {
+    get top() { return top; },
+    /** The reader dragging the bar, thumb and all: move it, then tell the component. */
+    readerScrollsTo(v: number) { top = v; fireEvent.scroll(document.querySelector(".transcript")!); },
+  };
+}
+
+afterEach(() => {
+  for (const k of ["scrollHeight", "clientHeight", "scrollTop"]) {
+    delete (HTMLElement.prototype as unknown as Record<string, unknown>)[k];
+  }
+});
+
+const seeded = () => reduceAll([
+  sessionEvent("user_message", { text: "what does this repo do", attachments: [] }),
+  sessionEvent("assistant_text", { messageId: "m1", text: "a long answer" }),
+]);
+
+async function mountPane() {
+  const api = fakeApi({ sessions: [session("se1", "s1", { status: "idle" })] });
+  const store = createAppStore(api);
+  await store.getState().boot();
+  store.setState({ sessionStatus: { se1: "idle" }, transcripts: { se1: { lastSeq: 2, t: seeded() } } });
+  const r = render(
+    <StoreContext.Provider value={store}>
+      <SessionPane item={item("i9", "s1", { kind: "session", refId: "se1", title: "Session" })} visible />
+    </StoreContext.Provider>,
+  );
+  return { api, store, ...r };
+}
+
+/** Another turn lands from the server — the same shape a peer's question or a late tool result has. */
+function arrives(store: Awaited<ReturnType<typeof mountPane>>["store"], text: string) {
+  store.setState({ transcripts: { se1: { lastSeq: 3, t: reduceAll([
+    sessionEvent("user_message", { text: "what does this repo do", attachments: [] }),
+    sessionEvent("assistant_text", { messageId: "m1", text: "a long answer" }),
+    sessionEvent("assistant_text", { messageId: "m2", text }),
+  ]) } } });
+}
+
+const box = () => screen.getByRole("textbox", { name: /message/i });
+
+describe("stick-to-bottom", () => {
+  it("a block arriving while the reader is halfway up raises the pill instead of yanking them down", async () => {
+    const scroller = stageTranscript({ height: 4000, view: 600 });
+    const { store } = await mountPane();
+    scroller.readerScrollsTo(1200);
+    arrives(store, "and here is more of it");
+    await waitFor(() => expect(screen.getByRole("button", { name: /New messages/ })).toBeInTheDocument());
+    expect(scroller.top).toBe(1200);
+  });
+
+  it("sending goes to the bottom even from halfway up, and stays there until the message lands", async () => {
+    const scroller = stageTranscript({ height: 4000, view: 600 });
+    const { api, store } = await mountPane();
+    const sent: string[] = [];
+    api.sendMessage = async (_id, text) => { sent.push(text); };
+
+    scroller.readerScrollsTo(1200);
+    fireEvent.change(box(), { target: { value: "and what about the server" } });
+    fireEvent.keyDown(box(), { key: "Enter" });
+
+    await waitFor(() => expect(sent).toEqual(["and what about the server"]));
+    expect(scroller.top).toBe(4000);
+    expect(screen.queryByRole("button", { name: /New messages/ })).toBeNull();
+
+    // The send is a round trip: the block itself only exists once the server has echoed it back, and
+    // the pin has to still be in force then — the pill here would mean the user was shown a notice
+    // about their own message.
+    arrives(store, "the server is a Fastify app");
+    await waitFor(() => expect(scroller.top).toBe(4000));
+    expect(screen.queryByRole("button", { name: /New messages/ })).toBeNull();
+  });
+
+  it("⌘⇧↩ dispatches into a new session, so it leaves this transcript where the reader parked it", async () => {
+    const scroller = stageTranscript({ height: 4000, view: 600 });
+    const { api } = await mountPane();
+    const sent: string[] = [];
+    api.sendMessage = async (_id, text) => { sent.push(text); };
+
+    scroller.readerScrollsTo(1200);
+    fireEvent.change(box(), { target: { value: "take this one away" } });
+    fireEvent.keyDown(box(), { key: "Enter", metaKey: true, shiftKey: true });
+
+    expect(sent).toEqual([]); // the window-level dispatch binding owns this chord, not the prompter
+    expect(scroller.top).toBe(1200);
+  });
+});

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -420,6 +420,27 @@ kbd { font: 11px var(--font-mono); }
 .mp-search { display: flex; align-items: center; gap: 8px; padding: 10px 12px; border-bottom: 1px solid var(--rl-hairline); color: var(--rl-text-faint); }
 .mp-search input { flex: 1; min-width: 0; border: none; outline: none; background: transparent; font: inherit; font-size: 12.5px; color: var(--rl-text-bright); }
 .mp-search input::placeholder { color: var(--rl-text-faint); }
+/* Provider filter (Plan: under the search). One horizontal row of the MAKERS behind the rows — see
+   `modelVendor` for why a provider here is the vendor and not the harness. It sits on the frame tint
+   rather than behind a second hairline: the search field above it already draws the one seam this
+   header needs, and two rules 30px apart would say the same thing twice.
+   Scrolls sideways when there are more vendors than fit, with its bar hidden the way the app's other
+   horizontal strips hide theirs — a scrollbar under a 26px row would be the tallest thing in it. */
+.mp-vendors { display: flex; align-items: center; gap: 4px; padding: 7px 12px; background: var(--rl-frame);
+  overflow-x: auto; overscroll-behavior-x: contain; scrollbar-width: none; }
+.mp-vendor { flex: none; padding: 3px 9px; border: 0; border-radius: var(--r-chip); background: transparent;
+  font: inherit; font-size: 11.5px; font-weight: var(--fw-medium); color: var(--rl-text-dim); white-space: nowrap; cursor: pointer; }
+.mp-vendor:hover { color: var(--rl-text-bright); background: var(--hover); }
+/* The lit chip wears the same raised-on-surface treatment as a chosen effort level, because it is
+   the same kind of answer: one of a set, currently in force. */
+.mp-vendor[aria-checked="true"] { color: var(--rl-text-bright); background: var(--surface); box-shadow: var(--rl-edge); }
+/* Nothing of this vendor's survives what has been typed. Still lit enough to read and still
+   clickable — the list answers in words, and dropping the chip would move the rest under the pointer. */
+.mp-vendor[data-empty] { opacity: .4; }
+/* The way back out of an empty provider, in the one place the user is looking when they need it. */
+.mp-empty-all { display: block; margin: 9px auto 0; padding: 4px 11px; border: 0; border-radius: var(--r-ctl);
+  background: var(--hover); color: var(--rl-text-bright); font: inherit; font-size: 11.5px; cursor: pointer; }
+.mp-empty-all:hover { background: var(--hover-2); }
 /* The two columns share ONE height, set here rather than on either child: the detail pane grows with
    whatever the highlighted model has to say, and a list that capped itself independently would leave
    the divider hanging in mid-air below it. `stretch` then makes the shorter column fill. */

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -1510,10 +1510,25 @@ button.panel-title:hover { background: var(--rl-hover); }
    chips would eat the overflow the measurement is looking for. */
 .composer-opts { display: flex; align-items: center; gap: 4px; min-width: 0; flex-wrap: nowrap; overflow: hidden; }
 .composer-opts > * { flex: none; }
-/* The branch group (§3): still one button, still the way into the diff pane. */
-.composer-git { display: inline-flex; align-items: center; gap: 2px; padding: 0; border-radius: var(--r-chip); background: transparent; min-width: 0; }
+/* The branch group (§3): still one button, still the way into the diff pane.
+   `--branch-reserved` is everything of FIXED width the row has to fit before the branch name gets
+   any: the card's margins and padding, the "+" and mode chips, the model chip and the send button,
+   plus whichever of the two number chips is still on the row (the narrow steps below restate it as
+   they drop them). Whatever is left over is the name's. Measured with
+   apps/desktop/scripts/composer-bar-live.mjs, which sweeps the row across pane widths and fails on
+   any chip the group has clipped. It is deliberately the figure for the COLLAPSED row: sized for the
+   wider un-collapsed one, panes between the two would fold the permission chip away to buy the
+   branch pixels it did not need. */
+.composer-git { --branch-reserved: 456px; display: inline-flex; align-items: center; gap: 2px; padding: 0; border-radius: var(--r-chip); background: transparent; min-width: 0; }
 .composer-git:hover .ghost-chip { background: var(--rl-hover); color: var(--rl-text-bright); }
-.composer-git .git-branch { max-width: 160px; }
+/* A branch name is the one thing on this row whose width is user data, and the flat 160px cap it had
+   was wrong at both ends: it truncated a 30-character branch in a 1000px pane with 500px going
+   spare, and in anything under ~565px the chip was amputated outright by the group's clip — a button
+   sliced down the middle, which reads as a rendering fault rather than as a name that did not fit.
+   Capped against the pane instead, the name grows and shrinks with the room it actually has. The
+   chip stays `flex: none` with everything else on the row, so the collapse measurement above still
+   sees a real overflow rather than one this chip quietly absorbed. */
+.composer-git .git-branch { max-width: clamp(0px, calc(100cqw - var(--branch-reserved)), 240px); }
 .composer-git .git-diff { gap: 6px; font-variant-numeric: tabular-nums; }
 .composer-git .diff-add { color: var(--rl-success); }
 .composer-git .diff-del { color: var(--rl-danger); }
@@ -1538,6 +1553,20 @@ button.panel-title:hover { background: var(--rl-hover); }
 /* One-time bypass confirm (U-M7): warning-toned status pill (§3 formula), clickable, gone in 5s. */
 .bypass-confirm { color: var(--orange); background: var(--orange-tint); cursor: pointer; }
 .bypass-confirm:hover { background: color-mix(in srgb, var(--orange) 24%, transparent); }
+/* Narrow panes, in the order the row can afford to lose things. Every threshold is the pane width at
+   which the branch would otherwise be squeezed under its floor, read off a measured sweep rather than
+   guessed, and every one is the SESSION PANE's own width — a session in a three-way split is narrow
+   on a wide screen, which no window query would notice.
+   "N changed" goes first: the +/− pair beside it answers the same question and the file count is in
+   the button's own tip, so it is the only thing here that is purely a second telling. The pair
+   follows. Last the name itself gives way to the mark it already carries — a branch nobody can read
+   is a worse chip than a glyph that still opens the diff, and the name stays legible to a screen
+   reader (`.visually-hidden`'s own declarations) and one hover away for everyone else. */
+@container (max-width: 520px) { .composer-git { --branch-reserved: 376px; } .composer-git .git-dirty { display: none; } }
+@container (max-width: 460px) { .composer-git { --branch-reserved: 310px; } .composer-git .git-diff { display: none; } }
+@container (max-width: 360px) {
+  .composer-git .git-branch .chip-label { position: absolute; width: 1px; height: 1px; overflow: hidden; clip-path: inset(50%); white-space: nowrap; }
+}
 .composer-actions { display: flex; align-items: center; gap: 4px; flex: none; }
 .composer-attach { color: var(--ink-3); }
 .composer-attach:hover { color: var(--ink); background: var(--rl-hover); }

--- a/apps/desktop/src/renderer/src/styles.test.ts
+++ b/apps/desktop/src/renderer/src/styles.test.ts
@@ -295,6 +295,31 @@ describe("Ara refresh §3/§4 geometry", () => {
     expect(body).toContain("overflow: hidden");
     expect(bodiesFor(".composer-opts > *").join(" ")).toContain("flex: none");
   });
+
+  it("the branch name is capped by the pane it is in, never by a flat number", () => {
+    // The named mutant: put `max-width: 160px` back. Every pane over ~600px then truncates a name it
+    // had hundreds of pixels of room for, and every pane under ~565px has the whole chip amputated by
+    // the clip above — a button sliced down the middle. Neither is visible from here (jsdom has no
+    // layout); composer-bar-live.mjs sweeps the real row and fails on a chip the group has cut.
+    const branch = bodiesFor(".composer-git .git-branch").join(" ");
+    expect(branch).toContain("100cqw");
+    expect(branch).toContain("var(--branch-reserved)");
+    expect(bodiesFor(".composer-git").join(" ")).toContain("--branch-reserved:");
+  });
+
+  it("a narrow pane spends its width on the branch's NAME, dropping the counts that restate it", () => {
+    const noDirty = blockAfter("@container (max-width: 520px)");
+    expect(noDirty).toMatch(/\.git-dirty \{[^}]*display: none/);
+    const noDiff = blockAfter("@container (max-width: 460px)");
+    expect(noDiff).toMatch(/\.git-diff \{[^}]*display: none/);
+    // The reserve has to be restated as each count leaves, or the name goes on being capped against
+    // room the row has just handed back to it — the silent half of this, and the one worth pinning.
+    expect(noDirty).toContain("--branch-reserved:");
+    expect(noDiff).toContain("--branch-reserved:");
+    // Last step: the chip becomes the mark it already carries. Hidden from the eye, not from a
+    // screen reader — the button's whole remaining content would otherwise be an icon.
+    expect(blockAfter("@container (max-width: 360px)")).toMatch(/\.chip-label \{[^}]*clip-path: inset\(50%\)/);
+  });
 });
 
 describe("Plan 9 W1 — the BUI bridge", () => {


### PR DESCRIPTION
Stacked on #24.

**Sending pins the transcript to the bottom.** `send()` never touched the scroller. The user's own message landed as a new block, but if they had scrolled up to read something, `atBottom.current` was `false` — so their own send answered them with a "New messages" pill instead of taking them to it. Sending is an unambiguous statement of intent to be at the bottom.

The pin is `atBottom.current = true` rather than one scroll, which is what carries it across the RPC round trip until the message actually arrives. `atBottom` stays a ref and the transcript still re-renders once per send, never per scroll event.

Proved against the *unfixed* build, not just the fixed one: `scripts/prompter-pin-live.mjs` boots the real app, builds real scrollback and asserts on real geometry, and with the fix reverted three checks flip to FAIL showing exactly the reported bug — `{"top":0,"slack":1684,"pill":true}`. jsdom can see this only with layout staged in, because with `scrollHeight`/`clientHeight` at 0 every scroller looks pinned already; `transcript-scroll.test.tsx` stages it the same way `session-pane.test.tsx` already does.

**The branch chip.** Below about 565px of pane it was not truncated, it was **amputated** — sliced down the middle by `.composer-opts { overflow: hidden }` against a `flex: none` child. Measured with a 48-character branch: at pane 500 the row needed 420px and had 307; at 340 it had 147; at 280 the mode chip was cut too. Meanwhile at pane 1000 the branch was capped at a flat 160px with ~500px going spare.

The cap is now a container query against the pane, with the reserve restated as each derived chip leaves — 520px drops "N changed", 460px drops the +/− pair, 360px clips the name and keeps the mark. The chip keeps `flex: none` so the existing measured collapse still sees a real overflow. `need == have` at every swept width afterwards.

Two approaches were tried and reverted for making it worse: shrink-based sizing (a nested flex item's automatic minimum is its content's min-content, so the button crushed to 35px while the branch kept its floor and spilled through the clip — the same amputation one box in), and a shrinkable actions group (a 16px model-chip stub below pane 280, rescuing no supported width).

Below ~320px the row is over-subscribed by its fixed controls alone, before a branch is mentioned. That needs the mode chip to learn the fold the permission chip already has, which is `Composer.tsx` — the live script reports it as INFO rather than pretending otherwise.

**Provider filter = the model's vendor, not the harness.** The harness axis is already expressed twice (`groupRows` blocks by resolved harness, `filterRows` matches harness labels), and the popover already carries a horizontal strip of harness names inches below as the "run it through" route pills — a second horizontal strip of the same names meaning *filter* instead of *route* is the exact collision to avoid. Vendor is the axis nothing else could express: one model reached through two harnesses has two routes and exactly one maker.

It composes with the query rather than replacing it. Chips derive from the unfiltered rows so the strip never reflows under the pointer; a vendor the query has emptied dims but stays clickable, and the list then names which constraint emptied it. Arrow keys are bound on the strip, not the popover, so the search field's existing route-walk is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)