### PR TITLE
Seven palettes on their own axis, and the sidebar's transparency handed to the person looking at it

### DIFF
--- a/apps/desktop/scripts/themes-live.mjs
+++ b/apps/desktop/scripts/themes-live.mjs
@@ -45,13 +45,13 @@ const SYNTAX_FLOOR = 2.7;
 /** Every palette, and the modes each one has. Read off THEMES; a theme added there and not here is
  *  simply not screenshotted, which check 5 catches. */
 const PALETTES = [
-  ["Realm", ["light", "dark"]],
-  ["One", ["light", "dark"]],
-  ["Monokai", ["dark"]],
-  ["Dracula", ["dark"]],
-  ["Nord", ["dark"]],
-  ["Solarized", ["light", "dark"]],
-  ["Gruvbox", ["light", "dark"]],
+  ["Realm", "realm", ["light", "dark"]],
+  ["One", "one", ["light", "dark"]],
+  ["Monokai", "monokai", ["dark"]],
+  ["Dracula", "dracula", ["dark"]],
+  ["Nord", "nord", ["dark"]],
+  ["Solarized", "solarized", ["light", "dark"]],
+  ["Gruvbox", "gruvbox", ["light", "dark"]],
 ];
 const SYNTAX_ROLES = ["keyword", "string", "number", "title", "type", "attr", "comment"];
 
@@ -255,16 +255,19 @@ async function main() {
 
   const grounds = new Map();
   const shots = [];
-  for (const [label, modes] of PALETTES) {
+  for (const [label, name, modes] of PALETTES) {
     await evalIn(c, `__live.menu(${JSON.stringify(`Palette: ${label}`)})`);
     await sleep(250);
     for (const mode of modes) {
       await evalIn(c, `__live.menu(${JSON.stringify(`Theme: ${mode[0].toUpperCase()}${mode.slice(1)}`)})`);
       await sleep(300);
       const p = await evalIn(c, `__live.probe()`);
-      const tag = `${p.theme}-${p.mode}`;
+      const tag = `${name}-${mode}`;
+      // BOTH halves of the selection, not just the mode. `tag` is built from what was ASKED for, so
+      // a menu click that silently missed fails here by name instead of quietly relabelling every
+      // check below it with whatever palette was still on.
       check(`${tag}: the menu selection is the palette the window is actually wearing`,
-        p.mode === mode, { asked: mode, got: p.mode });
+        p.theme === name && p.mode === mode, { asked: `${name}/${mode}`, got: `${p.theme}/${p.mode}` });
 
       // 2. The token chain, end to end, through the real cascade.
       for (const role of SYNTAX_ROLES) {
@@ -306,9 +309,11 @@ async function main() {
   await evalIn(c, `__live.menu("Palette: Realm")`);
   await sleep(300);
   const back = await evalIn(c, `__live.probe()`);
-  // tokens.css: dark --canvas is oklch(0.231 0.004 264.487), light is oklch(0.961 0.002 247.84).
+  // tokens.css: dark --canvas is oklch(0.231 0.004 264.487) = #1c1d1f, light is
+  // oklch(0.961 0.002 247.84) = #f1f2f3. Tolerance 1, not 2 — at 2 a wrong expectation still passes,
+  // which is how the previous #1c1d20 went unnoticed.
   check("returning to Realm restores the shipped palette, not the last theme's",
-    near(back.canvas, back.mode === "dark" ? [28, 29, 32] : [241, 242, 243], 2), back.canvas);
+    near(back.canvas, back.mode === "dark" ? [28, 29, 31] : [241, 242, 243], 1), back.canvas);
 
   const errs = c.events.filter((e) => !e.includes("Autofill"));
   check("no renderer console errors", errs.length === 0, errs.slice(0, 5));

--- a/apps/desktop/scripts/themes-live.mjs
+++ b/apps/desktop/scripts/themes-live.mjs
@@ -1,0 +1,324 @@
+/**
+ * Live check for the custom palettes (run with: node apps/desktop/scripts/themes-live.mjs)
+ *
+ * Boots the REAL built app on a scratch REALM_HOME, walks every palette through the space menu, and
+ * measures what reaches the screen. The vitest suite proves the derivation clears its floors on
+ * numbers it computed itself; it cannot prove those numbers ever became pixels. jsdom has no
+ * cascade, no `var()` resolution against a real stylesheet and no compositor, so to it
+ * `color: var(--syn-keyword)` and `color: var(--nonsense)` are the same declaration.
+ *
+ * Two kinds of claim, measured two different ways:
+ *   - The TOKEN CHAIN, off the real CSSOM: a `.hljs-keyword` span's resolved colour has to equal the
+ *     theme's own `--syn-keyword`, for every role, on every theme. That is the whole path — rule to
+ *     role to inline custom property — resolved by Chromium rather than asserted against a string.
+ *   - The GROUND, off a screenshot: the pane really paints the theme's `--canvas`. A palette that
+ *     was computed and never applied passes every CSSOM check and leaves the window grey.
+ *
+ * Its mutant is the gate: force `applyTheme` to skip the inline writes and the pane ground stops
+ * moving between themes, which check 4 fails by name. Check 2 is the mutant for the syntax roles —
+ * re-inline `var(--accent)` on `.hljs-keyword` and keyword stops matching `--syn-keyword` on every
+ * theme but the one the mapping was written for.
+ *
+ * Screenshots for every palette in every mode land in /tmp and are meant to be LOOKED at. A theme
+ * that clears a contrast assertion and looks wrong is still wrong.
+ *
+ * REBUILD FIRST (`pnpm build`): this boots apps/desktop/out, not the sources.
+ * Ports: env-overridable. Touches only a scratch dir; kills only the process it started.
+ */
+import { spawn } from "node:child_process";
+import { connect } from "node:net";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
+const CDP_PORT = Number(process.env.LIVE_CDP_PORT ?? 9341), SERVER_PORT = Number(process.env.LIVE_SERVER_PORT ?? 8907);
+const scratch = fs.mkdtempSync(path.join(os.tmpdir(), "realm-themes-live-"));
+let electron = null;
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+/** The syntax floor from packages/ui/src/themes.ts. Restated rather than imported: this script runs
+ *  under plain node against the BUILT app, and a copy that disagrees with the source is exactly the
+ *  drift the assertion is for. */
+const SYNTAX_FLOOR = 2.7;
+/** Every palette, and the modes each one has. Read off THEMES; a theme added there and not here is
+ *  simply not screenshotted, which check 5 catches. */
+const PALETTES = [
+  ["Realm", ["light", "dark"]],
+  ["One", ["light", "dark"]],
+  ["Monokai", ["dark"]],
+  ["Dracula", ["dark"]],
+  ["Nord", ["dark"]],
+  ["Solarized", ["light", "dark"]],
+  ["Gruvbox", ["light", "dark"]],
+];
+const SYNTAX_ROLES = ["keyword", "string", "number", "title", "type", "attr", "comment"];
+
+async function portFree(port) {
+  return new Promise((resolve) => {
+    const s = connect({ port, host: "127.0.0.1" });
+    s.once("connect", () => { s.destroy(); resolve(false); });
+    s.once("error", () => resolve(true));
+  });
+}
+
+async function until(fn, ms, tag) {
+  const t0 = Date.now();
+  for (;;) {
+    const v = await fn();
+    if (v) return v;
+    if (Date.now() - t0 > ms) throw new Error(`timeout:${tag}`);
+    await sleep(150);
+  }
+}
+
+function cdp(wsUrl) {
+  const ws = new WebSocket(wsUrl);
+  let id = 0;
+  const pending = new Map();
+  const events = [];
+  const ready = new Promise((res) => ws.addEventListener("open", res));
+  ws.addEventListener("message", (m) => {
+    const msg = JSON.parse(m.data);
+    if (msg.id !== undefined) pending.get(msg.id)?.(msg);
+    else if (msg.method === "Runtime.consoleAPICalled" && msg.params.type === "error") {
+      events.push(msg.params.args.map((a) => a.value ?? a.description ?? "").join(" "));
+    }
+  });
+  return {
+    ready, events,
+    send: (method, params) => new Promise((res, rej) => {
+      const i = ++id;
+      pending.set(i, (msg) => (msg.error ? rej(new Error(msg.error.message)) : res(msg.result)));
+      ws.send(JSON.stringify({ id: i, method, params }));
+    }),
+    close: () => ws.close(),
+  };
+}
+
+/** Installed in the page once. `probe` is the whole measurement: it plants a real highlight.js
+ *  fragment in the transcript column so the syntax roles are resolved by the same cascade the app
+ *  uses, then reports the resolved colours beside the custom properties they are supposed to be. */
+const HELPERS = `
+window.__live = window.__live ?? {
+  setInput(el, value) {
+    const proto = el instanceof HTMLTextAreaElement ? HTMLTextAreaElement.prototype : HTMLInputElement.prototype;
+    Object.getOwnPropertyDescriptor(proto, "value").set.call(el, value);
+    el.dispatchEvent(new Event("input", { bubbles: true }));
+  },
+  /** Click a menu item by its visible label, opening the space menu first. */
+  async menu(label) {
+    document.querySelector('[aria-label="Space menu"]').click();
+    for (let i = 0; i < 40 && !document.querySelector('[role="menu"]'); i++) await new Promise((r) => setTimeout(r, 25));
+    const hit = [...document.querySelectorAll('[role="menu"] button')].find((b) => b.textContent.trim() === label);
+    if (!hit) { document.querySelector('[role="menu"]')?.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true })); throw new Error("no menu item: " + label); }
+    hit.click();
+    return true;
+  },
+  /** A fenced-code fragment in the pane, carrying one span per syntax role. Reused across themes so
+   *  the sampled geometry never moves; the colours are re-read after every switch. */
+  plantCode() {
+    let host = document.getElementById("live-syntax");
+    if (!host) {
+      host = document.createElement("div");
+      host.id = "live-syntax";
+      host.className = "md";
+      host.style.cssText = "position:fixed;left:24px;bottom:24px;z-index:9999;width:360px";
+      host.innerHTML = '<div class="md-code"><div class="md-code-head"><span class="md-code-lang">ts</span></div>' +
+        '<pre><code class="hljs">' + ${JSON.stringify(SYNTAX_ROLES)}.map((r) =>
+          '<span class="hljs-' + (r === "title" ? "title" : r) + '" data-role="' + r + '">' + r.toUpperCase() + '</span>').join(" ") +
+        '</code></pre></div>';
+      document.body.appendChild(host);
+    }
+    return true;
+  },
+  /** Any CSS colour as an sRGB triple. Chromium reports a computed colour in the space it was
+   *  authored in — these tokens come back in oklch() — and contrast is defined on
+   *  sRGB luminance and on nothing else. Painting it and reading the pixel back is the conversion
+   *  the compositor itself will perform, including the gamut clip. */
+  srgb(color) {
+    const g = (this._cv ??= document.createElement("canvas").getContext("2d", { willReadFrequently: true }));
+    g.clearRect(0, 0, 1, 1);
+    g.fillStyle = color;
+    g.fillRect(0, 0, 1, 1);
+    return [...g.getImageData(0, 0, 1, 1).data].slice(0, 3);
+  },
+  probe() {
+    const cs = getComputedStyle(document.documentElement);
+    const tok = (n) => cs.getPropertyValue(n).trim();
+    const roles = {};
+    for (const el of document.querySelectorAll("#live-syntax [data-role]")) {
+      const s = getComputedStyle(el);
+      roles[el.dataset.role] = {
+        resolved: this.srgb(s.color),
+        token: this.srgb(s.getPropertyValue("--syn-" + el.dataset.role).trim()),
+      };
+    }
+    const card = document.querySelector("#live-syntax .md-code");
+    return {
+      theme: document.documentElement.dataset.theme,
+      mode: document.documentElement.dataset.mode,
+      page: this.srgb(tok("--page")), canvas: this.srgb(tok("--canvas")), surface: this.srgb(tok("--surface")),
+      cardGround: this.srgb(getComputedStyle(card).backgroundColor),
+      roles,
+      paneRect: (document.querySelector(".panel") ?? document.querySelector(".main")).getBoundingClientRect().toJSON(),
+    };
+  },
+  /** The mean colour of a band of the screenshot, as [r,g,b]. Solid grounds only — glyphs would drag
+   *  the mean by however much text happens to be in the band. */
+  async band(b64, x0, y0, x1, y1) {
+    const img = new Image();
+    img.src = "data:image/png;base64," + b64;
+    await img.decode();
+    const cv = document.createElement("canvas");
+    cv.width = img.width; cv.height = img.height;
+    const g = cv.getContext("2d");
+    g.drawImage(img, 0, 0);
+    const dpr = img.width / window.innerWidth;
+    const px = g.getImageData(Math.floor(x0 * dpr), Math.floor(y0 * dpr), Math.max(1, Math.floor((x1 - x0) * dpr)), Math.max(1, Math.floor((y1 - y0) * dpr))).data;
+    let r = 0, gg = 0, b = 0;
+    for (let i = 0; i < px.length; i += 4) { r += px[i]; gg += px[i + 1]; b += px[i + 2]; }
+    const n = px.length / 4;
+    return [r / n, gg / n, b / n];
+  },
+};
+void 0`;
+
+async function evalIn(c, expr) {
+  const r = await c.send("Runtime.evaluate", { expression: HELPERS + ";\n" + expr, awaitPromise: true, returnByValue: true });
+  if (r.exceptionDetails) throw new Error(`page exception: ${r.exceptionDetails.exception?.description ?? r.exceptionDetails.text}`);
+  return r.result.value;
+}
+
+let failures = 0;
+const check = (name, cond, detail) => {
+  if (!cond) { failures++; process.exitCode = 1; }
+  console.log(`${cond ? "PASS" : "FAIL"} ${name}${detail !== undefined ? " " + JSON.stringify(detail) : ""}`);
+};
+
+const rgb = (s) => (Array.isArray(s) ? s : s.match(/[\d.]+/g).slice(0, 3).map(Number));
+const near = (a, b, tol) => rgb(a).every((v, i) => Math.abs(v - rgb(b)[i]) <= tol);
+const relLum = (c) => {
+  const [r, g, b] = rgb(c).map((v) => { const x = v / 255; return x <= 0.04045 ? x / 12.92 : ((x + 0.055) / 1.055) ** 2.4; });
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+};
+const contrast = (a, b) => { const [x, y] = [relLum(a), relLum(b)]; return (Math.max(x, y) + 0.05) / (Math.min(x, y) + 0.05); };
+
+async function main() {
+  for (const p of [CDP_PORT, SERVER_PORT]) {
+    if (!(await portFree(p))) throw new Error(`port ${p} is in use — refusing to run`);
+  }
+  const mainEntry = path.join(repoRoot, "apps/desktop/out/main/index.js");
+  if (!fs.existsSync(mainEntry)) throw new Error("apps/desktop/out is missing — run `pnpm build` first");
+
+  const wrapper = path.join(scratch, "wrapper.mjs");
+  fs.writeFileSync(wrapper, [
+    'import { app } from "electron";',
+    'app.setPath("userData", process.env.LIVE_USER_DATA);',
+    "await import(process.env.LIVE_MAIN);",
+  ].join("\n"));
+  const electronBin = process.platform === "darwin"
+    ? path.join(repoRoot, "node_modules/.pnpm/electron@37.10.3/node_modules/electron/dist/Electron.app/Contents/MacOS/Electron")
+    : path.join(repoRoot, "apps/desktop/node_modules/.bin/electron");
+  electron = spawn(electronBin, [wrapper], {
+    env: {
+      ...process.env,
+      REALM_HOME: path.join(scratch, "home"),
+      REALM_PORT: String(SERVER_PORT),
+      REALM_DEVTOOLS_PORT: String(CDP_PORT),
+      REALM_SERVER_ENTRY: path.join(repoRoot, "apps/server/dist/main.js"),
+      LIVE_USER_DATA: path.join(scratch, "userData"),
+      LIVE_MAIN: mainEntry,
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  electron.stderr.on("data", () => {}); electron.stdout.on("data", () => {});
+
+  const targets = () => fetch(`http://127.0.0.1:${CDP_PORT}/json/list`).then((r) => r.json()).catch(() => []);
+  const rendererTarget = await until(async () => (await targets()).find((t) => t.type === "page" && t.url.startsWith("file://")), 30000, "renderer target");
+  const c = cdp(rendererTarget.webSocketDebuggerUrl);
+  await c.ready;
+  await c.send("Runtime.enable");
+  await c.send("Page.enable");
+
+  await until(() => evalIn(c, `!!document.querySelector('.onboarding input:not([type=radio])')`), 20000, "onboarding");
+  await evalIn(c, `(() => {
+    const input = document.querySelector('.onboarding input:not([type=radio])');
+    __live.setInput(input, "Live");
+    input.closest("form").requestSubmit();
+    return true; })()`);
+  await until(() => evalIn(c, `!!document.querySelector('.composer')`), 20000, "composer");
+  await c.send("Emulation.setDeviceMetricsOverride", { width: 1200, height: 820, deviceScaleFactor: 1, mobile: false });
+  await evalIn(c, `__live.plantCode()`);
+  await sleep(500);
+
+  const grounds = new Map();
+  const shots = [];
+  for (const [label, modes] of PALETTES) {
+    await evalIn(c, `__live.menu(${JSON.stringify(`Palette: ${label}`)})`);
+    await sleep(250);
+    for (const mode of modes) {
+      await evalIn(c, `__live.menu(${JSON.stringify(`Theme: ${mode[0].toUpperCase()}${mode.slice(1)}`)})`);
+      await sleep(300);
+      const p = await evalIn(c, `__live.probe()`);
+      const tag = `${p.theme}-${p.mode}`;
+      check(`${tag}: the menu selection is the palette the window is actually wearing`,
+        p.mode === mode, { asked: mode, got: p.mode });
+
+      // 2. The token chain, end to end, through the real cascade.
+      for (const role of SYNTAX_ROLES) {
+        const r = p.roles[role];
+        check(`${tag}: .hljs-${role} resolves to --syn-${role}`, r && near(r.resolved, r.token, 1), r);
+      }
+      // 3. The roles are still telling things apart — a mapping collapsed onto one token would
+      //    resolve consistently and highlight nothing.
+      const distinct = new Set(SYNTAX_ROLES.map((r) => rgb(p.roles[r].resolved).map(Math.round).join(",")));
+      check(`${tag}: the seven syntax roles are seven colours`, distinct.size >= 6, { distinct: distinct.size });
+      // 4. …and each is legible on the card it is drawn on.
+      for (const role of SYNTAX_ROLES) {
+        const ratio = contrast(p.roles[role].resolved, p.cardGround);
+        check(`${tag}: --syn-${role} clears ${SYNTAX_FLOOR}:1 on the code card`, ratio >= SYNTAX_FLOOR, { ratio: +ratio.toFixed(2) });
+      }
+
+      const shot = (await c.send("Page.captureScreenshot", { format: "png" })).data;
+      // 5. The composited pane ground, which is the claim the CSSOM cannot make: --rl-panel is
+      //    --canvas and the pane is opaque, so the pixel is the token or the palette never landed.
+      const r = p.paneRect;
+      const sampled = await evalIn(c, `__live.band(${JSON.stringify(shot)}, ${r.x + r.width - 60}, ${r.y + 60}, ${r.x + r.width - 20}, ${r.y + 100})`);
+      grounds.set(tag, sampled.map((v) => Math.round(v)));
+
+      const out = path.join(os.tmpdir(), `realm-theme-${tag}.png`);
+      fs.writeFileSync(out, Buffer.from(shot, "base64"));
+      shots.push(out);
+      console.log(`SCREENSHOT ${tag} ${out}  pane=${sampled.map((v) => Math.round(v)).join(",")}`);
+    }
+  }
+
+  // 6. THE never-applied mutant: strip the inline writes from applyTheme and every one of these
+  //    grounds is the same grey. Distinct grounds are the only evidence the palette reached the
+  //    compositor rather than merely being computed.
+  const uniq = new Set([...grounds.values()].map((v) => v.join(",")));
+  check("every palette paints a ground of its own", uniq.size === grounds.size,
+    { faces: grounds.size, distinct: uniq.size });
+
+  // 7. …and returning to the default lands exactly back on the palette that shipped.
+  await evalIn(c, `__live.menu("Palette: Realm")`);
+  await sleep(300);
+  const back = await evalIn(c, `__live.probe()`);
+  // tokens.css: dark --canvas is oklch(0.231 0.004 264.487), light is oklch(0.961 0.002 247.84).
+  check("returning to Realm restores the shipped palette, not the last theme's",
+    near(back.canvas, back.mode === "dark" ? [28, 29, 32] : [241, 242, 243], 2), back.canvas);
+
+  const errs = c.events.filter((e) => !e.includes("Autofill"));
+  check("no renderer console errors", errs.length === 0, errs.slice(0, 5));
+  console.log(failures === 0 ? "\nALL CLEAR" : `\n${failures} failures`);
+  c.close();
+}
+
+main()
+  .catch((e) => { console.error("ERROR", e.message); process.exitCode = 1; })
+  .finally(() => {
+    electron?.kill("SIGTERM");
+    setTimeout(() => { electron?.kill("SIGKILL"); fs.rmSync(scratch, { recursive: true, force: true }); process.exit(process.exitCode ?? 0); }, 1200);
+  });

--- a/apps/desktop/scripts/transparency-live.mjs
+++ b/apps/desktop/scripts/transparency-live.mjs
@@ -1,0 +1,255 @@
+/**
+ * Live check for the background transparency control (run with:
+ * node apps/desktop/scripts/transparency-live.mjs)
+ *
+ * Boots the REAL built app on a scratch REALM_HOME, drives the slider in Settings → App, and reads
+ * what the cascade actually produces.
+ *
+ * Note what this deliberately does NOT do: sample the sidebar off a screenshot. The macOS material
+ * is composited by the window server BELOW the web contents, so `Page.captureScreenshot` never sees
+ * it — a translucent sidebar comes back as the overlay colour over nothing. The claim that can be
+ * measured is therefore the one that matters anyway: how much of the ground the sidebar paints, and
+ * which surfaces are translucent at all. What is behind it is macOS's business.
+ *
+ * Three things nothing in vitest can establish, because jsdom has no cascade, no `color-mix()` and
+ * no media emulation:
+ *   1. The slider reaches the sidebar. `--ground-alpha` → `--sidebar-ground` → `.sidebar`, resolved
+ *      by Chromium, with the alpha coming out where it was put.
+ *   2. The scope holds. Every pane stays fully opaque at every setting — the reason the control is
+ *      allowed to exist at all is that text never renders over the desktop.
+ *   3. `prefers-reduced-transparency: reduce` wins over the user's value, which is only true because
+ *      the composition lives in CSS. THE mutant: compose `--sidebar-ground` inline in applyTheme.
+ *      Everything still looks right until someone turns Reduce Transparency on, and then nothing
+ *      happens — an inline custom property beats every media query there is.
+ *
+ * REBUILD FIRST (`pnpm build`): this boots apps/desktop/out, not the sources.
+ * Ports: env-overridable. Touches only a scratch dir; kills only the process it started.
+ */
+import { spawn } from "node:child_process";
+import { connect } from "node:net";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
+const CDP_PORT = Number(process.env.LIVE_CDP_PORT ?? 9342), SERVER_PORT = Number(process.env.LIVE_SERVER_PORT ?? 8908);
+const scratch = fs.mkdtempSync(path.join(os.tmpdir(), "realm-transparency-live-"));
+let electron = null;
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+/** The default and the ends of the range, from packages/ui/src/theme.ts. */
+const DEFAULT_ALPHA = 82, MIN_ALPHA = 55, MAX_ALPHA = 100;
+
+async function portFree(port) {
+  return new Promise((resolve) => {
+    const s = connect({ port, host: "127.0.0.1" });
+    s.once("connect", () => { s.destroy(); resolve(false); });
+    s.once("error", () => resolve(true));
+  });
+}
+
+async function until(fn, ms, tag) {
+  const t0 = Date.now();
+  for (;;) {
+    const v = await fn();
+    if (v) return v;
+    if (Date.now() - t0 > ms) throw new Error(`timeout:${tag}`);
+    await sleep(150);
+  }
+}
+
+function cdp(wsUrl) {
+  const ws = new WebSocket(wsUrl);
+  let id = 0;
+  const pending = new Map();
+  const events = [];
+  const ready = new Promise((res) => ws.addEventListener("open", res));
+  ws.addEventListener("message", (m) => {
+    const msg = JSON.parse(m.data);
+    if (msg.id !== undefined) pending.get(msg.id)?.(msg);
+    else if (msg.method === "Runtime.consoleAPICalled" && msg.params.type === "error") {
+      events.push(msg.params.args.map((a) => a.value ?? a.description ?? "").join(" "));
+    }
+  });
+  return {
+    ready, events,
+    send: (method, params) => new Promise((res, rej) => {
+      const i = ++id;
+      pending.set(i, (msg) => (msg.error ? rej(new Error(msg.error.message)) : res(msg.result)));
+      ws.send(JSON.stringify({ id: i, method, params }));
+    }),
+    close: () => ws.close(),
+  };
+}
+
+const HELPERS = `
+window.__live = window.__live ?? {
+  setInput(el, value) {
+    const proto = el instanceof HTMLTextAreaElement ? HTMLTextAreaElement.prototype : HTMLInputElement.prototype;
+    Object.getOwnPropertyDescriptor(proto, "value").set.call(el, value);
+    el.dispatchEvent(new Event("input", { bubbles: true }));
+    el.dispatchEvent(new Event("change", { bubbles: true }));
+  },
+  /** Any CSS colour as [r,g,b,a] on 0..255 / 0..1. Painting it is the only way to read a
+   *  color-mix() result back as numbers — the computed value is still a color-mix() expression. */
+  rgba(color) {
+    const g = (this._cv ??= document.createElement("canvas").getContext("2d", { willReadFrequently: true }));
+    g.clearRect(0, 0, 1, 1);
+    g.fillStyle = color;
+    g.fillRect(0, 0, 1, 1);
+    const [r, gr, b, a] = g.getImageData(0, 0, 1, 1).data;
+    return [r, gr, b, +(a / 255).toFixed(3)];
+  },
+  openSettings() {
+    const hit = [...document.querySelectorAll(".sidebar button")].find((b) => b.textContent.trim() === "Settings");
+    if (!hit) throw new Error("no Settings nav item");
+    hit.click();
+    return true;
+  },
+  slider() { return document.querySelector('input[aria-label="Background transparency"]'); },
+  /** The settings tabs are radio INPUTS inside labels, so the visible word is on the label. */
+  tab(name) {
+    const hit = [...document.querySelectorAll("label")].find((l) => l.textContent.trim() === name && l.querySelector('input[type="radio"]'));
+    if (!hit) throw new Error("no settings tab: " + name + " — have " + [...document.querySelectorAll("label input[type=radio]")].map((i) => i.closest("label").textContent.trim()).join("|"));
+    hit.querySelector("input").click();
+    return true;
+  },
+  probe() {
+    const root = getComputedStyle(document.documentElement);
+    const sidebar = document.querySelector(".sidebar");
+    const pane = document.querySelector(".panel") ?? document.querySelector(".main");
+    return {
+      alphaToken: root.getPropertyValue("--ground-alpha").trim(),
+      page: this.rgba(root.getPropertyValue("--page").trim()),
+      sidebar: this.rgba(getComputedStyle(sidebar).backgroundColor),
+      pane: this.rgba(getComputedStyle(pane).backgroundColor),
+      sliderValue: this.slider()?.value ?? null,
+      readout: document.querySelector(".ground-alpha-value")?.textContent ?? null,
+    };
+  },
+};
+void 0`;
+
+async function evalIn(c, expr) {
+  const r = await c.send("Runtime.evaluate", { expression: HELPERS + ";\n" + expr, awaitPromise: true, returnByValue: true });
+  if (r.exceptionDetails) throw new Error(`page exception: ${r.exceptionDetails.exception?.description ?? r.exceptionDetails.text}`);
+  return r.result.value;
+}
+
+let failures = 0;
+const check = (name, cond, detail) => {
+  if (!cond) { failures++; process.exitCode = 1; }
+  console.log(`${cond ? "PASS" : "FAIL"} ${name}${detail !== undefined ? " " + JSON.stringify(detail) : ""}`);
+};
+const near = (a, b, tol) => Math.abs(a - b) <= tol;
+
+async function main() {
+  for (const p of [CDP_PORT, SERVER_PORT]) {
+    if (!(await portFree(p))) throw new Error(`port ${p} is in use — refusing to run`);
+  }
+  const mainEntry = path.join(repoRoot, "apps/desktop/out/main/index.js");
+  if (!fs.existsSync(mainEntry)) throw new Error("apps/desktop/out is missing — run `pnpm build` first");
+
+  const wrapper = path.join(scratch, "wrapper.mjs");
+  fs.writeFileSync(wrapper, [
+    'import { app } from "electron";',
+    'app.setPath("userData", process.env.LIVE_USER_DATA);',
+    "await import(process.env.LIVE_MAIN);",
+  ].join("\n"));
+  const electronBin = process.platform === "darwin"
+    ? path.join(repoRoot, "node_modules/.pnpm/electron@37.10.3/node_modules/electron/dist/Electron.app/Contents/MacOS/Electron")
+    : path.join(repoRoot, "apps/desktop/node_modules/.bin/electron");
+  electron = spawn(electronBin, [wrapper], {
+    env: {
+      ...process.env,
+      REALM_HOME: path.join(scratch, "home"),
+      REALM_PORT: String(SERVER_PORT),
+      REALM_DEVTOOLS_PORT: String(CDP_PORT),
+      REALM_SERVER_ENTRY: path.join(repoRoot, "apps/server/dist/main.js"),
+      LIVE_USER_DATA: path.join(scratch, "userData"),
+      LIVE_MAIN: mainEntry,
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  electron.stderr.on("data", () => {}); electron.stdout.on("data", () => {});
+
+  const targets = () => fetch(`http://127.0.0.1:${CDP_PORT}/json/list`).then((r) => r.json()).catch(() => []);
+  const rendererTarget = await until(async () => (await targets()).find((t) => t.type === "page" && t.url.startsWith("file://")), 30000, "renderer target");
+  const c = cdp(rendererTarget.webSocketDebuggerUrl);
+  await c.ready;
+  await c.send("Runtime.enable");
+  await c.send("Page.enable");
+
+  await until(() => evalIn(c, `!!document.querySelector('.onboarding input:not([type=radio])')`), 20000, "onboarding");
+  await evalIn(c, `(() => {
+    const input = document.querySelector('.onboarding input:not([type=radio])');
+    __live.setInput(input, "Live");
+    input.closest("form").requestSubmit();
+    return true; })()`);
+  await until(() => evalIn(c, `!!document.querySelector('.composer')`), 20000, "composer");
+  await c.send("Emulation.setDeviceMetricsOverride", { width: 1200, height: 820, deviceScaleFactor: 1, mobile: false });
+  await sleep(400);
+
+  const rest = await evalIn(c, `__live.probe()`);
+  check("out of the box the sidebar paints the shipped 82% of the window ground",
+    rest.alphaToken === `${DEFAULT_ALPHA}%` && near(rest.sidebar[3], DEFAULT_ALPHA / 100, 0.01), rest);
+  check("and the ground it paints is --page, not a colour of the sidebar's own",
+    rest.sidebar.slice(0, 3).every((v, i) => near(v, rest.page[i], 2)), { sidebar: rest.sidebar, page: rest.page });
+
+  await evalIn(c, `__live.openSettings()`);
+  await until(() => evalIn(c, `!!document.querySelector('label input[type="radio"]')`), 10000, "settings page");
+  await evalIn(c, `__live.tab("App")`);
+  await until(() => evalIn(c, `!!__live.slider()`), 10000, "the slider");
+
+  // 1. The slider reaches the sidebar, at both ends of its range and in the middle.
+  for (const alpha of [MAX_ALPHA, MIN_ALPHA, 64]) {
+    // The control is labelled by TRANSPARENCY and stores OPACITY, so the value it takes is flipped.
+    await evalIn(c, `__live.setInput(__live.slider(), "${MIN_ALPHA + MAX_ALPHA - alpha}")`);
+    await sleep(200);
+    const p = await evalIn(c, `__live.probe()`);
+    check(`at ${alpha}% opaque the sidebar's ground carries that alpha`,
+      p.alphaToken === `${alpha}%` && near(p.sidebar[3], alpha / 100, 0.01), { token: p.alphaToken, sidebar: p.sidebar, readout: p.readout });
+    // 2. The scope: whatever the slider says, a pane is opaque. This is the claim that lets the
+    //    control ship at all — pane text never renders over the desktop, so its contrast is the
+    //    theme's business and not the wallpaper's.
+    check(`at ${alpha}% opaque the panes are still fully opaque`, p.pane[3] === 1, { pane: p.pane });
+    check(`the readout is the complement of what is stored`, p.readout === `${100 - alpha}%`, { readout: p.readout, alpha });
+  }
+
+  // 3. Reduced transparency wins, and does not eat the value.
+  await evalIn(c, `__live.setInput(__live.slider(), "${MIN_ALPHA + MAX_ALPHA - MIN_ALPHA}")`);
+  await sleep(200);
+  await c.send("Emulation.setEmulatedMedia", { features: [{ name: "prefers-reduced-transparency", value: "reduce" }] });
+  await sleep(250);
+  const reduced = await evalIn(c, `__live.probe()`);
+  check("Reduce Transparency makes the sidebar opaque however far the slider is pushed",
+    reduced.sidebar[3] === 1, { sidebar: reduced.sidebar, token: reduced.alphaToken });
+  check("...and the sidebar is still the window ground, not a fallback colour",
+    reduced.sidebar.slice(0, 3).every((v, i) => near(v, reduced.page[i], 2)), { sidebar: reduced.sidebar, page: reduced.page });
+  check("...and the user's value is kept rather than reset by the preference",
+    reduced.alphaToken === `${MIN_ALPHA}%`, reduced.alphaToken);
+
+  await c.send("Emulation.setEmulatedMedia", { features: [] });
+  await sleep(250);
+  const back = await evalIn(c, `__live.probe()`);
+  check("turning the preference off restores the setting untouched",
+    near(back.sidebar[3], MIN_ALPHA / 100, 0.01), back.sidebar);
+
+  const shot = (await c.send("Page.captureScreenshot", { format: "png" })).data;
+  const out = path.join(os.tmpdir(), "realm-transparency-settings.png");
+  fs.writeFileSync(out, Buffer.from(shot, "base64"));
+  console.log(`SCREENSHOT settings ${out}`);
+
+  const errs = c.events.filter((e) => !e.includes("Autofill"));
+  check("no renderer console errors", errs.length === 0, errs.slice(0, 5));
+  console.log(failures === 0 ? "\nALL CLEAR" : `\n${failures} failures`);
+  c.close();
+}
+
+main()
+  .catch((e) => { console.error("ERROR", e.message); process.exitCode = 1; })
+  .finally(() => {
+    electron?.kill("SIGTERM");
+    setTimeout(() => { electron?.kill("SIGKILL"); fs.rmSync(scratch, { recursive: true, force: true }); process.exit(process.exitCode ?? 0); }, 1200);
+  });

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -11,6 +11,10 @@ export type ScrollPhaseMessage = { phase: string; momentum: string; dx: number; 
 export type BrowserViewState = { id: string; url: string; title: string; loading: boolean; canGoBack: boolean; canGoForward: boolean };
 contextBridge.exposeInMainWorld("realm", {
   port: port === undefined ? NaN : Number(port), home: arg("realm-home") ?? "",
+  /** Which OS this is, for the one preference that only exists on one of them: macOS is the only
+   *  platform where the window has a material behind it, so the sidebar's transparency has nothing
+   *  to reveal anywhere else (main/index.ts gives Windows and Linux an opaque backgroundColor). */
+  platform: process.platform,
   pickFolder: (): Promise<string | null> => ipcRenderer.invoke("pick-folder"),
   /** Native multi-select file picker; [] when cancelled. */
   pickFiles: (): Promise<PickedFile[]> => ipcRenderer.invoke("pick-files"),

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -54,7 +54,8 @@ function ThemeBridge() {
   const color = useApp((s) => s.activeSpace()?.color ?? null);
   const pref = useApp((s) => s.themePref);
   const theme = useApp((s) => s.themeName);
-  useApplyTheme(color, pref, theme);
+  const groundAlpha = useApp((s) => s.groundAlpha);
+  useApplyTheme(color, pref, theme, groundAlpha);
   return null;
 }
 

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -53,7 +53,8 @@ export function AppShell() {
 function ThemeBridge() {
   const color = useApp((s) => s.activeSpace()?.color ?? null);
   const pref = useApp((s) => s.themePref);
-  useApplyTheme(color, pref);
+  const theme = useApp((s) => s.themeName);
+  useApplyTheme(color, pref, theme);
   return null;
 }
 

--- a/apps/desktop/src/renderer/src/components/CommandPalette.tsx
+++ b/apps/desktop/src/renderer/src/components/CommandPalette.tsx
@@ -1,4 +1,4 @@
-import { Icon } from "@realm/ui";
+import { Icon, THEMES, resolveMode } from "@realm/ui";
 import { AGENT_META, PRESETS, SELECTABLE_AGENT_KINDS, emptyLayout, itemIdOfLeaf, allItems as openItemIds, type DestinationPageKind, type Item, type PresetName, type SearchResults, type SearchSnippet } from "@realm/contracts";
 import { Fragment, useEffect, useMemo, useRef, useState, type KeyboardEvent as ReactKeyboardEvent, type ReactNode } from "react";
 import type { StoreApi } from "zustand";
@@ -72,7 +72,7 @@ export function relTime(ts: number, now = Date.now()): string {
   return `${Math.floor(d / 365)}y`;
 }
 
-const THEMES: ThemePref[] = ["system", "light", "dark"];
+const MODES: ThemePref[] = ["system", "light", "dark"];
 
 /** The palette's CSS width (styles.css `.palette`); the no-overlay path needs the number. */
 const PALETTE_WIDTH = 560;
@@ -106,6 +106,8 @@ function PaletteBody() {
   const sessions = useApp((s) => s.sessions);
   const sessionStatus = useApp((s) => s.sessionStatus);
   const themePref = useApp((s) => s.themePref);
+  const themeName = useApp((s) => s.themeName);
+  const setThemeName = useApp((s) => s.setThemeName);
   const selectSpace = useApp((s) => s.selectSpace);
   const openItem = useApp((s) => s.openItem);
   const newTerminal = useApp((s) => s.newTerminal);
@@ -289,15 +291,24 @@ function PaletteBody() {
       ...(activeSpaceId ? PRESETS.map((p) => act(`layout-${p}`, `Layout: ${PRESET_LABELS[p]}`, "layout", () => run(() => applyPreset(p)))) : []),
     ];
 
-    const themes = THEMES.map<Entry>((t) => ({
+    const themes = MODES.map<Entry>((t) => ({
       id: `theme:${t}`, label: `Theme: ${t[0]!.toUpperCase()}${t.slice(1)}`, hint: themePref === t ? "current" : undefined,
       icon: <Icon name={t === "dark" ? "moon" : "sun"} size={15} />, section: "Theme", run: () => run(() => setThemePref(t)),
     }));
 
-    return [...open, ...activeRest, ...others, ...actions, ...themes];
-  }, [spaces, activeSpaceId, items, allItems, layout, focusedLeafId, sessions, sessionStatus, themePref, drafts, dispatchDraft,
+    // The palette axis, in the same section: light/dark and which colours are the same question to
+    // anyone reaching for ⌘K. A one-faced theme says so in the hint rather than surprising the user
+    // by pinning the mode on select.
+    const palettes = THEMES.map<Entry>((t) => ({
+      id: `palette:${t.name}`, label: `Palette: ${t.label}`, section: "Theme",
+      hint: themeName === t.name ? "current" : t.dark && t.light ? undefined : `${resolveMode(t.name, "light")} only`,
+      icon: <Icon name="paintBucket" size={15} />, run: () => run(() => setThemeName(t.name)),
+    }));
+
+    return [...open, ...activeRest, ...others, ...actions, ...themes, ...palettes];
+  }, [spaces, activeSpaceId, items, allItems, layout, focusedLeafId, sessions, sessionStatus, themePref, themeName, drafts, dispatchDraft,
       selectSpace, openItem, newTerminal, newBrowser, openDocuments, newSession, newSessionInstant, newSessionInWorktree, splitFocused, closeFromLayout, requestRename,
-      interruptSession, jumpToPermission, applyPreset, setThemePref, openSheet, openSpacePage, openDestinationPage, destinationPageElsewhere, openProfilePage, openActivity, setSpacesOpen, run,
+      interruptSession, jumpToPermission, applyPreset, setThemePref, setThemeName, openSheet, openSpacePage, openDestinationPage, destinationPageElsewhere, openProfilePage, openActivity, setSpacesOpen, run,
       groups, zoomedLeaf, activatePaneGroup, newPaneGroup, toggleFocusPane]);
 
   // Empty query: everything, grouped under faint section headers. With a query: a flat list ranked

--- a/apps/desktop/src/renderer/src/components/sidebar/SpaceHeader.tsx
+++ b/apps/desktop/src/renderer/src/components/sidebar/SpaceHeader.tsx
@@ -1,4 +1,4 @@
-import { Icon } from "@realm/ui";
+import { Icon, THEMES } from "@realm/ui";
 import { useCallback, useRef, useState } from "react";
 import type { Space } from "@realm/contracts";
 import { useApp } from "../../state/store";
@@ -6,12 +6,14 @@ import { Menu } from "../Menu";
 import { SpaceIcon } from "../SpaceIcon";
 import type { ThemePref } from "../../theme/useTheme";
 
-const THEMES: { pref: ThemePref; label: string }[] = [{ pref: "system", label: "System" }, { pref: "light", label: "Light" }, { pref: "dark", label: "Dark" }];
+const MODES: { pref: ThemePref; label: string }[] = [{ pref: "system", label: "System" }, { pref: "light", label: "Light" }, { pref: "dark", label: "Dark" }];
 
 export function SpaceHeader({ space }: { space: Space }) {
   const profile = useApp((s) => s.profiles.find((p) => p.id === space.profileId));
   const themePref = useApp((s) => s.themePref);
   const setThemePref = useApp((s) => s.setThemePref);
+  const themeName = useApp((s) => s.themeName);
+  const setThemeName = useApp((s) => s.setThemeName);
   const swipeInvert = useApp((s) => s.swipeInvert);
   const setSwipeInvert = useApp((s) => s.setSwipeInvert);
   const openSpacePage = useApp((s) => s.openSpacePage);
@@ -43,7 +45,9 @@ export function SpaceHeader({ space }: { space: Space }) {
               // deliberate choice — it makes a branch — so it lives behind the menu.
               { label: "New session in a worktree", onSelect: () => run(() => newSessionInWorktree()) },
               { kind: "separator" },
-              ...THEMES.map((t) => ({ label: `Theme: ${t.label}`, checked: themePref === t.pref, onSelect: () => run(() => setThemePref(t.pref)) })),
+              ...MODES.map((t) => ({ label: `Theme: ${t.label}`, checked: themePref === t.pref, onSelect: () => run(() => setThemePref(t.pref)) })),
+              { kind: "separator" as const },
+              ...THEMES.map((t) => ({ label: `Palette: ${t.label}`, checked: themeName === t.name, onSelect: () => run(() => setThemeName(t.name)) })),
               { kind: "separator" as const },
               { label: "Invert swipe direction", checked: swipeInvert, onSelect: () => run(() => setSwipeInvert(!swipeInvert)) },
           ]} />

--- a/apps/desktop/src/renderer/src/env.d.ts
+++ b/apps/desktop/src/renderer/src/env.d.ts
@@ -6,6 +6,9 @@ interface PickedFile { path: string; mime: string; name: string; size: number }
 interface Window {
   realm: {
     port: number; home: string;
+    /** `process.platform` from the preload. Absent in jsdom, which has no bridge — every reader has
+     *  to treat "unknown" as "no window material" rather than guessing macOS. */
+    platform?: string;
     pickFolder(): Promise<string | null>;
     /** Native multi-select file picker; [] when cancelled. */
     pickFiles(): Promise<PickedFile[]>;

--- a/apps/desktop/src/renderer/src/panes/settings/SettingsPage.tsx
+++ b/apps/desktop/src/renderer/src/panes/settings/SettingsPage.tsx
@@ -3,12 +3,12 @@ import {
   CREDENTIAL_2FA_NOTE, CREDENTIAL_PRESENCE_TTLS, CREDENTIAL_STORAGE_NOTE, NOTIFICATION_CATEGORIES,
   PERMISSION_MODES, SELECTABLE_AGENT_KINDS, type AgentKind, type NotificationCategory,
 } from "@realm/contracts";
-import { Icon, THEMES, resolveMode, themeSwatches } from "@realm/ui";
+import { GROUND_ALPHA_RANGE, Icon, THEMES, resolveMode, themeSwatches } from "@realm/ui";
 import { useEffect, useState } from "react";
 import { agentAvailability, isBlocked } from "../../state/agent-availability";
 import { useApp, type SubmitKey } from "../../state/store";
 import type { PaneProps } from "../registry";
-import { useSystemMode, type ThemePref } from "../../theme/useTheme";
+import { hasWindowMaterial, useSystemMode, type ThemePref } from "../../theme/useTheme";
 import { ImportPanel } from "../../components/settings/ImportPanel";
 import { UsagePanel } from "./usage/UsagePanel";
 
@@ -164,6 +164,13 @@ const THEME_CHOICES: { pref: ThemePref; label: string }[] = [
   { pref: "system", label: "System" }, { pref: "light", label: "Light" }, { pref: "dark", label: "Dark" },
 ];
 
+/** Opacity ⇄ transparency across the allowed range. Its own involution, so one function serves the
+ *  read and the write and the two can never disagree about which end is which. */
+const flip = (pct: number): number => GROUND_ALPHA_RANGE.min + GROUND_ALPHA_RANGE.max - pct;
+
+/** Only for the sentence explaining why the transparency control is inert; nothing branches on it. */
+const PLATFORM_NAMES: Record<string, string> = { win32: "Windows", linux: "Linux" };
+
 const SUBMIT_KEY_CHOICES: { pref: SubmitKey; label: string }[] = [
   { pref: "enter", label: "Enter" }, { pref: "cmdEnter", label: "⌘/Ctrl+Enter" },
 ];
@@ -186,6 +193,8 @@ function AppTab() {
   const setThemePref = useApp((s) => s.setThemePref);
   const themeName = useApp((s) => s.themeName);
   const setThemeName = useApp((s) => s.setThemeName);
+  const groundAlpha = useApp((s) => s.groundAlpha);
+  const setGroundAlpha = useApp((s) => s.setGroundAlpha);
   const submitKey = useApp((s) => s.submitKey);
   const setSubmitKey = useApp((s) => s.setSubmitKey);
   const prefs = useApp((s) => s.settingsPrefs);
@@ -215,6 +224,7 @@ function AppTab() {
   const effective = resolveMode(themeName, wanted);
   const pinned = effective !== wanted;
   const palette = THEMES.find((t) => t.name === themeName) ?? THEMES[0]!;
+  const material = hasWindowMaterial();
 
   const supported = SELECTABLE_AGENT_KINDS.filter((k) => AGENT_SUPPORTS_PERMISSION_MODES[k]);
   const unsupported = SELECTABLE_AGENT_KINDS.filter((k) => !AGENT_SUPPORTS_PERMISSION_MODES[k]);
@@ -263,6 +273,23 @@ function AppTab() {
           })}
         </fieldset>
         <p className="settings-hint">{palette.blurb}{palette.credit ? ` ${palette.credit}.` : ""}</p>
+      </div>
+
+      <div className="field"><span>Background transparency</span>
+        {/* The slider runs the way the label reads — right is MORE transparent — while the stored
+            value is the ground's OPACITY, because that is what the stylesheet composes. `flip` is
+            the one place the two meet.
+            step 1, not a coarser grid: the range spans an odd number of points, so any step above 1
+            leaves one of its two ends unreachable — including 100%, which is how this is turned off. */}
+        <div className="ground-alpha">
+          <input type="range" aria-label="Background transparency" disabled={!material}
+            min={GROUND_ALPHA_RANGE.min} max={GROUND_ALPHA_RANGE.max} step={1}
+            value={flip(groundAlpha)} onChange={(e) => run(() => setGroundAlpha(flip(Number(e.target.value))))} />
+          <span className="ground-alpha-value">{100 - groundAlpha}%</span>
+        </div>
+        <p className="settings-hint">{material
+          ? "The sidebar is the one surface thin enough to show the desktop behind the window. Panes stay opaque on purpose — at any setting where a pane looked translucent, text on it would fall below the contrast every theme here is held to. Realm also follows the system's Reduce Transparency setting: with it on the sidebar is opaque whatever this says, and your value comes back when you turn it off."
+          : `${PLATFORM_NAMES[window.realm?.platform ?? ""] ?? "This platform"} has no window material — the window is opaque, so there is nothing behind the sidebar to reveal. The setting is kept and applies on a Mac.`}</p>
       </div>
 
       <div className="field"><span>Send message with</span>

--- a/apps/desktop/src/renderer/src/panes/settings/SettingsPage.tsx
+++ b/apps/desktop/src/renderer/src/panes/settings/SettingsPage.tsx
@@ -3,12 +3,12 @@ import {
   CREDENTIAL_2FA_NOTE, CREDENTIAL_PRESENCE_TTLS, CREDENTIAL_STORAGE_NOTE, NOTIFICATION_CATEGORIES,
   PERMISSION_MODES, SELECTABLE_AGENT_KINDS, type AgentKind, type NotificationCategory,
 } from "@realm/contracts";
-import { Icon } from "@realm/ui";
+import { Icon, THEMES, resolveMode, themeSwatches } from "@realm/ui";
 import { useEffect, useState } from "react";
 import { agentAvailability, isBlocked } from "../../state/agent-availability";
 import { useApp, type SubmitKey } from "../../state/store";
 import type { PaneProps } from "../registry";
-import type { ThemePref } from "../../theme/useTheme";
+import { useSystemMode, type ThemePref } from "../../theme/useTheme";
 import { ImportPanel } from "../../components/settings/ImportPanel";
 import { UsagePanel } from "./usage/UsagePanel";
 
@@ -184,6 +184,8 @@ const CATEGORY_COPY: Record<NotificationCategory, { label: string; desc: string 
 function AppTab() {
   const themePref = useApp((s) => s.themePref);
   const setThemePref = useApp((s) => s.setThemePref);
+  const themeName = useApp((s) => s.themeName);
+  const setThemeName = useApp((s) => s.setThemeName);
   const submitKey = useApp((s) => s.submitKey);
   const setSubmitKey = useApp((s) => s.setSubmitKey);
   const prefs = useApp((s) => s.settingsPrefs);
@@ -195,6 +197,7 @@ function AppTab() {
   const setDesktopNotifications = useApp((s) => s.setDesktopNotifications);
   const setDefaultPermissionMode = useApp((s) => s.setDefaultPermissionMode);
   const run = useApp((s) => s.run);
+  const sys = useSystemMode();
   useEffect(() => { void run(() => refreshSettingsPrefs()); }, [run, refreshSettingsPrefs]);
   // bypassPermissions must never be a one-click slip, HERE least of all — this is every future
   // session at once. Same two-step as the composer chip (U-M7): arm for 5s, apply only on the
@@ -206,6 +209,13 @@ function AppTab() {
     return () => clearTimeout(t);
   }, [confirmBypass]);
 
+  // The mode the preference resolves to before the palette has its say, and what it becomes after.
+  // Both are needed: the cards preview against what the user ASKED for, the hint explains the gap.
+  const wanted = themePref === "system" ? sys : themePref;
+  const effective = resolveMode(themeName, wanted);
+  const pinned = effective !== wanted;
+  const palette = THEMES.find((t) => t.name === themeName) ?? THEMES[0]!;
+
   const supported = SELECTABLE_AGENT_KINDS.filter((k) => AGENT_SUPPORTS_PERMISSION_MODES[k]);
   const unsupported = SELECTABLE_AGENT_KINDS.filter((k) => !AGENT_SUPPORTS_PERMISSION_MODES[k]);
   const labels = (ks: readonly AgentKind[]) => ks.map((k) => AGENT_META[k].label).join(", ");
@@ -213,7 +223,11 @@ function AppTab() {
   return (
     <div className="form">
       <div className="field"><span>Theme</span>
-        <fieldset className="settings-tabs" aria-label="Theme">
+        {/* `data-pinned` when the chosen palette has only one face. The radios stay LIVE — the
+            preference is still recorded and still applies the moment a two-faced palette is chosen —
+            but a control that cannot change what is on screen right now has to say so rather than
+            look broken. */}
+        <fieldset className="settings-tabs" aria-label="Theme" data-pinned={pinned || undefined}>
           {THEME_CHOICES.map((t) => (
             <label key={t.pref} className="settings-tab" data-selected={themePref === t.pref || undefined}>
               <input type="radio" name="settings-theme" value={t.pref} checked={themePref === t.pref}
@@ -222,9 +236,33 @@ function AppTab() {
             </label>
           ))}
         </fieldset>
+        {pinned && <p className="settings-hint">{`${palette.label} has no ${wanted} variant, so the window stays ${effective} while it is chosen. Your preference is kept.`}</p>}
         {/* One line, not a switch (Plan 14 W5): the OS setting is the control, and styles.css's global
             prefers-reduced-motion kill is what makes this sentence true. */}
         <p className="settings-hint">Realm follows the system's Reduce Motion setting everywhere — with it on, animations and transitions are disabled app-wide.</p>
+      </div>
+
+      <div className="field"><span>Palette</span>
+        {/* Each card is painted in the palette it names, in the mode that palette would actually
+            resolve to — the swatches are the same derivation the app runs, so what is on the card is
+            what the window becomes. */}
+        <fieldset className="theme-grid" aria-label="Palette">
+          {THEMES.map((t) => {
+            const [page, surface, accent, string] = themeSwatches(t.name, wanted);
+            return (
+              <label key={t.name} className="theme-card" data-selected={themeName === t.name || undefined}
+                style={{ background: page, borderColor: surface }}>
+                <input type="radio" name="settings-palette" value={t.name} checked={themeName === t.name}
+                  onChange={() => run(() => setThemeName(t.name))} />
+                <span className="theme-card-swatches" aria-hidden>
+                  {[surface, accent, string].map((c, i) => <span key={i} style={{ background: c }} />)}
+                </span>
+                <span className="theme-card-name" style={{ color: accent }}>{t.label}</span>
+              </label>
+            );
+          })}
+        </fieldset>
+        <p className="settings-hint">{palette.blurb}{palette.credit ? ` ${palette.credit}.` : ""}</p>
       </div>
 
       <div className="field"><span>Send message with</span>

--- a/apps/desktop/src/renderer/src/panes/settings/settings-page.test.tsx
+++ b/apps/desktop/src/renderer/src/panes/settings/settings-page.test.tsx
@@ -1,4 +1,5 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { GROUND_ALPHA_RANGE } from "@realm/ui";
 import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { AGENT_CLI_COMMANDS, DEFAULT_PERMISSION_MODE_KEY, NOTIFICATIONS_DESKTOP_KEY, NOTIFICATIONS_DISABLED_KEY, PAGE_REF_IDS } from "@realm/contracts";
 import { engineVersionLabel, SettingsPage } from "./SettingsPage";
@@ -33,6 +34,8 @@ async function mount(overrides: FakeData = {}) {
   const r = render(<StoreContext.Provider value={store}><SettingsPage item={pageItem} visible /></StoreContext.Provider>);
   return { store, api, ...r };
 }
+
+afterEach(() => { vi.unstubAllGlobals(); });
 
 describe("the Settings page (Plan 12 W6)", () => {
   it("wears the page pattern: head, an Engines · Usage · App · Sign-ins · Permissions rail, Engines first", async () => {
@@ -163,6 +166,31 @@ describe("App tab", () => {
     expect(screen.getByText(/Monokai has no light variant/)).toBeInTheDocument();
     // Still operable: the preference it records applies again under a two-faced palette.
     expect(screen.getByRole("radio", { name: "Light" })).not.toBeDisabled();
+  });
+
+  it("background transparency runs the way its label reads and persists the ground's opacity", async () => {
+    // The bridge is what says this platform has a material; jsdom has none, so the mac case is
+    // stubbed rather than assumed. An unstubbed renderer must not guess macOS.
+    vi.stubGlobal("realm", { platform: "darwin" });
+    const { store, api } = await openApp();
+    const slider = screen.getByRole("slider", { name: "Background transparency" });
+    expect(slider).not.toBeDisabled();
+    // Stored 82% opaque shows as 18% transparent, and the thumb sits at the complement.
+    expect(screen.getByText("18%")).toBeInTheDocument();
+    // Dragging to the transparent end has to land on the OPAQUE end of the stored range.
+    fireEvent.change(slider, { target: { value: String(GROUND_ALPHA_RANGE.max) } });
+    // THE inverted-slider mutant: drop the flip on one side only. Dragging right would then make
+    // the sidebar MORE opaque while the readout says more transparent.
+    await waitFor(() => expect(store.getState().groundAlpha).toBe(GROUND_ALPHA_RANGE.min));
+    expect(screen.getByText(`${100 - GROUND_ALPHA_RANGE.min}%`)).toBeInTheDocument();
+    await waitFor(() => expect(api.calls).toContain(`setSetting:ui.groundAlpha=${GROUND_ALPHA_RANGE.min}`));
+  });
+
+  it("off macOS the control is inert and says why, rather than appearing and doing nothing", async () => {
+    vi.stubGlobal("realm", { platform: "win32" });
+    await openApp();
+    expect(screen.getByRole("slider", { name: "Background transparency" })).toBeDisabled();
+    expect(screen.getByText(/Windows has no window material/)).toBeInTheDocument();
   });
 
   it("submit key defaults to Enter and can switch to ⌘/Ctrl+Enter, writing ui.submitKey", async () => {

--- a/apps/desktop/src/renderer/src/panes/settings/settings-page.test.tsx
+++ b/apps/desktop/src/renderer/src/panes/settings/settings-page.test.tsx
@@ -144,6 +144,27 @@ describe("App tab", () => {
     expect(api.calls).toContain("setSetting:ui.theme=dark");
   });
 
+  it("the palette is a card per theme; choosing one writes ui.themeName and not ui.theme", async () => {
+    const { store, api } = await openApp();
+    expect(screen.getByRole("radio", { name: "Realm" })).toBeChecked();
+    fireEvent.click(screen.getByRole("radio", { name: "One" }));
+    await waitFor(() => expect(store.getState().themeName).toBe("one"));
+    expect(api.calls).toContain("setSetting:ui.themeName=one");
+    // THE conflated-axis mutant: have the picker set the mode too. The light/dark preference is the
+    // user's and a palette choice is not permission to overwrite it.
+    expect(api.calls.filter((c) => c.startsWith("setSetting:ui.theme="))).toEqual([]);
+    expect(store.getState().themePref).toBe("system");
+  });
+
+  it("a one-faced palette says so rather than leaving the mode control looking broken", async () => {
+    const { store } = await openApp();
+    fireEvent.click(screen.getByRole("radio", { name: "Monokai" }));
+    await waitFor(() => expect(store.getState().themeName).toBe("monokai"));
+    expect(screen.getByText(/Monokai has no light variant/)).toBeInTheDocument();
+    // Still operable: the preference it records applies again under a two-faced palette.
+    expect(screen.getByRole("radio", { name: "Light" })).not.toBeDisabled();
+  });
+
   it("submit key defaults to Enter and can switch to ⌘/Ctrl+Enter, writing ui.submitKey", async () => {
     const { store, api } = await openApp();
     expect(screen.getByRole("radio", { name: "Enter" })).toBeChecked();

--- a/apps/desktop/src/renderer/src/state/store.test.ts
+++ b/apps/desktop/src/renderer/src/state/store.test.ts
@@ -235,6 +235,29 @@ describe("app store", () => {
     expect(store.getState().themePref).toBe("dark"); expect(set).toContain("ui.theme=dark");
   });
 
+  it("themeName persists under its own key, leaving the mode preference untouched", async () => {
+    // THE compound-key mutant: fold the palette into ui.theme as "dark:monokai". It reads back fine
+    // here and an older build finds a mode it cannot parse where it used to find "dark".
+    const set: string[] = []; const store = createAppStore({ ...api, setSetting: async (k, v) => { set.push(`${k}=${v}`); } });
+    await store.getState().boot(); await store.getState().setThemeName("one");
+    expect(store.getState().themeName).toBe("one");
+    expect(store.getState().themePref).toBe("system");
+    expect(set).toContain("ui.themeName=one");
+    expect(set.filter((k) => k.startsWith("ui.theme="))).toEqual([]);
+  });
+
+  it("boot reads the palette; garbage and an unknown name both fall back to realm", async () => {
+    const named = async (v: unknown) => {
+      const s = createAppStore({ ...api, getSetting: async (k) => (k === "ui.themeName" ? v : null) });
+      await s.getState().boot(); return s.getState().themeName;
+    };
+    expect(await named("one")).toBe("one");
+    // A home written by a build that shipped a theme this one does not have must not leave the app
+    // with a palette it cannot derive.
+    expect(await named("cobalt")).toBe("realm");
+    expect(await named({ mode: "x" })).toBe("realm");
+  });
+
   it("updateItem merges the returned item (pin/rename)", async () => {
     const store = createAppStore(api); await store.getState().boot();
     await store.getState().updateItem({ id: "i1", pinned: true, title: "GitHub" });

--- a/apps/desktop/src/renderer/src/state/store.test.ts
+++ b/apps/desktop/src/renderer/src/state/store.test.ts
@@ -246,6 +246,32 @@ describe("app store", () => {
     expect(set.filter((k) => k.startsWith("ui.theme="))).toEqual([]);
   });
 
+  it("groundAlpha persists once per gesture, and boot clamps whatever it reads back", async () => {
+    const set: string[] = []; const store = createAppStore({ ...api, setSetting: async (k, v) => { set.push(`${k}=${v}`); } });
+    await store.getState().boot();
+    expect(store.getState().groundAlpha).toBe(82);
+    // A drag is many calls; the window follows each one and only the last is written.
+    for (const v of [80, 74, 68, 62]) await store.getState().setGroundAlpha(v);
+    expect(store.getState().groundAlpha).toBe(62);
+    await vi.waitFor(() => expect(set).toContain("ui.groundAlpha=62"));
+    expect(set.filter((k) => k.startsWith("ui.groundAlpha="))).toEqual(["ui.groundAlpha=62"]);
+
+    // THE unclamped-setter mutant: store whatever the caller passed. The slider's min/max cannot be
+    // the guard — this is the store's API, and a 5 written here is a sidebar nobody can read a
+    // control off to undo it with.
+    await store.getState().setGroundAlpha(5);
+    expect(store.getState().groundAlpha).toBe(55);
+    await vi.waitFor(() => expect(set).toContain("ui.groundAlpha=55"));
+
+    const read = async (v: unknown) => {
+      const s = createAppStore({ ...api, getSetting: async (k) => (k === "ui.groundAlpha" ? v : null) });
+      await s.getState().boot(); return s.getState().groundAlpha;
+    };
+    expect(await read(64)).toBe(64);
+    expect(await read(0)).toBe(55);   // clamped on the way in, not only on the way out
+    expect(await read("very")).toBe(82);
+  });
+
   it("boot reads the palette; garbage and an unknown name both fall back to realm", async () => {
     const named = async (v: unknown) => {
       const s = createAppStore({ ...api, getSetting: async (k) => (k === "ui.themeName" ? v : null) });

--- a/apps/desktop/src/renderer/src/state/store.ts
+++ b/apps/desktop/src/renderer/src/state/store.ts
@@ -11,6 +11,7 @@ import {
 } from "@realm/contracts";
 import { createContext, useCallback, useContext, useMemo, useSyncExternalStore } from "react";
 import { SHEET_MIN_WIDTH, complementOf, snapBrowserLeaves } from "./no-overlay";
+import { isThemeName, type ThemeName } from "@realm/ui";
 import type { ThemePref } from "../theme/useTheme";
 import { emptyTranscript, reduceTranscript, type Transcript } from "../panes/session/transcript-model";
 import { allowlistKey, getBrowserBridges, parseAllowlist } from "../panes/browser/browser-client";
@@ -417,6 +418,10 @@ export type SubmitKey = "enter" | "cmdEnter";
 export const PERSIST_DEBOUNCE_MS = 300;
 export const SETTING_ACTIVE_SPACE = "ui.activeSpaceId";
 export const SETTING_THEME = "ui.theme";
+/** The palette, which is a second axis from `ui.theme`'s light/dark: one says which mode, the other
+ *  says what the colours are in it. Its own key rather than a compound value in `ui.theme`, so an
+ *  older build reading `ui.theme` still finds a mode it understands. */
+export const SETTING_THEME_NAME = "ui.themeName";
 /** Agent of the most recent session the user created or switched to — what "+"/⌘N reach for next. */
 export const SETTING_LAST_AGENT = "ui.lastAgentKind";
 const SETTING_SWIPE_INVERT = "ui.swipeInvert";
@@ -490,6 +495,9 @@ export type AppState = {
   /** All spaces across profiles, in user sort order. Exactly one is active at a time. */
   spaces: Space[]; activeSpaceId: string | null;
   themePref: ThemePref;
+  /** The palette. Orthogonal to `themePref`: a theme with only one face pins the effective mode
+   *  while it is selected, and leaves the preference alone (see `useApplyTheme`). */
+  themeName: ThemeName;
   /** Invert the two-finger swipe direction (default: fingers-left → next space, like Arc/Spaces). */
   swipeInvert: boolean;
   submitKey: SubmitKey;
@@ -789,6 +797,7 @@ export type AppState = {
   deleteSpace(id: string): Promise<void>;
   reorderSpaces(ids: string[]): Promise<void>;
   setThemePref(pref: ThemePref): Promise<void>;
+  setThemeName(name: ThemeName): Promise<void>;
   setSwipeInvert(v: boolean): Promise<void>;
   /** Flip the sidebar between full column and top rail, and persist it. */
   toggleSidebar(): Promise<void>;
@@ -1765,7 +1774,7 @@ export function createAppStore(api: Api): StoreApi<AppState> {
 
     return {
       booted: false,
-      profiles: [], spaces: [], activeSpaceId: null, themePref: "system", swipeInvert: false, submitKey: "enter", sidebarCollapsed: false, items: [], groups: null, layout: null, focusedLeafId: null, projects: [], environments: {}, error: null,
+      profiles: [], spaces: [], activeSpaceId: null, themePref: "system", themeName: "realm", swipeInvert: false, submitKey: "enter", sidebarCollapsed: false, items: [], groups: null, layout: null, focusedLeafId: null, projects: [], environments: {}, error: null,
       allItems: [], lastAgentKind: null, renamingItemId: null, renamingGroupId: null,
       connectionState: "connected",
       paletteOpen: false, spacesOpen: false, lastSpaceByProfile: {}, sheet: null, browserRects: [], sheetSnap: null, browserActions: {}, browserDriving: {},
@@ -1787,15 +1796,15 @@ export function createAppStore(api: Api): StoreApi<AppState> {
       activeIndex() { const id = get().activeSpaceId; return id ? get().spaces.findIndex((s) => s.id === id) : -1; },
 
       async boot() {
-        const [profiles, spaces, saved, theme, swipeInvert, submitKey, sidebarCollapsed, lastAgent, panels, system] = await Promise.all([
-          api.listProfiles(), api.listSpaces(), api.getSetting(SETTING_ACTIVE_SPACE), api.getSetting(SETTING_THEME), api.getSetting(SETTING_SWIPE_INVERT), api.getSetting(SETTING_SUBMIT_KEY), api.getSetting(SETTING_SIDEBAR_COLLAPSED), api.getSetting(SETTING_LAST_AGENT),
+        const [profiles, spaces, saved, theme, themeName, swipeInvert, submitKey, sidebarCollapsed, lastAgent, panels, system] = await Promise.all([
+          api.listProfiles(), api.listSpaces(), api.getSetting(SETTING_ACTIVE_SPACE), api.getSetting(SETTING_THEME), api.getSetting(SETTING_THEME_NAME), api.getSetting(SETTING_SWIPE_INVERT), api.getSetting(SETTING_SUBMIT_KEY), api.getSetting(SETTING_SIDEBAR_COLLAPSED), api.getSetting(SETTING_LAST_AGENT),
           api.getSetting(SETTING_TERMINAL_PANEL),
           // Labels, not dependencies: a failure here must not take boot down with it — the strip
           // simply shows no machine name, and the greeting no name.
           api.systemInfo().catch(() => ({ machineName: "", userName: "" })),
         ]);
         const agent = AgentKindSchema.safeParse(lastAgent);
-        set({ profiles, themePref: isThemePref(theme) ? theme : "system", swipeInvert: swipeInvert === true,
+        set({ profiles, themePref: isThemePref(theme) ? theme : "system", themeName: isThemeName(themeName) ? themeName : "realm", swipeInvert: swipeInvert === true,
           submitKey: isSubmitKey(submitKey) ? submitKey : "enter", sidebarCollapsed: sidebarCollapsed === true, lastAgentKind: agent.success ? agent.data : null,
           terminalPanel: parseTerminalPanels(panels), machineName: system.machineName, userName: system.userName });
         // AppShell is already mounted during boot: keep spaces unpublished until each saved custom
@@ -1952,6 +1961,10 @@ export function createAppStore(api: Api): StoreApi<AppState> {
       async setThemePref(pref) {
         set({ themePref: pref });
         await api.setSetting(SETTING_THEME, pref);
+      },
+      async setThemeName(name) {
+        set({ themeName: name });
+        await api.setSetting(SETTING_THEME_NAME, name);
       },
       async setSwipeInvert(v) {
         set({ swipeInvert: v });

--- a/apps/desktop/src/renderer/src/state/store.ts
+++ b/apps/desktop/src/renderer/src/state/store.ts
@@ -11,7 +11,7 @@ import {
 } from "@realm/contracts";
 import { createContext, useCallback, useContext, useMemo, useSyncExternalStore } from "react";
 import { SHEET_MIN_WIDTH, complementOf, snapBrowserLeaves } from "./no-overlay";
-import { isThemeName, type ThemeName } from "@realm/ui";
+import { DEFAULT_GROUND_ALPHA, clampGroundAlpha, isThemeName, type ThemeName } from "@realm/ui";
 import type { ThemePref } from "../theme/useTheme";
 import { emptyTranscript, reduceTranscript, type Transcript } from "../panes/session/transcript-model";
 import { allowlistKey, getBrowserBridges, parseAllowlist } from "../panes/browser/browser-client";
@@ -422,6 +422,8 @@ export const SETTING_THEME = "ui.theme";
  *  says what the colours are in it. Its own key rather than a compound value in `ui.theme`, so an
  *  older build reading `ui.theme` still finds a mode it understands. */
 export const SETTING_THEME_NAME = "ui.themeName";
+/** How opaque the sidebar's ground is over the macOS window material, in percent. */
+export const SETTING_GROUND_ALPHA = "ui.groundAlpha";
 /** Agent of the most recent session the user created or switched to — what "+"/⌘N reach for next. */
 export const SETTING_LAST_AGENT = "ui.lastAgentKind";
 const SETTING_SWIPE_INVERT = "ui.swipeInvert";
@@ -498,6 +500,10 @@ export type AppState = {
   /** The palette. Orthogonal to `themePref`: a theme with only one face pins the effective mode
    *  while it is selected, and leaves the preference alone (see `useApplyTheme`). */
   themeName: ThemeName;
+  /** The sidebar's opacity over the macOS vibrancy material, 40–100. Persisted on every platform —
+   *  a preference set on a Mac should survive opening the same home somewhere without a material,
+   *  and come back unchanged. */
+  groundAlpha: number;
   /** Invert the two-finger swipe direction (default: fingers-left → next space, like Arc/Spaces). */
   swipeInvert: boolean;
   submitKey: SubmitKey;
@@ -798,6 +804,7 @@ export type AppState = {
   reorderSpaces(ids: string[]): Promise<void>;
   setThemePref(pref: ThemePref): Promise<void>;
   setThemeName(name: ThemeName): Promise<void>;
+  setGroundAlpha(pct: number): Promise<void>;
   setSwipeInvert(v: boolean): Promise<void>;
   /** Flip the sidebar between full column and top rail, and persist it. */
   toggleSidebar(): Promise<void>;
@@ -1772,9 +1779,11 @@ export function createAppStore(api: Api): StoreApi<AppState> {
       await get().openItem(itemId, targetLeafId);
     };
 
+    let groundAlphaTimer: ReturnType<typeof setTimeout> | null = null;
+
     return {
       booted: false,
-      profiles: [], spaces: [], activeSpaceId: null, themePref: "system", themeName: "realm", swipeInvert: false, submitKey: "enter", sidebarCollapsed: false, items: [], groups: null, layout: null, focusedLeafId: null, projects: [], environments: {}, error: null,
+      profiles: [], spaces: [], activeSpaceId: null, themePref: "system", themeName: "realm", groundAlpha: DEFAULT_GROUND_ALPHA, swipeInvert: false, submitKey: "enter", sidebarCollapsed: false, items: [], groups: null, layout: null, focusedLeafId: null, projects: [], environments: {}, error: null,
       allItems: [], lastAgentKind: null, renamingItemId: null, renamingGroupId: null,
       connectionState: "connected",
       paletteOpen: false, spacesOpen: false, lastSpaceByProfile: {}, sheet: null, browserRects: [], sheetSnap: null, browserActions: {}, browserDriving: {},
@@ -1796,15 +1805,16 @@ export function createAppStore(api: Api): StoreApi<AppState> {
       activeIndex() { const id = get().activeSpaceId; return id ? get().spaces.findIndex((s) => s.id === id) : -1; },
 
       async boot() {
-        const [profiles, spaces, saved, theme, themeName, swipeInvert, submitKey, sidebarCollapsed, lastAgent, panels, system] = await Promise.all([
-          api.listProfiles(), api.listSpaces(), api.getSetting(SETTING_ACTIVE_SPACE), api.getSetting(SETTING_THEME), api.getSetting(SETTING_THEME_NAME), api.getSetting(SETTING_SWIPE_INVERT), api.getSetting(SETTING_SUBMIT_KEY), api.getSetting(SETTING_SIDEBAR_COLLAPSED), api.getSetting(SETTING_LAST_AGENT),
+        const [profiles, spaces, saved, theme, themeName, groundAlpha, swipeInvert, submitKey, sidebarCollapsed, lastAgent, panels, system] = await Promise.all([
+          api.listProfiles(), api.listSpaces(), api.getSetting(SETTING_ACTIVE_SPACE), api.getSetting(SETTING_THEME), api.getSetting(SETTING_THEME_NAME), api.getSetting(SETTING_GROUND_ALPHA), api.getSetting(SETTING_SWIPE_INVERT), api.getSetting(SETTING_SUBMIT_KEY), api.getSetting(SETTING_SIDEBAR_COLLAPSED), api.getSetting(SETTING_LAST_AGENT),
           api.getSetting(SETTING_TERMINAL_PANEL),
           // Labels, not dependencies: a failure here must not take boot down with it — the strip
           // simply shows no machine name, and the greeting no name.
           api.systemInfo().catch(() => ({ machineName: "", userName: "" })),
         ]);
         const agent = AgentKindSchema.safeParse(lastAgent);
-        set({ profiles, themePref: isThemePref(theme) ? theme : "system", themeName: isThemeName(themeName) ? themeName : "realm", swipeInvert: swipeInvert === true,
+        set({ profiles, themePref: isThemePref(theme) ? theme : "system", themeName: isThemeName(themeName) ? themeName : "realm",
+          groundAlpha: typeof groundAlpha === "number" ? clampGroundAlpha(groundAlpha) : DEFAULT_GROUND_ALPHA, swipeInvert: swipeInvert === true,
           submitKey: isSubmitKey(submitKey) ? submitKey : "enter", sidebarCollapsed: sidebarCollapsed === true, lastAgentKind: agent.success ? agent.data : null,
           terminalPanel: parseTerminalPanels(panels), machineName: system.machineName, userName: system.userName });
         // AppShell is already mounted during boot: keep spaces unpublished until each saved custom
@@ -1965,6 +1975,17 @@ export function createAppStore(api: Api): StoreApi<AppState> {
       async setThemeName(name) {
         set({ themeName: name });
         await api.setSetting(SETTING_THEME_NAME, name);
+      },
+      async setGroundAlpha(pct) {
+        // Clamped before it is stored, not just before it is painted: an out-of-range value written
+        // by an older build (or by hand) must not be what the next boot reads back.
+        const next = clampGroundAlpha(pct);
+        set({ groundAlpha: next });
+        // The window follows the thumb — a transparency control the user cannot see the effect of
+        // while dragging is a guessing game — but a drag fires on every step, and the settings table
+        // does not need forty rows of one gesture. Same debounce the layout persist uses.
+        if (groundAlphaTimer) clearTimeout(groundAlphaTimer);
+        groundAlphaTimer = setTimeout(() => { groundAlphaTimer = null; void api.setSetting(SETTING_GROUND_ALPHA, next); }, PERSIST_DEBOUNCE_MS);
       },
       async setSwipeInvert(v) {
         set({ swipeInvert: v });

--- a/apps/desktop/src/renderer/src/state/store.ts
+++ b/apps/desktop/src/renderer/src/state/store.ts
@@ -1985,7 +1985,9 @@ export function createAppStore(api: Api): StoreApi<AppState> {
         // while dragging is a guessing game — but a drag fires on every step, and the settings table
         // does not need forty rows of one gesture. Same debounce the layout persist uses.
         if (groundAlphaTimer) clearTimeout(groundAlphaTimer);
-        groundAlphaTimer = setTimeout(() => { groundAlphaTimer = null; void api.setSetting(SETTING_GROUND_ALPHA, next); }, PERSIST_DEBOUNCE_MS);
+        // Through `run`, like the layout persist above: this fires long after the caller's promise
+        // settled, so a failed write has nowhere else to surface and would otherwise be swallowed.
+        groundAlphaTimer = setTimeout(() => { groundAlphaTimer = null; get().run(() => api.setSetting(SETTING_GROUND_ALPHA, next)); }, PERSIST_DEBOUNCE_MS);
       },
       async setSwipeInvert(v) {
         set({ swipeInvert: v });

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -142,10 +142,12 @@ kbd { font: 11px var(--font-mono); }
 /* position: relative for the collapsed corner below, which is the only thing in the shell that is
    placed against the WINDOW rather than flowed. */
 .app { position: relative; display: flex; height: 100%; background: transparent; }
-/* §5 + Plan 9 W1: the sidebar paints the BUI window ground (--page) at ~0.82 so the macOS
-   vibrancy material shows through; --page flips with data-mode, so one rule serves both themes. */
+/* §5 + Plan 9 W1: the sidebar paints the BUI window ground (--page) over the macOS vibrancy material
+   — the app's one adjustable ground, composed in tokens.css so the user's setting and
+   prefers-reduced-transparency both reach it. --page flips with data-mode, so one rule serves both
+   themes and every palette. */
 .sidebar { width: var(--sidebar-w); flex: none; display: flex; flex-direction: column; min-height: 0;
-  background: color-mix(in srgb, var(--page) 82%, transparent); border-right: 1px solid var(--rl-hairline); -webkit-app-region: drag; }
+  background: var(--sidebar-ground); border-right: 1px solid var(--rl-hairline); -webkit-app-region: drag; }
 .sidebar button, .sidebar input, .sidebar [data-swiper] { -webkit-app-region: no-drag; }
 /* The traffic-light band, as a real row rather than .sb-top's old 40px of top padding: the toggle
    sits at its right edge, mirroring the lights at its left. Height + .sb-top's new padding sum to
@@ -2821,6 +2823,14 @@ body[data-media-lightbox] .transcript .media-el { visibility: hidden; }
    the tile already has the ring and the rounding, and a second frame around it would read as a
    different kind of thing. */
 .msg-user-file-open { display: block; padding: 0; border: none; background: none; cursor: zoom-in; }
+
+/* ——— Settings → App: the background transparency slider ——————————————————————
+   A native range on the app's accent, with the value beside it in tabular figures so the number does
+   not jitter as the thumb moves. Disabled off macOS, where the window has no material behind it. */
+.ground-alpha { display: flex; align-items: center; gap: 10px; }
+.ground-alpha input { flex: 1; min-width: 0; max-width: 260px; accent-color: var(--rl-accent); }
+.ground-alpha input:disabled { cursor: default; opacity: .45; }
+.ground-alpha-value { font-size: 12px; color: var(--rl-text-dim); font-variant-numeric: tabular-nums; }
 
 /* ——— Settings → App: the palette picker ——————————————————————————————————————
    Each card is painted in the theme it names, so the row is a set of previews rather than a list of

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -995,7 +995,7 @@ button.panel-title:hover { background: var(--rl-hover); }
 .md-code { margin: 6px 0 8px; border-radius: var(--r-panel); background: var(--surface); box-shadow: var(--shadow-hairline); overflow: hidden; }
 .md-code-head { display: flex; align-items: center; gap: 8px; min-height: 32px; padding: 0 8px 0 12px; border-bottom: 1px solid var(--line); }
 .md-code-lang { font: 11px var(--font-mono); color: var(--ink-3); }
-.md-code pre { margin: 0; padding: 10px 12px; border-radius: 0; background: none; font-size: 12.5px; line-height: 1.65; color: var(--ink-2); }
+.md-code pre { margin: 0; padding: 10px 12px; border-radius: 0; background: none; font-size: 12.5px; line-height: 1.65; color: var(--syn-fg); }
 .md a { color: var(--rl-accent); text-decoration: underline; text-underline-offset: 2px; } /* Ara refresh §4: ink underline, no hue */
 .md blockquote { margin: 0 0 8px; padding: 2px 10px; border-left: 3px solid var(--rl-line); color: var(--rl-text-dim); }
 /* A 1px low-alpha outline keeps an image's edge legible on any surface it lands on. Pure white in
@@ -1143,16 +1143,20 @@ button.panel-title:hover { background: var(--rl-hover); }
 /* Syntax colours (highlight.js token classes; rich/highlight.ts emits them). One muted, six-hue
    ramp shared by fenced code, file previews and the composer's code chips — deliberately quieter
    than an editor theme, because a transcript is prose with code in it rather than an editor. */
-.hljs { color: var(--ink-2); }
-.hljs-comment, .hljs-quote { color: var(--ink-3); font-style: italic; }
-.hljs-keyword, .hljs-selector-tag, .hljs-literal, .hljs-doctag, .hljs-name { color: var(--accent); }
-.hljs-string, .hljs-regexp, .hljs-addition, .hljs-attribute, .hljs-meta .hljs-string { color: var(--green); }
-.hljs-number, .hljs-symbol, .hljs-bullet, .hljs-link, .hljs-template-variable, .hljs-variable { color: var(--orange); }
-.hljs-title, .hljs-section, .hljs-title.class_, .hljs-title.function_, .hljs-selector-id { color: var(--ink); font-weight: var(--fw-title); }
-.hljs-type, .hljs-built_in, .hljs-class .hljs-title, .hljs-params { color: var(--ink); }
-.hljs-attr, .hljs-selector-attr, .hljs-selector-class, .hljs-property { color: var(--ink-2); }
-.hljs-meta, .hljs-comment .hljs-doctag { color: var(--ink-3); }
-.hljs-deletion { color: var(--red); }
+/* Every colour here is a `--syn-*` role, not a palette token: a code theme is half of what makes
+   Monokai Monokai, so the mapping has to be somewhere a theme can repaint in seven values rather
+   than thirty. tokens.css defines the roles against the ramps these rules used to name inline, so
+   the default palette highlights exactly as before. */
+.hljs { color: var(--syn-fg); }
+.hljs-comment, .hljs-quote { color: var(--syn-comment); font-style: italic; }
+.hljs-keyword, .hljs-selector-tag, .hljs-literal, .hljs-doctag, .hljs-name { color: var(--syn-keyword); }
+.hljs-string, .hljs-regexp, .hljs-addition, .hljs-attribute, .hljs-meta .hljs-string { color: var(--syn-string); }
+.hljs-number, .hljs-symbol, .hljs-bullet, .hljs-link, .hljs-template-variable, .hljs-variable { color: var(--syn-number); }
+.hljs-title, .hljs-section, .hljs-title.class_, .hljs-title.function_, .hljs-selector-id { color: var(--syn-title); font-weight: var(--fw-title); }
+.hljs-type, .hljs-built_in, .hljs-class .hljs-title, .hljs-params { color: var(--syn-type); }
+.hljs-attr, .hljs-selector-attr, .hljs-selector-class, .hljs-property { color: var(--syn-attr); }
+.hljs-meta, .hljs-comment .hljs-doctag { color: var(--syn-meta); }
+.hljs-deletion { color: var(--syn-deleted); }
 .hljs-emphasis { font-style: italic; } .hljs-strong { font-weight: var(--fw-strong); }
 
 /* A file, with a line-number rail (rich/ToolViews.tsx CodeBlock). The rail is its own column and
@@ -2818,6 +2822,28 @@ body[data-media-lightbox] .transcript .media-el { visibility: hidden; }
    different kind of thing. */
 .msg-user-file-open { display: block; padding: 0; border: none; background: none; cursor: zoom-in; }
 
+/* ——— Settings → App: the palette picker ——————————————————————————————————————
+   Each card is painted in the theme it names, so the row is a set of previews rather than a list of
+   words. auto-fill rather than a fixed column count: this field sits in a settings pane whose width
+   is whatever the user left the split at. */
+.theme-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(116px, 1fr)); gap: 8px; margin: 0; padding: 0; border: 0; }
+.theme-card {
+  display: flex; flex-direction: column; gap: 8px; padding: 10px; cursor: pointer;
+  border: 1px solid; border-radius: var(--r-panel); box-shadow: var(--shadow-card-lift);
+  transition: box-shadow var(--dur-hover) ease;
+}
+.theme-card input { position: absolute; opacity: 0; pointer-events: none; }
+/* The selection ring is the APP's accent, not the card's: it belongs to the control the user is
+   operating, and a card whose own accent happened to match its ground would show no ring at all. */
+.theme-card[data-selected] { box-shadow: 0 0 0 2px var(--rl-accent), var(--shadow-card-lift); }
+.theme-card:has(input:focus-visible) { outline: 2px solid var(--rl-accent); outline-offset: 2px; }
+.theme-card-swatches { display: flex; gap: 4px; }
+.theme-card-swatches span { width: 14px; height: 14px; border-radius: 999px; }
+.theme-card-name { font-size: 12px; font-weight: var(--fw-label); }
+/* A mode control the palette has overruled. Dimmed, never disabled — it still records a preference
+   that applies again the moment a two-faced palette is chosen. */
+.settings-tabs[data-pinned] { opacity: .5; }
+
 /* ——— Settings → Usage ————————————————————————————————————————————————————————
    Spend, tokens and activity. The palette itself lives in tokens.css (`--series-1..8`, validated as
    a set against Realm's own chart surface in both modes); everything here is chrome, and chrome's
@@ -2849,9 +2875,12 @@ body[data-media-lightbox] .transcript .media-el { visibility: hidden; }
 
 /* ——— stat tiles ——— */
 .usage-tiles { display: grid; grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); gap: 8px; }
+/* --chart-surface, not --rl-raised: the sparkline in this tile is drawn in the same eight series
+   colours the plots below use, and those are validated against a ground of a particular lightness
+   (tokens.css). On the shipped palette the two are the same value. */
 .stat-tile {
   display: flex; flex-direction: column; gap: 2px; min-width: 0; padding: 12px;
-  border: 1px solid var(--rl-line); border-radius: var(--r-panel); background: var(--rl-raised);
+  border: 1px solid var(--rl-line); border-radius: var(--r-panel); background: var(--chart-surface);
 }
 .stat-label { font-size: 11.5px; color: var(--rl-text-dim); }
 /* Proportional figures, deliberately: `tabular-nums` gives every digit a zero's width, which makes
@@ -2865,7 +2894,7 @@ body[data-media-lightbox] .transcript .media-el { visibility: hidden; }
 /* ——— cards ——— */
 .usage-card {
   display: flex; flex-direction: column; gap: 10px; padding: 14px;
-  border: 1px solid var(--rl-line); border-radius: var(--r-panel); background: var(--rl-raised);
+  border: 1px solid var(--rl-line); border-radius: var(--r-panel); background: var(--chart-surface);
 }
 .usage-card-head { display: flex; flex-wrap: wrap; align-items: baseline; gap: 8px; }
 .usage-card-head h3 { margin: 0; font-size: 13px; font-weight: var(--fw-title); color: var(--rl-text-bright); }

--- a/apps/desktop/src/renderer/src/styles.test.ts
+++ b/apps/desktop/src/renderer/src/styles.test.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { describe, expect, it } from "vitest";
+import { themeSwatches } from "@realm/ui";
 
 /** §6's motion table and its "do NOT animate" list are enforceable only against the stylesheet
  *  itself — jsdom has no layout, no compositor and no CSSOM for a raw file, so nothing else in the
@@ -1197,17 +1198,72 @@ describe("Plan 24 W1: inline UI in the transcript", () => {
       expect(bodiesFor(sel).join(" "), `${sel} must cap its height`).toMatch(/max-height: \d+px/);
   });
 
-  it("syntax colour is the ink ramp plus four hues — a transcript is prose with code in it", () => {
+  it("syntax colour is ten named roles and nothing else — a code theme has to be repaintable", () => {
     // `color:` only. A .hljs rule may also reach for the weight ladder (a title is 560, strong is
     // 600) and those are not hues — folding them in would make this assert the ladder twice and
     // fail the moment a rung is used where a bare weight used to be.
+    //
+    // THE re-inlined mutant: put `var(--accent)` back on `.hljs-keyword`. Every default-theme
+    // screenshot is identical, and Monokai's keywords come out Realm blue — because `--accent` is a
+    // theme's chrome hue and a code palette's keyword colour is a different decision that only
+    // happens to coincide in the palette this mapping was written for.
     const hues = new Set(RULES.filter((r) => r.selectors.some((s) => s.startsWith(".hljs")))
       .flatMap((r) => [...r.body.matchAll(/(?:^|[;{]|\s)color:\s*var\((--[a-z0-9-]+)\)/g)].map((m) => m[1]!)));
-    expect([...hues].sort()).toEqual(["--accent", "--green", "--ink", "--ink-2", "--ink-3", "--orange", "--red"]);
+    expect([...hues].sort()).toEqual(SYNTAX_ROLES);
   });
 
   it("the todo bar is the one accent fill, and finished items are struck through rather than dropped", () => {
     expect(bodiesFor(".todo-fill").join(" ")).toContain("background: var(--rl-accent)");
     expect(bodiesFor('.todo-list li[data-status="completed"] .todo-text').join(" ")).toContain("line-through");
+  });
+});
+
+/** Custom themes. The palette a theme writes is inline custom properties (packages/ui/src/themes.ts,
+ *  pinned by its own suite there); what has to hold HERE is that the stylesheet reads those
+ *  properties at all — a token nothing reaches for is a theme that repaints nothing. */
+const SYNTAX_ROLES = [
+  "--syn-attr", "--syn-comment", "--syn-deleted", "--syn-fg", "--syn-keyword",
+  "--syn-meta", "--syn-number", "--syn-string", "--syn-title", "--syn-type",
+];
+
+describe("custom themes", () => {
+  const tokens = readFileSync(repoFile("apps/desktop/src/renderer/src/theme/tokens.css"), "utf8");
+
+  it("the default palette defines every syntax role in terms of the ramps the old block wrote inline", () => {
+    // Byte-for-byte the mapping styles.css used to carry, so introducing the roles cannot have
+    // changed how the shipped theme highlights code. A drift here is a silent restyle of every
+    // transcript for every user who never chose a theme.
+    for (const [role, source] of [
+      ["--syn-fg", "var(--ink-2)"], ["--syn-comment", "var(--ink-3)"], ["--syn-keyword", "var(--accent)"],
+      ["--syn-string", "var(--green)"], ["--syn-number", "var(--orange)"], ["--syn-title", "var(--ink)"],
+      ["--syn-type", "var(--ink)"], ["--syn-attr", "var(--ink-2)"], ["--syn-meta", "var(--ink-3)"],
+      ["--syn-deleted", "var(--red)"],
+    ] as const) {
+      expect(tokens, role).toContain(`${role}: ${source};`);
+    }
+    // One block, not one per mode: every source above already flips on data-mode, so a second copy
+    // under `[data-mode="light"]` would be a mapping that has to be kept in sync with itself.
+    for (const role of SYNTAX_ROLES) {
+      expect(tokens.split(`${role}:`).length - 1, `${role} is declared more than once in tokens.css`).toBe(1);
+    }
+  });
+
+  it("the chart ground is its own token, and the Usage cards are what paints it", () => {
+    // THE chart-drift mutant: point .usage-card back at --rl-raised. The card follows the theme's
+    // surface, which for every dark theme in the set is lighter than the one the eight series were
+    // validated against, and slot 6 quietly stops being distinguishable from its neighbours.
+    expect(tokens).toContain("--chart-surface: var(--surface);");
+    expect(tokens).toContain("--chart-gap: var(--chart-surface);");
+    for (const sel of [".usage-card", ".stat-tile"]) {
+      expect(bodiesFor(sel).join(" "), sel).toContain("background: var(--chart-surface)");
+    }
+  });
+
+  it("the picker's copy of Realm's own colours has not drifted from tokens.css", () => {
+    // themeSwatches cannot read the live values — under any other theme they are that theme's — so
+    // it carries four literals. This is the pin that keeps the copy honest.
+    for (const mode of ["dark", "light"] as const) {
+      for (const value of themeSwatches("realm", mode)) expect(tokens, `${mode} ${value}`).toContain(value);
+    }
   });
 });

--- a/apps/desktop/src/renderer/src/styles.test.ts
+++ b/apps/desktop/src/renderer/src/styles.test.ts
@@ -454,10 +454,31 @@ describe("Plan 9 W1 — the BUI bridge", () => {
     expect(bodiesFor(".app[data-sidebar-collapsed] .main > .group-bar:first-child").join(" ")).toContain("min-height: 40px");
   });
 
-  it("the sidebar keeps its vibrancy: BUI --page at 82%, one mode-agnostic rule", () => {
-    expect(bodiesFor(".sidebar").join(" ")).toContain("color-mix(in srgb, var(--page) 82%, transparent)");
+  it("the sidebar keeps its vibrancy, and it is the app's ONE adjustable ground", () => {
+    // The intent this pins moved: the sidebar used to be --page at a literal 82%, and is now the
+    // composed --sidebar-ground, because the number is the user's. What has NOT moved is which
+    // surface is translucent — exactly one, so text on a pane never renders over the desktop.
+    expect(bodiesFor(".sidebar").join(" ")).toContain("background: var(--sidebar-ground)");
     // The old per-mode rgba override is gone — --page flips with data-mode on its own.
     expect(css).not.toContain("rgba(244,244,244,.82)");
+    // THE second-ground mutant: give .main or a pane a color-mix over --page too. The window looks
+    // better on a nice wallpaper and every pane's body text starts depending on it.
+    const translucent = RULES.filter((r) => /background:[^;]*var\(--sidebar-ground\)/.test(r.body)).flatMap((r) => r.selectors);
+    expect(translucent).toEqual([".sidebar"]);
+  });
+
+  it("the ground's alpha is driven, defaulted opaque in CSS, and overridden by reduced transparency", () => {
+    // The default 82 lives in packages/ui/src/theme.ts and nowhere else; what the stylesheet states
+    // is the no-JS fallback, which is deliberately the OPPOSITE — a renderer that never ran should
+    // leave an opaque sidebar, not a see-through one.
+    expect(tokens).toContain("--ground-alpha: 100%;");
+    expect(tokens).toContain("--sidebar-ground: color-mix(in srgb, var(--page) var(--ground-alpha), transparent);");
+    expect(tokens).not.toMatch(/--ground-alpha:\s*82%/);
+    // THE inline-composition mutant: compose --sidebar-ground in applyTheme instead. An inline
+    // custom property beats every stylesheet rule, so the media query below would stop working and
+    // Reduce Transparency would silently do nothing for the one surface it exists for.
+    const reduced = tokens.slice(tokens.indexOf("@media (prefers-reduced-transparency: reduce)"));
+    expect(reduced).toContain("--sidebar-ground: var(--page)");
   });
 
   it("Inter and JetBrains Mono are self-hosted with Inter leading the UI stack", () => {

--- a/apps/desktop/src/renderer/src/styles.test.ts
+++ b/apps/desktop/src/renderer/src/styles.test.ts
@@ -1,7 +1,7 @@
 import { existsSync, readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { describe, expect, it } from "vitest";
-import { themeSwatches } from "@realm/ui";
+import { deriveVars, oklchToHex, themeSwatches } from "@realm/ui";
 
 /** §6's motion table and its "do NOT animate" list are enforceable only against the stylesheet
  *  itself — jsdom has no layout, no compositor and no CSSOM for a raw file, so nothing else in the
@@ -1277,6 +1277,55 @@ describe("custom themes", () => {
     expect(tokens).toContain("--chart-gap: var(--chart-surface);");
     for (const sel of [".usage-card", ".stat-tile"]) {
       expect(bodiesFor(sel).join(" "), sel).toContain("background: var(--chart-surface)");
+    }
+  });
+
+  it("the ramp reproduces the palette it was measured from", () => {
+    // packages/ui/src/themes.ts derives every theme from twelve seeds using ramp constants its
+    // comments claim were measured off THIS file. That claim is only worth anything if something
+    // re-measures it, so: take the seeds out of tokens.css, run them through the same derivation
+    // every theme goes through, and require that what comes back IS tokens.css.
+    //
+    // THE drifted-ramp mutant: nudge any offset in DARK or LIGHT — the ΔL of --hover, an ink
+    // exponent, the tooltip's inversion. Every theme still clears every contrast floor, because the
+    // floors are about legibility and this is about SHAPE; only this notices that the derived
+    // palettes have stopped being the same system as the one they sit beside.
+    const L = (name: string, block: string): number => {
+      const m = new RegExp(`${name}: oklch\\(([\\d.]+) ([\\d.]+) ([\\d.]+)`).exec(block);
+      expect(m, `${name} is not a plain oklch value in tokens.css`).not.toBeNull();
+      return Number(m![1]);
+    };
+    const hex = (name: string, block: string): string => {
+      const m = new RegExp(`${name}: oklch\\(([\\d.]+) ([\\d.]+) ([\\d.]+)`).exec(block)!;
+      return oklchToHex({ l: Number(m[1]), c: Number(m[2]), h: Number(m[3]) });
+    };
+    const derivedL = (v: string): number => Number(/^oklch\(([\d.]+)/.exec(v)![1]);
+
+    for (const mode of ["dark", "light"] as const) {
+      const at = tokens.indexOf(mode === "dark" ? ":root {\n  color-scheme: dark" : ':root[data-mode="light"] {');
+      expect(at, `no ${mode} token block in tokens.css`).toBeGreaterThan(-1);
+      const block = tokens.slice(at, tokens.indexOf("\n}", at));
+      // The seeds are read back out of the palette rather than written here, so this cannot drift
+      // by someone updating tokens.css and the copy in the test to match each other.
+      const derived = deriveVars({
+        bg: hex("--page", block), ink: hex("--ink", block), accent: hex("--accent", block),
+        green: hex("--green", block), orange: hex("--orange", block), red: hex("--red", block),
+        // The same role mapping the base --syn-* block states, so the seeds are Realm's own.
+        syntax: { comment: hex("--ink-3", block), keyword: hex("--accent", block), string: hex("--green", block),
+          number: hex("--orange", block), title: hex("--ink", block), type: hex("--ink", block), attr: hex("--ink-2", block) },
+      }, mode);
+
+      // The surface ladder and the tooltip chip are pure geometry off the seed: they have to land on
+      // the shipped lightness to finer than a display can resolve.
+      for (const token of ["--canvas", "--surface", "--inset", "--hover", "--hover-2", "--field",
+        "--stripe-bg", "--tooltip-bg", "--tooltip-border", "--tooltip-fg"]) {
+        expect(derivedL(derived[token]!), `${mode} ${token}`).toBeCloseTo(L(token, block), 3);
+      }
+      // The ink ramp is placed by CONTRAST rather than by lightness, so it lands within one step of
+      // the walk that places it (0.002) rather than exactly on the shipped value.
+      for (const token of ["--ink-2", "--ink-3", "--tooltip-muted"]) {
+        expect(Math.abs(derivedL(derived[token]!) - L(token, block)), `${mode} ${token}`).toBeLessThan(0.004);
+      }
     }
   });
 

--- a/apps/desktop/src/renderer/src/theme/tokens.css
+++ b/apps/desktop/src/renderer/src/theme/tokens.css
@@ -98,9 +98,9 @@
    * dashing reads as "projected" or "threshold" when it is only a grid. */
   --chart-grid: oklch(1 0 0 / 0.08);
   --chart-axis: oklch(1 0 0 / 0.14);
-  /* The 2px gap and ring that separate touching marks. It is the SURFACE showing through, not a
-   * stroke: a border around a mark adds ink that is not data. */
-  --chart-gap: var(--surface);
+  /* The 2px gap and ring that separate touching marks. It is the CHART SURFACE showing through, not
+   * a stroke: a border around a mark adds ink that is not data. */
+  --chart-gap: var(--chart-surface);
 
   /* shadows — hairline ring + layered stacks. Elevation rings go to a subtle *light* hairline in
    * dark mode: the ring paints over the surface behind the element, so a low-alpha white edge
@@ -162,7 +162,7 @@
   --series-8: #e34948;
   --chart-grid: oklch(0 0 0 / 0.07);
   --chart-axis: oklch(0 0 0 / 0.13);
-  --chart-gap: var(--surface);
+  --chart-gap: var(--chart-surface);
 
   /* Light-mode shadow stacks are restated in the TEMBO ALIGNMENT block below. */
 }
@@ -486,4 +486,39 @@ a {
   --radius-card: 12px;
   --radius-window: 16px;
   --radius-pill: 999px;
+}
+
+/* ══ SYNTAX AND THE CHART GROUND ══════════════════════════════════════════════
+ * Two token sets a custom theme repaints and the shipped palette does not.
+ *
+ * `--syn-*` is the highlight.js mapping, named by ROLE rather than by class so a theme states seven
+ * hues instead of thirty selectors. The values here are the mapping styles.css used to write inline
+ * — accent for keywords, green for strings, orange for numbers, the ink ramp for everything
+ * structural — so the default theme renders code exactly as it always has. `--syn-fg` is the ink
+ * ramp's second step because code body IS body text; `--syn-meta` shares the comment colour and
+ * `--syn-deleted` the red, which is what the old block did by writing those tokens twice.
+ *
+ * These are declared once rather than per mode: every one of them resolves through a token that
+ * already flips on `data-mode`, so a second block would be a second copy of the same mapping. */
+:root {
+  --syn-fg: var(--ink-2);
+  --syn-comment: var(--ink-3);
+  --syn-keyword: var(--accent);
+  --syn-string: var(--green);
+  --syn-number: var(--orange);
+  --syn-title: var(--ink);
+  --syn-type: var(--ink);
+  --syn-attr: var(--ink-2);
+  --syn-meta: var(--ink-3);
+  --syn-deleted: var(--red);
+
+  /* The ground the Usage cards paint, and the only thing about a chart a theme is allowed to move.
+   * The eight `--series-*` above are validated AS A SET against a surface of a particular lightness;
+   * a theme that repainted them would break a colour-vision-deficiency guarantee that has nothing to
+   * do with its mood, and a theme that simply let them land on its own lighter `--surface` would
+   * break the same guarantee more quietly — every dark theme in the set fails slot 6 (#008300) on a
+   * ground lighter than #232427. So the series stay put and the CARD moves, carrying the theme's hue
+   * at a lightness clamped back into the validated band (packages/ui/src/themes.ts, `chartL`).
+   * Identical to `--surface` here, because the shipped palette IS the validated one. */
+  --chart-surface: var(--surface);
 }

--- a/apps/desktop/src/renderer/src/theme/tokens.css
+++ b/apps/desktop/src/renderer/src/theme/tokens.css
@@ -522,3 +522,31 @@ a {
    * Identical to `--surface` here, because the shipped palette IS the validated one. */
   --chart-surface: var(--surface);
 }
+
+/* ══ THE ADJUSTABLE GROUND ═════════════════════════════════════════════════════
+ * macOS paints a material behind the window and the sidebar is the one surface thin enough to show
+ * it (main/index.ts asks for `vibrancy: "sidebar"`; every pane paints opaque so text never renders
+ * over the desktop). How much of it shows through is the user's, and this is the one place the two
+ * halves of that meet.
+ *
+ * `--ground-alpha` is written on :root by applyTheme; the 100% here is what the sidebar falls back
+ * to if the renderer never gets that far, which is the honest failure — an opaque sidebar rather
+ * than a see-through one. The DEFAULT is 82, and it lives in packages/ui/src/theme.ts, because a
+ * number in both places is a number that drifts.
+ *
+ * `--sidebar-ground` is composed HERE rather than inline for one specific reason: an inline custom
+ * property beats every stylesheet rule, so composing it in JavaScript would put it out of reach of
+ * the media query below — and the codebase already honours prefers-reduced-transparency in its fade
+ * bands. Under that preference the ground goes fully opaque no matter where the slider is, which is
+ * what the preference asks for; the slider still records its value and applies again when it is off.
+ *
+ * No `setVibrancy()` and no IPC hop. The material is always on under the window on macOS, and at
+ * 100% the sidebar simply covers it — visually identical to not having asked for it. */
+:root {
+  --ground-alpha: 100%;
+  --sidebar-ground: color-mix(in srgb, var(--page) var(--ground-alpha), transparent);
+}
+
+@media (prefers-reduced-transparency: reduce) {
+  :root { --sidebar-ground: var(--page); }
+}

--- a/apps/desktop/src/renderer/src/theme/use-theme.test.ts
+++ b/apps/desktop/src/renderer/src/theme/use-theme.test.ts
@@ -1,8 +1,9 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { act, cleanup, renderHook } from "@testing-library/react";
+import type { ThemeName } from "@realm/ui";
 import { suppressTransitions, useApplyTheme, type ThemePref } from "./useTheme";
 
-afterEach(() => { cleanup(); vi.useRealTimers(); document.documentElement.removeAttribute("data-theme-switching"); });
+afterEach(() => { cleanup(); vi.useRealTimers(); document.documentElement.removeAttribute("data-theme-switching"); document.documentElement.removeAttribute("style"); });
 
 /** §6's do-NOT-animate list includes theme/mode switching. Rewriting the palette changes every
  *  colour at once; the surfaces carrying a 100ms hover transition would tween to the new theme
@@ -45,5 +46,51 @@ describe("theme switching is not animated (§6)", () => {
     expect(marked()).toBe(true);
     unmount();
     expect(marked()).toBe(false);
+  });
+});
+
+/** The palette is a second axis over light/dark, so the interesting cases are the ones where the two
+ *  disagree: a theme with no light face, and the trip back out of it. */
+describe("theme and mode compose", () => {
+  const root = () => document.documentElement;
+
+  it("a one-faced palette pins the effective mode, and the preference survives it", () => {
+    const { result, rerender } = renderHook(
+      ({ theme }) => useApplyTheme("#7c6cff", "light" as ThemePref, theme),
+      { initialProps: { theme: "monokai" as ThemeName } },
+    );
+    expect(result.current).toBe("dark");
+    expect(root().dataset.mode).toBe("dark");
+    expect(root().dataset.theme).toBe("monokai");
+    // THE pinning-by-preference mutant: implement this by writing "dark" into themePref. The window
+    // looks identical and the user's "light" is gone — this rerender would then still say dark.
+    rerender({ theme: "one" });
+    expect(result.current).toBe("light");
+    expect(root().dataset.mode).toBe("light");
+  });
+
+  it("a custom palette paints inline and the default palette scrubs it off again", () => {
+    const { rerender } = renderHook(
+      ({ theme }) => useApplyTheme("#7c6cff", "dark" as ThemePref, theme),
+      { initialProps: { theme: "one" as ThemeName } },
+    );
+    expect(root().style.getPropertyValue("--page")).toMatch(/^oklch\(/);
+    rerender({ theme: "realm" });
+    expect(root().style.getPropertyValue("--page")).toBe("");
+    expect(root().dataset.theme).toBe("realm");
+  });
+
+  it("switching palette is fenced by the no-transition mark, exactly like switching mode", () => {
+    vi.useFakeTimers();
+    const { rerender } = renderHook(
+      ({ theme }) => useApplyTheme("#7c6cff", "dark" as ThemePref, theme),
+      { initialProps: { theme: "realm" as ThemeName } },
+    );
+    act(() => { vi.advanceTimersByTime(100); });
+    expect(root().hasAttribute("data-theme-switching")).toBe(false);
+    // Repainting 34 custom properties at once is the same smear §6 fenced mode switching for; a
+    // theme change that skipped the fence would tween the hovered row and snap everything else.
+    rerender({ theme: "one" });
+    expect(root().hasAttribute("data-theme-switching")).toBe(true);
   });
 });

--- a/apps/desktop/src/renderer/src/theme/use-theme.test.ts
+++ b/apps/desktop/src/renderer/src/theme/use-theme.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { act, cleanup, renderHook } from "@testing-library/react";
 import type { ThemeName } from "@realm/ui";
-import { suppressTransitions, useApplyTheme, type ThemePref } from "./useTheme";
+import { hasWindowMaterial, suppressTransitions, useApplyTheme, type ThemePref } from "./useTheme";
 
 afterEach(() => { cleanup(); vi.useRealTimers(); document.documentElement.removeAttribute("data-theme-switching"); document.documentElement.removeAttribute("style"); });
 
@@ -92,5 +92,30 @@ describe("theme and mode compose", () => {
     // theme change that skipped the fence would tween the hovered row and snap everything else.
     rerender({ theme: "one" });
     expect(root().hasAttribute("data-theme-switching")).toBe(true);
+  });
+});
+
+describe("the adjustable ground reaches :root", () => {
+  afterEach(() => { vi.unstubAllGlobals(); });
+
+  it("carries the user's value, and a change to it repaints without a mode or theme change", () => {
+    const { rerender } = renderHook(
+      ({ alpha }) => useApplyTheme("#7c6cff", "dark" as ThemePref, "realm", alpha),
+      { initialProps: { alpha: 82 } },
+    );
+    expect(document.documentElement.style.getPropertyValue("--ground-alpha")).toBe("82%");
+    // THE missing-dependency mutant: leave groundAlpha out of the layout effect's deps. The slider
+    // moves, the store updates, and the window does not change until something else forces a
+    // re-apply — which for most users is never.
+    rerender({ alpha: 60 });
+    expect(document.documentElement.style.getPropertyValue("--ground-alpha")).toBe("60%");
+  });
+
+  it("an unknown platform is not macOS — a bridgeless renderer must not guess a material it may not have", () => {
+    expect(hasWindowMaterial()).toBe(false);
+    vi.stubGlobal("realm", { platform: "linux" });
+    expect(hasWindowMaterial()).toBe(false);
+    vi.stubGlobal("realm", { platform: "darwin" });
+    expect(hasWindowMaterial()).toBe(true);
   });
 });

--- a/apps/desktop/src/renderer/src/theme/useTheme.ts
+++ b/apps/desktop/src/renderer/src/theme/useTheme.ts
@@ -1,5 +1,5 @@
 import { useEffect, useLayoutEffect, useState } from "react";
-import { applyTheme, type Mode } from "@realm/ui";
+import { applyTheme, resolveMode, type Mode, type ThemeName } from "@realm/ui";
 
 export type ThemePref = "system" | "light" | "dark";
 
@@ -30,17 +30,21 @@ export function suppressTransitions(root: HTMLElement, ms = SETTLE_MS): () => vo
   return () => { clearTimeout(id); root.removeAttribute("data-theme-switching"); };
 }
 
-/** Resolves the effective mode from the user preference and stamps it (plus the space colour) on
- *  `:root`. The palette itself is static CSS now (Plan 9 W1: BUI tokens in theme/tokens.css keyed
- *  on `data-mode`) — the only runtime writes left are `--rl-space` and the mode attribute. */
-export function useApplyTheme(color: string | null, pref: ThemePref): Mode {
+/** Resolves the effective mode from the two axes — the user's light/dark preference and the theme,
+ *  which may only have one face — and stamps it (plus the space colour and the theme's palette) on
+ *  `:root`. On the default theme the palette is still static CSS (BUI tokens in theme/tokens.css
+ *  keyed on `data-mode`) and the only runtime writes are `--rl-space` and the two attributes.
+ *
+ *  The PREFERENCE is deliberately not clamped here, only the resolved mode: choosing Monokai pins
+ *  the window dark, and choosing a two-faced theme afterwards must find "system" where it left it. */
+export function useApplyTheme(color: string | null, pref: ThemePref, theme: ThemeName = "realm"): Mode {
   const sys = useSystemMode();
-  const mode: Mode = pref === "system" ? sys : pref;
+  const mode = resolveMode(theme, pref === "system" ? sys : pref);
   // Layout effect so the first paint already carries the mode (no flash of default vars).
   useLayoutEffect(() => {
     const done = suppressTransitions(document.documentElement);
-    applyTheme(color ?? "#7c6cff", mode);
+    applyTheme(color ?? "#7c6cff", mode, theme);
     return done;
-  }, [color, mode]);
+  }, [color, mode, theme]);
   return mode;
 }

--- a/apps/desktop/src/renderer/src/theme/useTheme.ts
+++ b/apps/desktop/src/renderer/src/theme/useTheme.ts
@@ -1,5 +1,5 @@
 import { useEffect, useLayoutEffect, useState } from "react";
-import { applyTheme, resolveMode, type Mode, type ThemeName } from "@realm/ui";
+import { DEFAULT_GROUND_ALPHA, applyTheme, resolveMode, type Mode, type ThemeName } from "@realm/ui";
 
 export type ThemePref = "system" | "light" | "dark";
 
@@ -37,14 +37,21 @@ export function suppressTransitions(root: HTMLElement, ms = SETTLE_MS): () => vo
  *
  *  The PREFERENCE is deliberately not clamped here, only the resolved mode: choosing Monokai pins
  *  the window dark, and choosing a two-faced theme afterwards must find "system" where it left it. */
-export function useApplyTheme(color: string | null, pref: ThemePref, theme: ThemeName = "realm"): Mode {
+export function useApplyTheme(color: string | null, pref: ThemePref, theme: ThemeName = "realm",
+  groundAlpha: number = DEFAULT_GROUND_ALPHA): Mode {
   const sys = useSystemMode();
   const mode = resolveMode(theme, pref === "system" ? sys : pref);
   // Layout effect so the first paint already carries the mode (no flash of default vars).
   useLayoutEffect(() => {
     const done = suppressTransitions(document.documentElement);
-    applyTheme(color ?? "#7c6cff", mode, theme);
+    applyTheme({ space: color ?? "#7c6cff", mode, theme, groundAlpha });
     return done;
-  }, [color, mode, theme]);
+  }, [color, mode, theme, groundAlpha]);
   return mode;
 }
+
+/** macOS is the only platform with a material behind the window, so it is the only one where the
+ *  sidebar's transparency reveals anything. An unknown platform answers false: this gates a control
+ *  that would otherwise do nothing visible, and a control that appears and does nothing is worse
+ *  than one that explains why it is not there. */
+export const hasWindowMaterial = (): boolean => window.realm?.platform === "darwin";

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,6 +1,7 @@
 export { Icon, icons, isIconName, type IconName } from "./Icon";
 export { brandMarks, isBrandName, type BrandMark, type BrandName } from "./brand-icons";
-export { applyTheme, hexToHsl, hslToHex, spaceColor, type Hsl, type Mode } from "./theme";
+export { applyTheme, clampGroundAlpha, DEFAULT_GROUND_ALPHA, GROUND_ALPHA_RANGE, hexToHsl, hslToHex, spaceColor,
+  type Hsl, type Mode } from "./theme";
 export { contrast, hexToOklch, luminance, oklchToHex, type Oklch } from "./oklch";
 export { CONTRAST_FLOOR, isThemeName, resolveMode, THEMES, THEME_VARS, themeModes, themeSwatches, themeVars,
   type SyntaxSeed, type ThemeDef, type ThemeName, type ThemeSeed } from "./themes";

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -2,6 +2,9 @@ export { Icon, icons, isIconName, type IconName } from "./Icon";
 export { brandMarks, isBrandName, type BrandMark, type BrandName } from "./brand-icons";
 export { applyTheme, clampGroundAlpha, DEFAULT_GROUND_ALPHA, GROUND_ALPHA_RANGE, hexToHsl, hslToHex, spaceColor,
   type Hsl, type Mode } from "./theme";
-export { contrast, hexToOklch, luminance, oklchToHex, type Oklch } from "./oklch";
-export { CONTRAST_FLOOR, deriveVars, isThemeName, resolveMode, THEMES, THEME_VARS, themeModes, themeSwatches, themeVars,
-  type SyntaxSeed, type ThemeDef, type ThemeName, type ThemeSeed } from "./themes";
+/* Only what is consumed OUTSIDE this package. The colour maths and the derivation internals
+   (hexToOklch, contrast, luminance, CONTRAST_FLOOR, THEME_VARS, themeVars, themeModes and the seed
+   types) stay exported from their own modules, where applyTheme and the package's own suites import
+   them directly — a barrel entry for each would advertise a public API nothing consumes. */
+export { oklchToHex } from "./oklch";
+export { deriveVars, isThemeName, resolveMode, THEMES, themeSwatches, type ThemeName } from "./themes";

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -3,5 +3,5 @@ export { brandMarks, isBrandName, type BrandMark, type BrandName } from "./brand
 export { applyTheme, clampGroundAlpha, DEFAULT_GROUND_ALPHA, GROUND_ALPHA_RANGE, hexToHsl, hslToHex, spaceColor,
   type Hsl, type Mode } from "./theme";
 export { contrast, hexToOklch, luminance, oklchToHex, type Oklch } from "./oklch";
-export { CONTRAST_FLOOR, isThemeName, resolveMode, THEMES, THEME_VARS, themeModes, themeSwatches, themeVars,
+export { CONTRAST_FLOOR, deriveVars, isThemeName, resolveMode, THEMES, THEME_VARS, themeModes, themeSwatches, themeVars,
   type SyntaxSeed, type ThemeDef, type ThemeName, type ThemeSeed } from "./themes";

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,3 +1,6 @@
 export { Icon, icons, isIconName, type IconName } from "./Icon";
 export { brandMarks, isBrandName, type BrandMark, type BrandName } from "./brand-icons";
 export { applyTheme, hexToHsl, hslToHex, spaceColor, type Hsl, type Mode } from "./theme";
+export { contrast, hexToOklch, luminance, oklchToHex, type Oklch } from "./oklch";
+export { CONTRAST_FLOOR, isThemeName, resolveMode, THEMES, THEME_VARS, themeModes, themeSwatches, themeVars,
+  type SyntaxSeed, type ThemeDef, type ThemeName, type ThemeSeed } from "./themes";

--- a/packages/ui/src/oklch.test.ts
+++ b/packages/ui/src/oklch.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { contrast, css, hexToOklch, luminance, oklchToHex } from "./oklch";
+
+/** These numbers are checkable against something outside this repo, which is the point of testing a
+ *  colour space at all: an arithmetic slip in one matrix row produces colours that still look like
+ *  colours. The hex values below are the ones theme/tokens.css itself records for its OKLCH tokens,
+ *  and the contrast figures are WCAG's own worked examples. */
+
+describe("hex ⇄ oklch", () => {
+  it("reproduces the hexes tokens.css documents for its own tokens", () => {
+    // tokens.css: "Realm's OWN chart surface (--surface, #232427)" and main/index.ts's non-mac
+    // backgroundColor "#17181a ≈ oklch(.209 .004 264.477)" — two independent notes about the same
+    // two tokens, so a broken conversion cannot agree with both by accident.
+    expect(oklchToHex({ l: 0.26, c: 0.006, h: 271.191 })).toBe("#232427");
+    expect(oklchToHex({ l: 0.209, c: 0.004, h: 264.477 })).toBe("#17181a");
+  });
+
+  it("round-trips an 8-bit colour through the space and back", () => {
+    for (const hex of ["#7c6cff", "#282c34", "#f92672", "#fdf6e3", "#000000", "#ffffff"]) {
+      expect(oklchToHex(hexToOklch(hex))).toBe(hex);
+    }
+  });
+
+  it("reports a neutral's hue as 0 rather than as rounding noise", () => {
+    expect(hexToOklch("#888888").c).toBeLessThan(0.001);
+    expect(hexToOklch("#888888").h).toBe(0);
+  });
+
+  it("clips out-of-gamut chroma instead of wrapping it into another colour", () => {
+    // oklch(0.6 0.4 150) is far outside sRGB. The browser clips; so must this, or every contrast
+    // figure computed near the gamut boundary would describe a colour nobody can display.
+    const hex = oklchToHex({ l: 0.6, c: 0.4, h: 150 });
+    expect(hex).toMatch(/^#[0-9a-f]{6}$/);
+    expect(luminance({ l: 0.6, c: 0.4, h: 150 })).toBeLessThanOrEqual(1);
+  });
+});
+
+describe("WCAG contrast", () => {
+  it("matches the two anchors of the scale", () => {
+    expect(contrast(hexToOklch("#ffffff"), hexToOklch("#000000"))).toBeCloseTo(21, 2);
+    expect(contrast(hexToOklch("#777777"), hexToOklch("#777777"))).toBeCloseTo(1, 6);
+  });
+
+  it("is order-independent", () => {
+    const [a, b] = [hexToOklch("#1a1a1a"), hexToOklch("#cccccc")];
+    expect(contrast(a, b)).toBeCloseTo(contrast(b, a), 10);
+  });
+
+  it("agrees with the figure tokens.css records for its light chart palette", () => {
+    // "Three slots (3 aqua 2.82:1, 4 yellow 2.17:1, 5 magenta 2.69:1) sit below 3:1 on white."
+    const white = hexToOklch("#ffffff");
+    expect(contrast(hexToOklch("#1baf7a"), white)).toBeCloseTo(2.82, 1);
+    expect(contrast(hexToOklch("#eda100"), white)).toBeCloseTo(2.17, 1);
+    expect(contrast(hexToOklch("#e87ba4"), white)).toBeCloseTo(2.69, 1);
+  });
+});
+
+describe("css()", () => {
+  it("writes the form tokens.css writes, and carries alpha when asked", () => {
+    expect(css({ l: 0.209, c: 0.004, h: 264.477 })).toBe("oklch(0.209 0.004 264.48)");
+    expect(css({ l: 0.68, c: 0.173, h: 253.301 }, 0.16)).toBe("oklch(0.68 0.173 253.3 / 0.16)");
+  });
+});

--- a/packages/ui/src/oklch.ts
+++ b/packages/ui/src/oklch.ts
@@ -1,0 +1,85 @@
+/** OKLCH ⇄ sRGB, and WCAG contrast on top of it.
+ *
+ *  The palette in theme/tokens.css is written in OKLCH because that is the space its ladders were
+ *  designed in: a surface ladder is a lightness ramp, and only a perceptual space makes "one step
+ *  lighter" mean the same thing at the bottom of the ramp as at the top. Deriving a theme from a
+ *  handful of seeds means doing that arithmetic here rather than by eye, and CHECKING the result —
+ *  which needs the trip back to sRGB, because contrast is defined on sRGB luminance and on nothing
+ *  else.
+ *
+ *  Matrices are Björn Ottosson's (bottosson.github.io/posts/oklab, public domain). Written out
+ *  rather than pulled in: the app ships no colour library, this is the whole of what a theme needs,
+ *  and a dependency whose only caller is one derivation is a dependency to explain forever. */
+
+export type Oklch = { l: number; c: number; h: number };
+
+const clamp01 = (x: number): number => (x < 0 ? 0 : x > 1 ? 1 : x);
+
+/** sRGB transfer function and its inverse, on 0..1 channels. */
+const toLinear = (c: number): number => (c <= 0.04045 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4);
+const fromLinear = (c: number): number => (c <= 0.0031308 ? c * 12.92 : 1.055 * c ** (1 / 2.4) - 0.055);
+
+function parseHex(hex: string): [number, number, number] {
+  const m = hex.trim().replace("#", "");
+  const full = m.length === 3 ? m.split("").map((c) => c + c).join("") : m;
+  if (!/^[0-9a-fA-F]{6}$/.test(full)) throw new Error(`not a hex colour: ${hex}`);
+  const n = parseInt(full, 16);
+  return [((n >> 16) & 255) / 255, ((n >> 8) & 255) / 255, (n & 255) / 255];
+}
+
+export function hexToOklch(hex: string): Oklch {
+  const [r, g, b] = parseHex(hex).map(toLinear) as [number, number, number];
+  const l = Math.cbrt(0.4122214708 * r + 0.5363325363 * g + 0.0514459929 * b);
+  const m = Math.cbrt(0.2119034982 * r + 0.6806995451 * g + 0.1073969566 * b);
+  const s = Math.cbrt(0.0883024619 * r + 0.2817188376 * g + 0.6299787005 * b);
+  const L = 0.2104542553 * l + 0.793617785 * m - 0.0040720468 * s;
+  const A = 1.9779984951 * l - 2.428592205 * m + 0.4505937099 * s;
+  const B = 0.0259040371 * l + 0.7827717662 * m - 0.808675766 * s;
+  const c = Math.hypot(A, B);
+  // Hue of a neutral is arbitrary noise; report 0 so `hexToOklch("#888").h` is stable rather than
+  // whatever the rounding of two near-zero components happened to produce.
+  const h = c < 1e-6 ? 0 : ((Math.atan2(B, A) * 180) / Math.PI + 360) % 360;
+  return { l: L, c, h };
+}
+
+/** Linear-light sRGB, CLIPPED per channel. An OKLCH triple can name a colour sRGB cannot show; the
+ *  browser clips it to the gamut boundary, so a contrast figure computed on the unclipped value
+ *  would describe a colour nobody will ever see. */
+function toLinearRgb({ l, c, h }: Oklch): [number, number, number] {
+  const rad = (h * Math.PI) / 180;
+  const A = c * Math.cos(rad), B = c * Math.sin(rad);
+  const l_ = (l + 0.3963377774 * A + 0.2158037573 * B) ** 3;
+  const m_ = (l - 0.1055613458 * A - 0.0638541728 * B) ** 3;
+  const s_ = (l - 0.0894841775 * A - 1.291485548 * B) ** 3;
+  return [
+    clamp01(4.0767416621 * l_ - 3.3077115913 * m_ + 0.2309699292 * s_),
+    clamp01(-1.2684380046 * l_ + 2.6097574011 * m_ - 0.3413193965 * s_),
+    clamp01(-0.0041960863 * l_ - 0.7034186147 * m_ + 1.707614701 * s_),
+  ];
+}
+
+export function oklchToHex(o: Oklch): string {
+  const to = (x: number) => Math.round(clamp01(fromLinear(x)) * 255).toString(16).padStart(2, "0");
+  const [r, g, b] = toLinearRgb(o);
+  return `#${to(r)}${to(g)}${to(b)}`;
+}
+
+/** The CSS form. Three decimals on lightness and chroma is what tokens.css already writes, and it is
+ *  finer than an 8-bit channel can resolve — rounding here never moves a pixel. */
+export function css(o: Oklch, alpha?: number): string {
+  const n = (x: number, p: number) => Number(x.toFixed(p)).toString();
+  const base = `${n(o.l, 3)} ${n(o.c, 4)} ${n(o.h, 2)}`;
+  return alpha === undefined ? `oklch(${base})` : `oklch(${base} / ${n(alpha, 3)})`;
+}
+
+/** WCAG 2.x relative luminance. */
+export function luminance(o: Oklch): number {
+  const [r, g, b] = toLinearRgb(o);
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+
+/** WCAG 2.x contrast ratio, 1..21. Order-independent. */
+export function contrast(a: Oklch, b: Oklch): number {
+  const x = luminance(a), y = luminance(b);
+  return (Math.max(x, y) + 0.05) / (Math.min(x, y) + 0.05);
+}

--- a/packages/ui/src/theme.test.ts
+++ b/packages/ui/src/theme.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { applyTheme, hexToHsl, hslToHex, spaceColor } from "./theme";
 import { THEME_VARS } from "./themes";
+import { DEFAULT_GROUND_ALPHA, GROUND_ALPHA_RANGE, clampGroundAlpha } from "./theme";
 
 /** Plan 9 W1 re-scope: the ink-grayscale palette generator is gone — surfaces, text tiers, accent,
  *  semantic colours and shadows are the Beautiful UI token set, static CSS in the renderer
@@ -55,7 +56,7 @@ describe("applyTheme (runtime writes: --rl-space, the two attributes, and a cust
   it("writes the clamped space colour to --rl-space and stamps data-mode", () => {
     for (const mode of ["dark", "light"] as const) {
       const { root, props, dataset } = fakeRoot();
-      applyTheme("#3ddc97", mode, "realm", root);
+      applyTheme({ space: "#3ddc97", mode: mode, theme: "realm" }, root);
       expect(props["--rl-space"]).toBe(spaceColor("#3ddc97", mode));
       expect(dataset.mode).toBe(mode);
     }
@@ -67,24 +68,53 @@ describe("applyTheme (runtime writes: --rl-space, the two attributes, and a cust
     // a validated chart palette; a mechanism that "re-derived" them would silently repaint the app
     // for every user who never asked for a theme.
     const { root, props } = fakeRoot();
-    applyTheme("#7c6cff", "dark", "realm", root);
-    expect(Object.keys(props)).toEqual(["--rl-space"]);
+    applyTheme({ space: "#7c6cff", mode: "dark", theme: "realm" }, root);
+    expect(Object.keys(props).sort()).toEqual(["--ground-alpha", "--rl-space"]);
   });
 
   it("a custom theme writes its whole palette inline, and returning to the default clears every one", () => {
     const { root, props } = fakeRoot();
-    applyTheme("#7c6cff", "dark", "one", root);
+    applyTheme({ space: "#7c6cff", mode: "dark", theme: "one" }, root);
     for (const name of THEME_VARS) expect(props[name], name).toMatch(/^oklch\(/);
-    applyTheme("#7c6cff", "dark", "realm", root);
+    applyTheme({ space: "#7c6cff", mode: "dark", theme: "realm" }, root);
     // THE stale-palette mutant: drop the removeProperty branch and this keeps One Dark's inline
     // values, which beat both token blocks in tokens.css — the app would be stuck on the last theme
     // chosen with no way back short of a reload.
-    expect(Object.keys(props)).toEqual(["--rl-space"]);
+    expect(Object.keys(props).sort()).toEqual(["--ground-alpha", "--rl-space"]);
   });
 
   it("stamps the theme on the root so the stylesheet and the live checks can name it", () => {
     const { root, dataset } = fakeRoot();
-    applyTheme("#7c6cff", "dark", "one", root);
+    applyTheme({ space: "#7c6cff", mode: "dark", theme: "one" }, root);
     expect(dataset.theme).toBe("one");
+  });
+});
+
+describe("the adjustable ground", () => {
+  it("is written as a percentage on every apply, defaulting to the value the sidebar always had", () => {
+    const props: Record<string, string> = {};
+    const root = { style: { setProperty: (k: string, v: string) => { props[k] = v; }, removeProperty: () => {} }, dataset: {} } as unknown as HTMLElement;
+    applyTheme({ space: "#7c6cff", mode: "dark" }, root);
+    expect(props["--ground-alpha"]).toBe(`${DEFAULT_GROUND_ALPHA}%`);
+    expect(DEFAULT_GROUND_ALPHA).toBe(82);
+  });
+
+  it("clamps, so no stored or hand-edited value can make the sidebar unreadable or negative", () => {
+    // THE unclamped mutant: pass the stored number straight through. `ui.groundAlpha` is a settings
+    // row like any other — a 0 in it would make the app's own navigation a window onto the desktop,
+    // with no control on screen able to explain what happened.
+    expect(clampGroundAlpha(0)).toBe(GROUND_ALPHA_RANGE.min);
+    expect(clampGroundAlpha(-40)).toBe(GROUND_ALPHA_RANGE.min);
+    expect(clampGroundAlpha(1000)).toBe(GROUND_ALPHA_RANGE.max);
+    expect(clampGroundAlpha(63.4)).toBe(63);
+    expect(GROUND_ALPHA_RANGE.min).toBe(55);
+    expect(GROUND_ALPHA_RANGE.max).toBe(100); // fully opaque has to be reachable — that is "off"
+  });
+
+  it("does not compose the ground itself — that stays in CSS, where a media query can reach it", () => {
+    const props: Record<string, string> = {};
+    const root = { style: { setProperty: (k: string, v: string) => { props[k] = v; }, removeProperty: () => {} }, dataset: {} } as unknown as HTMLElement;
+    applyTheme({ space: "#7c6cff", mode: "dark", groundAlpha: 60 }, root);
+    expect(props["--sidebar-ground"]).toBeUndefined();
   });
 });

--- a/packages/ui/src/theme.test.ts
+++ b/packages/ui/src/theme.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { applyTheme, hexToHsl, hslToHex, spaceColor } from "./theme";
+import { THEME_VARS } from "./themes";
 
 /** Plan 9 W1 re-scope: the ink-grayscale palette generator is gone — surfaces, text tiers, accent,
  *  semantic colours and shadows are the Beautiful UI token set, static CSS in the renderer
@@ -38,28 +39,52 @@ describe("spaceColor (the one identity pixel, clamp rules unchanged from spec 20
   });
 });
 
-describe("applyTheme (runtime writes: --rl-space and data-mode, nothing else)", () => {
+describe("applyTheme (runtime writes: --rl-space, the two attributes, and a custom theme's palette)", () => {
   const fakeRoot = () => {
     const props: Record<string, string> = {};
     const root = {
-      style: { setProperty: (k: string, v: string) => { props[k] = v; } },
+      style: {
+        setProperty: (k: string, v: string) => { props[k] = v; },
+        removeProperty: (k: string) => { delete props[k]; },
+      },
       dataset: {} as Record<string, string>,
     } as unknown as HTMLElement;
-    return { root, props };
+    return { root, props, dataset: (root as unknown as { dataset: Record<string, string> }).dataset };
   };
 
   it("writes the clamped space colour to --rl-space and stamps data-mode", () => {
     for (const mode of ["dark", "light"] as const) {
-      const { root, props } = fakeRoot();
-      applyTheme("#3ddc97", mode, root);
+      const { root, props, dataset } = fakeRoot();
+      applyTheme("#3ddc97", mode, "realm", root);
       expect(props["--rl-space"]).toBe(spaceColor("#3ddc97", mode));
-      expect((root as unknown as { dataset: Record<string, string> }).dataset.mode).toBe(mode);
+      expect(dataset.mode).toBe(mode);
     }
   });
 
-  it("writes no other custom property — the BUI tokens are CSS truth, not runtime writes", () => {
+  it("the default theme writes no other custom property — the BUI tokens are CSS truth, not runtime writes", () => {
+    // THE default-theme mutant: make `realm` derive a palette like any other theme and this goes red.
+    // Realm's own colours are 85 properties of hand-tuned static CSS with per-mode shadow stacks and
+    // a validated chart palette; a mechanism that "re-derived" them would silently repaint the app
+    // for every user who never asked for a theme.
     const { root, props } = fakeRoot();
-    applyTheme("#7c6cff", "dark", root);
+    applyTheme("#7c6cff", "dark", "realm", root);
     expect(Object.keys(props)).toEqual(["--rl-space"]);
+  });
+
+  it("a custom theme writes its whole palette inline, and returning to the default clears every one", () => {
+    const { root, props } = fakeRoot();
+    applyTheme("#7c6cff", "dark", "one", root);
+    for (const name of THEME_VARS) expect(props[name], name).toMatch(/^oklch\(/);
+    applyTheme("#7c6cff", "dark", "realm", root);
+    // THE stale-palette mutant: drop the removeProperty branch and this keeps One Dark's inline
+    // values, which beat both token blocks in tokens.css — the app would be stuck on the last theme
+    // chosen with no way back short of a reload.
+    expect(Object.keys(props)).toEqual(["--rl-space"]);
+  });
+
+  it("stamps the theme on the root so the stylesheet and the live checks can name it", () => {
+    const { root, dataset } = fakeRoot();
+    applyTheme("#7c6cff", "dark", "one", root);
+    expect(dataset.theme).toBe("one");
   });
 });

--- a/packages/ui/src/theme.ts
+++ b/packages/ui/src/theme.ts
@@ -1,3 +1,5 @@
+import { THEME_VARS, themeVars, type ThemeName } from "./themes";
+
 export type Mode = "light" | "dark";
 export type Hsl = { h: number; s: number; l: number };
 
@@ -46,10 +48,24 @@ export function spaceColor(hex: string, mode: Mode): string {
     : { h: h.h, s, l: Math.min(55, Math.max(35, h.l)) });
 }
 
-/** Writes the one runtime token (`--rl-space`) and stamps the mode on the root. `data-mode` is what
- *  flips the CSS token blocks (and Tailwind's `dark:` variant, remapped onto it) between the dark
- *  and light BUI ramps — the rest of the theme never touches JavaScript. */
-export function applyTheme(space: string, mode: Mode, root: HTMLElement = document.documentElement): void {
+/** Writes the runtime tokens and stamps the mode and theme on the root. `data-mode` is what flips the
+ *  CSS token blocks (and Tailwind's `dark:` variant, remapped onto it) between the dark and light BUI
+ *  ramps; `data-theme` is a label for the stylesheet and the live checks to read, never a selector
+ *  the palette hangs off.
+ *
+ *  A custom theme is a set of INLINE custom properties, which is what lets it win over both token
+ *  blocks in tokens.css without a third block or a generated stylesheet. The default theme states
+ *  none, so choosing `realm` clears the whole set and the app is back on the static CSS it has always
+ *  been. Every name in THEME_VARS is cleared before the new set is written, or the properties a
+ *  theme happens not to state would still be pointing at the theme before it. */
+export function applyTheme(space: string, mode: Mode, theme: ThemeName = "realm", root: HTMLElement = document.documentElement): void {
   root.style.setProperty("--rl-space", spaceColor(space, mode));
   root.dataset.mode = mode;
+  root.dataset.theme = theme;
+  const vars = themeVars(theme, mode);
+  for (const name of THEME_VARS) {
+    const value = vars[name];
+    if (value === undefined) root.style.removeProperty(name);
+    else root.style.setProperty(name, value);
+  }
 }

--- a/packages/ui/src/theme.ts
+++ b/packages/ui/src/theme.ts
@@ -48,6 +48,29 @@ export function spaceColor(hex: string, mode: Mode): string {
     : { h: h.h, s, l: Math.min(55, Math.max(35, h.l)) });
 }
 
+/** How much of the window ground the sidebar paints over the macOS material, as a percentage. 82 is
+ *  the value the sidebar has always used and the one the design was calibrated on; it lives here
+ *  rather than in the stylesheet so there is exactly one of it. tokens.css declares 100% for the case
+ *  where this module never runs, which is a different fact — a renderer that failed to boot should
+ *  show an opaque sidebar, not a see-through one. */
+export const DEFAULT_GROUND_ALPHA = 82;
+
+/** Fully opaque at the top — which is what "off" means, since covering the material is the same as
+ *  not having asked for it. The floor is where the ground stops carrying the sidebar's own text:
+ *  screenshotting the built app over a bright desktop, the nav labels wash out somewhere below 55%,
+ *  because past that point their legibility is a property of the user's wallpaper rather than of the
+ *  palette. Apple's own sidebars go all the way to bare material and stay readable, so this is a
+ *  judgement about Realm's denser sidebar and not a limit of the material — but it is a floor,
+ *  because a control that can make the app's navigation unreadable is not a preference.
+ *
+ *  It cannot be checked automatically: the material is composited by the window server BELOW the web
+ *  contents, so a CDP screenshot never sees it (see transparency-live.mjs). This number came from
+ *  looking. */
+export const GROUND_ALPHA_RANGE = { min: 55, max: 100 } as const;
+
+export const clampGroundAlpha = (pct: number): number =>
+  Math.round(Math.min(GROUND_ALPHA_RANGE.max, Math.max(GROUND_ALPHA_RANGE.min, pct)));
+
 /** Writes the runtime tokens and stamps the mode and theme on the root. `data-mode` is what flips the
  *  CSS token blocks (and Tailwind's `dark:` variant, remapped onto it) between the dark and light BUI
  *  ramps; `data-theme` is a label for the stylesheet and the live checks to read, never a selector
@@ -57,9 +80,22 @@ export function spaceColor(hex: string, mode: Mode): string {
  *  blocks in tokens.css without a third block or a generated stylesheet. The default theme states
  *  none, so choosing `realm` clears the whole set and the app is back on the static CSS it has always
  *  been. Every name in THEME_VARS is cleared before the new set is written, or the properties a
- *  theme happens not to state would still be pointing at the theme before it. */
-export function applyTheme(space: string, mode: Mode, theme: ThemeName = "realm", root: HTMLElement = document.documentElement): void {
+ *  theme happens not to state would still be pointing at the theme before it.
+ *
+ *  `--ground-alpha` rides along rather than getting a writer of its own: `:root` has one owner, and
+ *  the transparency and the palette change together often enough (every theme switch repaints the
+ *  ground the alpha is applied to) that two writers would be two chances to leave them disagreeing.
+ *  Note what it does NOT write: `--sidebar-ground`, the composed value the stylesheet actually reads.
+ *  That composition stays in CSS so `prefers-reduced-transparency` can override it — an inline
+ *  property would beat any media query, and the app already honours that preference in its fade
+ *  bands. */
+export function applyTheme(
+  { space, mode, theme = "realm", groundAlpha = DEFAULT_GROUND_ALPHA }:
+    { space: string; mode: Mode; theme?: ThemeName; groundAlpha?: number },
+  root: HTMLElement = document.documentElement,
+): void {
   root.style.setProperty("--rl-space", spaceColor(space, mode));
+  root.style.setProperty("--ground-alpha", `${clampGroundAlpha(groundAlpha)}%`);
   root.dataset.mode = mode;
   root.dataset.theme = theme;
   const vars = themeVars(theme, mode);

--- a/packages/ui/src/themes.test.ts
+++ b/packages/ui/src/themes.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, it } from "vitest";
+import { contrast, hexToOklch, type Oklch } from "./oklch";
+import { CONTRAST_FLOOR, THEMES, THEME_VARS, resolveMode, themeModes, themeSwatches, themeVars } from "./themes";
+import type { Mode } from "./theme";
+
+const parse = (value: string): Oklch => {
+  const m = /^oklch\(([\d.]+) ([\d.]+) ([\d.]+)/.exec(value);
+  if (!m) throw new Error(`not an oklch value: ${value}`);
+  return { l: Number(m[1]), c: Number(m[2]), h: Number(m[3]) };
+};
+
+/** The grounds each ink tier actually lands on, read off styles.css rather than taken as the whole
+ *  ladder: `--ink-2` never appears on `--hover-2` or `--field` (both are written with `--ink` in
+ *  every rule that uses them), and `--ink-3` never leaves the resting surfaces. Widening these to the
+ *  full cross-product would fail themes over pairings the stylesheet never produces; narrowing them
+ *  past what it does produce is how an unreadable pairing ships. */
+const GROUNDS = {
+  ink: ["--page", "--canvas", "--surface", "--inset", "--hover", "--hover-2", "--field"],
+  ink2: ["--page", "--canvas", "--surface", "--inset", "--hover"],
+  ink3: ["--page", "--canvas", "--surface", "--inset"],
+} as const;
+
+/** The eight validated chart series, copied from tokens.css. A theme does not repaint them; what it
+ *  moves is the ground under them, so this is the set the clamp has to keep working for. */
+const SERIES_DARK = ["#3987e5", "#d95926", "#199e70", "#c98500", "#d55181", "#008300", "#9085e9", "#e66767"];
+
+const faces = (): { theme: (typeof THEMES)[number]; mode: Mode }[] =>
+  THEMES.flatMap((theme) => themeModes(theme.name).map((mode) => ({ theme, mode })));
+
+describe("the two axes compose", () => {
+  it("a theme with both faces takes whichever mode the preference resolved to", () => {
+    for (const mode of ["dark", "light"] as const) {
+      expect(resolveMode("realm", mode)).toBe(mode);
+      expect(resolveMode("one", mode)).toBe(mode);
+    }
+  });
+
+  it("a theme with one face pins the mode, and every theme still resolves to something", () => {
+    for (const { theme } of THEMES.map((theme) => ({ theme }))) {
+      const modes = themeModes(theme.name);
+      expect(modes.length, theme.name).toBeGreaterThan(0);
+      for (const mode of ["dark", "light"] as const) expect(modes).toContain(resolveMode(theme.name, mode));
+    }
+  });
+
+  it("pinning is a fact about the theme, not a write to the preference", () => {
+    // THE clobber mutant: have the picker call setThemePref("dark") when a dark-only palette is
+    // chosen. Nothing here would notice — which is why `resolveMode` is a pure function of the two
+    // inputs and the preference is never an output. A user who prefers "system" and tries Monokai
+    // for an afternoon must find "system" again afterwards.
+    expect(resolveMode("monokai", "light")).toBe("dark");
+    expect(resolveMode("one", "light")).toBe("light");
+  });
+});
+
+describe("the default theme is the absence of a theme", () => {
+  it("realm states no seeds and derives no palette", () => {
+    for (const mode of ["dark", "light"] as const) expect(themeVars("realm", mode)).toEqual({});
+  });
+
+  it("every other theme fills exactly THEME_VARS — no property escapes the clear-down list", () => {
+    // THE orphan-property mutant: add a token to the derivation and forget to list it in
+    // THEME_VARS. It would be written on every theme switch and never removed, so returning to
+    // Realm would leave one of Monokai's colours behind on a palette that never asked for it.
+    for (const { theme, mode } of faces()) {
+      if (theme.name === "realm") continue;
+      expect(Object.keys(themeVars(theme.name, mode)).sort(), theme.name).toEqual([...THEME_VARS].sort());
+    }
+  });
+});
+
+describe("what a theme states survives derivation", () => {
+  it("the ground and the ink are the seed exactly — those two are never corrected", () => {
+    for (const { theme, mode } of faces()) {
+      const seed = mode === "dark" ? theme.dark : theme.light;
+      if (!seed) continue;
+      const v = themeVars(theme.name, mode);
+      for (const [token, hex] of [["--page", seed.bg], ["--ink", seed.ink]] as const) {
+        const [a, b] = [parse(v[token]!), hexToOklch(hex)];
+        expect(a.l, `${theme.name}/${mode} ${token}`).toBeCloseTo(b.l, 3);
+        expect(a.c, `${theme.name}/${mode} ${token}`).toBeCloseTo(b.c, 3);
+      }
+    }
+  });
+
+  it("a corrected colour moves along lightness only — hue and chroma are the theme's identity", () => {
+    // THE mix-to-white mutant: fix contrast by blending the colour towards the ground's opposite
+    // instead of stepping its lightness. It clears the same floors and desaturates every hue on the
+    // way, which is how a vendored palette quietly stops being that palette.
+    for (const { theme, mode } of faces()) {
+      const seed = mode === "dark" ? theme.dark : theme.light;
+      if (!seed) continue;
+      const v = themeVars(theme.name, mode);
+      const pairs = [
+        ["--green", seed.green], ["--orange", seed.orange], ["--red", seed.red],
+        ["--syn-keyword", seed.syntax.keyword], ["--syn-string", seed.syntax.string],
+        ["--syn-number", seed.syntax.number], ["--syn-title", seed.syntax.title],
+        ["--syn-type", seed.syntax.type], ["--syn-attr", seed.syntax.attr],
+        ["--syn-comment", seed.syntax.comment], ["--accent", seed.accent],
+      ] as const;
+      for (const [token, hex] of pairs) {
+        const [got, want] = [parse(v[token]!), hexToOklch(hex)];
+        const where = `${theme.name}/${mode} ${token}`;
+        expect(got.c, where).toBeCloseTo(want.c, 3);
+        expect(Math.abs(got.h - want.h), where).toBeLessThan(0.5);
+        // ...and moved no further than the budget, or the "correction" is a repaint.
+        expect(Math.abs(got.l - want.l), where).toBeLessThanOrEqual(0.121);
+      }
+    }
+  });
+});
+
+describe(`every theme clears the floor (ink ${CONTRAST_FLOOR.ink}:1, ink-2 ${CONTRAST_FLOOR.ink2}:1, syntax ${CONTRAST_FLOOR.syntax}:1)`, () => {
+  it.each(faces().map(({ theme, mode }) => [`${theme.label} ${mode}`, theme.name, mode] as const))(
+    "%s", (_label, name, mode) => {
+      const v = themeVars(name, mode);
+      if (name === "realm") return; // tokens.css is the palette; styles.test.ts pins it there.
+      const worst = (token: string, grounds: readonly string[]) =>
+        Math.min(...grounds.map((g) => contrast(parse(v[token]!), parse(v[g]!))));
+      const onSurface = (token: string) => contrast(parse(v[token]!), parse(v["--surface"]!));
+
+      // The one assertion here that no derivation can rescue: `--ink` is a seed, held to AA on every
+      // ground the stylesheet puts it on. A theme whose foreground is too close to its background is
+      // a bug in the theme, and this is the line that says so.
+      expect(worst("--ink", GROUNDS.ink), "--ink").toBeGreaterThanOrEqual(CONTRAST_FLOOR.ink);
+      expect(worst("--ink-2", GROUNDS.ink2), "--ink-2").toBeGreaterThanOrEqual(CONTRAST_FLOOR.ink2);
+      expect(worst("--ink-3", GROUNDS.ink3), "--ink-3").toBeGreaterThanOrEqual(CONTRAST_FLOOR.ink3);
+
+      for (const token of ["--accent", "--green", "--orange", "--red"]) {
+        expect(onSurface(token), token).toBeGreaterThanOrEqual(CONTRAST_FLOOR.chrome);
+      }
+      expect(onSurface("--accent-ink"), "--accent-ink").toBeGreaterThanOrEqual(CONTRAST_FLOOR.accentInk);
+      expect(contrast(parse(v["--rl-accent-contrast"]!), parse(v["--accent"]!)), "label on the accent fill")
+        .toBeGreaterThanOrEqual(CONTRAST_FLOOR.onAccent);
+
+      for (const token of THEME_VARS.filter((t) => t.startsWith("--syn-"))) {
+        expect(onSurface(token), token).toBeGreaterThanOrEqual(CONTRAST_FLOOR.syntax);
+      }
+
+      if (mode === "dark") {
+        for (const [i, hex] of SERIES_DARK.entries()) {
+          expect(contrast(hexToOklch(hex), parse(v["--chart-surface"]!)), `--series-${i + 1}`)
+            .toBeGreaterThanOrEqual(CONTRAST_FLOOR.series);
+        }
+      }
+    });
+
+  it("the floor can actually fail — a ground and an ink half a step apart do not clear it", () => {
+    // Without this the suite above proves only that the derivation is self-consistent. `--ink` is
+    // the un-derived seed, so it is the one that demonstrates the check has teeth: #2b2b2b on
+    // #282828 is a plausible-looking pair and it is 1.03:1.
+    expect(contrast(hexToOklch("#2b2b2b"), hexToOklch("#282828"))).toBeLessThan(CONTRAST_FLOOR.ink);
+  });
+});
+
+describe("the ramps derivation reproduces", () => {
+  it("the ink ramp still reads as three steps on every theme", () => {
+    // THE lightness-fraction mutant: derive --ink-2 and --ink-3 as fixed fractions of the way from
+    // --ink to --page, the way the shipped palette's own values sit. Realm's span is near-white over
+    // near-black; on One Dark's #282c34 the same fractions put --ink-2 at 3.4:1 and --ink-3 at 1.9:1,
+    // which is a ramp with no legible bottom. Deriving by CONTRAST instead keeps the steps apart.
+    for (const { theme, mode } of faces()) {
+      if (theme.name === "realm") continue;
+      const v = themeVars(theme.name, mode);
+      const g = parse(v["--surface"]!);
+      const [ink, ink2, ink3] = ["--ink", "--ink-2", "--ink-3"].map((k) => contrast(parse(v[k]!), g));
+      expect(ink!, `${theme.name}/${mode}`).toBeGreaterThan(ink2! * 1.15);
+      expect(ink2!, `${theme.name}/${mode}`).toBeGreaterThan(ink3! * 1.15);
+    }
+  });
+
+  it("the surface ladder climbs in dark and sinks in light, off the theme's own ground", () => {
+    for (const { theme, mode } of faces()) {
+      if (theme.name === "realm") continue;
+      const v = themeVars(theme.name, mode);
+      const [page, surface, canvas] = ["--page", "--surface", "--canvas"].map((k) => parse(v[k]!).l);
+      if (mode === "dark") { expect(surface!).toBeGreaterThan(page!); expect(canvas!).toBeGreaterThan(page!); }
+      else { expect(surface!).toBeGreaterThan(page!); expect(canvas!).toBeLessThan(page!); }
+    }
+  });
+
+  it("the chart ground is pulled back into the band the series were validated in", () => {
+    // THE unclamped-chart mutant: point --chart-surface at --surface. Every dark theme here has a
+    // ground lighter than Realm's #232427, and slot 6 (#008300) drops under 3:1 on all of them —
+    // silently, because nothing about a chart looks broken when two segments stop being telling
+    // apart. At least one shipped theme must therefore have a chart ground strictly darker than its
+    // own surface, or the clamp is dead code.
+    const clamped = faces().filter(({ theme, mode }) => {
+      if (theme.name === "realm" || mode !== "dark") return false;
+      const v = themeVars(theme.name, mode);
+      return parse(v["--chart-surface"]!).l < parse(v["--surface"]!).l - 1e-6;
+    });
+    expect(clamped.length).toBeGreaterThan(0);
+  });
+});
+
+describe("the picker's swatches", () => {
+  it("preview the mode the theme would really resolve to", () => {
+    // Asked for light, Monokai has none: the card must show its dark face rather than a fabricated
+    // light one, because that is what clicking it produces.
+    expect(themeSwatches("monokai", "light")).toEqual(themeSwatches("monokai", "dark"));
+  });
+
+  it("come from the same derivation the app applies, so a card cannot lie about its theme", () => {
+    const v = themeVars("one", "dark");
+    expect(themeSwatches("one", "dark")).toEqual([v["--page"], v["--surface"], v["--accent"], v["--syn-string"]]);
+  });
+});
+
+describe("provenance", () => {
+  it("every vendored palette credits its upstream and its licence", () => {
+    for (const theme of THEMES) {
+      if (theme.name === "realm") { expect(theme.credit).toBeNull(); continue; }
+      expect(theme.credit, theme.name).toMatch(/MIT ©/);
+    }
+  });
+});

--- a/packages/ui/src/themes.test.ts
+++ b/packages/ui/src/themes.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { contrast, hexToOklch, type Oklch } from "./oklch";
-import { CONTRAST_FLOOR, THEMES, THEME_VARS, resolveMode, themeModes, themeSwatches, themeVars } from "./themes";
+import { CONTRAST_FLOOR, THEMES, THEME_VARS, deriveVars, resolveMode, themeModes, themeSwatches, themeVars } from "./themes";
 import type { Mode } from "./theme";
 
 const parse = (value: string): Oklch => {
@@ -144,6 +144,26 @@ describe(`every theme clears the floor (ink ${CONTRAST_FLOOR.ink}:1, ink-2 ${CON
         }
       }
     });
+
+  it("the budget REFUSES rather than over-lifting — which is what makes a stated hue vendored", () => {
+    // Every syntax seed in this file is the value its upstream publishes, and `lift` is what makes
+    // that safe: it corrects along lightness and stops at LIFT_BUDGET. If it kept going instead,
+    // every published hue would "clear" at whatever distance from the published colour it took, and
+    // the provenance in the comments would be decoration.
+    //
+    // Nord is the case that proves it. Its spec comment is nord3 (#4c566a), which measures 1.39:1 on
+    // the surface derived from nord0 and needs 0.160 of lightness — past the budget. The palette
+    // therefore states #616e88, the tone Nord's own editor ports adopted, which needs 0.074.
+    const nord = THEMES.find((t) => t.name === "nord")!.dark!;
+    const spec = deriveVars({ ...nord, syntax: { ...nord.syntax, comment: "#4c566a" } }, "dark");
+    const asShipped = deriveVars(nord, "dark");
+    const onSurface = (v: Record<string, string>) => contrast(parse(v["--syn-comment"]!), parse(v["--surface"]!));
+    // THE runaway-lift mutant: drop the budget from `lift`'s loop bound. This flips green, nord3
+    // "works", and the one seed in the set that upstream's own value cannot carry stops being
+    // visible to anyone reading the file.
+    expect(onSurface(spec), "nord3 must NOT be rescued past the budget").toBeLessThan(CONTRAST_FLOOR.syntax);
+    expect(onSurface(asShipped), "the value the palette actually states does clear").toBeGreaterThanOrEqual(CONTRAST_FLOOR.syntax);
+  });
 
   it("the floor can actually fail — a ground and an ink half a step apart do not clear it", () => {
     // Without this the suite above proves only that the derivation is self-consistent. `--ink` is

--- a/packages/ui/src/themes.ts
+++ b/packages/ui/src/themes.ts
@@ -22,6 +22,12 @@ import type { Mode } from "./theme";
  *  The border ramp, the shadow stacks and the scrims state nothing here on purpose: tembo's ramps are
  *  ALPHA overlays over whatever ground they land on, so they already follow a repainted surface. That
  *  is the property that makes a twelve-value seed enough. */
+/** Every hue below is the value its upstream PUBLISHES, not a value tuned to clear Realm's floors.
+ *  It can be, because `lift` corrects a stated hue along lightness until it clears — and refuses to
+ *  move it further than `LIFT_BUDGET`, which is what makes "vendored" mean something. Hand-brightening
+ *  a seed to clear the floor routes around that guarantee: it clears silently, at whatever distance
+ *  from the published colour it took, and the budget never gets to object. The one seed here that
+ *  upstream's own value cannot carry is named where it is written. */
 export type SyntaxSeed = {
   /** Comments and doc tags. The one syntax colour allowed to sit near the ground. */
   comment: string;
@@ -414,12 +420,12 @@ export const THEMES: readonly ThemeDef[] = [
     dark: {
       bg: "#282c34", ink: "#d7dae0", accent: "#61afef",
       green: "#98c379", orange: "#d19a66", red: "#e06c75",
-      syntax: { comment: "#7f848e", keyword: "#c678dd", string: "#98c379", number: "#d19a66", title: "#61afef", type: "#e5c07b", attr: "#56b6c2" },
+      syntax: { comment: "#5c6370", keyword: "#c678dd", string: "#98c379", number: "#d19a66", title: "#61afef", type: "#e5c07b", attr: "#56b6c2" },
     },
     light: {
       bg: "#fafafa", ink: "#383a42", accent: "#4078f2",
       green: "#50a14f", orange: "#986801", red: "#e45649",
-      syntax: { comment: "#8e8f96", keyword: "#a626a4", string: "#50a14f", number: "#986801", title: "#4078f2", type: "#c18401", attr: "#0184bc" },
+      syntax: { comment: "#a0a1a7", keyword: "#a626a4", string: "#50a14f", number: "#986801", title: "#4078f2", type: "#c18401", attr: "#0184bc" },
     },
   },
   {
@@ -435,7 +441,7 @@ export const THEMES: readonly ThemeDef[] = [
     dark: {
       bg: "#272822", ink: "#f8f8f2", accent: "#f92672",
       green: "#a6e22e", orange: "#fd971f", red: "#f92672",
-      syntax: { comment: "#8f907e", keyword: "#f92672", string: "#e6db74", number: "#ae81ff", title: "#a6e22e", type: "#66d9ef", attr: "#a6e22e" },
+      syntax: { comment: "#88846f", keyword: "#f92672", string: "#e6db74", number: "#ae81ff", title: "#a6e22e", type: "#66d9ef", attr: "#a6e22e" },
     },
     light: null,
   },
@@ -449,15 +455,19 @@ export const THEMES: readonly ThemeDef[] = [
     dark: {
       bg: "#282a36", ink: "#f8f8f2", accent: "#bd93f9",
       green: "#50fa7b", orange: "#ffb86c", red: "#ff5555",
-      syntax: { comment: "#7f8ec0", keyword: "#ff79c6", string: "#f1fa8c", number: "#bd93f9", title: "#50fa7b", type: "#8be9fd", attr: "#50fa7b" },
+      syntax: { comment: "#6272a4", keyword: "#ff79c6", string: "#f1fa8c", number: "#bd93f9", title: "#50fa7b", type: "#8be9fd", attr: "#50fa7b" },
     },
     light: null,
   },
   {
     /* Nord — arcticicestudio/nord, MIT © Sven Greb. Dark only: Nord is specified as one palette
      * (Polar Night grounds, Snow Storm ink), and the "Nord Light" builds in the wild are community
-     * inversions rather than upstream. Comments are #616e88, the brightened value Nord's own
-     * editor ports moved to — nord3 (#4c566a) does not clear the contrast floor on nord0. */
+     * inversions rather than upstream.
+     * The one seed in this file that is not the value its spec publishes: comments are #616e88, the
+     * brightened tone Nord's own editor ports adopted, because nord3 (#4c566a) measures 1.39:1 on
+     * the surface derived from nord0 and needs 0.160 of lightness to clear the syntax floor — past
+     * LIFT_BUDGET, which is the mechanism refusing to pretend and saying so. #616e88 needs 0.074 and
+     * is corrected in the ordinary way. */
     name: "nord",
     label: "Nord",
     credit: "Nord — MIT © Sven Greb",
@@ -465,18 +475,18 @@ export const THEMES: readonly ThemeDef[] = [
     dark: {
       bg: "#2e3440", ink: "#eceff4", accent: "#88c0d0",
       green: "#a3be8c", orange: "#d08770", red: "#bf616a",
-      syntax: { comment: "#7c8aa5", keyword: "#81a1c1", string: "#a3be8c", number: "#b48ead", title: "#88c0d0", type: "#8fbcbb", attr: "#d8dee9" },
+      syntax: { comment: "#616e88", keyword: "#81a1c1", string: "#a3be8c", number: "#b48ead", title: "#88c0d0", type: "#8fbcbb", attr: "#d8dee9" },
     },
     light: null,
   },
   {
     /* Solarized — altercation/solarized, MIT © Ethan Schoonover. Both faces, which is the whole point
      * of Solarized: one set of accent hues over two symmetric grounds.
-     * Two deviations from the reference, both forced by the contrast floor and both in the same
-     * direction — Solarized's own text tones are tuned for a code editor, not for UI chrome:
-     *   - `ink` is base2/base02 rather than base0/base00, so primary UI text clears 7:1.
-     *   - the LIGHT comment is #7a8a8a, one step down from base1 (#93a1a1), which reads 2.46:1 on
-     *     base3 and is the one value in this set that could not be vendored as written. */
+     * One deviation, and it is the one `lift` cannot make: `ink` is base2/base02 rather than
+     * base0/base00. Solarized's text tones are an editor foreground, and as UI chrome base0 measures
+     * 3.16:1 and base00 3.54:1 against the grounds this palette derives — under the 4.5:1 that
+     * primary text is held to. `--ink` is deliberately the one seed nothing corrects, so a palette
+     * whose foreground will not carry chrome has to say which tone it borrowed instead. */
     name: "solarized",
     label: "Solarized",
     credit: "Solarized — MIT © Ethan Schoonover",
@@ -484,12 +494,12 @@ export const THEMES: readonly ThemeDef[] = [
     dark: {
       bg: "#002b36", ink: "#eee8d5", accent: "#268bd2",
       green: "#859900", orange: "#cb4b16", red: "#dc322f",
-      syntax: { comment: "#657b83", keyword: "#859900", string: "#2aa198", number: "#d33682", title: "#268bd2", type: "#b58900", attr: "#6c71c4" },
+      syntax: { comment: "#586e75", keyword: "#859900", string: "#2aa198", number: "#d33682", title: "#268bd2", type: "#b58900", attr: "#6c71c4" },
     },
     light: {
       bg: "#fdf6e3", ink: "#073642", accent: "#268bd2",
       green: "#859900", orange: "#cb4b16", red: "#dc322f",
-      syntax: { comment: "#7a8a8a", keyword: "#859900", string: "#2aa198", number: "#d33682", title: "#268bd2", type: "#b58900", attr: "#6c71c4" },
+      syntax: { comment: "#93a1a1", keyword: "#859900", string: "#2aa198", number: "#d33682", title: "#268bd2", type: "#b58900", attr: "#6c71c4" },
     },
   },
   {
@@ -503,7 +513,7 @@ export const THEMES: readonly ThemeDef[] = [
     dark: {
       bg: "#282828", ink: "#ebdbb2", accent: "#83a598",
       green: "#b8bb26", orange: "#fe8019", red: "#fb4934",
-      syntax: { comment: "#a89984", keyword: "#fb4934", string: "#b8bb26", number: "#d3869b", title: "#fabd2f", type: "#8ec07c", attr: "#83a598" },
+      syntax: { comment: "#928374", keyword: "#fb4934", string: "#b8bb26", number: "#d3869b", title: "#fabd2f", type: "#8ec07c", attr: "#83a598" },
     },
     light: {
       bg: "#fbf1c7", ink: "#3c3836", accent: "#076678",

--- a/packages/ui/src/themes.ts
+++ b/packages/ui/src/themes.ts
@@ -77,7 +77,7 @@ export type ThemeName = "realm" | "one" | "monokai" | "dracula" | "nord" | "sola
  * little chroma as they climb, while light surfaces mostly sink below the page and hold the paper's
  * tint. Changing a number here retunes every theme at once, which is the point — there is no
  * per-theme surface ladder to drift. */
-type SurfaceStep = "canvas" | "surface" | "inset" | "hover" | "hover-2" | "field" | "stripe-bg" | "tooltip-bg" | "tooltip-border";
+type SurfaceStep = "canvas" | "surface" | "inset" | "hover" | "hover-2" | "field" | "stripe-bg";
 
 type Ramp = {
   /** Lightness offsets from `bg`, in OKLCH L. */
@@ -95,35 +95,51 @@ type Ramp = {
    *  copying its CONTRAST structure reproduces what the ramp is for. */
   ink2: number;
   ink3: number;
+  /** The tooltip chip, which is the one surface that does not sit on the ladder. Dark mode recesses
+   *  it below the page and writes the theme's own ink on it; light mode INVERTS it into a dark chip
+   *  with light text — a different construction, not different numbers, which is why this is a
+   *  function and not two more rows of the table above. Written as rows, whichever mode did not need
+   *  a given entry would carry a zero nothing ever reads. */
+  tooltip: (p: { bg: Oklch; ink: Oklch; ink2: Oklch }) => Record<"bg" | "fg" | "muted" | "border", Oklch>;
   /** `--accent-ink` (links, accent text on a surface): a step from the accent towards the ink, with
    *  its chroma pulled back so a hyperlink is not louder than the button it sits beside. */
   accentInk: { step: number; chroma: number };
-  /** The 8% wash behind an accent chip. Dark tints are the hue at low alpha over the surface; light
-   *  tints are the hue at PAPER lightness, because alpha over near-white washes out to nothing. */
+  /** The wash behind a chip. Dark tints are the hue at 15% over whatever surface it lands on; light
+   *  tints are the hue at PAPER lightness with its chroma cut to a tenth, because alpha over a
+   *  near-white ground washes out to nothing. Both are the mean of the four the shipped palette
+   *  states (its own spread is 14–16% dark, L .956–.964 light), rather than four seeds per theme for
+   *  a difference no one can see. */
   tint: { alpha: number } | { lightness: number; chroma: number };
   /** Chart ground clamp — see `--chart-surface` below. */
   chartL: { min: number; max: number };
 };
 
 const DARK: Ramp = {
-  surfaces: { canvas: 0.022, surface: 0.051, inset: 0.034, hover: 0.08, "hover-2": 0.109, field: 0.084, "stripe-bg": 0.017, "tooltip-bg": -0.027, "tooltip-border": 0.099 },
-  chroma: { surface: 0.002, hover: 0.002, "hover-2": 0.003, field: 0.002, "tooltip-border": 0.002 },
-  ink2: 0.66,
-  ink3: 0.37,
+  surfaces: { canvas: 0.022, surface: 0.051, inset: 0.034, hover: 0.08, "hover-2": 0.109, field: 0.084, "stripe-bg": 0.017 },
+  chroma: { surface: 0.002, hover: 0.002, "hover-2": 0.003, field: 0.002 },
+  ink2: 0.7,
+  ink3: 0.427,
+  tooltip: ({ bg, ink, ink2 }) => ({ bg: step(bg, -0.027), fg: ink, muted: ink2, border: step(bg, 0.099, 0.002) }),
   accentInk: { step: 0.38, chroma: 0.65 },
   tint: { alpha: 0.15 },
   chartL: { min: 0, max: 0.245 },
 };
 
 const LIGHT: Ramp = {
-  surfaces: { canvas: -0.024, surface: 0.015, inset: -0.006, hover: -0.015, "hover-2": -0.052, field: -0.024, "stripe-bg": -0.015, "tooltip-bg": 0, "tooltip-border": 0 },
-  chroma: {},
+  surfaces: { canvas: -0.024, surface: 0.015, inset: -0.006, hover: -0.015, "hover-2": -0.052, field: -0.024, "stripe-bg": -0.015 },
+  chroma: { canvas: 0.001, inset: 0.001, hover: 0.001, "hover-2": 0.002 },
   ink2: 0.62,
-  ink3: 0.33,
+  ink3: 0.333,
+  // The inversion: the chip is built off the INK, and the light text on it is the page.
+  tooltip: ({ bg, ink }) => ({
+    bg: step(ink, 0.025, 0.002), fg: step(bg, -0.009),
+    muted: { l: 0.731, c: ink.c, h: ink.h }, border: step(ink, 0.109, 0.001),
+  }),
   accentInk: { step: 0.185, chroma: 0.91 },
   tint: { lightness: 0.959, chroma: 0.105 },
   chartL: { min: 0.97, max: 1 },
 };
+
 
 /** The contrast every derived colour is held to, and the roles they belong to. These are WCAG
  *  numbers, not Realm's: the shipped palette clears all of them with room (its worst pairing is
@@ -215,7 +231,13 @@ export const THEME_VARS = [
  *  generated CSS file would have to be regenerated, checked in, and then checked for staleness. */
 export function themeVars(name: ThemeName, mode: Mode): Record<string, string> {
   const seed = seedFor(name, mode);
-  if (!seed) return {};
+  return seed ? deriveVars(seed, mode) : {};
+}
+
+/** The derivation itself, on a bare seed. Exported so the guardrail can feed it the seeds tokens.css
+ *  was built from and check that what comes out IS tokens.css — the ramp constants above are only
+ *  "measured off the shipped palette" for as long as something re-measures them. */
+export function deriveVars(seed: ThemeSeed, mode: Mode): Record<string, string> {
   const r = mode === "dark" ? DARK : LIGHT;
   const bg = hexToOklch(seed.bg);
   const ink = hexToOklch(seed.ink);
@@ -258,12 +280,14 @@ export function themeVars(name: ThemeName, mode: Mode): Record<string, string> {
    *  breaks a promise about colour-vision deficiency that has nothing to do with taste. What moves
    *  instead is the ground: the Usage cards take a chart surface that carries the theme's hue but is
    *  clamped back into the band the palette was validated in. Without the clamp every theme here
-   *  fails slot 6 (#008300 needs a ground at or below Realm's own #232427 to clear 3:1), which is a
-   *  property of the series, not of the themes. */
+   *  fails slot 6: #008300 clears 3:1 on Realm's own #232427 (L 0.26) by 0.14, so the clamp sits a
+   *  little under it at L 0.245 to leave the margin a theme's chroma can eat. That is a property of
+   *  the series, not of the themes. */
   const chart = { ...surface, l: clamp(surface.l, r.chartL.min, r.chartL.max) };
 
   const ink2 = inkStep(ink, worst(["canvas", "surface", "inset", "hover"]), r.ink2, CONTRAST_FLOOR.ink2);
   const ink3 = inkStep(ink, worst(["canvas", "surface", "inset"]), r.ink3, CONTRAST_FLOOR.ink3);
+  const tip = r.tooltip({ bg, ink, ink2 });
 
   /** Chrome and syntax are stated as hues and corrected as lightnesses. Every one of these lands on
    *  `--surface` — semantic text and chips on a card, code inside `.md-code` — so that is the ground
@@ -300,12 +324,12 @@ export function themeVars(name: ThemeName, mode: Mode): Record<string, string> {
     "--red": css(red),
     "--red-tint": tint(red),
 
-    /* A tooltip is an inverted chip in light mode and a recessed one in dark — the shipped palette's
-     * own asymmetry, kept: in light mode the chip is the INK colour with the page written on it. */
-    "--tooltip-bg": mode === "dark" ? css(surf("tooltip-bg")) : css(step(ink, 0.025)),
-    "--tooltip-fg": mode === "dark" ? css(ink) : css(step(bg, -0.009)),
-    "--tooltip-muted": mode === "dark" ? css(ink2) : css({ l: 0.731, c: ink.c, h: ink.h }),
-    "--tooltip-border": mode === "dark" ? css(surf("tooltip-border")) : css(step(ink, 0.109)),
+    /* A recessed chip in dark and an inverted one in light — the shipped palette's own asymmetry,
+     * kept, and constructed by the ramp rather than branched on here. */
+    "--tooltip-bg": css(tip.bg),
+    "--tooltip-fg": css(tip.fg),
+    "--tooltip-muted": css(tip.muted),
+    "--tooltip-border": css(tip.border),
 
     "--chart-surface": css(chart),
 

--- a/packages/ui/src/themes.ts
+++ b/packages/ui/src/themes.ts
@@ -1,0 +1,418 @@
+import { contrast, css, hexToOklch, luminance, type Oklch } from "./oklch";
+import type { Mode } from "./theme";
+
+/** Custom themes.
+ *
+ *  Realm already had one colour axis — light / dark / system — and a theme is a SECOND axis, not a
+ *  replacement for it. `themePref` still says which mode the user wants; a theme says what the
+ *  palette looks like in that mode. The two compose through `resolveMode`: a theme that has both
+ *  faces takes whichever mode the preference resolves to, and a theme with only a dark face pins the
+ *  window dark WITHOUT touching the preference, so switching back to Realm restores "system" intact.
+ *  That is why themes carry `dark`/`light` as nullable seeds rather than a single palette and a
+ *  boolean — "Monokai has no light variant" is a fact about the theme, and the UI can say it.
+ *
+ *  `realm` is the palette in theme/tokens.css and states NO seeds. Selecting it means writing no
+ *  overrides at all, so the default experience is byte-for-byte the static CSS it has always been —
+ *  the theme mechanism cannot regress the theme nobody chose. */
+
+/** What a theme has to state. Everything else in the 85-property token set is derived from these —
+ *  see `themeVars` — because a palette is a set of RELATIONSHIPS (a surface ladder, an ink ramp, a
+ *  border overlay ramp) and only the anchors of those relationships are a matter of taste.
+ *
+ *  The border ramp, the shadow stacks and the scrims state nothing here on purpose: tembo's ramps are
+ *  ALPHA overlays over whatever ground they land on, so they already follow a repainted surface. That
+ *  is the property that makes a twelve-value seed enough. */
+export type SyntaxSeed = {
+  /** Comments and doc tags. The one syntax colour allowed to sit near the ground. */
+  comment: string;
+  /** Keywords, storage, literals, HTML tag names. */
+  keyword: string;
+  /** Strings, regexes, and the additions in a diff. */
+  string: string;
+  /** Numbers, symbols, links, template holes. */
+  number: string;
+  /** The name being DEFINED: functions, classes, sections, `#id` selectors. */
+  title: string;
+  /** Types, built-ins and parameters. */
+  type: string;
+  /** Attributes, properties, `.class` selectors. */
+  attr: string;
+};
+
+export type ThemeSeed = {
+  /** The window ground. The whole surface ladder is this colour at other lightnesses, so its HUE and
+   *  CHROMA are what make a theme's greys look like that theme's greys rather than Realm's. */
+  bg: string;
+  /** Primary UI ink — chrome, not code. Deliberately brighter than an editor's foreground in most of
+   *  these themes: `--ink-2` derives from it and lands on the editor foreground of its own accord. */
+  ink: string;
+  /** The one hue the app uses for itself: primary buttons, focus rings, links, carets, active ticks. */
+  accent: string;
+  /** State colours. A theme states them because "green means it worked" has to survive a repaint,
+   *  and every one of these palettes has its own green. */
+  green: string;
+  orange: string;
+  red: string;
+  syntax: SyntaxSeed;
+};
+
+export type ThemeDef = {
+  name: ThemeName;
+  label: string;
+  /** Provenance for a vendored palette: upstream, licence, holder. Null only for `realm`, which is
+   *  not vendored from anywhere. */
+  credit: string | null;
+  /** One line for the picker — what the theme IS, not an advertisement for it. */
+  blurb: string;
+  dark: ThemeSeed | null;
+  light: ThemeSeed | null;
+};
+
+export type ThemeName = "realm" | "one" | "monokai";
+
+/* ── how a seed becomes a palette ──────────────────────────────────────────────
+ * Every constant below was MEASURED off the shipped palette in theme/tokens.css, so a derived theme
+ * reproduces the shape of a ramp the design already validated instead of inventing a new one. They
+ * differ per mode because the shipped ramps do: dark surfaces climb away from the ground and gain a
+ * little chroma as they climb, while light surfaces mostly sink below the page and hold the paper's
+ * tint. Changing a number here retunes every theme at once, which is the point — there is no
+ * per-theme surface ladder to drift. */
+type SurfaceStep = "canvas" | "surface" | "inset" | "hover" | "hover-2" | "field" | "stripe-bg" | "tooltip-bg" | "tooltip-border";
+
+type Ramp = {
+  /** Lightness offsets from `bg`, in OKLCH L. */
+  surfaces: Record<SurfaceStep, number>;
+  /** Chroma offsets for the same steps, ADDED rather than multiplied. The shipped dark ramp gains
+   *  0.002–0.003 of chroma as it climbs, off a ground whose own chroma is 0.004; expressed as a
+   *  multiplier that reads as ×1.75, which on a ground with real chroma of its own (Solarized's
+   *  0.05) would be a hue shift rather than the faint warming the ramp actually does. */
+  chroma: Partial<Record<SurfaceStep, number>>;
+  /** How far `--ink-2` and `--ink-3` sit below `--ink`, as an exponent on the ink's own contrast
+   *  against the ground it has to survive: contrast(ink-2) = contrast(ink) ** ink2. Measured off the
+   *  shipped ramp, and an exponent rather than a lightness fraction because the shipped palette's
+   *  span (near-white ink over a near-black page) is far wider than any of these themes': copying
+   *  its LIGHTNESS fractions onto a ground half as dark collapses the ramp to nothing, while
+   *  copying its CONTRAST structure reproduces what the ramp is for. */
+  ink2: number;
+  ink3: number;
+  /** `--accent-ink` (links, accent text on a surface): a step from the accent towards the ink, with
+   *  its chroma pulled back so a hyperlink is not louder than the button it sits beside. */
+  accentInk: { step: number; chroma: number };
+  /** The 8% wash behind an accent chip. Dark tints are the hue at low alpha over the surface; light
+   *  tints are the hue at PAPER lightness, because alpha over near-white washes out to nothing. */
+  tint: { alpha: number } | { lightness: number; chroma: number };
+  /** Chart ground clamp — see `--chart-surface` below. */
+  chartL: { min: number; max: number };
+};
+
+const DARK: Ramp = {
+  surfaces: { canvas: 0.022, surface: 0.051, inset: 0.034, hover: 0.08, "hover-2": 0.109, field: 0.084, "stripe-bg": 0.017, "tooltip-bg": -0.027, "tooltip-border": 0.099 },
+  chroma: { surface: 0.002, hover: 0.002, "hover-2": 0.003, field: 0.002, "tooltip-border": 0.002 },
+  ink2: 0.66,
+  ink3: 0.37,
+  accentInk: { step: 0.38, chroma: 0.65 },
+  tint: { alpha: 0.15 },
+  chartL: { min: 0, max: 0.245 },
+};
+
+const LIGHT: Ramp = {
+  surfaces: { canvas: -0.024, surface: 0.015, inset: -0.006, hover: -0.015, "hover-2": -0.052, field: -0.024, "stripe-bg": -0.015, "tooltip-bg": 0, "tooltip-border": 0 },
+  chroma: {},
+  ink2: 0.62,
+  ink3: 0.33,
+  accentInk: { step: 0.185, chroma: 0.91 },
+  tint: { lightness: 0.959, chroma: 0.105 },
+  chartL: { min: 0.97, max: 1 },
+};
+
+/** The contrast every derived colour is held to, and the roles they belong to. These are WCAG
+ *  numbers, not Realm's: the shipped palette clears all of them with room (its worst pairing is
+ *  --ink-2 at 5.2:1), and holding a vendored palette to Realm's headroom instead would mean
+ *  repainting it into something that is no longer that palette. `ink3` is the one number taken from
+ *  Realm rather than from WCAG — the shipped light `--ink-3` measures 2.43:1 on `--canvas`, so a
+ *  higher floor would fail the default theme, and "no custom theme is less legible than the one that
+ *  ships" is the honest claim to make about a hint tier. */
+export const CONTRAST_FLOOR = {
+  /** Primary UI text on every ground it lands on. WCAG AA for body copy. */
+  ink: 4.5,
+  /** The secondary tier (`--rl-text-dim`): labels, metadata, the dim half of a row. AA large. */
+  ink2: 3,
+  /** Hints, placeholders, timestamps. */
+  ink3: 2.4,
+  /** Accent and the three semantic hues, on the card ground they are drawn against. */
+  chrome: 2.9,
+  /** Every syntax colour, on the code card. */
+  syntax: 2.7,
+  /** Accent TEXT — links, an accent label on a card — which is body text and is held to AA. */
+  accentInk: 4.5,
+  /** The label written on an accent fill. */
+  onAccent: 4.5,
+  /** The eight chart series on `--chart-surface`. Dark only: the light set ships three slots below
+   *  3:1 against a standing obligation documented in tokens.css (the breakdown table beside every
+   *  chart), and a custom theme does not get to inherit that obligation quietly. */
+  series: 3,
+} as const;
+
+/** How far a stated colour may be pushed to meet its floor. A theme states hues; this budget is what
+ *  separates "the palette lifted Nord's red half a step so error text is readable on Nord's own
+ *  surface" from "the palette invented a colour and called it Nord". A seed that needs more than
+ *  this is a bug in the theme, and the contrast suite says so by name. */
+const LIFT_BUDGET = 0.12;
+
+const clamp = (x: number, lo: number, hi: number): number => (x < lo ? lo : x > hi ? hi : x);
+/** A step along the L axis, holding hue and offsetting chroma. Lightness is clamped to the display's
+ *  range rather than allowed to wrap: a theme whose ground is already near black would otherwise
+ *  derive a `--tooltip-bg` blacker than black and quietly lose the step. */
+const step = (base: Oklch, dl: number, dc = 0): Oklch =>
+  ({ l: clamp(base.l + dl, 0, 1), c: Math.max(0, base.c + dc), h: base.h });
+
+/** Move `o` along L, AWAY from `ground`, until it clears `floor` against it — or until the budget
+ *  runs out, in which case the best effort is returned and the contrast suite fails the theme.
+ *  Hue and chroma are untouched: what a theme states is a colour's identity, and identity is the one
+ *  thing a correctness fix must not quietly edit. */
+function lift(o: Oklch, ground: Oklch, floor: number, budget = LIFT_BUDGET): Oklch {
+  const dir = luminance(o) >= luminance(ground) ? 1 : -1;
+  let best = o;
+  for (let d = 0; d <= budget + 1e-9; d += 0.002) {
+    best = { ...o, l: clamp(o.l + dir * d, 0, 1) };
+    if (contrast(best, ground) >= floor) return best;
+  }
+  return best;
+}
+
+/** The lightness at which `o` sits `exp` of the way down the ink's contrast ladder against `ground`,
+ *  never dimmer than `floor`. Solved by walking L rather than inverting the transfer function: the
+ *  walk is exact to a step no display can resolve, and it stays correct where the naive inverse does
+ *  not — at the gamut boundary, where raising L stops raising luminance. */
+function inkStep(ink: Oklch, ground: Oklch, exp: number, floor: number): Oklch {
+  const target = Math.max(floor, contrast(ink, ground) ** exp);
+  const dir = luminance(ink) >= luminance(ground) ? -1 : 1;
+  let best = ink;
+  for (let d = 0; d <= 1; d += 0.002) {
+    const next = { ...ink, l: clamp(ink.l + dir * d, 0, 1) };
+    if (contrast(next, ground) < target) break;
+    best = next;
+  }
+  return best;
+}
+
+/** Every custom property a theme writes. Exported because `applyTheme` has to be able to REMOVE the
+ *  full set when the user returns to `realm` — a switch that only overwrote would leave whichever
+ *  properties the new theme happened not to state pointing at the old one's values. */
+export const THEME_VARS = [
+  "--page", "--canvas", "--surface", "--inset", "--hover", "--hover-2", "--field", "--stripe-bg",
+  "--ink", "--ink-2", "--ink-3",
+  "--accent", "--accent-ink", "--accent-tint", "--rl-accent-contrast",
+  "--green", "--green-tint", "--orange", "--orange-tint", "--red", "--red-tint",
+  "--tooltip-bg", "--tooltip-fg", "--tooltip-muted", "--tooltip-border",
+  "--chart-surface",
+  "--syn-fg", "--syn-comment", "--syn-keyword", "--syn-string", "--syn-number",
+  "--syn-title", "--syn-type", "--syn-attr", "--syn-meta", "--syn-deleted",
+] as const;
+
+/** The palette a seed expands to: `THEME_VARS` → CSS colour. `themeVars` is pure and cheap enough to
+ *  call on every switch, which is why the derived palette is not precomputed into a stylesheet — a
+ *  generated CSS file would have to be regenerated, checked in, and then checked for staleness. */
+export function themeVars(name: ThemeName, mode: Mode): Record<string, string> {
+  const seed = seedFor(name, mode);
+  if (!seed) return {};
+  const r = mode === "dark" ? DARK : LIGHT;
+  const bg = hexToOklch(seed.bg);
+  const ink = hexToOklch(seed.ink);
+
+  const surf = (k: SurfaceStep): Oklch => step(bg, r.surfaces[k], r.chroma[k] ?? 0);
+  const surface = surf("surface");
+  /** The ground a tier has the least contrast against — its binding case, whichever step of the
+   *  ladder that turns out to be, so the derivation does not have to know that dark ramps climb and
+   *  light ramps sink. The tiers differ because the stylesheet's pairings do: `--ink-2` never lands
+   *  on `--hover-2` or `--field`, and `--ink-3` never leaves the resting surfaces. */
+  const worst = (steps: SurfaceStep[]): Oklch =>
+    [bg, ...steps.map(surf)].reduce((a, b) => (contrast(ink, a) <= contrast(ink, b) ? a : b));
+
+  /** A tint is the same hue as the colour it stands behind, at whatever strength that mode's grounds
+   *  can actually show. */
+  const tint = (o: Oklch): string =>
+    "alpha" in r.tint ? css(o, r.tint.alpha) : css({ l: r.tint.lightness, c: o.c * r.tint.chroma, h: o.h });
+
+  /** The label on an accent fill, and the fill it is legible on. Realm writes white on its accent in
+   *  both modes because its accent is a mid blue in both; a theme whose accent is Monokai's pink or
+   *  One Light's blue cannot keep that unchanged, so the pair is SOLVED rather than assumed: try the
+   *  theme's own ink and its own ground as the label, lift the fill away from each until the label
+   *  clears, and keep whichever needed the smaller move. A button is the one place in the app where
+   *  colour is load-bearing for reading a word. */
+  const seedAccent = hexToOklch(seed.accent);
+  const candidates = [ink, bg].map((label) => {
+    const fill = lift(seedAccent, label, CONTRAST_FLOOR.onAccent);
+    return { label, fill, moved: Math.abs(fill.l - seedAccent.l), ok: contrast(fill, surface) >= CONTRAST_FLOOR.chrome };
+  });
+  /* Both floors, not one. Lifting the fill to carry a dark label pushes it TOWARDS a light card, so
+   * satisfying the button can cost the accent its own legibility as a link or a focus ring on that
+   * card — which is exactly what Solarized Light does if the label is chosen on the button alone.
+   * Prefer a label that leaves both true; among those, the one that moved the stated hue least. */
+  const viable = candidates.filter((c) => c.ok);
+  const best = (viable.length ? viable : candidates).reduce((a, b) => (b.moved < a.moved ? b : a));
+  const accent = best.fill, onAccent = best.label;
+
+  /** The eight `--series-*` are a dataviz palette with a documented ΔE and contrast guarantee against
+   *  a ground of a specific lightness (tokens.css), so they are NOT themed — a hue swapped for taste
+   *  breaks a promise about colour-vision deficiency that has nothing to do with taste. What moves
+   *  instead is the ground: the Usage cards take a chart surface that carries the theme's hue but is
+   *  clamped back into the band the palette was validated in. Without the clamp every theme here
+   *  fails slot 6 (#008300 needs a ground at or below Realm's own #232427 to clear 3:1), which is a
+   *  property of the series, not of the themes. */
+  const chart = { ...surface, l: clamp(surface.l, r.chartL.min, r.chartL.max) };
+
+  const ink2 = inkStep(ink, worst(["canvas", "surface", "inset", "hover"]), r.ink2, CONTRAST_FLOOR.ink2);
+  const ink3 = inkStep(ink, worst(["canvas", "surface", "inset"]), r.ink3, CONTRAST_FLOOR.ink3);
+
+  /** Chrome and syntax are stated as hues and corrected as lightnesses. Every one of these lands on
+   *  `--surface` — semantic text and chips on a card, code inside `.md-code` — so that is the ground
+   *  they are held against. */
+  const onSurface = (hex: string, floor: number): string => css(lift(hexToOklch(hex), surface, floor));
+  const syn = (k: keyof SyntaxSeed): string => onSurface(seed.syntax[k], CONTRAST_FLOOR.syntax);
+  const semantic = (hex: string): Oklch => lift(hexToOklch(hex), surface, CONTRAST_FLOOR.chrome);
+  const [green, orange, red] = [semantic(seed.green), semantic(seed.orange), semantic(seed.red)];
+  const comment = syn("comment");
+
+  return {
+    "--page": css(bg),
+    "--canvas": css(surf("canvas")),
+    "--surface": css(surface),
+    "--inset": css(surf("inset")),
+    "--hover": css(surf("hover")),
+    "--hover-2": css(surf("hover-2")),
+    "--field": css(surf("field")),
+    "--stripe-bg": css(surf("stripe-bg")),
+
+    "--ink": css(ink),
+    "--ink-2": css(ink2),
+    "--ink-3": css(ink3),
+
+    "--accent": css(accent),
+    "--accent-ink": css(lift({ l: accent.l + (ink.l - accent.l) * r.accentInk.step, c: accent.c * r.accentInk.chroma, h: accent.h }, surface, CONTRAST_FLOOR.accentInk)),
+    "--accent-tint": tint(accent),
+    "--rl-accent-contrast": css(onAccent),
+
+    "--green": css(green),
+    "--green-tint": tint(green),
+    "--orange": css(orange),
+    "--orange-tint": tint(orange),
+    "--red": css(red),
+    "--red-tint": tint(red),
+
+    /* A tooltip is an inverted chip in light mode and a recessed one in dark — the shipped palette's
+     * own asymmetry, kept: in light mode the chip is the INK colour with the page written on it. */
+    "--tooltip-bg": mode === "dark" ? css(surf("tooltip-bg")) : css(step(ink, 0.025)),
+    "--tooltip-fg": mode === "dark" ? css(ink) : css(step(bg, -0.009)),
+    "--tooltip-muted": mode === "dark" ? css(ink2) : css({ l: 0.731, c: ink.c, h: ink.h }),
+    "--tooltip-border": mode === "dark" ? css(surf("tooltip-border")) : css(step(ink, 0.109)),
+
+    "--chart-surface": css(chart),
+
+    /* Syntax. `--syn-fg` is the ink ramp's second step rather than a seed: code body is body text,
+     * and every one of these palettes sets its editor foreground within a hair of where --ink-2
+     * already lands. `--syn-meta` shares the comment colour and `--syn-deleted` the red, exactly as
+     * the base mapping in tokens.css does. */
+    "--syn-fg": css(ink2),
+    "--syn-comment": comment,
+    "--syn-keyword": syn("keyword"),
+    "--syn-string": syn("string"),
+    "--syn-number": syn("number"),
+    "--syn-title": syn("title"),
+    "--syn-type": syn("type"),
+    "--syn-attr": syn("attr"),
+    "--syn-meta": comment,
+    "--syn-deleted": css(red),
+  };
+}
+
+const seedFor = (name: ThemeName, mode: Mode): ThemeSeed | null => {
+  const def = THEMES.find((t) => t.name === name);
+  return (mode === "dark" ? def?.dark : def?.light) ?? null;
+};
+
+/** Which modes a theme actually has a palette for. `realm` has both and states neither — it IS
+ *  tokens.css, whose two blocks the mode attribute already flips. */
+export function themeModes(name: ThemeName): Mode[] {
+  if (name === "realm") return ["dark", "light"];
+  const def = THEMES.find((t) => t.name === name);
+  return [...(def?.dark ? (["dark"] as const) : []), ...(def?.light ? (["light"] as const) : [])];
+}
+
+/** The composition rule for the two axes. A theme with one face pins the window to it; the MODE
+ *  PREFERENCE is untouched, so it comes back the moment a two-faced theme is chosen again. */
+export function resolveMode(name: ThemeName, mode: Mode): Mode {
+  const modes = themeModes(name);
+  return modes.includes(mode) ? mode : (modes[0] ?? mode);
+}
+
+/** Realm's own window, card, accent and string colours, copied from theme/tokens.css.
+ *  The picker cannot read them off the document: by the time it renders under any other theme the
+ *  live `var(--page)` is THAT theme's page, so a preview built from computed styles would draw every
+ *  card in the colours of whichever palette is already on. Copied, therefore, and pinned by a test
+ *  against the stylesheet so the copy cannot drift. */
+const REALM_SWATCHES: Record<Mode, [string, string, string, string]> = {
+  dark: ["oklch(0.209 0.004 264.477)", "oklch(0.26 0.006 271.191)", "oklch(0.68 0.173 253.301)", "oklch(0.705 0.154 153.814)"],
+  light: ["oklch(0.985 0.001 286.376)", "oklch(1 0 0)", "oklch(0.626 0.205 254.947)", "oklch(0.603 0.155 150.883)"],
+};
+
+/** The four colours a picker shows for a theme: the window, the card that floats on it, the accent,
+ *  and the one syntax hue that says most about a code palette. */
+export function themeSwatches(name: ThemeName, mode: Mode): [string, string, string, string] {
+  const v = themeVars(name, resolveMode(name, mode));
+  if (!v["--page"]) return REALM_SWATCHES[mode];
+  return [v["--page"]!, v["--surface"]!, v["--accent"]!, v["--syn-string"]!];
+}
+
+export function isThemeName(x: unknown): x is ThemeName {
+  return typeof x === "string" && THEMES.some((t) => t.name === x);
+}
+
+export const THEMES: readonly ThemeDef[] = [
+  {
+    name: "realm",
+    label: "Realm",
+    credit: null,
+    blurb: "The cool near-neutral palette Realm ships with.",
+    // No seeds: theme/tokens.css is this theme, and choosing it writes nothing.
+    dark: null,
+    light: null,
+  },
+  {
+    /* One — atom/one-dark-syntax and atom/one-light-syntax, MIT © GitHub Inc. Hex values read off
+     * those two packages' settings files. `ink` is the Atom ONE UI foreground (#d7dae0), not the
+     * syntax foreground (#abb2bf): --ink is chrome, and the ink ramp's second step lands on #abb2bf
+     * by itself, which is a fair check that the ramp is the right shape. */
+    name: "one",
+    label: "One",
+    credit: "Atom One Dark / One Light — MIT © GitHub, Inc.",
+    blurb: "Atom's One, in both of its faces.",
+    dark: {
+      bg: "#282c34", ink: "#d7dae0", accent: "#61afef",
+      green: "#98c379", orange: "#d19a66", red: "#e06c75",
+      syntax: { comment: "#7f848e", keyword: "#c678dd", string: "#98c379", number: "#d19a66", title: "#61afef", type: "#e5c07b", attr: "#56b6c2" },
+    },
+    light: {
+      bg: "#fafafa", ink: "#383a42", accent: "#4078f2",
+      green: "#50a14f", orange: "#986801", red: "#e45649",
+      syntax: { comment: "#8e8f96", keyword: "#a626a4", string: "#50a14f", number: "#986801", title: "#4078f2", type: "#c18401", attr: "#0184bc" },
+    },
+  },
+  {
+    /* Monokai — microsoft/vscode, extensions/theme-monokai (MIT © Microsoft), itself a port of
+     * Wimer Hazenberg's Monokai. Dark only, and honestly so: there is no upstream Monokai light. The
+     * seed choices worth naming, because Monokai does not map one-to-one onto seven roles — numbers
+     * take the violet (#ae81ff), attributes the same lime as function names, and the app accent is
+     * the signature pink even though that costs a dark button label rather than a white one. */
+    name: "monokai",
+    label: "Monokai",
+    credit: "Monokai — MIT © Microsoft (VS Code), after Wimer Hazenberg",
+    blurb: "The classic Monokai. Dark only.",
+    dark: {
+      bg: "#272822", ink: "#f8f8f2", accent: "#f92672",
+      green: "#a6e22e", orange: "#fd971f", red: "#f92672",
+      syntax: { comment: "#8f907e", keyword: "#f92672", string: "#e6db74", number: "#ae81ff", title: "#a6e22e", type: "#66d9ef", attr: "#a6e22e" },
+    },
+    light: null,
+  },
+];

--- a/packages/ui/src/themes.ts
+++ b/packages/ui/src/themes.ts
@@ -68,7 +68,7 @@ export type ThemeDef = {
   light: ThemeSeed | null;
 };
 
-export type ThemeName = "realm" | "one" | "monokai";
+export type ThemeName = "realm" | "one" | "monokai" | "dracula" | "nord" | "solarized" | "gruvbox";
 
 /* ── how a seed becomes a palette ──────────────────────────────────────────────
  * Every constant below was MEASURED off the shipped palette in theme/tokens.css, so a derived theme
@@ -414,5 +414,77 @@ export const THEMES: readonly ThemeDef[] = [
       syntax: { comment: "#8f907e", keyword: "#f92672", string: "#e6db74", number: "#ae81ff", title: "#a6e22e", type: "#66d9ef", attr: "#a6e22e" },
     },
     light: null,
+  },
+  {
+    /* Dracula — dracula/visual-studio-code, MIT © Dracula Theme. Dark only on purpose: Dracula's
+     * light counterpart (Alucard) ships with the paid Dracula PRO and is not ours to vendor. */
+    name: "dracula",
+    label: "Dracula",
+    credit: "Dracula — MIT © Dracula Theme",
+    blurb: "Dracula's purple night. Dark only.",
+    dark: {
+      bg: "#282a36", ink: "#f8f8f2", accent: "#bd93f9",
+      green: "#50fa7b", orange: "#ffb86c", red: "#ff5555",
+      syntax: { comment: "#7f8ec0", keyword: "#ff79c6", string: "#f1fa8c", number: "#bd93f9", title: "#50fa7b", type: "#8be9fd", attr: "#50fa7b" },
+    },
+    light: null,
+  },
+  {
+    /* Nord — arcticicestudio/nord, MIT © Sven Greb. Dark only: Nord is specified as one palette
+     * (Polar Night grounds, Snow Storm ink), and the "Nord Light" builds in the wild are community
+     * inversions rather than upstream. Comments are #616e88, the brightened value Nord's own
+     * editor ports moved to — nord3 (#4c566a) does not clear the contrast floor on nord0. */
+    name: "nord",
+    label: "Nord",
+    credit: "Nord — MIT © Sven Greb",
+    blurb: "Arctic blue-greys. Dark only.",
+    dark: {
+      bg: "#2e3440", ink: "#eceff4", accent: "#88c0d0",
+      green: "#a3be8c", orange: "#d08770", red: "#bf616a",
+      syntax: { comment: "#7c8aa5", keyword: "#81a1c1", string: "#a3be8c", number: "#b48ead", title: "#88c0d0", type: "#8fbcbb", attr: "#d8dee9" },
+    },
+    light: null,
+  },
+  {
+    /* Solarized — altercation/solarized, MIT © Ethan Schoonover. Both faces, which is the whole point
+     * of Solarized: one set of accent hues over two symmetric grounds.
+     * Two deviations from the reference, both forced by the contrast floor and both in the same
+     * direction — Solarized's own text tones are tuned for a code editor, not for UI chrome:
+     *   - `ink` is base2/base02 rather than base0/base00, so primary UI text clears 7:1.
+     *   - the LIGHT comment is #7a8a8a, one step down from base1 (#93a1a1), which reads 2.46:1 on
+     *     base3 and is the one value in this set that could not be vendored as written. */
+    name: "solarized",
+    label: "Solarized",
+    credit: "Solarized — MIT © Ethan Schoonover",
+    blurb: "Ethan Schoonover's symmetric pair.",
+    dark: {
+      bg: "#002b36", ink: "#eee8d5", accent: "#268bd2",
+      green: "#859900", orange: "#cb4b16", red: "#dc322f",
+      syntax: { comment: "#657b83", keyword: "#859900", string: "#2aa198", number: "#d33682", title: "#268bd2", type: "#b58900", attr: "#6c71c4" },
+    },
+    light: {
+      bg: "#fdf6e3", ink: "#073642", accent: "#268bd2",
+      green: "#859900", orange: "#cb4b16", red: "#dc322f",
+      syntax: { comment: "#7a8a8a", keyword: "#859900", string: "#2aa198", number: "#d33682", title: "#268bd2", type: "#b58900", attr: "#6c71c4" },
+    },
+  },
+  {
+    /* Gruvbox — morhetz/gruvbox, MIT © Pavel Pertsev. Both faces. Gruvbox paints strings and function
+     * names the same green upstream; here the title takes the yellow it uses for types, because two
+     * roles sharing one hue in a nine-token mapping loses a distinction the mapping exists to make. */
+    name: "gruvbox",
+    label: "Gruvbox",
+    credit: "Gruvbox — MIT © Pavel Pertsev",
+    blurb: "Warm retro contrast, light and dark.",
+    dark: {
+      bg: "#282828", ink: "#ebdbb2", accent: "#83a598",
+      green: "#b8bb26", orange: "#fe8019", red: "#fb4934",
+      syntax: { comment: "#a89984", keyword: "#fb4934", string: "#b8bb26", number: "#d3869b", title: "#fabd2f", type: "#8ec07c", attr: "#83a598" },
+    },
+    light: {
+      bg: "#fbf1c7", ink: "#3c3836", accent: "#076678",
+      green: "#79740e", orange: "#af3a03", red: "#9d0006",
+      syntax: { comment: "#7c6f64", keyword: "#9d0006", string: "#79740e", number: "#8f3f71", title: "#b57614", type: "#427b58", attr: "#076678" },
+    },
   },
 ];


### PR DESCRIPTION
Stacked on #26.

**A palette is a second axis, not a third mode.** `ui.theme` still records `system | light | dark`; a new `ui.themeName` records the palette, and `resolveMode` composes them at paint time. Picking Monokai pins the resolved mode — it has no light face, so the window stays dark — but never the preference, so choosing a two-faced palette afterwards finds "system" exactly where it was left. `realm` states no seeds at all: choosing it clears every inline property and the app is back on the static CSS it has always had.

**Twelve seeds per face, thirty-four properties derived.** A theme states `bg`, `ink`, `accent`, three semantics and seven syntax hues. The surface ladder, the ink ramp, all four tints, the tooltip chip, `--accent-ink`, the accent fill and its label, and `--chart-surface` are computed. The border ramp, the shadow stacks and the scrims are stated by nobody: Tembo's overlays are alpha over whatever ground they land on, so they follow a repainted surface for free. That property is what keeps the seed set at twelve rather than eighty-five.

**Syntax is half the point.** `.hljs-*` was painted straight out of the chrome palette, so a naive theme would have left Monokai's keywords Realm blue. It now goes through ten named roles defined against exactly the ramps the old block wrote inline, so the default theme highlights byte-identically — pinned by a test. The terminal is deliberately excluded: xterm parses `--rl-terminal-bg` once at hub creation, so a themed terminal would only be correct for hubs opened after a switch, and a half-applied theme is worse than an unthemed one.

**Contrast is constructed, not hoped for.** WCAG per role rather than Realm's own headroom, since holding a vendored palette to 12.8:1 would repaint it into something that is no longer that palette. Stated hues are corrected along lightness only, inside a 0.12 budget, so a fix can never desaturate a vendored colour into something else.

Every dark palette here is lighter than the `#232427` the eight chart series were validated against, and slot 6 drops under 3:1 on all of them. The series are untouched — their ΔE guarantee under simulated protanopia is not a mood — so the **ground** moves instead: `--chart-surface` carries the theme's hue at a lightness clamped back into the validated band.

**A review pass found three real defects**, all fixed. The dark ink exponents were `0.66/0.37` when the shipped palette actually sits at `0.700/0.427`, so every dark theme's secondary text was a step dimmer than the ramp it claimed to reproduce. Two light-ramp entries were dead. And a comment described the tint as an 8% wash when the alpha is 15%.

The durable fix is the guardrail: `d3d8a9b` reads the seeds back out of `tokens.css`, runs them through the same derivation every theme uses, and requires the ladder that comes back to *be* `tokens.css`. Nothing else in the suite could have noticed a drifted ramp, because the contrast floors are about legibility and a ramp is about shape — a theme can stop being the same system as the palette beside it while clearing every floor.

**Six seeds had been hand-brightened off their published values, and two of those needed no correction at all.** All six are back to what upstream ships, with `lift` doing the work — which is the point, since hand-tuning a seed routes around the very budget that is supposed to fail loudly. Nord's spec value is the one case the budget refuses, and there is now a test pinning that refusal.

**Transparency: the sidebar, and it stops there.** Range 55–100, default 82 — the shipped number, now living in exactly one place. Panes stay opaque deliberately: at any setting where a pane looked translucent its text falls below the same 4.5:1 floor the themes are held to. No IPC and no `setVibrancy()` — the material is always on under the window and at 100% the sidebar simply covers it, so CSS alone was sufficient. That is also what lets `prefers-reduced-transparency` win, since an inline custom property beats every media query. Off macOS the control renders disabled and names the platform, and an unknown platform answers "no material" rather than guessing.

The 55 floor came from looking at a screenshot, because it could not come from anywhere else: macOS composites the material *below* the web contents, so a CDP capture never sees it. That limitation is in the script header.

17 mutants verified red. One is documented as unreachable: no test can know what a vendor published, so "this hex is what Nord ships" is enforced by review rather than by the suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)