### PR TITLE
Show a session the agents it spawned, and nest their work under the call that spawned it

### DIFF
--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -236,6 +236,10 @@ export function App() {
     // A review verdict landed (or was dismissed/cleared) for an environment (Plan 13 W3): apply the
     // payload directly — the diff pane's review section reads `reviews[environmentId]`.
     const offR = rpc().on("review.changed", (p) => store.getState().applyReviewChanged(p));
+    // The set of sessions a session is waiting on. Applied in every window and gated on
+    // nothing: the delegating session's pane may be open in any of them, and the payload is a
+    // handful of ids — the store drops the key when the set is empty.
+    const offDel = rpc().on("delegation.changed", (p) => store.getState().applyDelegationChanged(p));
     // No payload — `mcp.changed` just means "something about some server changed". Only worth a refetch
     // while a space page's Connections tab is actually mounted on a space's server list (Plan 12 W3:
     // the settings sheet is gone; `mcpPanelSpaceId` is McpSection's mounted-for-which-space record).
@@ -263,7 +267,7 @@ export function App() {
     window.addEventListener("dragover", swallowDrop);
     window.addEventListener("drop", swallowDrop);
     return () => {
-      offS(); offI(); offV(); offW(); offSh(); offRun(); offP(); offK(); offMem(); offB(); offDO(); offSA(); offBA(); offBD(); offE(); offT(); offN(); offDN?.(); offR(); offM(); offMS(); offMC(); offC();
+      offS(); offI(); offV(); offW(); offSh(); offRun(); offP(); offK(); offMem(); offB(); offDO(); offSA(); offBA(); offBD(); offE(); offT(); offN(); offDN?.(); offR(); offDel(); offM(); offMS(); offMC(); offC();
       window.removeEventListener("pagehide", onPageHide);
       window.removeEventListener("dragover", swallowDrop);
       window.removeEventListener("drop", swallowDrop);

--- a/apps/desktop/src/renderer/src/panes/session-labels.ts
+++ b/apps/desktop/src/renderer/src/panes/session-labels.ts
@@ -1,0 +1,18 @@
+import type { DispatchKind } from "@realm/contracts";
+
+/** Origin glyph + words per dispatch kind (Plan 13 W2). The agent kinds carry a parent-session link
+ *  in the row; `user-dispatch` has no parent by definition.
+ *
+ *  Shared by the Tasks lens and the delegating session's own dock, so a delegated child is named the
+ *  same way whether the user meets it in a list of everything or beside the agent that spawned it. */
+export const ORIGIN_META: Record<DispatchKind, { icon: string; label: string }> = {
+  "user-dispatch": { icon: "send", label: "Dispatched (⌘⇧↵)" },
+  agent_run: { icon: "bot", label: "Delegated via agent_run" },
+  browser_agent_run: { icon: "browser", label: "Browser agent" },
+  review: { icon: "diff", label: "Reviewer" },
+  fork: { icon: "branch", label: "Forked from a checkpoint" },
+  import: { icon: "download", label: "Imported from an agent CLI" },
+  run: { icon: "bot", label: "Durable run" },
+};
+
+export const SESSION_STATUS_LABEL = { idle: "idle", running: "running", waiting_permission: "needs permission", error: "error", ended: "ended" } as const;

--- a/apps/desktop/src/renderer/src/panes/session/DelegatedRuns.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/DelegatedRuns.tsx
@@ -11,7 +11,7 @@ import { useElapsed } from "./use-elapsed";
 const ASKED_META = { icon: "session", label: "Asked a question (agent_ask)" };
 
 /**
- * What this session is waiting on, docked between its transcript and its prompter.
+ * The agents this session has in flight, docked between its transcript and its prompter.
  *
  * A delegated child has always been a real session with a pane of its own, but the parent's
  * transcript said nothing at all while it worked — the child's report arrives as one MCP tool result
@@ -48,10 +48,12 @@ function Dock({ sessionId, running }: { sessionId: string; running: readonly Del
   const [open, setOpen] = useState(true);
   const rows = [...running].sort((a, b) => a.startedAt - b.startedAt);
   const since = rows[0]!.startedAt;
+  // Always ticking: this component only exists while the engine is holding runs open, so the clock
+  // stops by unmounting rather than by a flag. One clock for every row too — reading `Date.now()`
+  // per row instead would have them disagree with the header by however long the render took.
   const elapsed = useElapsed(since, true);
-  /** One clock for every row, off the ticking value rather than a fresh `Date.now()` per render —
-   *  otherwise the rows disagree with the header by however long the render took. */
   const now = since + elapsed;
+  const count = rows.length === 1 ? "1 agent" : `${rows.length} agents`;
   const title = sessions[sessionId]?.title ?? "this session";
 
   const jump = (childId: string) => {
@@ -64,10 +66,13 @@ function Dock({ sessionId, running }: { sessionId: string; running: readonly Del
 
   return (
     <div className="delegation-dock">
+      {/* "running", not "waiting on": an `agent_start` the parent deliberately backgrounded is in
+          this list too, and that parent is not blocked on anything. Everything here has an
+          unsettled drain, which is precisely what "still running" means. */}
       <button type="button" className="delegation-row" aria-expanded={open} onClick={() => setOpen((o) => !o)}
-        aria-label={`${rows.length === 1 ? "1 agent" : `${rows.length} agents`} ${title} is waiting on`}>
+        aria-label={`${count} in flight for ${title}`}>
         <Icon name="bot" size={13} />
-        <span className="delegation-summary">Waiting on {rows.length === 1 ? "1 agent" : `${rows.length} agents`}</span>
+        <span className="delegation-summary">{count} running</span>
         <span className="delegation-elapsed">{formatDuration(elapsed)}</span>
         <Icon name="chevronRight" size={12} className="tool-chevron" />
       </button>

--- a/apps/desktop/src/renderer/src/panes/session/DelegatedRuns.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/DelegatedRuns.tsx
@@ -1,0 +1,104 @@
+import { Icon } from "@realm/ui";
+import { useEffect, useState } from "react";
+import type { DelegatedRun } from "@realm/contracts";
+import { useApp } from "../../state/store";
+import { ORIGIN_META, SESSION_STATUS_LABEL } from "../session-labels";
+import { formatDuration } from "./tool-group";
+import { useElapsed } from "./use-elapsed";
+
+/** A peer `agent_ask` reached is NOT a session this one spawned: it was doing its own work before the
+ *  question arrived and goes on doing it afterwards. Calling it a sub-agent would be wrong twice. */
+const ASKED_META = { icon: "session", label: "Asked a question (agent_ask)" };
+
+/**
+ * What this session is waiting on, docked between its transcript and its prompter.
+ *
+ * A delegated child has always been a real session with a pane of its own, but the parent's
+ * transcript said nothing at all while it worked — the child's report arrives as one MCP tool result
+ * at the very end, so for however long the child ran the parent showed a shimmer and no reason for
+ * it. This is the reason, and the way over to it.
+ *
+ * Docked rather than a pane of its own, deliberately. The engine's registry lives in the server's
+ * memory and dies with the process, while a pane is a layout leaf that persists — a pane kind for
+ * this would leave an empty panel behind from a run that finished yesterday, and would keep pointing
+ * at a session after the layout had moved on from it. Living inside the delegating session's pane IS
+ * the link to that session: it cannot be dragged away from what it describes, and it leaves when the
+ * session's runs do.
+ */
+export function DelegatedRuns({ sessionId }: { sessionId: string }) {
+  const running = useApp((s) => s.delegatedRuns[sessionId]);
+  const refreshDelegatedRuns = useApp((s) => s.refreshDelegatedRuns);
+  const run = useApp((s) => s.run);
+  // Covers the runs that began before this window connected — a reload, a second window, a pane
+  // opened ten minutes into a delegation. Every later change arrives on `delegation.changed`.
+  useEffect(() => { run(() => refreshDelegatedRuns(sessionId)); }, [sessionId, refreshDelegatedRuns, run]);
+  if (!running || running.length === 0) return null;
+  return <Dock sessionId={sessionId} running={running} />;
+}
+
+/** Split out so the hooks below only ever run for a session that actually has runs — and so the
+ *  open/closed choice is discarded with the dock rather than surviving until the next delegation. */
+function Dock({ sessionId, running }: { sessionId: string; running: readonly DelegatedRun[] }) {
+  const sessions = useApp((s) => s.sessions);
+  const sessionStatus = useApp((s) => s.sessionStatus);
+  const items = useApp((s) => s.items);
+  const openItemBeside = useApp((s) => s.openItemBeside);
+  const revealSession = useApp((s) => s.revealSession);
+  const run = useApp((s) => s.run);
+  const [open, setOpen] = useState(true);
+  const rows = [...running].sort((a, b) => a.startedAt - b.startedAt);
+  const since = rows[0]!.startedAt;
+  const elapsed = useElapsed(since, true);
+  /** One clock for every row, off the ticking value rather than a fresh `Date.now()` per render —
+   *  otherwise the rows disagree with the header by however long the render took. */
+  const now = since + elapsed;
+  const title = sessions[sessionId]?.title ?? "this session";
+
+  const jump = (childId: string) => {
+    const it = items.find((i) => i.kind === "session" && i.refId === childId);
+    // Beside, never in place: the point of going to look is to watch the child WITH the parent that
+    // spawned it, and openItem would evict the pane the user pressed the button in. A child in
+    // another space has no item here, and revealing it is the only way through.
+    run(() => (it ? openItemBeside(it.id) : revealSession(childId, null)));
+  };
+
+  return (
+    <div className="delegation-dock">
+      <button type="button" className="delegation-row" aria-expanded={open} onClick={() => setOpen((o) => !o)}
+        aria-label={`${rows.length === 1 ? "1 agent" : `${rows.length} agents`} ${title} is waiting on`}>
+        <Icon name="bot" size={13} />
+        <span className="delegation-summary">Waiting on {rows.length === 1 ? "1 agent" : `${rows.length} agents`}</span>
+        <span className="delegation-elapsed">{formatDuration(elapsed)}</span>
+        <Icon name="chevronRight" size={12} className="tool-chevron" />
+      </button>
+      {open && (
+        <ul className="delegation-list">
+          {rows.map((r) => {
+            const child = sessions[r.sessionId];
+            const status = sessionStatus[r.sessionId] ?? child?.status;
+            // The Tasks lens's own vocabulary for how a session came to exist, so a delegated child
+            // is named the same here as it is there. A child whose row has not landed yet (the
+            // session and the run are announced separately) still gets its origin from the run.
+            const meta = r.owned ? ORIGIN_META[child?.dispatchedBy?.kind ?? "agent_run"] : ASKED_META;
+            return (
+              <li key={r.sessionId}>
+                <button type="button" className="delegation-item" title={meta.label}
+                  aria-label={`${child?.title ?? "Starting"} — ${meta.label}`} onClick={() => jump(r.sessionId)}>
+                  <Icon name={meta.icon} size={14} />
+                  {/* The row lands before the session row does often enough to matter: `agent_run`
+                      registers the run and only then sends the child its first message. */}
+                  <span className="delegation-title">{child?.title ?? "Starting…"}</span>
+                  {/* `detached` is the difference between "this session is blocked until you finish"
+                      and "go at your own pace" — the parent kept working after agent_start. */}
+                  {r.detached && <span className="delegation-dim">not collected yet</span>}
+                  <span className="delegation-dim">{formatDuration(now - r.startedAt)}</span>
+                  {status && <span className="status-dot item-status" data-status={status} title={SESSION_STATUS_LABEL[status]} />}
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/src/panes/session/SessionPane.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/SessionPane.tsx
@@ -9,6 +9,7 @@ import type { PaneProps } from "../registry";
 import { Composer } from "./Composer";
 import { InstallCard } from "./InstallCard";
 import { Transcript } from "./Transcript";
+import { DelegatedRuns } from "./DelegatedRuns";
 import { emptyTranscript } from "./transcript-model";
 import { promptHint } from "./prompt-hint";
 
@@ -294,6 +295,10 @@ export function SessionPane({ item, visible, focused = false }: PaneProps) {
       <Transcript transcript={transcript} sessionStatus={status} visible={visible} focused={focused} cwd={session.cwd}
         sends={sends}
         onDecide={(requestId, d, answers) => run(() => respondPermission(id, requestId, d, answers))} />
+      {/* Between the log and the prompter, not inside the scroller: a delegated child running RIGHT
+          NOW is not history, and it must not scroll away from the reader who went back to re-read
+          something. It draws nothing at all when this session is waiting on no one. */}
+      <DelegatedRuns sessionId={id} />
       {blocked && isBlocked(availability)
         ? <InstallCard availability={availability} onRetry={reprobe}
             onOpenInTerminal={(command) => run(() => prefillTerminal(id, command))} />

--- a/apps/desktop/src/renderer/src/panes/session/ToolCard.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/ToolCard.tsx
@@ -3,7 +3,7 @@ import { memo, useEffect, useRef, useState, type ReactNode } from "react";
 import type { SessionStatus } from "@realm/contracts";
 import { Spinner } from "../../components/Spinner";
 import { clip, editStat, prettyJson, toolSummary } from "./tool-summary";
-import { formatDuration, formatToolRun, summarizeToolRun, type ToolBlock } from "./tool-group";
+import { formatDuration, formatToolRun, summarizeToolRun, type ToolBlock, type ToolStep } from "./tool-group";
 import { ToolInputBody, ToolResultBody } from "./rich/ToolViews";
 import { DRAW_LIMIT, mediaWorkFor, toolInputView, toolMediaPath, toolResultView } from "./rich/tool-view";
 import { GeneratingCanvas, ToolMedia } from "./media/MediaView";
@@ -70,7 +70,13 @@ function Well({ label, text, error = false, rich = null }: { label: string; text
  *  landed compares equal on all three props and is skipped — a 300-call transcript stops re-deriving
  *  300 summaries and edit stats behind an assistant message that is still typing. `enter` is stable
  *  for a key's whole life (transcript-enter.ts), so memoizing cannot strand a card mid-animation. */
-export const ToolCard = memo(function ToolCard({ block, sessionStatus, enter = false }: { block: ToolBlock; sessionStatus: SessionStatus; enter?: boolean }) {
+export const ToolCard = memo(function ToolCard({ block, sessionStatus, enter = false, nested }: {
+  block: ToolBlock; sessionStatus: SessionStatus; enter?: boolean;
+  /** The calls a sub-agent made under this one (`groupTranscript`). Undefined on every card but a
+   *  Task/Agent one whose child actually did something — and undefined rather than `[]` so the
+   *  memo above still holds for the other 299 cards. */
+  nested?: readonly ToolStep[];
+}) {
   const [open, setOpen] = useState(false);
   const everOpened = useRef(false);
   everOpened.current ||= open;
@@ -116,6 +122,10 @@ export const ToolCard = memo(function ToolCard({ block, sessionStatus, enter = f
           happens, and a canvas the reader has to open a card to find would be a spinner with extra
           steps. It leaves of its own accord when the result lands. */}
       {work && <GeneratingCanvas kind={work.kind} label={work.label} detail={work.detail} aspect={work.aspect} />}
+      {/* The sub-agent's own ledger, hanging off the call that spawned it and ABOVE the expander:
+          what the child is doing is the thing worth seeing, and burying it under the raw input and
+          result wells would make it something the reader has to go looking for. */}
+      {nested && nested.length > 0 && <ToolGroup steps={nested} sessionStatus={sessionStatus} subagent />}
       {/* §6 expands the row by transitioning grid-template-rows 0fr→1fr, which only animates if the
           content is in the DOM on both sides of the flip. So the body is built on first open and
           stays built: collapsing animates too, and re-opening is instant. `inert` keeps the hidden
@@ -157,8 +167,11 @@ function useWorkedFor(working: boolean, firstTs: number, settledMs: number): str
  *  of sight is the one thing this treatment must not do — and a manual toggle then wins for good.
  *  The collapsed row reads `Worked for <duration> ›` (Ara refresh §4); the counts line the ledger
  *  still computes ("3 tools · 1 file · 2 commands") survives as the row's tooltip. */
-export function ToolGroup({ steps, sessionStatus }: {
-  steps: { key: string; block: ToolBlock; enter: boolean }[]; sessionStatus: SessionStatus;
+export function ToolGroup({ steps, sessionStatus, subagent = false }: {
+  steps: readonly ToolStep[]; sessionStatus: SessionStatus;
+  /** These steps are a sub-agent's, not a run of the agent's own calls. Sitting directly under a
+   *  Task row, an unqualified "Worked for 42s" would read as that Task's own elapsed time. */
+  subagent?: boolean;
 }) {
   const [manual, setManual] = useState<boolean | null>(null);
   const live = sessionStatus === "running" || sessionStatus === "waiting_permission";
@@ -167,18 +180,18 @@ export function ToolGroup({ steps, sessionStatus }: {
   const summary = summarizeToolRun(steps.map((s) => s.block));
   const workedFor = useWorkedFor(working, steps[0]!.block.ts, summary.durationMs);
   return (
-    <div className="tool-group" data-open={open || undefined} data-working={working || undefined}>
+    <div className="tool-group" data-subagent={subagent || undefined} data-open={open || undefined} data-working={working || undefined}>
       {/* Plan 9 W2: the row wears ThinkingState's header treatment — while the run is live the label
           shimmers (BUI's working treatment); the label itself stays the kept Ara decision,
           `Worked for <duration>`, ticking live and freezing on settle. */}
-      <button className="tool-group-row" aria-expanded={open} aria-label={`${steps.length} tool calls`}
+      <button className="tool-group-row" aria-expanded={open} aria-label={`${steps.length} ${subagent ? "sub-agent " : ""}tool calls`}
         title={formatToolRun(summary)} onClick={() => setManual(!open)}>
-        <span className="tool-group-summary">Worked for {workedFor}</span>
+        <span className="tool-group-summary">{subagent ? "Sub-agent worked for" : "Worked for"} {workedFor}</span>
         <Icon name="chevronRight" size={12} className="tool-chevron" />
       </button>
       {open && (
         <div className="tool-group-steps">
-          {steps.map((s) => <ToolCard key={s.key} block={s.block} sessionStatus={sessionStatus} enter={s.enter} />)}
+          {steps.map((s) => <ToolCard key={s.key} block={s.block} sessionStatus={sessionStatus} enter={s.enter} nested={s.nested} />)}
         </div>
       )}
     </div>

--- a/apps/desktop/src/renderer/src/panes/session/ToolCard.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/ToolCard.tsx
@@ -7,6 +7,7 @@ import { formatDuration, formatToolRun, summarizeToolRun, type ToolBlock, type T
 import { ToolInputBody, ToolResultBody } from "./rich/ToolViews";
 import { DRAW_LIMIT, mediaWorkFor, toolInputView, toolMediaPath, toolResultView } from "./rich/tool-view";
 import { GeneratingCanvas, ToolMedia } from "./media/MediaView";
+import { useElapsed } from "./use-elapsed";
 
 type ToolState = "running" | "ok" | "error" | "none";
 
@@ -152,14 +153,8 @@ export const ToolCard = memo(function ToolCard({ block, sessionStatus, enter = f
  *  working it ticks live off the group's own first timestamp; once settled it freezes on the ledger's
  *  first→last span — the same duration the counts line has always computed. */
 function useWorkedFor(working: boolean, firstTs: number, settledMs: number): string {
-  const [now, setNow] = useState(() => Date.now());
-  useEffect(() => {
-    if (!working) return;
-    setNow(Date.now());
-    const t = setInterval(() => setNow(Date.now()), 1000);
-    return () => clearInterval(t);
-  }, [working]);
-  return formatDuration(working ? Math.max(0, now - firstTs) : settledMs);
+  const elapsed = useElapsed(firstTs, working);
+  return formatDuration(working ? elapsed : settledMs);
 }
 
 /** §2.8/§5: a run of consecutive tool calls, folded behind one ledger line with a dashed connector.

--- a/apps/desktop/src/renderer/src/panes/session/ToolCard.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/ToolCard.tsx
@@ -3,7 +3,7 @@ import { memo, useEffect, useRef, useState, type ReactNode } from "react";
 import type { SessionStatus } from "@realm/contracts";
 import { Spinner } from "../../components/Spinner";
 import { clip, editStat, prettyJson, toolSummary } from "./tool-summary";
-import { formatDuration, formatToolRun, summarizeToolRun, type ToolBlock, type ToolStep } from "./tool-group";
+import { flattenRun, formatDuration, formatToolRun, summarizeToolRun, type ToolBlock, type ToolStep } from "./tool-group";
 import { ToolInputBody, ToolResultBody } from "./rich/ToolViews";
 import { DRAW_LIMIT, mediaWorkFor, toolInputView, toolMediaPath, toolResultView } from "./rich/tool-view";
 import { GeneratingCanvas, ToolMedia } from "./media/MediaView";
@@ -68,14 +68,14 @@ function Well({ label, text, error = false, rich = null }: { label: string; text
  *
  *  Memoized because a streaming answer re-renders the whole transcript around it. The reducer rebuilds
  *  the block ARRAY on each update but keeps every settled block's object, so a card whose call has
- *  landed compares equal on all three props and is skipped — a 300-call transcript stops re-deriving
+ *  landed compares equal on all four props and is skipped — a 300-call transcript stops re-deriving
  *  300 summaries and edit stats behind an assistant message that is still typing. `enter` is stable
  *  for a key's whole life (transcript-enter.ts), so memoizing cannot strand a card mid-animation. */
 export const ToolCard = memo(function ToolCard({ block, sessionStatus, enter = false, nested }: {
   block: ToolBlock; sessionStatus: SessionStatus; enter?: boolean;
-  /** The calls a sub-agent made under this one (`groupTranscript`). Undefined on every card but a
-   *  Task/Agent one whose child actually did something — and undefined rather than `[]` so the
-   *  memo above still holds for the other 299 cards. */
+  /** The calls a sub-agent made under this one (`groupTranscript`). Empty for every card but a
+   *  Task/Agent one whose child did some work — and empty via `withEnter`'s shared array, which is
+   *  what keeps the memo above holding for the other 299 cards. */
   nested?: readonly ToolStep[];
 }) {
   const [open, setOpen] = useState(false);
@@ -170,16 +170,23 @@ export function ToolGroup({ steps, sessionStatus, subagent = false }: {
 }) {
   const [manual, setManual] = useState<boolean | null>(null);
   const live = sessionStatus === "running" || sessionStatus === "waiting_permission";
-  const working = live && steps.some((s) => !s.block.result);
+  // The whole subtree, not the top level: a run whose only unfinished work is inside a sub-agent is
+  // still working, and a ledger that counted only the parent's own calls would under-report the run
+  // AND end its clock at the moment the Task was CALLED — the row would shrink from 5m to <1s on
+  // settle, having just spent five minutes ticking upward.
+  const blocks = flattenRun(steps);
+  const working = live && blocks.some((b) => !b.result);
   const open = manual ?? working;
-  const summary = summarizeToolRun(steps.map((s) => s.block));
-  const workedFor = useWorkedFor(working, steps[0]!.block.ts, summary.durationMs);
+  const summary = summarizeToolRun(blocks);
+  // The run's first call really is its earliest: blocks arrive in order, and a sub-agent's calls
+  // postdate the one that spawned them. Only the END of the span needs looking for (summarizeToolRun).
+  const workedFor = useWorkedFor(working, blocks[0]!.ts, summary.durationMs);
   return (
     <div className="tool-group" data-subagent={subagent || undefined} data-open={open || undefined} data-working={working || undefined}>
       {/* Plan 9 W2: the row wears ThinkingState's header treatment — while the run is live the label
           shimmers (BUI's working treatment); the label itself stays the kept Ara decision,
           `Worked for <duration>`, ticking live and freezing on settle. */}
-      <button className="tool-group-row" aria-expanded={open} aria-label={`${steps.length} ${subagent ? "sub-agent " : ""}tool calls`}
+      <button className="tool-group-row" aria-expanded={open} aria-label={`${blocks.length} ${subagent ? "sub-agent " : ""}tool calls`}
         title={formatToolRun(summary)} onClick={() => setManual(!open)}>
         <span className="tool-group-summary">{subagent ? "Sub-agent worked for" : "Worked for"} {workedFor}</span>
         <Icon name="chevronRight" size={12} className="tool-chevron" />

--- a/apps/desktop/src/renderer/src/panes/session/Transcript.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/Transcript.tsx
@@ -8,7 +8,7 @@ import { PermissionCard } from "./PermissionCard";
 import { PlanCard, PlanDecision, isPlanDecision } from "./PlanCard";
 import { QuestionCard, questionCardFor } from "./QuestionCard";
 import { ToolCard, ToolGroup } from "./ToolCard";
-import { formatDuration, groupTranscript } from "./tool-group";
+import { formatDuration, groupTranscript, withEnter } from "./tool-group";
 import { blockKey, type Transcript as TranscriptModel } from "./transcript-model";
 import { runLabelFor } from "./run-label";
 import { useEnterTracker } from "./transcript-enter";
@@ -160,8 +160,7 @@ export function Transcript({ transcript, sessionStatus, onDecide, visible = true
             // The group container itself never animates in: when a run crosses the grouping
             // threshold the cards it swallows are already on screen, and wrapping them in a fresh
             // entrance would replay motion for items the reader has been watching.
-            return <ToolGroup key={it.key} sessionStatus={sessionStatus}
-              steps={it.steps.map((s) => ({ ...s, enter: isEntering(s.key) }))} />;
+            return <ToolGroup key={it.key} sessionStatus={sessionStatus} steps={withEnter(it.steps, isEntering)} />;
           const b = it.block, key = it.key, enter = isEntering(key);
           switch (b.kind) {
             case "user": return (
@@ -183,7 +182,7 @@ export function Transcript({ transcript, sessionStatus, onDecide, visible = true
               </div>);
             case "assistant": return <AssistantMessage key={key} text={b.text} streaming={b.streaming} enter={enter} cwd={cwd} />;
             case "thinking": return <Thinking key={key} text={b.text} enter={enter} />;
-            case "tool": return <ToolCard key={key} block={b} sessionStatus={sessionStatus} enter={enter} />;
+            case "tool": return <ToolCard key={key} block={b} sessionStatus={sessionStatus} enter={enter} nested={withEnter(it.nested, isEntering)} />;
             case "plan": return <PlanCard key={key} text={b.text} steps={b.steps} enter={enter} />;
             case "error": return <div key={key} className="msg-error" role="alert" data-enter={enter || undefined}><Icon name="alert" size={14} /><pre>{b.message}</pre></div>;
             // The shimmer the reader was watching, settled: same verb, past tense, with the wait it

--- a/apps/desktop/src/renderer/src/panes/session/delegated-runs.test.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/delegated-runs.test.tsx
@@ -29,7 +29,7 @@ async function mount(delegatedRuns: Record<string, DelegatedRun[]> = {}) {
   return { api, store, ...r };
 }
 
-const dock = () => screen.queryByRole("button", { name: /agents? Parent is waiting on/ });
+const dock = () => screen.queryByRole("button", { name: /agents? in flight for Parent/ });
 
 afterEach(() => cleanup());
 
@@ -58,6 +58,19 @@ describe("the delegating session's dock", () => {
     // it — the registry has already forgotten the run.
     await waitFor(() => expect(dock()).toBeNull());
     expect(store.getState().delegatedRuns).not.toHaveProperty("se1");
+  });
+
+  it("refetches when the socket comes back, because the registry may have died with the server", async () => {
+    const scripted: Record<string, DelegatedRun[]> = { se1: [KID] };
+    const { store } = await mount(scripted);
+    await waitFor(() => expect(dock()).not.toBeNull());
+    delete scripted["se1"]; // the server restarted while we were away: it is holding nothing now
+    store.getState().applyConnectionState("reconnecting");
+    store.getState().applyConnectionState("connected");
+    // THE MUTANT: leave delegation out of the reconnect refetch. Every other kind of stale state
+    // that gap covers is backed by a table the server can re-read; this one is not backed by
+    // anything, so nothing will ever arrive to correct it and the dock names agents that are gone.
+    await waitFor(() => expect(dock()).toBeNull());
   });
 
   it("replaces the set rather than accumulating: the payload is the whole truth", async () => {

--- a/apps/desktop/src/renderer/src/panes/session/delegated-runs.test.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/delegated-runs.test.tsx
@@ -1,0 +1,86 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { allItems, type DelegatedRun } from "@realm/contracts";
+import { StoreContext, createAppStore } from "../../state/store";
+import { fakeApi, item, session } from "../../state/store.test-fakes";
+import { SessionPane } from "./SessionPane";
+import { reduceAll } from "./transcript-model";
+
+const KID: DelegatedRun = { sessionId: "se2", startedAt: 0, detached: false, owned: true };
+const PEER: DelegatedRun = { sessionId: "se3", startedAt: 0, detached: false, owned: false };
+
+const ITEMS = { s1: [
+  item("i9", "s1", { kind: "session", title: "Parent", refId: "se1" }),
+  item("i8", "s1", { kind: "session", title: "Agent: audit the mapper", refId: "se2" }),
+  item("i7", "s1", { kind: "session", title: "A colleague", refId: "se3" }),
+] };
+const SESSIONS = [
+  session("se1", "s1", { title: "Parent" }),
+  session("se2", "s1", { title: "Agent: audit the mapper", status: "running", dispatchedBy: { sessionId: "se1", kind: "agent_run" } }),
+  session("se3", "s1", { title: "A colleague" }),
+];
+
+async function mount(delegatedRuns: Record<string, DelegatedRun[]> = {}) {
+  const api = fakeApi({ items: ITEMS, sessions: SESSIONS, delegatedRuns });
+  const store = createAppStore(api); await store.getState().boot();
+  store.setState({ sessionStatus: { se1: "running", se2: "running" }, transcripts: { se1: { lastSeq: 0, t: reduceAll([]) } } });
+  await store.getState().openItem("i9");
+  const r = render(<StoreContext.Provider value={store}><SessionPane item={ITEMS.s1[0]!} visible /></StoreContext.Provider>);
+  return { api, store, ...r };
+}
+
+const dock = () => screen.queryByRole("button", { name: /agents? Parent is waiting on/ });
+
+afterEach(() => cleanup());
+
+describe("the delegating session's dock", () => {
+  it("draws nothing at all for a session that is waiting on no one", async () => {
+    await mount();
+    expect(dock()).toBeNull();
+  });
+
+  it("fetches on mount, so a pane opened mid-delegation still sees the run", async () => {
+    const { api } = await mount({ se1: [KID] });
+    // THE MUTANT: drop the fetch and rely on `delegation.changed` alone. The registry is in the
+    // server's memory, so a reload — or a second window, or opening the pane ten minutes in — would
+    // show nothing until the run ENDED, which is exactly when it stops being worth showing.
+    await waitFor(() => expect(dock()).not.toBeNull());
+    expect(api.calls).toContain("listDelegatedRuns:se1");
+    expect(screen.getByRole("button", { name: /Agent: audit the mapper/ })).toBeInTheDocument();
+  });
+
+  it("leaves when the last run settles rather than sitting there stale", async () => {
+    const { store } = await mount({ se1: [KID] });
+    await waitFor(() => expect(dock()).not.toBeNull());
+    store.getState().applyDelegationChanged({ sessionId: "se1", running: [] });
+    // THE MUTANT: have `applyDelegationChanged` merge, or park the empty array under the key. The
+    // pane then keeps announcing an agent that finished, with nothing left that will ever correct
+    // it — the registry has already forgotten the run.
+    await waitFor(() => expect(dock()).toBeNull());
+    expect(store.getState().delegatedRuns).not.toHaveProperty("se1");
+  });
+
+  it("replaces the set rather than accumulating: the payload is the whole truth", async () => {
+    const { store } = await mount({ se1: [KID] });
+    await waitFor(() => expect(dock()).not.toBeNull());
+    store.getState().applyDelegationChanged({ sessionId: "se1", running: [PEER] });
+    expect(store.getState().delegatedRuns["se1"]).toEqual([PEER]);
+  });
+
+  it("opens a sub-agent BESIDE its parent, never over the top of it", async () => {
+    const { store } = await mount({ se1: [KID] });
+    await waitFor(() => expect(dock()).not.toBeNull());
+    fireEvent.click(screen.getByRole("button", { name: /Agent: audit the mapper/ }));
+    // THE MUTANT: open in place. The pane the user pressed the button in is the parent whose work
+    // they are trying to follow, and evicting it to show the child destroys the comparison.
+    await waitFor(() => expect(allItems(store.getState().layout!)).toEqual(expect.arrayContaining(["i9", "i8"])));
+  });
+
+  it("does not call a peer it merely asked a question a sub-agent", async () => {
+    await mount({ se1: [PEER] });
+    // THE MUTANT: read the origin off the session row for every run. A peer was doing its own work
+    // before the question arrived and keeps doing it after — `agent_ask` neither spawned it nor owns
+    // it, and its own row says nothing about this session at all.
+    await waitFor(() => expect(screen.getByRole("button", { name: /A colleague/ })).toHaveAccessibleName(/Asked a question/));
+  });
+});

--- a/apps/desktop/src/renderer/src/panes/session/tool-card.test.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/tool-card.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, fireEvent, cleanup, within, act } from "@testing-librar
 import { ToolCard, ToolGroup, RESULT_CLAMP } from "./ToolCard";
 import { editStat } from "./tool-summary";
 import * as summaryModule from "./tool-summary";
-import { GROUP_MIN, formatDuration, formatToolRun, groupTranscript, summarizeToolRun, type ToolBlock, type ToolNode } from "./tool-group";
+import { GROUP_MIN, formatDuration, formatToolRun, groupTranscript, summarizeToolRun, withEnter, type ToolBlock, type ToolNode } from "./tool-group";
 import { Transcript } from "./Transcript";
 import type { Block, Transcript as TranscriptModel } from "./transcript-model";
 
@@ -155,6 +155,26 @@ describe("in-harness sub-agents (Claude's parent_tool_use_id)", () => {
     // walking the tree to mark enter flags recurses until the stack goes.
     expect(items.map((i) => i.key)).toEqual(["tool:ping"]);
     expect(items[0]!.kind === "block" && items[0]!.nested.map((n) => n.key)).toEqual(["tool:pong"]);
+  });
+
+  it("counts the sub-agent's calls in the run that spawned them, over the run's real span", () => {
+    // The child outlives the parent's own next call, which is the ordinary shape: they run
+    // concurrently, so the LAST call in tree order is not the last one to happen.
+    const items = groupTranscript([
+      tool("t1", "Read", { file_path: "/a.ts" }, 1_000),
+      tool("task1", "Task", { description: "audit" }, 2_000),
+      tool("t2", "Read", { file_path: "/c.ts" }, 5_000),
+      sub("s1", "task1", "Read", { file_path: "/b.ts" }, 302_000),
+    ]);
+    const group = items[0]!;
+    render(<ToolGroup steps={withEnter(group.kind === "group" ? group.steps : [], () => false)} sessionStatus="idle" />);
+    // TWO MUTANTS. Summarize the top-level steps alone: nesting took the child's call out of the run,
+    // so the counts under-report it and the span ends when the parent stopped, not when the work did.
+    // Or keep first→last instead of min→max: tree order ends on `t2` at 5s, and a row that ticked
+    // upward for five minutes would freeze at "3s" the instant it settled.
+    const row = screen.getByRole("button", { name: "4 tool calls" });
+    expect(row).toHaveTextContent("Worked for 5m 1s");
+    expect(row).toHaveAttribute("title", "4 tools · 3 files · 5m 1s");
   });
 
   it("draws the sub-agent's steps under its Task row, labelled as the sub-agent's own work", () => {

--- a/apps/desktop/src/renderer/src/panes/session/tool-card.test.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/tool-card.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, fireEvent, cleanup, within, act } from "@testing-librar
 import { ToolCard, ToolGroup, RESULT_CLAMP } from "./ToolCard";
 import { editStat } from "./tool-summary";
 import * as summaryModule from "./tool-summary";
-import { GROUP_MIN, formatDuration, formatToolRun, groupTranscript, summarizeToolRun, type ToolBlock } from "./tool-group";
+import { GROUP_MIN, formatDuration, formatToolRun, groupTranscript, summarizeToolRun, type ToolBlock, type ToolNode } from "./tool-group";
 import { Transcript } from "./Transcript";
 import type { Block, Transcript as TranscriptModel } from "./transcript-model";
 
@@ -88,6 +88,81 @@ describe("tool-run grouping (§5: group consecutive tools under a collapsed summ
   });
 });
 
+/** A tool call a sub-agent made: same shape, plus the Task call it was made under. */
+const sub = (id: string, parent: string, name: string, input: Record<string, unknown>, ts = 0, done = true): ToolBlock =>
+  ({ ...tool(id, name, input, ts, done), parentToolUseId: parent });
+
+describe("in-harness sub-agents (Claude's parent_tool_use_id)", () => {
+  it("hangs a sub-agent's calls off the Task call that spawned them instead of leaving them in the stream", () => {
+    const items = groupTranscript([
+      tool("task1", "Task", { description: "audit the mapper" }),
+      sub("s1", "task1", "Read", { file_path: "/a.ts" }),
+      sub("s2", "task1", "Grep", { pattern: "foo" }),
+    ]);
+    // Kills "ignore parentToolUseId and keep folding by position": that renders three sibling cards
+    // in one run, and the reader cannot tell which two the sub-agent made.
+    expect(items).toHaveLength(1);
+    expect(items[0]!.kind === "block" && items[0]!.block.kind === "tool" && items[0]!.block.name).toBe("Task");
+    expect(items[0]!.kind === "block" && items[0]!.nested.map((n) => n.key)).toEqual(["tool:s1", "tool:s2"]);
+  });
+
+  it("closes the gap the lifted calls leave: the parent's own calls either side of them become one run", () => {
+    const items = groupTranscript([
+      tool("t1", "Read", { file_path: "/a" }),
+      sub("s1", "task1", "Read", { file_path: "/x" }),
+      tool("t2", "Read", { file_path: "/b" }),
+    ]);
+    // s1 names a parent this transcript does not hold, so it stays top-level and splits the run.
+    expect(items.map((i) => i.kind)).toEqual(["group"]);
+    expect(items[0]!.kind === "group" && items[0]!.steps.map((x) => x.key)).toEqual(["tool:t1", "tool:s1", "tool:t2"]);
+
+    const withParent = groupTranscript([
+      tool("task1", "Task", { description: "go" }),
+      tool("t1", "Read", { file_path: "/a" }),
+      sub("s1", "task1", "Read", { file_path: "/x" }),
+      tool("t2", "Read", { file_path: "/b" }),
+    ]);
+    // Kills "lift the child but leave a hole where it was": t1 and t2 were one run all along, and a
+    // hole would have them read as two separate stretches of work.
+    expect(withParent.map((i) => i.kind)).toEqual(["group"]);
+    expect(withParent[0]!.kind === "group" && withParent[0]!.steps.map((x) => x.key)).toEqual(["tool:task1", "tool:t1", "tool:t2"]);
+  });
+
+  it("nests recursively, and never loses a call to an id it cannot resolve", () => {
+    const flatKeys = (ns: readonly ToolNode[]): string[] => ns.flatMap((n) => [n.key, ...flatKeys(n.nested)]);
+    const items = groupTranscript([
+      tool("task1", "Task", { description: "outer" }),
+      sub("task2", "task1", "Task", { description: "inner" }),
+      sub("s1", "task2", "Bash", { command: "ls" }),
+      sub("orphan", "gone", "Read", { file_path: "/o" }),
+      // A call naming itself would otherwise nest into itself and leave the transcript entirely.
+      sub("selfie", "selfie", "Read", { file_path: "/s" }),
+    ]);
+    expect(items).toHaveLength(1);
+    const group = items[0]!;
+    // Kills "drop any call whose parent cannot be resolved", which silently swallows work the agent
+    // really did — and kills losing a self-referential id down its own hole.
+    expect(group.kind === "group" && group.steps.map((x) => x.key)).toEqual(["tool:task1", "tool:orphan", "tool:selfie"]);
+    expect(group.kind === "group" && flatKeys(group.steps[0]!.nested)).toEqual(["tool:task2", "tool:s1"]);
+  });
+
+  it("draws the sub-agent's steps under its Task row, labelled as the sub-agent's own work", () => {
+    const nested = [
+      { key: "tool:s1", block: sub("s1", "task1", "Read", { file_path: "/a.ts" }), enter: false, nested: [] },
+      { key: "tool:s2", block: sub("s2", "task1", "Bash", { command: "pnpm test" }, 0, false), enter: false, nested: [] },
+    ];
+    render(<ToolCard sessionStatus="running" nested={nested}
+      block={{ kind: "tool", toolUseId: "task1", name: "Task", input: { description: "audit the mapper" }, result: null, ts: 0 }} />);
+    // Named apart from the agent's own runs: directly under a Task row, a bare "Worked for" reads as
+    // the Task's elapsed time rather than the child's.
+    const row = screen.getByRole("button", { name: "2 sub-agent tool calls" });
+    expect(row).toHaveTextContent("Sub-agent worked for");
+    // Open while the child is still working — the one thing this treatment must not do is collapse
+    // live activity out of sight.
+    expect(cards().map((c) => c.querySelector(".tool-name")!.textContent)).toEqual(["Task", "Read", "Bash"]);
+  });
+});
+
 describe("tool-run summary line", () => {
   it("counts distinct files, not file touches — reading one file four times edited one file", () => {
     const s = summarizeToolRun([
@@ -168,7 +243,7 @@ describe("editStat (Plan 9 W2: ThinkingState's measured +/− counts)", () => {
   });
 });
 
-const steps = (blocks: ToolBlock[]) => blocks.map((b) => ({ key: b.toolUseId, block: b, enter: false }));
+const steps = (blocks: ToolBlock[]) => blocks.map((b) => ({ key: b.toolUseId, block: b, enter: false, nested: [] }));
 const cards = () => [...document.querySelectorAll<HTMLElement>(".tool-card")];
 const bodyOf = (card: HTMLElement) => card.querySelector(".tool-body");
 

--- a/apps/desktop/src/renderer/src/panes/session/tool-card.test.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/tool-card.test.tsx
@@ -135,7 +135,6 @@ describe("in-harness sub-agents (Claude's parent_tool_use_id)", () => {
       sub("task2", "task1", "Task", { description: "inner" }),
       sub("s1", "task2", "Bash", { command: "ls" }),
       sub("orphan", "gone", "Read", { file_path: "/o" }),
-      // A call naming itself would otherwise nest into itself and leave the transcript entirely.
       sub("selfie", "selfie", "Read", { file_path: "/s" }),
     ]);
     expect(items).toHaveLength(1);
@@ -144,6 +143,18 @@ describe("in-harness sub-agents (Claude's parent_tool_use_id)", () => {
     // really did — and kills losing a self-referential id down its own hole.
     expect(group.kind === "group" && group.steps.map((x) => x.key)).toEqual(["tool:task1", "tool:orphan", "tool:selfie"]);
     expect(group.kind === "group" && flatKeys(group.steps[0]!.nested)).toEqual(["tool:task2", "tool:s1"]);
+  });
+
+  it("cannot be talked into a cycle by two calls naming each other", () => {
+    const items = groupTranscript([
+      sub("ping", "pong", "Read", { file_path: "/p" }),
+      sub("pong", "ping", "Read", { file_path: "/q" }),
+    ]);
+    // A parent is only ever a call already seen. THE MUTANT: resolve against every call in the
+    // transcript instead, and this pair nests into each other — both leave the render entirely, and
+    // walking the tree to mark enter flags recurses until the stack goes.
+    expect(items.map((i) => i.key)).toEqual(["tool:ping"]);
+    expect(items[0]!.kind === "block" && items[0]!.nested.map((n) => n.key)).toEqual(["tool:pong"]);
   });
 
   it("draws the sub-agent's steps under its Task row, labelled as the sub-agent's own work", () => {

--- a/apps/desktop/src/renderer/src/panes/session/tool-group.ts
+++ b/apps/desktop/src/renderer/src/panes/session/tool-group.ts
@@ -46,21 +46,21 @@ const NO_NESTED: ToolNode[] = [];
  *  Lifting a sub-agent's calls out of the top level closes the gaps they left, so a parent's own
  *  calls that were only separated by its child's now group as the one run they always were. */
 export function groupTranscript(blocks: readonly Block[]): TranscriptItem[] {
+  // Only calls ALREADY seen are candidate parents — the map is written after the lookup, one pass,
+  // in arrival order. That is true of every real transcript (a sub-agent cannot act before the call
+  // that spawned it) and it is also what makes a cycle unrepresentable: a malformed pair of ids
+  // would otherwise nest into each other, vanish from the render, and recurse until the stack went.
   const nodes = new Map<string, ToolNode>();
-  for (let i = 0; i < blocks.length; i++) {
-    const b = blocks[i]!;
-    if (b.kind === "tool") nodes.set(b.toolUseId, { key: blockKey(b, i), block: b, nested: [] });
-  }
-
   const top: { key: string; block: Block; nested: ToolNode[] }[] = [];
   for (let i = 0; i < blocks.length; i++) {
     const b = blocks[i]!;
     if (b.kind !== "tool") { top.push({ key: blockKey(b, i), block: b, nested: NO_NESTED }); continue; }
-    const node = nodes.get(b.toolUseId)!;
     const parent = b.parentToolUseId === undefined ? undefined : nodes.get(b.parentToolUseId);
-    // A parent this transcript does not contain leaves the call where it is. An id Realm cannot
-    // resolve is still work the agent did, and hiding it would lose the call rather than nest it.
-    if (parent && parent !== node) parent.nested.push(node); else top.push(node);
+    const node: ToolNode = { key: blockKey(b, i), block: b, nested: [] };
+    nodes.set(b.toolUseId, node);
+    // A parent this transcript does not hold leaves the call where it is. An id Realm cannot resolve
+    // is still work the agent did, and hiding it would lose the call rather than nest it.
+    if (parent) parent.nested.push(node); else top.push(node);
   }
 
   const out: TranscriptItem[] = [];

--- a/apps/desktop/src/renderer/src/panes/session/tool-group.ts
+++ b/apps/desktop/src/renderer/src/panes/session/tool-group.ts
@@ -15,29 +15,79 @@ export const GROUP_MIN = 2;
 const FILE_TOOLS = new Set(["Read", "Write", "Edit", "MultiEdit", "NotebookEdit", "apply_patch"]);
 const COMMAND_TOOLS = new Set(["Bash", "exec_command"]);
 
-export type TranscriptItem =
-  | { kind: "block"; key: string; block: Block }
-  | { kind: "group"; key: string; steps: { key: string; block: ToolBlock }[] };
+/** A tool call together with the calls a sub-agent made underneath it.
+ *
+ *  A sub-agent's calls arrive INTERLEAVED with the parent's own — the harness runs them
+ *  concurrently and the transcript is one stream in arrival order — so nothing about position
+ *  separates them. The only thing that does is `parentToolUseId`, which is why this is a tree built
+ *  from ids rather than another fold over runs. */
+export type ToolNode = { key: string; block: ToolBlock; nested: ToolNode[] };
 
-/** Blocks in render order, with runs of GROUP_MIN+ consecutive tool calls folded into one group.
- *  Every item — grouped or not — keeps the key it would have had ungrouped, so a run crossing the
- *  threshold neither remounts its cards nor re-triggers their enter animation. */
+/** A `ToolNode` marked with §6's enter flag, which only the renderer can decide. */
+export type ToolStep = { key: string; block: ToolBlock; enter: boolean; nested: readonly ToolStep[] };
+
+/** One array, shared by every childless node. `withEnter` runs on each render, and handing each of
+ *  a 300-call transcript its own fresh `[]` would fail ToolCard's memo on all of them. */
+const NO_STEPS: readonly ToolStep[] = [];
+
+export type TranscriptItem =
+  /** `nested` is empty for everything but a tool call whose sub-agent did some work of its own. */
+  | { kind: "block"; key: string; block: Block; nested: ToolNode[] }
+  | { kind: "group"; key: string; steps: ToolNode[] };
+
+const NO_NESTED: ToolNode[] = [];
+
+/** Blocks in render order: sub-agent calls hung off the call that spawned them, and runs of
+ *  GROUP_MIN+ consecutive tool calls among what is left folded into one group.
+ *
+ *  Every item — grouped, nested or neither — keeps the key it would have had ungrouped, so a run
+ *  crossing the threshold neither remounts its cards nor re-triggers their enter animation.
+ *
+ *  Lifting a sub-agent's calls out of the top level closes the gaps they left, so a parent's own
+ *  calls that were only separated by its child's now group as the one run they always were. */
 export function groupTranscript(blocks: readonly Block[]): TranscriptItem[] {
+  const nodes = new Map<string, ToolNode>();
+  for (let i = 0; i < blocks.length; i++) {
+    const b = blocks[i]!;
+    if (b.kind === "tool") nodes.set(b.toolUseId, { key: blockKey(b, i), block: b, nested: [] });
+  }
+
+  const top: { key: string; block: Block; nested: ToolNode[] }[] = [];
+  for (let i = 0; i < blocks.length; i++) {
+    const b = blocks[i]!;
+    if (b.kind !== "tool") { top.push({ key: blockKey(b, i), block: b, nested: NO_NESTED }); continue; }
+    const node = nodes.get(b.toolUseId)!;
+    const parent = b.parentToolUseId === undefined ? undefined : nodes.get(b.parentToolUseId);
+    // A parent this transcript does not contain leaves the call where it is. An id Realm cannot
+    // resolve is still work the agent did, and hiding it would lose the call rather than nest it.
+    if (parent && parent !== node) parent.nested.push(node); else top.push(node);
+  }
+
   const out: TranscriptItem[] = [];
   let i = 0;
-  while (i < blocks.length) {
-    const b = blocks[i]!;
-    if (b.kind !== "tool") { out.push({ kind: "block", key: blockKey(b, i), block: b }); i++; continue; }
-    let end = i;
-    while (end < blocks.length && blocks[end]!.kind === "tool") end++;
-    const steps = blocks.slice(i, end).map((s, k) => ({ key: blockKey(s, i + k), block: s as ToolBlock }));
+  while (i < top.length) {
+    const e = top[i]!;
+    if (e.block.kind !== "tool") { out.push({ kind: "block", key: e.key, block: e.block, nested: NO_NESTED }); i++; continue; }
+    const steps: ToolNode[] = [];
+    while (i < top.length) {
+      const s = top[i]!;
+      if (s.block.kind !== "tool") break;
+      steps.push({ key: s.key, block: s.block, nested: s.nested });
+      i++;
+    }
     // Keyed on the run's first tool: a run only ever grows at its tail, so the group keeps its
     // identity — and the user's expand/collapse choice — as more tools land in it.
     if (steps.length >= GROUP_MIN) out.push({ kind: "group", key: `group:${steps[0]!.key}`, steps });
-    else for (const s of steps) out.push({ kind: "block", key: s.key, block: s.block });
-    i = end;
+    else for (const s of steps) out.push({ kind: "block", key: s.key, block: s.block, nested: s.nested });
   }
   return out;
+}
+
+/** Marks a tool tree with the enter flags the transcript's tracker just decided (transcript-enter).
+ *  Recursive because a sub-agent's cards animate in on arrival exactly as the agent's own do. */
+export function withEnter(nodes: readonly ToolNode[], isEntering: (key: string) => boolean): readonly ToolStep[] {
+  if (nodes.length === 0) return NO_STEPS;
+  return nodes.map((n) => ({ key: n.key, block: n.block, enter: isEntering(n.key), nested: withEnter(n.nested, isEntering) }));
 }
 
 export type ToolRunSummary = { tools: number; files: number; commands: number; durationMs: number };

--- a/apps/desktop/src/renderer/src/panes/session/tool-group.ts
+++ b/apps/desktop/src/renderer/src/panes/session/tool-group.ts
@@ -23,6 +23,18 @@ const COMMAND_TOOLS = new Set(["Bash", "exec_command"]);
  *  from ids rather than another fold over runs. */
 export type ToolNode = { key: string; block: ToolBlock; nested: ToolNode[] };
 
+/** The shape `flattenRun` walks — `ToolNode` before the renderer marks it, `ToolStep` after. */
+type ToolTree = { block: ToolBlock; nested: readonly ToolTree[] };
+
+/** Every call a run made, the sub-agents' included, in tree order.
+ *
+ *  The collapsed ledger counts what the RUN did. A sub-agent's calls stopped being top-level when
+ *  they were nested under the Task that spawned them, and leaving them out would have the one line
+ *  the reader sees under-report the work it claims to summarize. */
+export function flattenRun(nodes: readonly ToolTree[]): ToolBlock[] {
+  return nodes.flatMap((n) => [n.block, ...flattenRun(n.nested)]);
+}
+
 /** A `ToolNode` marked with §6's enter flag, which only the renderer can decide. */
 export type ToolStep = { key: string; block: ToolBlock; enter: boolean; nested: readonly ToolStep[] };
 
@@ -31,11 +43,12 @@ export type ToolStep = { key: string; block: ToolBlock; enter: boolean; nested: 
 const NO_STEPS: readonly ToolStep[] = [];
 
 export type TranscriptItem =
-  /** `nested` is empty for everything but a tool call whose sub-agent did some work of its own. */
-  | { kind: "block"; key: string; block: Block; nested: ToolNode[] }
+  /** `nested` is empty for everything but a tool call whose sub-agent did some work of its own.
+   *  Readonly because every childless entry is handed the SAME empty array — see `NO_NESTED`. */
+  | { kind: "block"; key: string; block: Block; nested: readonly ToolNode[] }
   | { kind: "group"; key: string; steps: ToolNode[] };
 
-const NO_NESTED: ToolNode[] = [];
+const NO_NESTED: readonly ToolNode[] = [];
 
 /** Blocks in render order: sub-agent calls hung off the call that spawned them, and runs of
  *  GROUP_MIN+ consecutive tool calls among what is left folded into one group.
@@ -51,30 +64,27 @@ export function groupTranscript(blocks: readonly Block[]): TranscriptItem[] {
   // that spawned it) and it is also what makes a cycle unrepresentable: a malformed pair of ids
   // would otherwise nest into each other, vanish from the render, and recurse until the stack went.
   const nodes = new Map<string, ToolNode>();
-  const top: { key: string; block: Block; nested: ToolNode[] }[] = [];
+  /** `node` is null for everything that is not a tool call, and IS the node otherwise — carried
+   *  rather than rebuilt so a card's `nested` keeps its identity across renders. */
+  const top: { key: string; block: Block; node: ToolNode | null }[] = [];
   for (let i = 0; i < blocks.length; i++) {
     const b = blocks[i]!;
-    if (b.kind !== "tool") { top.push({ key: blockKey(b, i), block: b, nested: NO_NESTED }); continue; }
+    if (b.kind !== "tool") { top.push({ key: blockKey(b, i), block: b, node: null }); continue; }
     const parent = b.parentToolUseId === undefined ? undefined : nodes.get(b.parentToolUseId);
     const node: ToolNode = { key: blockKey(b, i), block: b, nested: [] };
     nodes.set(b.toolUseId, node);
     // A parent this transcript does not hold leaves the call where it is. An id Realm cannot resolve
     // is still work the agent did, and hiding it would lose the call rather than nest it.
-    if (parent) parent.nested.push(node); else top.push(node);
+    if (parent) parent.nested.push(node); else top.push({ key: node.key, block: b, node });
   }
 
   const out: TranscriptItem[] = [];
   let i = 0;
   while (i < top.length) {
     const e = top[i]!;
-    if (e.block.kind !== "tool") { out.push({ kind: "block", key: e.key, block: e.block, nested: NO_NESTED }); i++; continue; }
+    if (!e.node) { out.push({ kind: "block", key: e.key, block: e.block, nested: NO_NESTED }); i++; continue; }
     const steps: ToolNode[] = [];
-    while (i < top.length) {
-      const s = top[i]!;
-      if (s.block.kind !== "tool") break;
-      steps.push({ key: s.key, block: s.block, nested: s.nested });
-      i++;
-    }
+    for (let n = top[i]?.node; n; n = top[i]?.node) { steps.push(n); i++; }
     // Keyed on the run's first tool: a run only ever grows at its tail, so the group keeps its
     // identity — and the user's expand/collapse choice — as more tools land in it.
     if (steps.length >= GROUP_MIN) out.push({ kind: "group", key: `group:${steps[0]!.key}`, steps });
@@ -101,8 +111,11 @@ export function summarizeToolRun(blocks: readonly ToolBlock[]): ToolRunSummary {
     if (FILE_TOOLS.has(b.name)) { const p = toolSummary(b.name, b.input); if (p) files.add(p); }
     if (COMMAND_TOOLS.has(b.name)) commands++;
   }
-  const first = blocks[0], last = blocks[blocks.length - 1];
-  return { tools: blocks.length, files: files.size, commands, durationMs: first && last ? Math.max(0, last.ts - first.ts) : 0 };
+  // The span is min→max rather than first→last: a sub-agent's calls are counted in here and they
+  // ran CONCURRENTLY with the parent's, so the last call in tree order is not the last to happen.
+  let lo = Infinity, hi = -Infinity;
+  for (const b of blocks) { lo = Math.min(lo, b.ts); hi = Math.max(hi, b.ts); }
+  return { tools: blocks.length, files: files.size, commands, durationMs: blocks.length ? Math.max(0, hi - lo) : 0 };
 }
 
 const plural = (n: number, word: string) => `${n} ${word}${n === 1 ? "" : "s"}`;

--- a/apps/desktop/src/renderer/src/panes/session/transcript-model.test.ts
+++ b/apps/desktop/src/renderer/src/panes/session/transcript-model.test.ts
@@ -68,6 +68,19 @@ describe("a plan the agent proposed", () => {
   });
 });
 
+describe("a tool call a sub-agent made", () => {
+  it("carries `parentToolUseId` onto the block, and leaves it absent for a call the agent made itself", () => {
+    let t = emptyTranscript();
+    t = reduceTranscript(t, sessionEvent("tool_call", { toolUseId: "t1", name: "Task", input: {}, parentToolUseId: null }));
+    // Absence is the ordinary case, and the adapters that report no hierarchy send null forever.
+    expect(t.blocks.at(-1)).not.toHaveProperty("parentToolUseId");
+    t = reduceTranscript(t, sessionEvent("tool_call", { toolUseId: "t2", name: "Read", input: {}, parentToolUseId: "t1" }));
+    // Kills the reducer dropping the field: the pane then has nothing to nest by and renders the
+    // sub-agent's calls flat among the agent's own, which is what it did before.
+    expect(t.blocks.at(-1)).toMatchObject({ kind: "tool", toolUseId: "t2", parentToolUseId: "t1" });
+  });
+});
+
 describe("transcript model", () => {
   it("builds blocks: user, assistant (deltas then final), tool with result, permission pending→resolved", () => {
     let t = emptyTranscript();

--- a/apps/desktop/src/renderer/src/panes/session/transcript-model.ts
+++ b/apps/desktop/src/renderer/src/panes/session/transcript-model.ts
@@ -10,7 +10,11 @@ export type Block =
   | { kind: "user"; text: string; attachments?: { path: string; mime: string }[]; from?: { sessionId: string; title: string }; ts: number }
   | { kind: "assistant"; messageId: string; text: string; streaming: boolean; ts: number }
   | { kind: "thinking"; messageId: string; text: string; ts: number }
-  | { kind: "tool"; toolUseId: string; name: string; input: Record<string, unknown>; result: { content: string; isError: boolean } | null; ts: number }
+  /** `parentToolUseId` is the Task/Agent call this one was made UNDER — Claude's
+   *  `parent_tool_use_id`, set only on a sub-agent's own calls. Absent is the ordinary case: the
+   *  agent made the call itself, and every adapter that reports no hierarchy at all leaves it
+   *  absent throughout, so those transcripts nest nothing and read exactly as before. */
+  | { kind: "tool"; toolUseId: string; name: string; input: Record<string, unknown>; parentToolUseId?: string; result: { content: string; isError: boolean } | null; ts: number }
   | { kind: "error"; message: string; ts: number }
   /** A plan the agent proposed. `text` is prose, `steps` a checklist, and at least one is present —
    *  which of them depends on the protocol, not on the agent's mood (see the `plan` event). A revised
@@ -68,7 +72,7 @@ export function reduceTranscript(t: Transcript, e: SessionEvent): Transcript {
       return { ...t, blocks };
     }
     case "thinking": blocks.push({ kind: "thinking", messageId: e.payload.messageId, text: e.payload.text, ts: e.ts }); return { ...t, blocks };
-    case "tool_call": blocks.push({ kind: "tool", toolUseId: e.payload.toolUseId, name: e.payload.name, input: e.payload.input, result: null, ts: e.ts }); return { ...t, blocks };
+    case "tool_call": blocks.push({ kind: "tool", toolUseId: e.payload.toolUseId, name: e.payload.name, input: e.payload.input, ...(e.payload.parentToolUseId ? { parentToolUseId: e.payload.parentToolUseId } : {}), result: null, ts: e.ts }); return { ...t, blocks };
     case "tool_result": {
       const i = findLast(blocks, (b) => b.kind === "tool" && b.toolUseId === e.payload.toolUseId);
       const b = i >= 0 ? blocks[i] : undefined;

--- a/apps/desktop/src/renderer/src/panes/session/use-elapsed.ts
+++ b/apps/desktop/src/renderer/src/panes/session/use-elapsed.ts
@@ -1,0 +1,16 @@
+import { useEffect, useState } from "react";
+
+/** Milliseconds since `since`, re-read once a second while `live` and frozen the moment it stops.
+ *
+ *  The interval is the part that matters: a transcript can hold hundreds of these at once, so the
+ *  clock has to stop with the work it measures rather than run for as long as the pane is open. */
+export function useElapsed(since: number, live: boolean): number {
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    if (!live) return;
+    setNow(Date.now());
+    const t = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(t);
+  }, [live]);
+  return Math.max(0, now - since);
+}

--- a/apps/desktop/src/renderer/src/panes/space/SpacePage.tsx
+++ b/apps/desktop/src/renderer/src/panes/space/SpacePage.tsx
@@ -1,8 +1,9 @@
-import { AGENT_META, SPACE_COLORS, isRunTerminal, type Checkpoint, type DispatchKind, type Environment, type Run, type RunAttemptOutcome, type RunState, type Session, type Ship } from "@realm/contracts";
+import { AGENT_META, SPACE_COLORS, isRunTerminal, type Checkpoint, type Environment, type Run, type RunAttemptOutcome, type RunState, type Session, type Ship } from "@realm/contracts";
 import { Icon } from "@realm/ui";
 import { useEffect, useRef, useState } from "react";
 import { useApp, type SpacePageTab } from "../../state/store";
 import { relativeTime } from "../../components/CheckpointsSheet";
+import { ORIGIN_META, SESSION_STATUS_LABEL } from "../session-labels";
 import { McpSection } from "../../components/sidebar/McpSection";
 import { BrowserOrigins } from "../../components/sidebar/BrowserOrigins";
 import { IconPicker } from "../../components/IconPicker";
@@ -154,7 +155,6 @@ function MemoryTab({ spaceId }: { spaceId: string }) {
   );
 }
 
-const SESSION_STATUS_LABEL = { idle: "idle", running: "running", waiting_permission: "needs permission", error: "error", ended: "ended" } as const;
 
 /** The Sessions tab: this space's sessions from the existing store data, newest first; each row opens
  *  the session's pane. Status dots ride the same `sessionStatus` plumbing as the sidebar rows.
@@ -202,18 +202,6 @@ function SessionsTab({ spaceId }: { spaceId: string }) {
     </ul>
   );
 }
-
-/** Origin glyph + words per dispatch kind (Plan 13 W2). The agent kinds carry a parent-session link
- *  in the row; `user-dispatch` has no parent by definition. */
-const ORIGIN_META: Record<DispatchKind, { icon: string; label: string }> = {
-  "user-dispatch": { icon: "send", label: "Dispatched (⌘⇧↵)" },
-  agent_run: { icon: "bot", label: "Delegated via agent_run" },
-  browser_agent_run: { icon: "browser", label: "Browser agent" },
-  review: { icon: "diff", label: "Reviewer" },
-  fork: { icon: "branch", label: "Forked from a checkpoint" },
-  import: { icon: "download", label: "Imported from an agent CLI" },
-  run: { icon: "bot", label: "Durable run" },
-};
 
 /** How a run's state reads in the lens. Deliberately not the raw state word: `blocked` is the one
  *  the user has to ACT on, so it says so. */

--- a/apps/desktop/src/renderer/src/panes/space/SpacePage.tsx
+++ b/apps/desktop/src/renderer/src/panes/space/SpacePage.tsx
@@ -155,7 +155,6 @@ function MemoryTab({ spaceId }: { spaceId: string }) {
   );
 }
 
-
 /** The Sessions tab: this space's sessions from the existing store data, newest first; each row opens
  *  the session's pane. Status dots ride the same `sessionStatus` plumbing as the sidebar rows.
  *

--- a/apps/desktop/src/renderer/src/state/live-api.ts
+++ b/apps/desktop/src/renderer/src/state/live-api.ts
@@ -151,4 +151,5 @@ export const liveApi = (): Api => ({
   requestReview: (environmentId) => rpc().call("review.request", { environmentId }),
   getReview: (environmentId) => rpc().call("review.get", { environmentId }),
   dismissReview: async (environmentId) => { await rpc().call("review.dismiss", { environmentId }); },
+  listDelegatedRuns: async (sessionId) => (await rpc().call("delegation.running", { sessionId })).running,
 });

--- a/apps/desktop/src/renderer/src/state/store.test-fakes.ts
+++ b/apps/desktop/src/renderer/src/state/store.test-fakes.ts
@@ -1,6 +1,6 @@
 /** Shared in-memory Api fake for renderer tests (store, sidebar, palette). Not a test file itself. */
 import { activeLayout, setActiveLayout, MCP_SECRET_STORAGE_NOTE, MEMORY_DOC_MAX } from "@realm/contracts";
-import type { GuideProgress, Lecture, PlynnMeeting, AgentsFileState, Attachment, BrowserCredential, Checkpoint, DiffSummary, Environment, FileDiff, GitInfo, IconAsset, ImportApplyParams, ImportResult, ImportScan, Item, McpCall, McpServer, McpTool, MemorySources, MemoryState, Notification, Profile, Project, RestorePreview, ReviewResult, Session, Ship, ShipResult, Skill, Space, StoredSessionEvent, WorktreeStatus, SkillSource, DocumentWorkspace, Run, RunAttempt } from "@realm/contracts";
+import type { GuideProgress, Lecture, PlynnMeeting, AgentsFileState, Attachment, BrowserCredential, Checkpoint, DiffSummary, Environment, FileDiff, GitInfo, IconAsset, ImportApplyParams, ImportResult, ImportScan, Item, McpCall, McpServer, McpTool, MemorySources, MemoryState, Notification, Profile, Project, RestorePreview, ReviewResult, DelegatedRun, Session, Ship, ShipResult, Skill, Space, StoredSessionEvent, WorktreeStatus, SkillSource, DocumentWorkspace, Run, RunAttempt } from "@realm/contracts";
 import type { AddMcpServerInput, AgentProbe, Api, CredentialStatus, McpTestResult, PickedAttachment, UpdateMcpServerInput } from "./store";
 import type { ModelInfo, SearchResults, UsageBudget, UsageSummary, UsageTotals } from "@realm/contracts";
 
@@ -225,6 +225,8 @@ export type FakeData = {
   notifications?: Notification[];
   /** Persisted review verdicts by environment id (Plan 13 W3) — what `review.get` answers. */
   reviews?: Record<string, ReviewResult | null>;
+  /** The delegation engine's live registry by delegating session id — what `delegation.running` answers. */
+  delegatedRuns?: Record<string, DelegatedRun[]>;
   /** What `search.query` answers (Plan 16 W2), regardless of query — palette tests script the groups.
    *  Delay it with `delays["search"]` to hold results in flight. */
   searchResults?: SearchResults;
@@ -355,6 +357,7 @@ export function fakeApi(overrides: FakeData = {}): FakeApi {
     documentFiles: overrides.documentFiles ?? {},
     notifications: overrides.notifications ?? [],
     reviews: overrides.reviews ?? {},
+    delegatedRuns: overrides.delegatedRuns ?? {},
     searchResults: overrides.searchResults ?? { sessions: [], items: [], skills: [], memory: [] },
     iconAssets: overrides.iconAssets ?? {},
     pickIconImage: overrides.pickIconImage ?? null,
@@ -1132,6 +1135,7 @@ export function fakeApi(overrides: FakeData = {}): FakeApi {
     },
     getReview: async (environmentId) => { calls.push(`getReview:${environmentId}`); return { review: data.reviews[environmentId] ?? null }; },
     dismissReview: async (environmentId) => { calls.push(`dismissReview:${environmentId}`); data.reviews[environmentId] = null; },
+    listDelegatedRuns: async (sessionId) => { calls.push(`listDelegatedRuns:${sessionId}`); return data.delegatedRuns[sessionId] ?? []; },
   };
   const wait = (key: string) => new Promise<void>((r) => setTimeout(r, api.delays[key] ?? 0));
   return api;

--- a/apps/desktop/src/renderer/src/state/store.ts
+++ b/apps/desktop/src/renderer/src/state/store.ts
@@ -7,7 +7,7 @@ import {
   AGENT_SKILL_SUPPORT, AGENT_SUPPORTS_PERMISSION_MODES, basenameOf, formatAttachmentSize, MAX_ATTACHMENT_BYTES, mentionIds, mimeForPath, PAGE_REF_IDS,
   DEFAULT_PERMISSION_MODE_KEY, NOTIFICATIONS_DESKTOP_KEY, NOTIFICATIONS_DISABLED_KEY, NOTIFICATION_CATEGORIES, PERMISSION_MODES, MODEL_FAVORITES_KEY, parseSpaceIcon, type ModelInfo,
   type DestinationPageKind, type NotificationCategory, type NavEntry, type PaneHistory, type DocumentEntry, type DocumentKind, type DocumentWorkspace,
-  type AgentKind, type Attachment, type BrowserCredential, type BrowserCredentialInput, type Checkpoint, type DiffSummary, type Environment, type FileDiff, type GitInfo, type IconAsset, type ImportApplyParams, type ImportResult, type ImportScan, type Item, type GuideProgress, type Lecture, type PlynnImportResult, type PlynnMeeting, type StartLectureResult, type Layout, type McpCall, type McpOauthStatus, type McpServer, type McpServerStatus, type McpTransport, type MemorySources, type MemoryState, type MethodResult, type Notification, type PaneGroup, type PresetName, type Profile, type Project, type RestorePreview, type RestoreResult, type ReviewResult, type SearchResults, type Session, type SessionMode, type SessionStatus, type Ship, type ShipResult, type Skill, type Space, type SpaceGroups, type StoredSessionEvent, type WorktreeAck, type WorktreeStatus, type SkillSource, type Run, type RunAttempt, type RunState, type UsageBudget, type UsageBucketKind, type UsageSummary,
+  type AgentKind, type Attachment, type BrowserCredential, type DelegatedRun, type BrowserCredentialInput, type Checkpoint, type DiffSummary, type Environment, type FileDiff, type GitInfo, type IconAsset, type ImportApplyParams, type ImportResult, type ImportScan, type Item, type GuideProgress, type Lecture, type PlynnImportResult, type PlynnMeeting, type StartLectureResult, type Layout, type McpCall, type McpOauthStatus, type McpServer, type McpServerStatus, type McpTransport, type MemorySources, type MemoryState, type MethodResult, type Notification, type PaneGroup, type PresetName, type Profile, type Project, type RestorePreview, type RestoreResult, type ReviewResult, type SearchResults, type Session, type SessionMode, type SessionStatus, type Ship, type ShipResult, type Skill, type Space, type SpaceGroups, type StoredSessionEvent, type WorktreeAck, type WorktreeStatus, type SkillSource, type Run, type RunAttempt, type RunState, type UsageBudget, type UsageBucketKind, type UsageSummary,
 } from "@realm/contracts";
 import { createContext, useCallback, useContext, useMemo, useSyncExternalStore } from "react";
 import { SHEET_MIN_WIDTH, complementOf, snapBrowserLeaves } from "./no-overlay";
@@ -348,6 +348,10 @@ export type Api = {
   getReview(environmentId: string): Promise<{ review: ReviewResult | null }>;
   /** `review.dismiss` — clear the persisted verdict (server-side, so every window's pane hears it). */
   dismissReview(environmentId: string): Promise<void>;
+  /** `delegation.running` — the sessions this one is waiting on right now. The server's registry is
+   *  in memory, so this is the only way a pane mounted mid-run learns about it; from then on
+   *  `delegation.changed` carries every change. */
+  listDelegatedRuns(sessionId: string): Promise<DelegatedRun[]>;
 };
 
 /** The two narrowing dimensions Activity's chips apply — `undefined` means "not filtering by this". */
@@ -692,6 +696,10 @@ export type AppState = {
   /** The selected run's attempt log, by run id. Fetched on selection (`runs.get`); the list rows
    *  carry the run itself, so this holds only what a row cannot. */
   runAttempts: Record<string, RunAttempt[]>;
+  /** What each session is waiting on right now, by DELEGATING session id — the server's in-memory
+   *  delegation registry, mirrored. A session waiting on nothing holds no entry rather than an empty
+   *  array, so the map stays the size of the delegation actually happening. */
+  delegatedRuns: Record<string, DelegatedRun[]>;
   /** The checkpoint the sheet is asking about, as the preview it is showing. Null = the list state;
    *  the preview carries its own `checkpointId`, so there is nothing else to remember. */
   checkpointPreview: RestorePreview | null;
@@ -1106,6 +1114,12 @@ export type AppState = {
   /** The `review.changed` handler: apply the payload directly (no refetch race) and clear the
    *  in-flight flag. */
   applyReviewChanged(payload: { environmentId: string; review: ReviewResult | null }): void;
+  /** Fetch what this session is waiting on (session pane mount). Covers the runs that began before
+   *  this window connected — every later change arrives as `delegation.changed`. */
+  refreshDelegatedRuns(sessionId: string): Promise<void>;
+  /** The `delegation.changed` handler. The payload is the WHOLE set, so it replaces rather than
+   *  merges; an empty one drops the key instead of parking an empty array nobody will clear. */
+  applyDelegationChanged(payload: { sessionId: string; running: DelegatedRun[] }): void;
   /** Open the space's PAGE (Plan 12 W3) — a `space-page` item whose refId is the space id, one per
    *  space (the diff pane's dedup precedent). `tab` lands the page on a section — the plus-menu's
    *  "Manage connections…" passes "connections"; omitted keeps whatever tab the page last showed. */
@@ -1759,7 +1773,7 @@ export function createAppStore(api: Api): StoreApi<AppState> {
       sessions: {}, sessionStatus: {}, sessionSpace: {}, transcripts: {}, agentProbe: [], settingsPrefs: null, tccRows: null, credentials: null, credentialStatus: null, macAccess: null, macGranting: null, macGrantQueue: [], computerAccess: null, computerRequesting: null, updateStatus: null, drafts: {}, pendingAttachments: {}, draftMentions: {}, spaceSkills: {}, skillsRoot: "", spaceMemory: {}, sessionMemorySources: {}, planReturn: {}, gitInfo: {}, iconAssets: {}, modelFavorites: [], modelInfo: {}, spaceSkillSources: {},
       diffs: {}, diffLoading: {}, patches: {}, commitMessages: {}, shipResults: {}, shipping: {}, reviews: {}, reviewing: {},
       worktreeStatuses: {}, worktreeAckStale: null,
-      checkpoints: {}, ships: {}, runs: {}, selectedRunId: {}, runAttempts: {}, checkpointPreview: null, checkpointAckStale: false, restoreResult: null,
+      checkpoints: {}, ships: {}, runs: {}, selectedRunId: {}, runAttempts: {}, delegatedRuns: {}, checkpointPreview: null, checkpointAckStale: false, restoreResult: null,
       terminalPanel: {}, sessionTerminals: {},
       machineName: "", userName: "", connectors: {}, browserAllowlists: {},
       mcpServers: [], mcpProviders: [], mcpToolsError: {},
@@ -2943,6 +2957,13 @@ export function createAppStore(api: Api): StoreApi<AppState> {
       applyReviewChanged({ environmentId, review }) {
         const { [environmentId]: _done, ...reviewing } = get().reviewing;
         set({ reviews: { ...get().reviews, [environmentId]: review }, reviewing });
+      },
+      async refreshDelegatedRuns(sessionId) {
+        get().applyDelegationChanged({ sessionId, running: await api.listDelegatedRuns(sessionId) });
+      },
+      applyDelegationChanged({ sessionId, running }) {
+        const { [sessionId]: _idle, ...rest } = get().delegatedRuns;
+        set({ delegatedRuns: running.length === 0 ? rest : { ...rest, [sessionId]: running } });
       },
       async openSpacePage(spaceId, tab) {
         // The tab lands even when the page item already exists — "Manage connections…" on an

--- a/apps/desktop/src/renderer/src/state/store.ts
+++ b/apps/desktop/src/renderer/src/state/store.ts
@@ -2259,6 +2259,13 @@ export function createAppStore(api: Api): StoreApi<AppState> {
         get().run(() => Promise.all([get().refreshSpaces(), get().refreshItems(), get().refreshSessions(), get().refreshAllSessions()]));
         // openSession fetches events after each transcript's lastSeq — exactly the missed tail.
         for (const id of Object.keys(get().transcripts)) get().run(() => get().openSession(id));
+        // The delegation registry lives in the server's MEMORY, so it is the one thing here with no
+        // table behind it: if the socket dropped because the server went away, every run being
+        // mirrored died with it and no `delegation.changed` will ever say so. Both key sets, because
+        // a run can have ENDED under a session being mirrored and BEGUN under one that was not.
+        for (const id of new Set([...Object.keys(get().delegatedRuns), ...Object.keys(get().transcripts)])) {
+          get().run(() => get().refreshDelegatedRuns(id));
+        }
       },
       // One overlay slot (U-M4/V-F5): sheets and the palette never stack — opening either closes the other.
       setPaletteOpen(open) { set(open ? { paletteOpen: true, spacesOpen: false, sheet: null, ...restoreSnap() } : { paletteOpen: false }); },

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -1023,9 +1023,9 @@ button.panel-title:hover { background: var(--rl-hover); }
 .delegation-row[aria-expanded="true"] .tool-chevron { transform: rotate(90deg); }
 .delegation-summary { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .delegation-elapsed { flex: none; font-variant-numeric: tabular-nums; color: var(--rl-text-faint); }
-/* The trace rail the grouped tool run wears, for the same reason: these rows hang off the line above. */
-/* Bounded like every other drawn surface: the per-parent cap is four, but peers asked a question
-   are not capped, and a dock that grew without limit would push the prompter off its own pane. */
+/* The trace rail the grouped tool run wears, for the same reason: these rows hang off the line
+   above. Bounded like every other drawn surface — the delegation caps keep this list short, but the
+   prompter is below it and must not be pushed off the pane by a list that got long anyway. */
 .delegation-list { margin-left: 15px; padding-left: 12px; border-left: 1px solid var(--line); display: flex; flex-direction: column; gap: 1px;
   max-height: 132px; overflow-y: auto; }
 .delegation-item { display: flex; align-items: center; gap: 8px; width: 100%; min-height: 26px; padding: 3px 8px;

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -1011,6 +1011,28 @@ button.panel-title:hover { background: var(--rl-hover); }
 /* Plan 9 W2 — BUI LoadingState's shimmer label replaces the spinner+text pair; under
    prefers-reduced-motion the global animation kill leaves a static, readable gradient. */
 .msg-working { display: flex; align-items: center; gap: 6px; font-size: 12.5px; font-weight: var(--fw-medium); color: var(--rl-text-dim); }
+
+/* The delegated-runs dock: what this session is waiting on, between the log and the prompter. It
+   sits on the transcript's own rails (the 680px column's 16px gutter) rather than the composer's
+   card, because it belongs to the reading side — it is the last thing above the fold, and the
+   composer's surface would make it read as another control. */
+.delegation-dock { flex: none; padding: 0 16px 6px; display: flex; flex-direction: column; gap: 2px; }
+.delegation-row { display: flex; align-items: center; gap: 8px; width: fit-content; max-width: 100%; padding: 5px 8px;
+  border-radius: var(--r-ctl); text-align: left; font-size: 12.5px; font-weight: var(--fw-medium); color: var(--rl-text-dim); }
+.delegation-row:hover { background: var(--rl-hover); color: var(--rl-text-bright); }
+.delegation-row[aria-expanded="true"] .tool-chevron { transform: rotate(90deg); }
+.delegation-summary { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.delegation-elapsed { flex: none; font-variant-numeric: tabular-nums; color: var(--rl-text-faint); }
+/* The trace rail the grouped tool run wears, for the same reason: these rows hang off the line above. */
+/* Bounded like every other drawn surface: the per-parent cap is four, but peers asked a question
+   are not capped, and a dock that grew without limit would push the prompter off its own pane. */
+.delegation-list { margin-left: 15px; padding-left: 12px; border-left: 1px solid var(--line); display: flex; flex-direction: column; gap: 1px;
+  max-height: 132px; overflow-y: auto; }
+.delegation-item { display: flex; align-items: center; gap: 8px; width: 100%; min-height: 26px; padding: 3px 8px;
+  border-radius: var(--r-ctl); text-align: left; font-size: 12px; color: var(--ink); }
+.delegation-item:hover { background: var(--rl-hover); }
+.delegation-title { flex: 1 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.delegation-dim { flex: none; font-size: 11.5px; color: var(--rl-text-faint); font-variant-numeric: tabular-nums; }
 /* The settled twin of .msg-working: the same verb in the past tense, with the wait it cost. Quieter
    than the live label — it is scrollback now, not the thing to watch — and tabular so a column of
    these down a long session does not jitter as the digits change. */
@@ -1823,6 +1845,7 @@ button.panel-title:hover { background: var(--rl-hover); }
 /* Hover fills (§6): 100ms `ease`, background (and the text colour riding along with it) only —
    never `all`, never geometry. */
 .item-row, .item-close, .item-shelf, .icon-btn, .btn, .ghost-chip, .tool-row, .tool-group-row, .tool-copy,
+.delegation-row, .delegation-item,
 .strip-space, .strip-profile, .space-card, .suggestion-chip, .palette-opt, .permission-option, .menu [role^="menuitem"],
 .question-option, .question-skip {
   transition: background-color var(--dur-hover) ease, color var(--dur-hover) ease;

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -1046,9 +1046,11 @@ button.panel-title:hover { background: var(--rl-hover); }
 /* Open, the row is the card's head rather than a free-standing control: it keeps the card's top
    corners and squares off against the body's divider. Rounding all four corners left the hover
    fill curving away from the hairline at both ends — two dark notches sitting on the divider. */
-.tool-card[data-open] .tool-row { border-radius: var(--r-ctl) var(--r-ctl) 0 0; }
+.tool-card[data-open] > .tool-row { border-radius: var(--r-ctl) var(--r-ctl) 0 0; }
 .tool-chevron { color: var(--rl-text-faint); transition: transform var(--dur-base) var(--ease-in-out-strong); flex: none; margin-left: auto; }
-.tool-card[data-open] .tool-chevron, .tool-group[data-open] .tool-chevron { transform: rotate(90deg); }
+/* Direct children throughout: a card now contains its sub-agent's cards, and a descendant selector
+   would have opening the parent rotate every chevron and unfold every body beneath it. */
+.tool-card[data-open] > .tool-row > .tool-chevron, .tool-group[data-open] > .tool-group-row > .tool-chevron { transform: rotate(90deg); }
 .tool-name { font-size: 12.5px; font-weight: var(--fw-label); flex: none; }
 /* Measured counts (editStat): green adds, red deletes, mono tabular — BUI's `+74 −41`. */
 .tool-stat { flex: none; font: 11px var(--font-mono); font-variant-numeric: tabular-nums; }
@@ -1058,9 +1060,9 @@ button.panel-title:hover { background: var(--rl-hover); }
 /* §6 tool-row expand: height animates via grid-template-rows 0fr→1fr over 200ms, content fades at
    120ms. .tool-body-clip is the overflow container the 0fr row needs to clip against. */
 .tool-body-wrap { display: grid; grid-template-rows: 0fr; transition: grid-template-rows var(--dur-base) var(--ease-in-out-strong); }
-.tool-card[data-open] .tool-body-wrap { grid-template-rows: 1fr; }
+.tool-card[data-open] > .tool-body-wrap { grid-template-rows: 1fr; }
 .tool-body-clip { overflow: hidden; min-height: 0; }
-.tool-card[data-open] .tool-body { opacity: 1; }
+.tool-card[data-open] > .tool-body-wrap .tool-body { opacity: 1; }
 
 /* Grouped runs (§2.8/§5) wear BUI ThinkingState's header + trace (Plan 9 W2): the collapsed row is
    `Worked for <duration> ›` at 13/500 — shimmering (BUI's working treatment) while the run is live,
@@ -1077,6 +1079,9 @@ button.panel-title:hover { background: var(--rl-hover); }
   background-size: 200% 100%; -webkit-background-clip: text; background-clip: text; color: transparent;
   animation: shimmer-text 1.4s linear infinite; }
 .tool-group-steps { margin-left: 15px; padding-left: 12px; border-left: 1px solid var(--line); display: flex; flex-direction: column; gap: 1px; }
+/* A sub-agent's ledger hangs off the Task call that spawned it. 24px sets its label under the tool
+   NAME rather than under the status glyph, so the rail reads as belonging to that row. */
+.tool-group[data-subagent] { margin-left: 24px; }
 /* The target chip: ToolChips' field-fill chip — mono 11.5, hairline ring, truncating. */
 .tool-summary { flex: 0 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: var(--ink-2);
   font: 11.5px var(--font-mono); font-variant-numeric: tabular-nums; background: var(--field); box-shadow: var(--shadow-hairline);

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -1796,7 +1796,7 @@ button.panel-title:hover { background: var(--rl-hover); }
   /* the diff pane */
   .diff-list, .diff-hunks, .diff-review-body, .commit-message,
   /* page panes */
-  .cp-list, .activity-list, .task-detail-result, .notif-list, .notif-detail, .notif-split,
+  .cp-list, .activity-list, .task-detail-result, .notif-list, .notif-detail, .notif-split, .delegation-list,
   .lecture-list, .install-cmd code,
   /* documents */
   .documents-tabs, .documents-picker, .documents-rich-surface, .documents-rich .tiptap, .documents-raw

--- a/apps/desktop/src/renderer/src/styles.test.ts
+++ b/apps/desktop/src/renderer/src/styles.test.ts
@@ -147,7 +147,7 @@ describe("§6 motion table", () => {
   it("the tool row expands by animating grid-template-rows over 200ms, with the content fading at 120ms", () => {
     expect(bodiesFor(".tool-body-wrap").join(" ")).toContain(`transition: grid-template-rows ${dur("--dur-base")} var(--ease-in-out-strong)`);
     expect(bodiesFor(".tool-body-wrap").join(" ")).toContain("grid-template-rows: 0fr");
-    expect(bodiesFor(".tool-card[data-open] .tool-body-wrap").join(" ")).toContain("grid-template-rows: 1fr");
+    expect(bodiesFor(".tool-card[data-open] > .tool-body-wrap").join(" ")).toContain("grid-template-rows: 1fr");
     expect(bodiesFor(".tool-body").join(" ")).toContain(`transition: opacity ${dur("--dur-press")} ease`);
   });
 
@@ -509,8 +509,16 @@ describe("Plan 9 W2 — BUI transcript primitives", () => {
     expect(bodiesFor(".tool-row").join(" ")).toContain("border-radius: var(--r-ctl)");
     // Open, the bottom two stop rounding: a curve there pulls the hover fill away from the
     // hairline and leaves a notch at each end of the divider.
-    expect(bodiesFor(".tool-card[data-open] .tool-row").join(" "))
+    expect(bodiesFor(".tool-card[data-open] > .tool-row").join(" "))
       .toContain("border-radius: var(--r-ctl) var(--r-ctl) 0 0");
+  });
+
+  it("an open card's rules reach its own row and body only — the cards inside it are a sub-agent's", () => {
+    for (const sel of [".tool-card[data-open] > .tool-row", ".tool-card[data-open] > .tool-body-wrap",
+      ".tool-card[data-open] > .tool-row > .tool-chevron", ".tool-group[data-open] > .tool-group-row > .tool-chevron"]) bodiesFor(sel);
+    // A descendant selector here reaches the whole sub-tree: opening one Task card would rotate every
+    // chevron beneath it and unfold every nested body along with its own.
+    expect(RULES.flatMap((r) => r.selectors).filter((s) => /^\.tool-(card|group)\[data-open\] [^>]/.test(s))).toEqual([]);
   });
 
   it("fenced code is CodeBlock's editor panel: surface + hairline ring, a language header, 12.5/1.65 mono body", () => {

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -25,6 +25,7 @@ import { createBrowserAgentProvider } from "./browsers/agent-tools";
 import { createComputerAgentProvider } from "./computer/agent-tools";
 import { BrowserAgentService, createRealmAgentProvider, REALM_AGENT_PROVIDER_NAME } from "./browsers/browser-agent";
 import { DelegationEngine } from "./delegation/engine";
+import { announceDelegation } from "./delegation/announce";
 import { AgentRunService } from "./delegation/agent-run";
 import { ReviewService } from "./delegation/review";
 import { AskService } from "./delegation/ask";
@@ -402,7 +403,10 @@ export async function createApp(opts: { home: string; port: number; adapters?: A
   // `realm-agent` provider serving `browser_agent_run` + `agent_run`. A delegated child is a REAL
   // session whose specialization all rides existing seams — see each service's class doc comment,
   // including the bypass-is-never-inherited rule both tools carry.
-  const delegationEngine = new DelegationEngine({ sessions, caps: opts.agentRun?.caps });
+  const delegationEngine: DelegationEngine = new DelegationEngine({
+    sessions, caps: opts.agentRun?.caps,
+    onChange: (parentSessionId) => announceDelegation(rpc, delegationEngine, parentSessionId),
+  });
   browserAgents = new BrowserAgentService({ settings, sessions, rpc, engine: delegationEngine, skillsRoot: skills.root, fallbackKind: opts.browserAgent?.fallbackKind, timeouts: opts.browserAgent?.timeouts });
   agentRuns = new AgentRunService({ settings, sessions, rpc, engine: delegationEngine, environments: envService, skills, otherDelegation: browserAgents,
     fallbackKind: opts.agentRun?.fallbackKind ?? opts.browserAgent?.fallbackKind, timeouts: opts.agentRun?.timeouts, maxDepth: opts.agentRun?.maxDepth });
@@ -478,7 +482,7 @@ export async function createApp(opts: { home: string; port: number; adapters?: A
   const [machine, user] = await Promise.all([machineName(), userFirstName()]);
   registerMethods({
     rpc, home: opts.home, version: SERVER_VERSION, machineName: machine, userName: user,
-    profiles, spaces, projects, environments, envService, items, settings, skills, mcp, hub: mcpHub, gateway: mcpGateway, oauth, calls: mcpCalls, memory, terminals, browsers, browserBridge, documents, sessions, gitInfo: new GitInfoService(), gitDiff: new GitDiffService(), gitWrite, ships, ports, checkpoints, notifications, runs, reviews, search, forks, imports, lectures, plynn, modelCatalog, usage, graphify,
+    profiles, spaces, projects, environments, envService, items, settings, skills, mcp, hub: mcpHub, gateway: mcpGateway, oauth, calls: mcpCalls, memory, terminals, browsers, browserBridge, documents, sessions, gitInfo: new GitInfoService(), gitDiff: new GitDiffService(), gitWrite, ships, ports, checkpoints, notifications, runs, reviews, search, forks, imports, lectures, plynn, modelCatalog, usage, graphify, delegation: delegationEngine,
     iconAssets, iconGeneration,
   });
   sessions.markStaleOnBoot();

--- a/apps/server/src/delegation/announce.test.ts
+++ b/apps/server/src/delegation/announce.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import type { SessionEvent, StoredSessionEvent } from "@realm/contracts";
+import type { RpcServer } from "../rpc/server";
+import { announceDelegation } from "./announce";
+import { DelegationEngine } from "./engine";
+
+/** A ULID-shaped id whose first characters spell the role — `IdSchema` rejects I, L, O and U. */
+const id = (tag: string) => tag.padEnd(26, "0");
+const PARENT = id("PARENT"), KID = id("KID"), PEER = id("PEER");
+
+const ev = (e: SessionEvent, seq: number): StoredSessionEvent => ({ seq, event: e } as StoredSessionEvent);
+const status = (s: string, seq: number) => ev({ type: "status", ts: 0, payload: { status: s } } as SessionEvent, seq);
+const said = (text: string, seq: number) => ev({ type: "assistant_text", ts: 0, payload: { messageId: "m", text } } as SessionEvent, seq);
+
+function recorder() {
+  const sent: { event: string; payload: unknown }[] = [];
+  const rpc: Pick<RpcServer, "broadcast"> = { broadcast: (event, payload) => { sent.push({ event, payload }); } };
+  return { sent, rpc };
+}
+
+/** An engine wired to `announceDelegation`, serving one scripted batch per poll (see engine.test.ts). */
+function wired(batches: StoredSessionEvent[][] = [[]]) {
+  const { sent, rpc } = recorder();
+  let i = 0;
+  const engine: DelegationEngine = new DelegationEngine({
+    sessions: { events: () => batches[Math.min(i++, batches.length - 1)] ?? [], interrupt: async () => { /* no child to stop */ } },
+    onChange: (parentSessionId) => announceDelegation(rpc, engine, parentSessionId),
+  });
+  const running = (n: number) => (sent[n]!.payload as { running: unknown[] }).running;
+  return { engine, sent, rpc, running };
+}
+
+describe("delegation.changed — the parent's live runs, straight off the registry", () => {
+  it("announces the set when a run begins and again when it settles", async () => {
+    const { engine, sent, running } = wired([[], [said("done", 1), status("idle", 2)]]);
+    const run = engine.begin(PARENT, KID);
+    // THE MUTANT: drop `begin`'s notify and a delegated agent starts with nothing on screen — which
+    // is exactly the state this feature exists to end.
+    expect(sent).toHaveLength(1);
+    expect(sent[0]).toMatchObject({ event: "delegation.changed", payload: { sessionId: PARENT, running: [{ sessionId: KID, detached: false, owned: true }] } });
+
+    engine.watch(run, KID, 0, Date.now() + 2_000, 1);
+    await run.settled;
+    // THE MUTANT: drop the notify from `watch`'s settle and the strip keeps claiming a finished
+    // agent is still working, with nothing that will ever correct it.
+    expect(sent).toHaveLength(2);
+    expect(running(1)).toEqual([]);
+  });
+
+  it("announces the empty set when the parent's last run is collected", () => {
+    const { engine, sent, running } = wired();
+    const run = engine.begin(PARENT, KID);
+    engine.end(PARENT, run);
+    // THE MUTANT: drop `end`'s notify. `agent_run` ends its run in a `finally` the instant the wait
+    // returns, so without this the last thing the renderer ever hears is "one running".
+    expect(sent).toHaveLength(2);
+    expect(running(1)).toEqual([]);
+  });
+
+  it("announces the empty set when a parent's runs are all evicted at once", () => {
+    const { engine, sent, running } = wired();
+    engine.begin(PARENT, KID);
+    engine.begin(PARENT, PEER, { interruptOnCancel: false });
+    engine.end(PARENT);
+    // `agent_ask`, `review` and `browser_agent_run` all end the no-arg way, as does deleting the
+    // parent session. THE MUTANT: notify from the single-run branch only, and every one of those
+    // paths leaves a pane insisting agents are still running that the registry has already dropped.
+    expect(running(sent.length - 1)).toEqual([]);
+    expect(sent).toHaveLength(3);
+  });
+
+  it("says nothing for a reviewer the user started from a diff pane", () => {
+    const { engine, sent } = wired();
+    // `review.ts` begins those under a synthetic key so they are still capped and cancellable.
+    // THE MUTANT: drop the id guard and a field typed as a session id carries `review-env:…`,
+    // a string no session in the renderer can ever match.
+    engine.begin(`review-env:${id("ENV")}`, KID);
+    expect(sent).toEqual([]);
+  });
+
+  it("drops a detached run that has settled: it is holding a report, not burning an agent", () => {
+    const { engine } = wired();
+    const run = engine.begin(PARENT, KID, { detached: true });
+    expect(engine.liveRuns(PARENT)).toMatchObject([{ sessionId: KID, detached: true }]);
+    run.done = { outcome: "done", finalText: "x", lastStatus: "idle" };
+    // THE MUTANT: derive liveRuns from `runsOf` rather than `running`, and an `agent_start` nobody
+    // has collected yet shows as a working agent until the parent gets round to `agent_wait`.
+    expect(engine.liveRuns(PARENT)).toEqual([]);
+    expect(engine.runsOf(PARENT)).toHaveLength(1);
+  });
+
+  it("marks a peer that was merely asked a question as not the parent's own", () => {
+    const { engine } = wired();
+    engine.begin(PARENT, PEER, { interruptOnCancel: false });
+    // THE MUTANT: hardcode `owned: true` and the pane calls a session that was already doing its own
+    // work a sub-agent the parent spawned.
+    expect(engine.liveRuns(PARENT)).toMatchObject([{ sessionId: PEER, owned: false }]);
+  });
+});

--- a/apps/server/src/delegation/announce.test.ts
+++ b/apps/server/src/delegation/announce.test.ts
@@ -69,6 +69,15 @@ describe("delegation.changed — the parent's live runs, straight off the regist
     expect(sent).toHaveLength(3);
   });
 
+  it("says nothing when a session that never delegated is released", () => {
+    const { engine, sent } = wired();
+    engine.end(PARENT);
+    // `release` reaches `end` for every session the user deletes, virtually none of which ever
+    // delegated. THE MUTANT: announce unconditionally, and clearing out fifty old sessions sends
+    // fifty broadcasts to every open window to report that nothing changed.
+    expect(sent).toEqual([]);
+  });
+
   it("says nothing for a reviewer the user started from a diff pane", () => {
     const { engine, sent } = wired();
     // `review.ts` begins those under a synthetic key so they are still capped and cancellable.

--- a/apps/server/src/delegation/announce.ts
+++ b/apps/server/src/delegation/announce.ts
@@ -1,0 +1,24 @@
+import { IdSchema } from "@realm/contracts";
+import type { RpcServer } from "../rpc/server";
+import type { DelegationEngine } from "./engine";
+
+/**
+ * Publish one parent's live delegated runs, read straight back off the engine.
+ *
+ * The engine says only WHICH parent changed, so the payload is built here and nowhere else, and the
+ * in-memory registry stays the single copy of who is waiting on what. A listener can never be handed
+ * a set the registry has already moved past, because there is no set to hand — only a lookup.
+ *
+ * `parentSessionId` is not always a session. A reviewer the user asks for from a diff pane has no
+ * delegating agent, so `review.ts` begins it under a synthetic key to keep it capped and
+ * cancellable; there is no transcript for it to appear in, and announcing it would put a string no
+ * session can ever match into a field typed as a session id.
+ */
+export function announceDelegation(
+  rpc: Pick<RpcServer, "broadcast">,
+  engine: Pick<DelegationEngine, "liveRuns">,
+  parentSessionId: string,
+): void {
+  if (!IdSchema.safeParse(parentSessionId).success) return;
+  rpc.broadcast("delegation.changed", { sessionId: parentSessionId, running: engine.liveRuns(parentSessionId) });
+}

--- a/apps/server/src/delegation/engine.test.ts
+++ b/apps/server/src/delegation/engine.test.ts
@@ -30,7 +30,7 @@ function engineOver(batches: StoredSessionEvent[][]) {
   return { engine, interrupted };
 }
 
-const run = (): ActiveRun => ({ childSessionId: "peer", cancelled: false, interruptOnCancel: false, detached: false, settled: null, done: null });
+const run = (): ActiveRun => ({ parentSessionId: "asker", childSessionId: "peer", cancelled: false, startedAt: 0, interruptOnCancel: false, detached: false, settled: null, done: null });
 const wait = (engine: DelegationEngine, r = run(), answer: { text: string | null } = { text: null }, deadlineMs = 2000) =>
   engine.awaitAnswer({ targetId: "peer", fromSeq: 0, run: r, answer, deadline: Date.now() + deadlineMs, pollMs: 1 });
 

--- a/apps/server/src/delegation/engine.ts
+++ b/apps/server/src/delegation/engine.ts
@@ -1,4 +1,4 @@
-import type { StoredSessionEvent } from "@realm/contracts";
+import type { DelegatedRun, StoredSessionEvent } from "@realm/contracts";
 
 /**
  * The delegation engine (Plan 13 W1) — the one settle/drain implementation behind BOTH delegation
@@ -53,6 +53,12 @@ export class DelegationEngine {
     };
     /** Tests tighten these to one and two so a cap is reachable without spawning four fake agents. */
     caps?: { perParent?: number; total?: number };
+    /** Called with a parent whose live set just changed — a run began, settled, or was collected.
+     *  The engine announces the CHANGE and nothing else: the listener reads the new set back off
+     *  `liveRuns`, so there is still exactly one description of who is waiting on what, and nobody
+     *  can be handed a snapshot the registry has already moved past. Optional, because settling must
+     *  not depend on anyone listening. */
+    onChange?: (parentSessionId: string) => void;
   }) {
     this.maxPerParent = d.caps?.perParent ?? MAX_RUNS_PER_PARENT;
     this.maxTotal = d.caps?.total ?? MAX_RUNS_TOTAL;
@@ -78,6 +84,15 @@ export class DelegationEngine {
    *  result, not a machine, so it is not counted against the cap and is not listed here. */
   running(parentSessionId: string): ActiveRun[] {
     return this.list(parentSessionId).filter((r) => r.done === null);
+  }
+
+  /** The parent's live runs as the renderer reads them (`DelegatedRunSchema`). Derived here rather
+   *  than at either call site, so the broadcast and the fetch cannot describe the registry
+   *  differently and nothing outside this class has to know what "live" counts as. */
+  liveRuns(parentSessionId: string): DelegatedRun[] {
+    return this.running(parentSessionId).map((r) => ({
+      sessionId: r.childSessionId, startedAt: r.startedAt, detached: r.detached, owned: r.interruptOnCancel,
+    }));
   }
 
   /** Every run of this parent the registry still holds, settled ones included — `agent_status`'s
@@ -117,11 +132,12 @@ export class DelegationEngine {
    */
   begin(parentSessionId: string, targetSessionId: string, opts: { interruptOnCancel?: boolean; detached?: boolean } = {}): ActiveRun {
     const run: ActiveRun = {
-      childSessionId: targetSessionId, cancelled: false,
+      parentSessionId, childSessionId: targetSessionId, cancelled: false, startedAt: Date.now(),
       interruptOnCancel: opts.interruptOnCancel ?? true,
       detached: opts.detached ?? false, done: null, settled: null,
     };
     this.runs.set(parentSessionId, [...this.list(parentSessionId), run]);
+    this.d.onChange?.(parentSessionId);
     return run;
   }
 
@@ -134,10 +150,11 @@ export class DelegationEngine {
    * a sibling's `finally` can never evict a detached run whose report has not been collected yet.
    */
   end(parentSessionId: string, run?: ActiveRun): void {
-    if (!run) { this.runs.delete(parentSessionId); return; }
+    if (!run) { this.runs.delete(parentSessionId); this.d.onChange?.(parentSessionId); return; }
     const rest = this.list(parentSessionId).filter((r) => r !== run);
     if (rest.length === 0) this.runs.delete(parentSessionId);
     else this.runs.set(parentSessionId, rest);
+    this.d.onChange?.(parentSessionId);
   }
 
   /** The PARENT was interrupted: ALL its delegated runs are cancelled and their children interrupted
@@ -168,7 +185,7 @@ export class DelegationEngine {
    * which never stops the child.
    */
   watch(run: ActiveRun, childId: string, fromSeq: number, deadline: number, pollMs: number): void {
-    run.settled = this.drain(childId, fromSeq, run, deadline, pollMs).then((s) => { run.done = s; return s; });
+    run.settled = this.drain(childId, fromSeq, run, deadline, pollMs).then((s) => { run.done = s; this.d.onChange?.(run.parentSessionId); return s; });
     // drain resolves for every outcome rather than throwing, but an unobserved promise that somehow
     // did reject would take the process down — and a detached run is unobserved by construction.
     void run.settled.catch(() => { /* surfaced through run.done / the awaiting tool */ });
@@ -318,8 +335,15 @@ export class DelegationEngine {
  * `done === null` and `agent_status` reads both.
  */
 export type ActiveRun = {
+  /** The registry's key, carried on the run as well. `watch` resolves in the background holding only
+   *  the run, and a settle nobody can attribute to a parent is a settle nobody can be told about.
+   *  `begin` is the only place a run is built, so the two cannot disagree. */
+  parentSessionId: string;
   childSessionId: string;
   cancelled: boolean;
+  /** When `begin` registered the run — wall clock, because its only reader is a human watching a
+   *  duration tick up in a pane. */
+  startedAt: number;
   interruptOnCancel: boolean;
   detached: boolean;
   settled: Promise<SettledRun> | null;

--- a/apps/server/src/delegation/engine.ts
+++ b/apps/server/src/delegation/engine.ts
@@ -56,8 +56,8 @@ export class DelegationEngine {
     /** Called with a parent whose live set just changed — a run began, settled, or was collected.
      *  The engine announces the CHANGE and nothing else: the listener reads the new set back off
      *  `liveRuns`, so there is still exactly one description of who is waiting on what, and nobody
-     *  can be handed a snapshot the registry has already moved past. Optional, because settling must
-     *  not depend on anyone listening. */
+     *  can be handed a snapshot the registry has already moved past. Optional, and its failures are
+     *  swallowed (`announce`), because a delegation must not be abortable by whoever is watching. */
     onChange?: (parentSessionId: string) => void;
   }) {
     this.maxPerParent = d.caps?.perParent ?? MAX_RUNS_PER_PARENT;
@@ -84,6 +84,13 @@ export class DelegationEngine {
    *  result, not a machine, so it is not counted against the cap and is not listed here. */
   running(parentSessionId: string): ActiveRun[] {
     return this.list(parentSessionId).filter((r) => r.done === null);
+  }
+
+  /** A listener's failure is its own. `begin` is called on the delegation's happy path and `watch`'s
+   *  settle runs unobserved in the background: a throw from either would abort a real run over a
+   *  notification nobody needed. */
+  private announce(parentSessionId: string): void {
+    try { this.d.onChange?.(parentSessionId); } catch { /* the registry is unaffected; the listener resyncs */ }
   }
 
   /** The parent's live runs as the renderer reads them (`DelegatedRunSchema`). Derived here rather
@@ -137,7 +144,7 @@ export class DelegationEngine {
       detached: opts.detached ?? false, done: null, settled: null,
     };
     this.runs.set(parentSessionId, [...this.list(parentSessionId), run]);
-    this.d.onChange?.(parentSessionId);
+    this.announce(parentSessionId);
     return run;
   }
 
@@ -150,11 +157,15 @@ export class DelegationEngine {
    * a sibling's `finally` can never evict a detached run whose report has not been collected yet.
    */
   end(parentSessionId: string, run?: ActiveRun): void {
-    if (!run) { this.runs.delete(parentSessionId); this.d.onChange?.(parentSessionId); return; }
-    const rest = this.list(parentSessionId).filter((r) => r !== run);
+    const held = this.list(parentSessionId);
+    // `release` (the parent session was deleted) reaches here for EVERY session, almost none of
+    // which ever delegated. Nothing changed, so nothing is announced.
+    if (held.length === 0) return;
+    if (!run) { this.runs.delete(parentSessionId); this.announce(parentSessionId); return; }
+    const rest = held.filter((r) => r !== run);
     if (rest.length === 0) this.runs.delete(parentSessionId);
     else this.runs.set(parentSessionId, rest);
-    this.d.onChange?.(parentSessionId);
+    this.announce(parentSessionId);
   }
 
   /** The PARENT was interrupted: ALL its delegated runs are cancelled and their children interrupted
@@ -185,7 +196,7 @@ export class DelegationEngine {
    * which never stops the child.
    */
   watch(run: ActiveRun, childId: string, fromSeq: number, deadline: number, pollMs: number): void {
-    run.settled = this.drain(childId, fromSeq, run, deadline, pollMs).then((s) => { run.done = s; this.d.onChange?.(run.parentSessionId); return s; });
+    run.settled = this.drain(childId, fromSeq, run, deadline, pollMs).then((s) => { run.done = s; this.announce(run.parentSessionId); return s; });
     // drain resolves for every outcome rather than throwing, but an unobserved promise that somehow
     // did reject would take the process down — and a detached run is unobserved by construction.
     void run.settled.catch(() => { /* surfaced through run.done / the awaiting tool */ });

--- a/apps/server/src/rpc/methods.ts
+++ b/apps/server/src/rpc/methods.ts
@@ -30,6 +30,7 @@ import type { UsageService } from "../usage/service";
 import type { GraphifyService } from "../graphify/service";
 import type { RunService } from "../runs/service";
 import type { ReviewService } from "../delegation/review";
+import type { DelegationEngine } from "../delegation/engine";
 import type { SearchService } from "../search/service";
 import type { ForkService } from "../sessions/fork";
 import type { ImportService } from "../import/service";
@@ -50,6 +51,7 @@ export type Deps = {
   rpc: RpcServer; home: string; version: string; machineName: string; userName: string;
   profiles: ProfilesStore; spaces: SpacesStore; projects: ProjectsStore; environments: EnvironmentsStore; envService: EnvironmentService; items: ItemsStore; settings: SettingsStore; skills: SkillsService; mcp: McpService; hub: McpHub; gateway: McpGateway; oauth: McpOauth; calls: McpCallLogStore; memory: MemoryService; terminals: TerminalService; browsers: BrowserService; browserBridge: BrowserHostBridge; documents: DocumentService; sessions: SessionService; gitInfo: GitInfoService; gitDiff: GitDiffService; gitWrite: GitWriteService; ships: ShipsStore; ports: PortAllocator; checkpoints: CheckpointService; notifications: NotificationsService; usage: UsageService; graphify: GraphifyService; runs: RunService; reviews: ReviewService; search: SearchService; forks: ForkService; imports: ImportService; lectures: LectureService; plynn: PlynnService; modelCatalog: ModelCatalogService;
   iconAssets: IconAssetsStore; iconGeneration: IconGenerationService;
+  delegation: DelegationEngine;
 };
 
 export function registerMethods(d: Deps): void {
@@ -495,6 +497,9 @@ export function registerMethods(d: Deps): void {
   reg("review.request", (p) => d.reviews.request(p.environmentId));
   reg("review.get", (p) => ({ review: d.reviews.get(p.environmentId) }));
   reg("review.dismiss", (p) => { d.reviews.dismiss(p.environmentId); return { ok: true as const }; });
+  // Live registry state, not a table: the engine holds it in memory and it dies with the process, so
+  // a pane mounting mid-run has no other way to learn what its session is waiting on.
+  reg("delegation.running", (p) => ({ running: d.delegation.liveRuns(p.sessionId) }));
 
   reg("agents.probe", (p) => d.sessions.probe({ force: p.force }));
   reg("models.catalog", async (p) => ({ rows: await d.modelCatalog.list({ force: p.force }) }));

--- a/packages/contracts/src/delegation.ts
+++ b/packages/contracts/src/delegation.ts
@@ -56,3 +56,25 @@ export type AgentRunConstraints = z.infer<typeof AgentRunConstraintsSchema>;
  * human's ship decision can rely on, and that is a safety line, not a budget.
  */
 export const MAX_DELEGATION_DEPTH = 2;
+
+/**
+ * A run the delegation engine is holding open for a parent session, as the renderer reads it.
+ *
+ * Deliberately thin. The child is a REAL session, so its title, agent, status and space already
+ * reach the renderer through the session row and the ordinary status stream; copying any of that
+ * here would put a second description of the same thing on the wire, free to drift. What is left is
+ * exactly what only the engine's in-memory registry knows — that this parent is waiting on this
+ * session, since when, and under which of the two waits.
+ */
+export const DelegatedRunSchema = z.object({
+  sessionId: IdSchema,
+  startedAt: z.number().int(),
+  /** True while the parent is free to keep working — an `agent_start` it has not collected yet.
+   *  False means the parent is blocked inside the delegation call at this moment. */
+  detached: z.boolean(),
+  /** False when the target is a PEER the parent merely asked a question of (`agent_ask`) rather than
+   *  a child it spawned. A peer was doing its own work before the question and is not the parent's
+   *  to stop, so calling it a sub-agent would be wrong in both directions. */
+  owned: z.boolean(),
+});
+export type DelegatedRun = z.infer<typeof DelegatedRunSchema>;

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -10,6 +10,7 @@ import { MEMORY_DOC_MAX, MemorySourcesSchema, MemoryStateSchema } from "./memory
 import { NotificationSchema } from "./notifications";
 import { RunAttemptSchema, RunConstraintsSchema, RunSchema, RunStateSchema } from "./runs";
 import { ReviewResultSchema } from "./review";
+import { DelegatedRunSchema } from "./delegation";
 import { SEARCH_GROUP_LIMIT, SEARCH_GROUP_LIMIT_MAX, SEARCH_QUERY_MAX, SearchResultsSchema } from "./search";
 import { ImportResultSchema, ImportScanSchema } from "./import";
 import { GuideProgressSchema } from "./documents";
@@ -842,6 +843,11 @@ export const Methods = {
   /** Dismiss the environment's persisted verdict (the diff-pane section's ✕). Server-side so every
    *  window's pane hears the `review.changed` that follows. */
   "review.dismiss": { params: z.object({ environmentId: IdSchema }), result: z.object({ ok: z.literal(true) }) },
+
+  /** The delegated runs this session is waiting on right now. The registry is in memory and dies
+   *  with the process, so this is a read of live state, not of a table — a pane opened after a run
+   *  began has no other way to learn about it, and `delegation.changed` carries it from then on. */
+  "delegation.running": { params: z.object({ sessionId: IdSchema }), result: z.object({ running: z.array(DelegatedRunSchema) }) },
   /** `force` skips the server's TTL cache — what the install card's "Check again" and its window-focus
    *  refresh send, because a cached "not installed" is exactly what the user just fixed. */
   /**
@@ -1039,6 +1045,13 @@ export const Events = {
    *  the fresh result), or was dismissed / cleared by a ship (`review` is null). Diff panes holding
    *  this environment apply the payload directly — no refetch race. */
   "review.changed": z.object({ environmentId: IdSchema, review: ReviewResultSchema.nullable() }),
+  /** The set of runs a session is waiting on changed — one began, settled, or was collected. Carries
+   *  the WHOLE fresh set rather than a delta: the engine's registry is the only copy of this fact,
+   *  and a renderer that had to accumulate deltas would drift out of step with it after one dropped
+   *  frame. An empty `running` means the session is waiting on nothing, which is the resting state.
+   *  Never sent for a reviewer the user started from the diff pane: that run has no delegating
+   *  session, so there is no transcript for it to appear in. */
+  "delegation.changed": z.object({ sessionId: IdSchema, running: z.array(DelegatedRunSchema) }),
   /** A mutating browser tool call SETTLED on this browser (Plan 11 W4) — the pane chrome's action
    *  ticker appends it. `text` is the same attributed description the permission card showed (page
    *  text only ever inside the `the page labels "…"` framing — never laundered into Realm's voice);


### PR DESCRIPTION
Stacked on #25. Two kinds of sub-agent, both previously invisible.

**In-harness sub-agents nest.** `parentToolUseId` has been arriving on `tool_call` since the Claude mapper was written, and the renderer threw it away — so a `Task`'s tool calls rendered flat, interleaved with the parent agent's own. `groupTranscript` now builds a tree from it before folding runs, and a Task card renders its child's steps through the *existing* `ToolGroup` (same rail, same auto-open-while-live rule) rather than a parallel component. Lifting the child out closes the gaps it left, so the parent's own calls that the child was splitting rejoin as the one run they always were.

Adapters that report no hierarchy are unaffected: Codex, ACP, the fake adapter and all four importers hardcode `parentToolUseId: null`, the reducer only writes the field when truthy, and `groupTranscript` is byte-identical for them.

The CSS selectors that open a card had to become direct-child selectors — a card now contains its sub-agent's cards, and a descendant selector would have opening the parent rotate every chevron and unfold every body beneath it.

**Realm's own delegated children get a dock.** `DelegationEngine` gained an optional `onChange(parentSessionId)` and a `liveRuns()` describer. It reports only *which parent changed*; the payload is built by reading the set back off `liveRuns`. That is what keeps the engine the single registry — there is no snapshot handed out, only a lookup, so no listener can hold a set the registry has moved past, and one method decides what "live" means for both the broadcast and the new `delegation.running` fetch. The payload is deliberately thin, because the child is a real session whose title, status and space already reach the renderer the ordinary way.

`structure.test.ts` — the structural test pinning "extract, don't fork" — is untouched and green.

**A dock inside the parent's pane, not a new pane kind.** A pane is a layout leaf that persists; the engine's registry is in memory and dies with the process, so a pane kind would leave an empty panel behind from a run that finished yesterday. The dock lives inside the delegating session's pane, which *is* the linkage — it cannot be dragged away from what it describes — renders nothing when the set is empty, and hands each child to `openItemBeside` so you watch it beside its parent rather than on top of it.

**A deslop review caught two bugs mid-flight**, both fixed and pinned: nesting made the collapsed ledger under-count, and worse, made its duration *shrink from 5m to 1s* the instant the run settled; and the dock survived a server restart forever, falsifying its own "it leaves when the runs do" comment.

22 mutants named and killed. One survived — a `Math.min` on a run's start stamp that no input could distinguish — and it was deleted as unreachable defensive code rather than tested.

**What remains:** no visual live check (driving a real sub-agent through the built app needs product code that would exist only for the screenshot — the RPC is verified end-to-end over a real socket instead); imported transcripts don't nest, because `import/claude.ts` skips sidechain lines entirely by a documented v1 decision; no delegation signal outside the parent's pane, though the store field is there for it; and sub-agent prose is still dropped by the mapper's v1 policy, so nesting surfaces the child's tool calls, not its reasoning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)