### PR TITLE
Popovers leave the way they arrived, disclosures unfold, and icon buttons get one way to change state

### DIFF
--- a/apps/desktop/scripts/disclosure-live.mjs
+++ b/apps/desktop/scripts/disclosure-live.mjs
@@ -1,0 +1,227 @@
+/**
+ * Live check for the sidebar's archived shelf (run with: node apps/desktop/scripts/disclosure-live.mjs)
+ *
+ * The shelf now unfolds on the tool row's `grid-template-rows: 0fr → 1fr`, which is a claim about
+ * layout and nothing else — and jsdom has no layout, so every part of it is invisible to the suite:
+ *
+ *   1. Folded really is ZERO. `0fr` only collapses if the row's content clips against an overflow
+ *      container AND nothing in the chain refuses to shrink; one `min-height: auto` anywhere and the
+ *      shelf sits permanently open at full height with a caret that lies about it. The sidebar is a
+ *      flex column, which is exactly where that goes wrong.
+ *   2. Open is the content's OWN height — `1fr` resolving to the rows' natural size, not to a
+ *      guessed maximum that clips a long list or leaves a short one padded.
+ *   3. The rows stay mounted while folded, so both directions animate, and a mounted-but-folded row
+ *      must be unreachable: no tab stop, no hit target, nothing a screen reader can find. That is
+ *      the cost of keeping them in the DOM and the only thing that makes it acceptable.
+ *   4. It is animating at all — a transition on a property the browser cannot interpolate would look
+ *      identical to a snap in every jsdom assertion.
+ *
+ * Each measurement is paired with a mutant that reproduces the bug it pins.
+ *
+ * Ports: env-overridable. Touches only a scratch dir; kills only the process it started.
+ */
+import { spawn } from "node:child_process";
+import { connect } from "node:net";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
+const CDP_PORT = Number(process.env.LIVE_CDP_PORT ?? 9342), SERVER_PORT = Number(process.env.LIVE_SERVER_PORT ?? 8908);
+const scratch = fs.mkdtempSync(path.join(os.tmpdir(), "realm-disclosure-"));
+let electron = null;
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+async function portFree(port) {
+  return new Promise((resolve) => {
+    const s = connect({ port, host: "127.0.0.1" });
+    s.once("connect", () => { s.destroy(); resolve(false); });
+    s.once("error", () => resolve(true));
+  });
+}
+
+async function until(fn, ms, tag) {
+  const t0 = Date.now();
+  for (;;) {
+    const v = await fn();
+    if (v) return v;
+    if (Date.now() - t0 > ms) throw new Error(`timeout:${tag}`);
+    await sleep(150);
+  }
+}
+
+function cdp(wsUrl) {
+  const ws = new WebSocket(wsUrl);
+  let id = 0;
+  const pending = new Map();
+  const events = [];
+  const ready = new Promise((res) => ws.addEventListener("open", res));
+  ws.addEventListener("message", (m) => {
+    const msg = JSON.parse(m.data);
+    if (msg.id !== undefined) pending.get(msg.id)?.(msg);
+    else if (msg.method === "Runtime.consoleAPICalled" && msg.params.type === "error") {
+      events.push(msg.params.args.map((a) => a.value ?? a.description ?? "").join(" "));
+    }
+  });
+  return {
+    ready, events,
+    send: (method, params) => new Promise((res, rej) => {
+      const i = ++id;
+      pending.set(i, (msg) => (msg.error ? rej(new Error(msg.error.message)) : res(msg.result)));
+      ws.send(JSON.stringify({ id: i, method, params }));
+    }),
+    close: () => ws.close(),
+  };
+}
+
+async function evalIn(c, expr) {
+  const r = await c.send("Runtime.evaluate", { expression: expr, awaitPromise: true, returnByValue: true });
+  if (r.exceptionDetails) throw new Error(`page exception: ${r.exceptionDetails.exception?.description ?? r.exceptionDetails.text}`);
+  return r.result.value;
+}
+
+/** `scrollHeight` is an integer ceiling and a border box is fractional, so the two readings of one
+ *  height differ by up to a pixel. The claim is "the same height", not "the same number". */
+const sameHeight = (a, b) => Math.abs(a - b) <= 1;
+
+const check = (name, cond, detail) => {
+  if (!cond) process.exitCode = 1;
+  console.log(`${cond ? "PASS" : "FAIL"} ${name}${detail !== undefined ? " " + JSON.stringify(detail) : ""}`);
+};
+
+/** The shelf's measured state. `rows` is what `1fr` has to resolve to; `hit` is what a click at the
+ *  first archived row's centre actually lands on, which is the only honest read on "unreachable". */
+const SHELF = `(() => {
+  const wrap = document.querySelector('.archived-wrap');
+  if (!wrap) return null;
+  const row = wrap.querySelector('.item-row');
+  const r = row?.getBoundingClientRect();
+  const hit = r && r.width > 0 ? document.elementFromPoint(Math.round(r.x + r.width / 2), Math.round(r.y + r.height / 2)) : null;
+  return {
+    open: wrap.hasAttribute('data-open'),
+    wrapH: Math.round(wrap.getBoundingClientRect().height),
+    rowsH: Math.round(wrap.querySelector('.archived-clip > *')?.scrollHeight ?? -1),
+    rowCount: wrap.querySelectorAll('.item-row').length,
+    tabbable: [...wrap.querySelectorAll('button, a, input')].some((e) => e.tabIndex >= 0 && !e.closest('[inert]')),
+    reachable: !!(hit && wrap.contains(hit)),
+    transitions: wrap.getAnimations().map((a) => a.transitionProperty ?? a.animationName),
+  };
+})()`;
+
+async function main() {
+  for (const p of [CDP_PORT, SERVER_PORT]) {
+    if (!(await portFree(p))) throw new Error(`port ${p} is in use — refusing to run`);
+  }
+
+  const wrapper = path.join(scratch, "wrapper.mjs");
+  fs.writeFileSync(wrapper, [
+    'import { app } from "electron";',
+    'app.setPath("userData", process.env.LIVE_USER_DATA);',
+    "await import(process.env.LIVE_MAIN);",
+  ].join("\n"));
+  const electronBin = process.platform === "darwin"
+    ? path.join(repoRoot, "node_modules/.pnpm/electron@37.10.3/node_modules/electron/dist/Electron.app/Contents/MacOS/Electron")
+    : path.join(repoRoot, "apps/desktop/node_modules/.bin/electron");
+  electron = spawn(electronBin, [wrapper], {
+    env: {
+      ...process.env,
+      REALM_HOME: path.join(scratch, "home"),
+      REALM_ENABLE_FAKE_AGENT: "1",
+      REALM_PORT: String(SERVER_PORT),
+      REALM_DEVTOOLS_PORT: String(CDP_PORT),
+      REALM_SERVER_ENTRY: path.join(repoRoot, "apps/server/dist/main.js"),
+      LIVE_USER_DATA: path.join(scratch, "userData"),
+      LIVE_MAIN: path.join(repoRoot, "apps/desktop/out/main/index.js"),
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  electron.stderr.on("data", () => {}); electron.stdout.on("data", () => {});
+
+  const targets = () => fetch(`http://127.0.0.1:${CDP_PORT}/json/list`).then((r) => r.json()).catch(() => []);
+  const rendererTarget = await until(async () => (await targets()).find((t) => t.type === "page" && t.url.startsWith("file://")), 30000, "renderer target");
+  const c = cdp(rendererTarget.webSocketDebuggerUrl);
+  await c.ready;
+  await c.send("Runtime.enable");
+  await c.send("Page.enable");
+
+  await until(() => evalIn(c, `!!document.querySelector('.onboarding input:not([type=radio])')`), 20000, "onboarding");
+  await evalIn(c, `(() => {
+    const input = document.querySelector('.onboarding input:not([type=radio])');
+    const set = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value').set;
+    set.call(input, 'Live'); input.dispatchEvent(new Event('input', { bubbles: true }));
+    input.closest('form').requestSubmit();
+    return true; })()`);
+  await until(() => evalIn(c, `!!document.querySelector('.composer')`), 20000, "composer");
+  await c.send("Emulation.setDeviceMetricsOverride", { width: 1200, height: 820, deviceScaleFactor: 1, mobile: false });
+  await sleep(400);
+
+  // Two sessions, one shelved: the shelf only exists when something is on it, and one row left in
+  // the space above it keeps the sidebar's own scroll out of the measurement.
+  await evalIn(c, `(() => { document.querySelector('.new-row').click(); return true; })()`);
+  await until(() => evalIn(c, `document.querySelectorAll('.item-list .item-row').length >= 2`), 15000, "two sessions");
+  await evalIn(c, `(() => {
+    const row = document.querySelector('.item-list .item-row');
+    row.dispatchEvent(new MouseEvent('contextmenu', { bubbles: true, clientX: 100, clientY: 300 }));
+    return true; })()`);
+  await evalIn(c, `(() => {
+    const it = [...document.querySelectorAll('[role="menuitem"]')].find((m) => m.textContent.trim() === 'Archive');
+    it.click(); return true; })()`);
+  const toggle = await until(() => evalIn(c, `!!document.querySelector('.archived-toggle')`), 15000, "the archived shelf's heading");
+  check("archiving puts the row on a shelf that appears only because something is on it", toggle === true);
+
+  /* ── 1. Before it has ever been opened, the shelf costs nothing ───────────────────────────── */
+  check("an unopened shelf builds no rows at all", (await evalIn(c, SHELF)) === null);
+
+  /* ── 2. Open: the wrap takes the rows' own height ─────────────────────────────────────────── */
+  await evalIn(c, `(() => { document.querySelector('.archived-toggle').click(); return true; })()`);
+  await sleep(400); // longer than --dur-base, so this is the settled height
+  const open = await evalIn(c, SHELF);
+  check("open, the shelf is exactly as tall as its rows — 1fr, not a guessed maximum",
+    open.open === true && open.rowCount === 1 && sameHeight(open.wrapH, open.rowsH) && open.wrapH > 20, open);
+  check("and an open row is reachable by pointer and by tab", open.reachable === true && open.tabbable === true, open);
+
+  /* ── 3. Folded: zero height, rows still mounted, nothing reachable ────────────────────────── */
+  await evalIn(c, `(() => { document.querySelector('.archived-toggle').click(); return true; })()`);
+  const during = await evalIn(c, SHELF);
+  // The whole point of `grid-template-rows`: the browser interpolates it, so a real transition is
+  // running on the way down. A property it could not interpolate would jump and look identical to
+  // this in every other assertion.
+  check("folding it back animates rather than snaps — grid-template-rows is mid-transition",
+    during.transitions.some((t) => String(t).includes("grid-template-rows")), during.transitions);
+  await sleep(400);
+  const folded = await evalIn(c, SHELF);
+  check("MUTANT-CATCHER: folded really is ZERO — no min-height in the sidebar's flex column props it open",
+    folded.wrapH === 0, folded);
+  check("the rows stayed in the DOM, so both directions animate", folded.rowCount === 1, folded);
+  check("…and a folded row is unreachable: no tab stop, no hit target",
+    folded.tabbable === false && folded.reachable === false, folded);
+  // Without this the two checks above would pass on a shelf that had simply unmounted its rows.
+  check("MUTANT: the rows are genuinely there to be unreachable, not merely gone",
+    (await evalIn(c, `document.querySelectorAll('.archived-clip .item-row').length`)) === 1);
+
+  const sidebar = await c.send("Page.captureScreenshot", { format: "png", clip: { x: 0, y: 0, width: 280, height: 820, scale: 2 } });
+  const out = path.join(os.tmpdir(), "realm-disclosure-folded.png");
+  fs.writeFileSync(out, Buffer.from(sidebar.data, "base64"));
+  console.log(`SCREENSHOT folded ${out}`);
+
+  /* ── 4. Reduced motion folds it instantly, and still to zero ──────────────────────────────── */
+  await c.send("Emulation.setEmulatedMedia", { features: [{ name: "prefers-reduced-motion", value: "reduce" }] });
+  await evalIn(c, `(() => { document.querySelector('.archived-toggle').click(); return true; })()`);
+  await sleep(60); // well inside --dur-base: with the preference on, the shelf is already all the way open
+  const reduced = await evalIn(c, SHELF);
+  check("under reduced motion the shelf is open at full height immediately, with no transition running",
+    sameHeight(reduced.wrapH, reduced.rowsH) && reduced.wrapH > 20 && reduced.transitions.length === 0, reduced);
+  await c.send("Emulation.setEmulatedMedia", { features: [] });
+
+  const errs = c.events.filter((e) => !e.includes("Autofill"));
+  check("no renderer console errors", errs.length === 0, errs.slice(0, 5));
+  c.close();
+}
+
+main()
+  .catch((e) => { console.error("ERROR", e.message); process.exitCode = 1; })
+  .finally(() => {
+    electron?.kill("SIGTERM");
+    setTimeout(() => { electron?.kill("SIGKILL"); fs.rmSync(scratch, { recursive: true, force: true }); process.exit(process.exitCode ?? 0); }, 1200);
+  });

--- a/apps/desktop/scripts/icon-state-live.mjs
+++ b/apps/desktop/scripts/icon-state-live.mjs
@@ -1,0 +1,245 @@
+/**
+ * Live check for what an icon button does when its STATE changes
+ * (run with: node apps/desktop/scripts/icon-state-live.mjs)
+ *
+ * Two claims, neither of which the suite can reach — styles.test.ts reads the stylesheet as text, so
+ * it can say a rule exists but never that it wins, resolves, or interpolates:
+ *
+ *   1. `.icon-btn[aria-pressed="true"]` actually PAINTS. It is declared after `.icon-btn:hover` at
+ *      the same specificity and deliberately overrides it, which is a cascade outcome rather than a
+ *      declaration — and `var(--hover-2)` has to resolve to a fill the eye can tell from both the
+ *      resting button and the hovered one, in whichever mode the app booted into.
+ *   2. The icon swap CROSS-FADES. Both glyphs are in the DOM at once and the one that is down is
+ *      scaled and blurred to nothing; the whole point is that the middle of the swap has two
+ *      partly-visible glyphs rather than one being replaced by the other. Only a real animation
+ *      clock has a middle. The send↔stop morph is the instance under test because it is reachable
+ *      without an agent; `.icon-swap` and the copy tick are the same two rules.
+ *
+ * Each measurement is paired with a mutant that reproduces the bug it pins.
+ *
+ * Ports: env-overridable. Touches only a scratch dir; kills only the process it started.
+ */
+import { spawn } from "node:child_process";
+import { connect } from "node:net";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
+const CDP_PORT = Number(process.env.LIVE_CDP_PORT ?? 9343), SERVER_PORT = Number(process.env.LIVE_SERVER_PORT ?? 8909);
+const scratch = fs.mkdtempSync(path.join(os.tmpdir(), "realm-icon-state-"));
+let electron = null;
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+async function portFree(port) {
+  return new Promise((resolve) => {
+    const s = connect({ port, host: "127.0.0.1" });
+    s.once("connect", () => { s.destroy(); resolve(false); });
+    s.once("error", () => resolve(true));
+  });
+}
+
+async function until(fn, ms, tag) {
+  const t0 = Date.now();
+  for (;;) {
+    const v = await fn();
+    if (v) return v;
+    if (Date.now() - t0 > ms) throw new Error(`timeout:${tag}`);
+    await sleep(150);
+  }
+}
+
+function cdp(wsUrl) {
+  const ws = new WebSocket(wsUrl);
+  let id = 0;
+  const pending = new Map();
+  const events = [];
+  const ready = new Promise((res) => ws.addEventListener("open", res));
+  ws.addEventListener("message", (m) => {
+    const msg = JSON.parse(m.data);
+    if (msg.id !== undefined) pending.get(msg.id)?.(msg);
+    else if (msg.method === "Runtime.consoleAPICalled" && msg.params.type === "error") {
+      events.push(msg.params.args.map((a) => a.value ?? a.description ?? "").join(" "));
+    }
+  });
+  return {
+    ready, events,
+    send: (method, params) => new Promise((res, rej) => {
+      const i = ++id;
+      pending.set(i, (msg) => (msg.error ? rej(new Error(msg.error.message)) : res(msg.result)));
+      ws.send(JSON.stringify({ id: i, method, params }));
+    }),
+    close: () => ws.close(),
+  };
+}
+
+async function evalIn(c, expr) {
+  const r = await c.send("Runtime.evaluate", { expression: expr, awaitPromise: true, returnByValue: true });
+  if (r.exceptionDetails) throw new Error(`page exception: ${r.exceptionDetails.exception?.description ?? r.exceptionDetails.text}`);
+  return r.result.value;
+}
+
+const check = (name, cond, detail) => {
+  if (!cond) process.exitCode = 1;
+  console.log(`${cond ? "PASS" : "FAIL"} ${name}${detail !== undefined ? " " + JSON.stringify(detail) : ""}`);
+};
+
+/** A computed colour reduced to its channels, so two fills can be compared rather than two strings.
+ *  Only ever used to compare readings the SAME engine produced for the same property — the app
+ *  authors in oklch and mixes in sRGB, and a token read raw comes back in whichever space it was
+ *  written in, which would make a cross-space comparison meaningless. A fully transparent colour
+ *  reads as `null`: "no fill", whatever channels sit behind the zero alpha. */
+const RGBA = `((s) => { const m = String(s).match(/[\\d.]+/g); if (!m) return null;
+  const a = m.length > 3 ? Number(m[3]) : 1;
+  return a === 0 ? null : { r: +m[0], g: +m[1], b: +m[2], a }; })`;
+
+async function main() {
+  for (const p of [CDP_PORT, SERVER_PORT]) {
+    if (!(await portFree(p))) throw new Error(`port ${p} is in use — refusing to run`);
+  }
+
+  const wrapper = path.join(scratch, "wrapper.mjs");
+  fs.writeFileSync(wrapper, [
+    'import { app } from "electron";',
+    'app.setPath("userData", process.env.LIVE_USER_DATA);',
+    "await import(process.env.LIVE_MAIN);",
+  ].join("\n"));
+  const electronBin = process.platform === "darwin"
+    ? path.join(repoRoot, "node_modules/.pnpm/electron@37.10.3/node_modules/electron/dist/Electron.app/Contents/MacOS/Electron")
+    : path.join(repoRoot, "apps/desktop/node_modules/.bin/electron");
+  electron = spawn(electronBin, [wrapper], {
+    env: {
+      ...process.env,
+      REALM_HOME: path.join(scratch, "home"),
+      REALM_ENABLE_FAKE_AGENT: "1",
+      REALM_PORT: String(SERVER_PORT),
+      REALM_DEVTOOLS_PORT: String(CDP_PORT),
+      REALM_SERVER_ENTRY: path.join(repoRoot, "apps/server/dist/main.js"),
+      LIVE_USER_DATA: path.join(scratch, "userData"),
+      LIVE_MAIN: path.join(repoRoot, "apps/desktop/out/main/index.js"),
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  electron.stderr.on("data", () => {}); electron.stdout.on("data", () => {});
+
+  const targets = () => fetch(`http://127.0.0.1:${CDP_PORT}/json/list`).then((r) => r.json()).catch(() => []);
+  const rendererTarget = await until(async () => (await targets()).find((t) => t.type === "page" && t.url.startsWith("file://")), 30000, "renderer target");
+  const c = cdp(rendererTarget.webSocketDebuggerUrl);
+  await c.ready;
+  await c.send("Runtime.enable");
+  await c.send("Page.enable");
+
+  await until(() => evalIn(c, `!!document.querySelector('.onboarding input:not([type=radio])')`), 20000, "onboarding");
+  await evalIn(c, `(() => {
+    const input = document.querySelector('.onboarding input:not([type=radio])');
+    const set = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value').set;
+    set.call(input, 'Live'); input.dispatchEvent(new Event('input', { bubbles: true }));
+    input.closest('form').requestSubmit();
+    return true; })()`);
+  await until(() => evalIn(c, `!!document.querySelector('.composer')`), 20000, "composer");
+  await c.send("Emulation.setDeviceMetricsOverride", { width: 1200, height: 820, deviceScaleFactor: 1, mobile: false });
+  await sleep(400);
+
+  /* ── 1. A pressed icon button paints, and paints past hover ───────────────────────────────── */
+  // The terminal drawer's ⌘J is the reachable instance; the rich-text toolbar's Bold is the same
+  // selector. Its rect is taken before the click, because toggling the drawer moves the bar.
+  const TOGGLE = '.panel-bar .icon-btn[aria-pressed]';
+  await until(() => evalIn(c, `!!document.querySelector(${JSON.stringify(TOGGLE)})`), 15000, "an aria-pressed icon button");
+  const fills = await evalIn(c, `(async () => {
+    const rgba = ${RGBA};
+    const el = document.querySelector(${JSON.stringify(TOGGLE)});
+    const bg = () => rgba(getComputedStyle(el).backgroundColor);
+    const rest = bg();
+    el.dispatchEvent(new PointerEvent('pointerover', { bubbles: true }));
+    el.click();
+    await new Promise((r) => setTimeout(r, 250)); // past --dur-hover, so this is the settled fill
+    return { pressed: el.getAttribute('aria-pressed'), rest, on: bg() };
+  })()`);
+  check("a pressed icon button takes a fill it does not have at rest",
+    fills.pressed === "true" && fills.rest === null && fills.on !== null, fills);
+  // The mutant this closes is the one the app shipped with: no rule at all, so the two are identical.
+  check("MUTANT-CATCHER: on and rest are genuinely different colours, not the same one twice",
+    fills.on && (fills.rest === null || fills.on.r !== fills.rest.r), fills);
+
+  /* ── 2. The hover fill and the on fill are different pictures ─────────────────────────────── */
+  // "On" sits one rung past hover on purpose: if the two resolved to the same colour, a hovered
+  // button would be indistinguishable from a pressed one and the state would be unreadable exactly
+  // while you point at it. Both are put through the same computed `background-color` — the app mixes
+  // one in sRGB and writes the other in oklch, so comparing the raw token values would report a
+  // difference no matter what they painted.
+  const rungs = await evalIn(c, `(() => {
+    const probe = document.createElement('span');
+    document.body.appendChild(probe);
+    const resolved = (token) => {
+      probe.style.backgroundColor = getComputedStyle(document.documentElement).getPropertyValue(token).trim();
+      return getComputedStyle(probe).backgroundColor;
+    };
+    const hover = resolved('--rl-hover');
+    probe.remove();
+    return { hover, on: getComputedStyle(document.querySelector(${JSON.stringify(TOGGLE)})).backgroundColor };
+  })()`);
+  check("the on fill is a step past the hover fill, not the same one",
+    !!rungs.hover && rungs.hover !== "rgba(0, 0, 0, 0)" && rungs.hover !== rungs.on, rungs);
+
+  /* ── 3. The icon swap has a middle ────────────────────────────────────────────────────────── */
+  // Both glyphs live in the send button at all times; `data-state` picks which is up. Driving the
+  // attribute directly rather than running an agent: the claim under test is the shared rule, not
+  // when the composer sets the state.
+  const swap = await evalIn(c, `(async () => {
+    const btn = document.querySelector('.composer-send');
+    const read = () => ['.send-icon', '.stop-icon'].map((s) => {
+      const cs = getComputedStyle(btn.querySelector(s));
+      return { opacity: Number(cs.opacity), transform: cs.transform, filter: cs.filter };
+    });
+    const before = read();
+    btn.setAttribute('data-state', 'stop');
+    await new Promise((r) => setTimeout(r, 70)); // ~halfway through --dur-swap
+    const during = read();
+    await new Promise((r) => setTimeout(r, 300));
+    const after = read();
+    btn.setAttribute('data-state', 'send');
+    return { present: btn.querySelectorAll('svg').length, before, during, after };
+  })()`);
+  check("both glyphs are in the button at once — the swap is a state, not a replacement",
+    swap.present === 2, { svgs: swap.present });
+  check("at rest exactly one glyph is up, and the other is scaled and blurred away",
+    swap.before[0].opacity === 1 && swap.before[1].opacity === 0
+      && swap.before[1].filter.includes("blur") && swap.before[1].transform !== "none", swap.before);
+  // The whole claim: a middle exists. A hard swap would read 1/0 here and be indistinguishable from
+  // a cross-fade in every jsdom assertion there is.
+  check("MUTANT-CATCHER: halfway through, BOTH glyphs are partly visible — it cross-fades",
+    swap.during[0].opacity < 1 && swap.during[0].opacity > 0
+      && swap.during[1].opacity < 1 && swap.during[1].opacity > 0, swap.during);
+  check("and it lands the other way up", swap.after[0].opacity === 0 && swap.after[1].opacity === 1, swap.after);
+
+  /* ── 4. Reduced motion keeps both readings, and takes only the tween ──────────────────────── */
+  await c.send("Emulation.setEmulatedMedia", { features: [{ name: "prefers-reduced-motion", value: "reduce" }] });
+  const reduced = await evalIn(c, `(async () => {
+    const btn = document.querySelector('.composer-send');
+    btn.setAttribute('data-state', 'stop');
+    await new Promise((r) => setTimeout(r, 40)); // well inside --dur-swap
+    const cs = ['.send-icon', '.stop-icon'].map((s) => Number(getComputedStyle(btn.querySelector(s)).opacity));
+    btn.setAttribute('data-state', 'send');
+    return cs;
+  })()`);
+  check("under reduced motion the swap is instant but still a swap — the right glyph, no middle",
+    reduced[0] === 0 && reduced[1] === 1, reduced);
+  await c.send("Emulation.setEmulatedMedia", { features: [] });
+
+  const bar = await c.send("Page.captureScreenshot", { format: "png", clip: { x: 280, y: 0, width: 920, height: 56, scale: 3 } });
+  const out = path.join(os.tmpdir(), "realm-icon-state.png");
+  fs.writeFileSync(out, Buffer.from(bar.data, "base64"));
+  console.log(`SCREENSHOT pane bar, terminal toggle pressed ${out}`);
+
+  const errs = c.events.filter((e) => !e.includes("Autofill"));
+  check("no renderer console errors", errs.length === 0, errs.slice(0, 5));
+  c.close();
+}
+
+main()
+  .catch((e) => { console.error("ERROR", e.message); process.exitCode = 1; })
+  .finally(() => {
+    electron?.kill("SIGTERM");
+    setTimeout(() => { electron?.kill("SIGKILL"); fs.rmSync(scratch, { recursive: true, force: true }); process.exit(process.exitCode ?? 0); }, 1200);
+  });

--- a/apps/desktop/scripts/popover-exit-live.mjs
+++ b/apps/desktop/scripts/popover-exit-live.mjs
@@ -1,0 +1,295 @@
+/**
+ * Live check for §6's popover exit (run with: node apps/desktop/scripts/popover-exit-live.mjs)
+ *
+ * Boots the REAL app on a scratch REALM_HOME and proves the things an exit animation can only be
+ * wrong about at runtime. jsdom can see that `data-closing` is set and that the node eventually
+ * goes; it cannot see any of these:
+ *
+ *   1. The exit actually RUNS. `rl-menu-out` is a compositor animation on a portalled node — jsdom
+ *      has no animation clock, so only `getAnimations()` on a real document can say the fade is
+ *      playing rather than the mark being set over nothing.
+ *   2. A closing menu is not in the way. It is still painted, so the question is whether the app
+ *      behind it can be reached: `elementFromPoint` through the middle of the fading surface has to
+ *      land on the app, not on the menu. jsdom has no hit-testing at all.
+ *   3. It is FROZEN where it was dismissed. The hook stops re-placing the moment the exit starts;
+ *      a surface that re-measured mid-fade — against an anchor its own action had moved, or against
+ *      no anchor at all — falls back to the window margin and fades from the wrong place. jsdom
+ *      reports every rect as zero, so only a real window can tell "did not move" from "never had a
+ *      position".
+ *   4. Nothing leaks. The failure mode this whole feature risks is a popover that stays in the DOM
+ *      after it has finished going: invisible in a screenshot, and fatal to everything under it.
+ *      Checked after a settle AND across ten open/close cycles faster than the exit runs.
+ *   5. prefers-reduced-motion skips the exit rather than running it invisibly. The global
+ *      `animation: none !important` would otherwise leave a fully painted, inert menu sitting there
+ *      for the length of an exit nobody asked to see — the opposite of the preference.
+ *
+ * Each measurement is paired with a mutant that reproduces the bug it pins, so a check that has
+ * quietly stopped measuring anything fails instead of passing.
+ *
+ * Ports: env-overridable. Touches only a scratch dir; kills only the process it started.
+ */
+import { spawn } from "node:child_process";
+import { connect } from "node:net";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
+const CDP_PORT = Number(process.env.LIVE_CDP_PORT ?? 9341), SERVER_PORT = Number(process.env.LIVE_SERVER_PORT ?? 8907);
+const scratch = fs.mkdtempSync(path.join(os.tmpdir(), "realm-popover-exit-"));
+let electron = null;
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+async function portFree(port) {
+  return new Promise((resolve) => {
+    const s = connect({ port, host: "127.0.0.1" });
+    s.once("connect", () => { s.destroy(); resolve(false); });
+    s.once("error", () => resolve(true));
+  });
+}
+
+async function until(fn, ms, tag) {
+  const t0 = Date.now();
+  for (;;) {
+    const v = await fn();
+    if (v) return v;
+    if (Date.now() - t0 > ms) throw new Error(`timeout:${tag}`);
+    await sleep(150);
+  }
+}
+
+function cdp(wsUrl) {
+  const ws = new WebSocket(wsUrl);
+  let id = 0;
+  const pending = new Map();
+  const events = [];
+  const ready = new Promise((res) => ws.addEventListener("open", res));
+  ws.addEventListener("message", (m) => {
+    const msg = JSON.parse(m.data);
+    if (msg.id !== undefined) pending.get(msg.id)?.(msg);
+    else if (msg.method === "Runtime.consoleAPICalled" && msg.params.type === "error") {
+      events.push(msg.params.args.map((a) => a.value ?? a.description ?? "").join(" "));
+    }
+  });
+  return {
+    ready, events,
+    send: (method, params) => new Promise((res, rej) => {
+      const i = ++id;
+      pending.set(i, (msg) => (msg.error ? rej(new Error(msg.error.message)) : res(msg.result)));
+      ws.send(JSON.stringify({ id: i, method, params }));
+    }),
+    close: () => ws.close(),
+  };
+}
+
+async function evalIn(c, expr) {
+  const r = await c.send("Runtime.evaluate", { expression: expr, awaitPromise: true, returnByValue: true });
+  if (r.exceptionDetails) throw new Error(`page exception: ${r.exceptionDetails.exception?.description ?? r.exceptionDetails.text}`);
+  return r.result.value;
+}
+
+const check = (name, cond, detail) => {
+  if (!cond) process.exitCode = 1;
+  console.log(`${cond ? "PASS" : "FAIL"} ${name}${detail !== undefined ? " " + JSON.stringify(detail) : ""}`);
+};
+
+/** A real press, not `element.click()`. The whole dismissal model turns on pointerdown arriving
+ *  before click — the hook commits a running exit on the first and the trigger reopens on the
+ *  second — so a synthetic click would exercise a sequence no pointer can produce. */
+async function press(c, selector) {
+  const box = await evalIn(c, `(() => {
+    const el = document.querySelector(${JSON.stringify(selector)});
+    if (!el) return null;
+    const r = el.getBoundingClientRect();
+    return { x: Math.round(r.x + r.width / 2), y: Math.round(r.y + r.height / 2) };
+  })()`);
+  if (!box) throw new Error(`no element for ${selector}`);
+  for (const type of ["mousePressed", "mouseReleased"]) {
+    await c.send("Input.dispatchMouseEvent", { type, x: box.x, y: box.y, button: "left", clickCount: 1 });
+  }
+  return box;
+}
+
+const escape = (c) => c.send("Input.dispatchKeyEvent", { type: "keyDown", key: "Escape", code: "Escape", windowsVirtualKeyCode: 27 });
+
+/** Everything worth knowing about a menu in one round trip — sampling these separately would let
+ *  the exit advance between them and turn one moment into three. */
+const SNAPSHOT = `(() => {
+  const m = document.querySelector('.menu');
+  if (!m) return { count: document.querySelectorAll('.menu').length };
+  const r = m.getBoundingClientRect();
+  const hit = document.elementFromPoint(Math.round(r.x + r.width / 2), Math.round(r.y + r.height / 2));
+  return {
+    count: document.querySelectorAll('.menu').length,
+    closing: m.hasAttribute('data-closing'),
+    inert: m.hasAttribute('inert'),
+    pointerEvents: getComputedStyle(m).pointerEvents,
+    animations: m.getAnimations().map((a) => a.animationName),
+    opacity: Number(getComputedStyle(m).opacity),
+    rect: { x: Math.round(r.x), y: Math.round(r.y) },
+    hitInsideMenu: !!(hit && m.contains(hit)),
+    holdsFocus: m.contains(document.activeElement),
+    focusOnTrigger: document.activeElement?.getAttribute('aria-label')?.startsWith('Pane menu') ?? false,
+  };
+})()`;
+
+async function main() {
+  for (const p of [CDP_PORT, SERVER_PORT]) {
+    if (!(await portFree(p))) throw new Error(`port ${p} is in use — refusing to run`);
+  }
+
+  const wrapper = path.join(scratch, "wrapper.mjs");
+  fs.writeFileSync(wrapper, [
+    'import { app } from "electron";',
+    'app.setPath("userData", process.env.LIVE_USER_DATA);',
+    "await import(process.env.LIVE_MAIN);",
+  ].join("\n"));
+  const electronBin = process.platform === "darwin"
+    ? path.join(repoRoot, "node_modules/.pnpm/electron@37.10.3/node_modules/electron/dist/Electron.app/Contents/MacOS/Electron")
+    : path.join(repoRoot, "apps/desktop/node_modules/.bin/electron");
+  electron = spawn(electronBin, [wrapper], {
+    env: {
+      ...process.env,
+      REALM_HOME: path.join(scratch, "home"),
+      REALM_ENABLE_FAKE_AGENT: "1",
+      REALM_PORT: String(SERVER_PORT),
+      REALM_DEVTOOLS_PORT: String(CDP_PORT),
+      REALM_SERVER_ENTRY: path.join(repoRoot, "apps/server/dist/main.js"),
+      LIVE_USER_DATA: path.join(scratch, "userData"),
+      LIVE_MAIN: path.join(repoRoot, "apps/desktop/out/main/index.js"),
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  electron.stderr.on("data", () => {}); electron.stdout.on("data", () => {});
+
+  const targets = () => fetch(`http://127.0.0.1:${CDP_PORT}/json/list`).then((r) => r.json()).catch(() => []);
+  const rendererTarget = await until(async () => (await targets()).find((t) => t.type === "page" && t.url.startsWith("file://")), 30000, "renderer target");
+  const c = cdp(rendererTarget.webSocketDebuggerUrl);
+  await c.ready;
+  await c.send("Runtime.enable");
+  await c.send("Page.enable");
+
+  await until(() => evalIn(c, `!!document.querySelector('.onboarding input:not([type=radio])')`), 20000, "onboarding");
+  await evalIn(c, `(() => {
+    const input = document.querySelector('.onboarding input:not([type=radio])');
+    const set = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value').set;
+    set.call(input, 'Live'); input.dispatchEvent(new Event('input', { bubbles: true }));
+    input.closest('form').requestSubmit();
+    return true; })()`);
+  await until(() => evalIn(c, `!!document.querySelector('.composer')`), 20000, "composer");
+
+  await c.send("Emulation.setDeviceMetricsOverride", { width: 1200, height: 820, deviceScaleFactor: 1, mobile: false });
+  await sleep(400);
+
+  const DOTS = '.panel-bar button[aria-label^="Pane menu"]';
+  await until(() => evalIn(c, `!!document.querySelector(${JSON.stringify(DOTS)})`), 15000, "the pane's ⋯ button");
+
+  /* ── 1. The exit runs, and is out of the way while it does ───────────────────────────────── */
+  await press(c, DOTS);
+  await until(() => evalIn(c, `!!document.querySelector('.menu')`), 5000, "menu open");
+  await sleep(250); // let the ENTER finish, so what we sample next is unambiguously the exit
+  await escape(c);
+  const mid = await evalIn(c, SNAPSHOT);
+  check("Escape starts the exit rather than unmounting: the menu is still there, marked closing", mid.closing === true, mid);
+  check("and the exit is genuinely playing — rl-menu-out, on the compositor", mid.animations?.includes("rl-menu-out"), mid.animations);
+  check("a closing menu is inert and pointer-dead", mid.inert === true && mid.pointerEvents === "none", { inert: mid.inert, pointerEvents: mid.pointerEvents });
+  // The one that matters: the app behind a fading menu has to be reachable. `pointer-events: none`
+  // and `inert` are both claims about hit-testing, and this is the only way to read the answer.
+  check("MUTANT-CATCHER: a click through the middle of the fading menu lands on the app, not on it",
+    mid.hitInsideMenu === false, { hit: mid.hitInsideMenu });
+  check("focus goes home with the gesture, not with the unmount",
+    mid.holdsFocus === false && mid.focusOnTrigger === true, { holdsFocus: mid.holdsFocus, onTrigger: mid.focusOnTrigger });
+
+  const shot = await c.send("Page.captureScreenshot", { format: "png", clip: { x: 0, y: 0, width: 1200, height: 300, scale: 2 } });
+  const shotOut = path.join(os.tmpdir(), "realm-popover-exit.png");
+  fs.writeFileSync(shotOut, Buffer.from(shot.data, "base64"));
+  console.log(`SCREENSHOT mid-exit ${shotOut}`);
+
+  await sleep(400);
+  const after = await evalIn(c, SNAPSHOT);
+  check("and then it is really gone — no node left behind", after.count === 0, after);
+  // Without this the check above would pass on a page that had stopped rendering menus entirely.
+  const seeded = await evalIn(c, `(() => {
+    const d = document.createElement('div'); d.className = 'menu'; d.dataset.seeded = '1';
+    document.body.appendChild(d);
+    const n = document.querySelectorAll('.menu').length;
+    d.remove();
+    return n; })()`);
+  check("MUTANT: a leaked menu WOULD be seen — the same predicate counts a planted one", seeded === 1, { seeded });
+
+  /* ── 2. A dismissed menu goes out from where it was ──────────────────────────────────────── */
+  // §6's exit is opacity and scale, never travel, and the hook stops re-placing the moment the exit
+  // begins — a menu that re-measured against an anchor its own action had removed would fall back to
+  // the window margin and fade from the corner instead of from the control it belongs to.
+  // The LAID-OUT position, not the painted box: the exit scales the surface, and a bounding rect
+  // shrinking around its transform-origin would read as travel. `left`/`top` are what placement
+  // writes and what freezing protects.
+  const RECT = `(() => { const m = document.querySelector('.menu');
+    return m ? { left: m.style.left, top: m.style.top } : null; })()`;
+  await press(c, DOTS);
+  await until(() => evalIn(c, `!!document.querySelector('.menu')`), 5000, "menu open (2)");
+  await sleep(250);
+  const before = await evalIn(c, RECT);
+  await escape(c);
+  const early = await evalIn(c, RECT);
+  await sleep(60);
+  const late = await evalIn(c, RECT);
+  check("the menu does not travel on its way out — placed once, then left alone",
+    !!before.left && early?.left === before.left && early?.top === before.top
+      && late?.left === before.left && late?.top === before.top, { before, early, late });
+  await evalIn(c, `(() => { const m = document.querySelector('.menu'); if (m) m.style.left = '0px'; return true; })()`);
+  const moved = await evalIn(c, RECT);
+  check("MUTANT-CATCHER: and a menu that DID move would read as moved", moved?.left === "0px", { before, moved });
+  await sleep(400);
+  check("the moved menu still left when its exit was up", (await evalIn(c, SNAPSHOT)).count === 0);
+
+  /* ── 3. A parent that unmounts mid-exit takes the surface with it ─────────────────────────── */
+  // "Close" removes the pane the menu hangs off, PanelBar and all. The exit's timer has to die with
+  // it: firing afterwards would drive a parent that no longer exists.
+  await press(c, DOTS);
+  await until(() => evalIn(c, `!!document.querySelector('.menu')`), 5000, "menu open (3)");
+  await sleep(250);
+  await evalIn(c, `(() => {
+    const it = [...document.querySelectorAll('[role="menuitem"]')].find((m) => m.textContent.trim().startsWith('Close'));
+    it.click(); return true; })()`);
+  await sleep(400);
+  check("the pane closed and its menu went with it", (await evalIn(c, SNAPSHOT)).count === 0);
+
+  /* ── 4. Ten cycles faster than the exit: no pile-up, nothing left ─────────────────────────── */
+  await until(() => evalIn(c, `!!document.querySelector(${JSON.stringify(DOTS)})`), 15000, "a pane with a ⋯ again");
+  let worst = 0;
+  for (let i = 0; i < 10; i++) {
+    await press(c, DOTS);
+    await sleep(30);
+    await escape(c);
+    await sleep(30);
+    worst = Math.max(worst, await evalIn(c, `document.querySelectorAll('.menu').length`));
+  }
+  check("opening and dismissing faster than the exit never stacks two menus", worst <= 1, { worst });
+  await sleep(500);
+  check("and the DOM is empty of menus once it settles", (await evalIn(c, `document.querySelectorAll('.menu').length`)) === 0);
+
+  /* ── 5. prefers-reduced-motion has no exit at all ─────────────────────────────────────────── */
+  await c.send("Emulation.setEmulatedMedia", { features: [{ name: "prefers-reduced-motion", value: "reduce" }] });
+  await press(c, DOTS);
+  await until(() => evalIn(c, `!!document.querySelector('.menu')`), 5000, "menu open (reduced)");
+  await sleep(250);
+  await escape(c);
+  const reduced = await evalIn(c, SNAPSHOT);
+  // Not "instant but still mounted": the preference must skip the hold, not run it invisibly.
+  check("under reduced motion the menu is gone on the keystroke — no closing frame to skip",
+    reduced.count === 0, reduced);
+  await c.send("Emulation.setEmulatedMedia", { features: [] });
+
+  const errs = c.events.filter((e) => !e.includes("Autofill"));
+  check("no renderer console errors", errs.length === 0, errs.slice(0, 5));
+  c.close();
+}
+
+main()
+  .catch((e) => { console.error("ERROR", e.message); process.exitCode = 1; })
+  .finally(() => {
+    electron?.kill("SIGTERM");
+    setTimeout(() => { electron?.kill("SIGKILL"); fs.rmSync(scratch, { recursive: true, force: true }); process.exit(process.exitCode ?? 0); }, 1200);
+  });

--- a/apps/desktop/src/renderer/src/components/IconPicker.tsx
+++ b/apps/desktop/src/renderer/src/components/IconPicker.tsx
@@ -49,7 +49,7 @@ function IconPickerPopover({ icon, profileId, anchorRef, onClose, onPick }: {
   onClose: () => void; onPick: (icon: string) => void;
 }) {
   const ref = useRef<HTMLDivElement>(null);
-  const pos = useAnchoredPopover({ ref, anchorRef, onClose });
+  const { pos, closing, close } = useAnchoredPopover({ ref, anchorRef, onClose, exit: true });
   const [tab, setTab] = useState<Tab>("default");
   const [query, setQuery] = useState("");
   const [prompt, setPrompt] = useState("");
@@ -89,7 +89,8 @@ function IconPickerPopover({ icon, profileId, anchorRef, onClose, onPick }: {
   return createPortal(
     <div ref={ref} className="icon-picker" role="dialog" aria-label="Choose an icon"
       style={{ position: "fixed", left: pos?.left ?? -9999, top: pos?.top ?? -9999,
-        visibility: pos ? "visible" : "hidden", transformOrigin: pos?.origin ?? "top left" }}>
+        visibility: pos ? "visible" : "hidden", transformOrigin: pos?.origin ?? "top left" }}
+      data-closing={closing || undefined} inert={closing}>
       <div className="ip-tabs" role="tablist" aria-label="Icon source">
         {TABS.map((t) => (
           <button key={t.id} type="button" role="tab" aria-selected={tab === t.id} className="ip-tab"

--- a/apps/desktop/src/renderer/src/components/Menu.tsx
+++ b/apps/desktop/src/renderer/src/components/Menu.tsx
@@ -27,7 +27,7 @@ export function Menu({ items, onClose, at, anchorRef, returnFocusRef, align = "l
   align?: "left" | "right"; placement?: "down" | "up"; label?: string;
 }) {
   const ref = useRef<HTMLDivElement>(null);
-  const pos = useAnchoredPopover({ ref, anchorRef, at, align, placement, onClose, returnFocusRef });
+  const { pos, closing, close } = useAnchoredPopover({ ref, anchorRef, at, align, placement, onClose, returnFocusRef, exit: true });
 
   // Focus-in on open. The hook already captured the restore target at mount, so the roving focus
   // this moves into the menu never becomes the thing focus returns to.
@@ -56,15 +56,20 @@ export function Menu({ items, onClose, at, anchorRef, returnFocusRef, align = "l
 
   const style: CSSProperties = { position: "fixed", left: pos?.left ?? -9999, top: pos?.top ?? -9999,
     visibility: pos ? "visible" : "hidden", transformOrigin: pos?.origin ?? "top left" };
+  // `inert` is the whole safety story for the exit: for the beat the menu spends fading it is out of
+  // the tab order, out of the accessibility tree, and un-hit-testable, so the app behind it behaves
+  // as though the menu had already gone. The stylesheet takes its pointer events away as well, for
+  // the browsers that paint the fade before they honour the attribute.
   return createPortal(
-    <div ref={ref} role="menu" aria-label={label} className="menu" style={style} onKeyDown={onKeyDown}>
+    <div ref={ref} role="menu" aria-label={label} className="menu" style={style} onKeyDown={onKeyDown}
+      data-closing={closing || undefined} inert={closing}>
       {items.map((it, i) => it.kind === "separator"
         ? <div key={i} className="menu-sep" role="separator" />
         : (
           <button key={i} role={it.checked !== undefined ? "menuitemcheckbox" : "menuitem"}
             disabled={it.disabled} title={it.title} aria-checked={it.checked !== undefined ? it.checked : undefined}
             className={(it.checked ? "checked" : "") + (it.danger ? " danger" : "")}
-            onClick={() => { it.onSelect(); if (!it.keepOpen) onClose(); }}>
+            onClick={() => { it.onSelect(); if (!it.keepOpen) close(); }}>
             <span className="menu-label">{it.label}</span>
             {it.kbd && <kbd className="menu-kbd">{it.kbd}</kbd>}
             {it.checked && <Icon name="check" size={13} className="menu-check" />}

--- a/apps/desktop/src/renderer/src/components/menu.test.tsx
+++ b/apps/desktop/src/renderer/src/components/menu.test.tsx
@@ -13,6 +13,10 @@ function mount(items: MenuItem[], over: Partial<Parameters<typeof Menu>[0]> = {}
 
 const plain = (label: string, onSelect = () => {}): MenuItem => ({ label, onSelect });
 
+/** §6's popover exit keeps a dismissed menu in the DOM for `--dur-press` and tells its parent at the
+ *  end of it, so anything asserting on the menu being GONE has to let that run. */
+const exited = () => act(async () => { await new Promise((r) => setTimeout(r, 200)); });
+
 describe("Menu placement", () => {
   const rect = (top: number, height: number, left = 100, width = 50) =>
     ({ top, bottom: top + height, left, right: left + width, width, height, x: left, y: top, toJSON: () => ({}) }) as DOMRect;
@@ -183,6 +187,97 @@ describe("Menu dismissal by its own trigger (I6)", () => {
     await armed();
     expect(screen.getByRole("menu")).toBeInTheDocument();
     fireEvent.pointerDown(document.body);
+    // The exit holds it for a beat, so "closed" is asserted on the mark rather than on absence…
+    expect(screen.getByRole("menu")).toHaveAttribute("data-closing");
+    await exited();
+    expect(screen.queryByRole("menu")).toBeNull(); // …and then it is really gone
+  });
+});
+
+/** §6's popover exit. React unmounts a `{open && <Menu/>}` child the instant its parent says so, so
+ *  the surface holds ITSELF for the length of the animation and tells the parent afterwards. The
+ *  failure mode is a leaked popover — invisible in a screenshot, fatal to the app behind it — so
+ *  everything here is about the surface really going away, and about it being harmless while it
+ *  has not. */
+describe("popover exit (§6)", () => {
+  afterEach(() => vi.restoreAllMocks());
+  function Harness({ onClose }: { onClose?: () => void } = {}) {
+    const btn = useRef<HTMLButtonElement>(null);
+    const [open, setOpen] = useState(false);
+    return (
+      <>
+        <button ref={btn} onClick={() => setOpen((v) => !v)}>Trigger</button>
+        {open && <Menu items={[plain("A")]} onClose={() => { setOpen(false); onClose?.(); }} anchorRef={btn} label="Exit menu" />}
+      </>
+    );
+  }
+  /** Opened the way a pointer opens it, because the hook captures its focus-restore target at mount:
+   *  a menu that was already open on the first render has nowhere to hand focus back to. */
+  /** The hook arms its outside-pointerdown listener on a 0ms timeout, so the opening click cannot
+   *  immediately close what it opened. Nothing below reaches that listener until this has run. */
+  const listening = () => act(async () => { await new Promise((r) => setTimeout(r, 0)); });
+  const open = async () => {
+    const trigger = screen.getByRole("button", { name: "Trigger" });
+    trigger.focus(); fireEvent.click(trigger);
+    await listening();
+    return trigger;
+  };
+  /** Select the focused item — the commonest way a menu closes. */
+  const select = () => fireEvent.keyDown(screen.getByRole("menu"), { key: "Enter" });
+
+  it("holds the menu for the exit, then removes it — and it is inert and pointer-dead in between", async () => {
+    render(<Harness />);
+    const trigger = await open();
+    select();
+    const menu = screen.getByRole("menu");
+    expect(menu).toHaveAttribute("data-closing");
+    // `inert` is what stops a fading menu from being tabbed into, read out, or clicked. Without it
+    // the exit would trade a visual nicety for a surface the app behind cannot get past.
+    expect(menu).toHaveAttribute("inert");
+    // Focus goes home with the gesture, not with the unmount: a keystroke landing on <body> for the
+    // length of the exit is exactly the "in the way" this must not be.
+    expect(trigger).toHaveFocus();
+    await exited();
+    expect(screen.queryByRole("menu")).toBeNull();
+  });
+
+  it("leaves nothing behind when it is opened and closed faster than the exit runs", async () => {
+    render(<Harness />);
+    const trigger = await open();
+    for (let i = 0; i < 6; i++) {
+      select();
+      // A real press is pointerdown then click: the first commits the exit that is still running,
+      // the second reopens. Two menus overlapping here — one fading, one arriving — is the leak.
+      fireEvent.pointerDown(trigger);
+      fireEvent.click(trigger);
+      expect(document.querySelectorAll(".menu")).toHaveLength(1);
+      await listening();
+    }
+    select();
+    await exited();
+    expect(document.querySelectorAll(".menu")).toHaveLength(0);
+  });
+
+  it("does not call onClose after the parent has already unmounted it mid-exit", async () => {
+    const onClose = vi.fn();
+    const { unmount } = render(<Harness onClose={onClose} />);
+    await open();
+    onClose.mockClear(); // the open itself does not close anything; only what follows counts
+    select();
+    unmount();
+    await exited();
+    // The armed timer has to die with the surface; firing it would drive a parent that has moved on.
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("under prefers-reduced-motion there is no exit to skip — the menu is gone the same tick", async () => {
+    vi.spyOn(window, "matchMedia").mockImplementation((q) =>
+      ({ matches: q.includes("prefers-reduced-motion"), media: q, addEventListener() {}, removeEventListener() {} }) as unknown as MediaQueryList);
+    render(<Harness />);
+    await open();
+    select();
+    // Not "instant but still mounted": the global `animation: none` would leave a fully painted,
+    // inert menu sitting there for 120ms, which is the opposite of what the preference asks for.
     expect(screen.queryByRole("menu")).toBeNull();
   });
 });
@@ -210,12 +305,13 @@ describe("Menu keyboard (U-M10/A-H3)", () => {
     expect(screen.getByRole("menuitem", { name: "A" })).toHaveFocus();
   });
 
-  it("Enter and Space select the focused item and close the menu", () => {
+  it("Enter and Space select the focused item and close the menu", async () => {
     const picked: string[] = [];
     const { onClose } = mount([plain("A", () => picked.push("A")), plain("B", () => picked.push("B"))]);
     fireEvent.keyDown(screen.getByRole("menu"), { key: "ArrowDown" });
     fireEvent.keyDown(screen.getByRole("menu"), { key: "Enter" });
     expect(picked).toEqual(["B"]);
+    await exited(); // the parent is told once the exit has run, not on the keystroke
     expect(onClose).toHaveBeenCalledTimes(1);
     fireEvent.keyDown(screen.getByRole("menu"), { key: "ArrowUp" });
     fireEvent.keyDown(screen.getByRole("menu"), { key: " " });

--- a/apps/desktop/src/renderer/src/components/panehost.test.tsx
+++ b/apps/desktop/src/renderer/src/components/panehost.test.tsx
@@ -138,17 +138,24 @@ describe("PaneHost", () => {
     expect(panel("L2").querySelectorAll(".panel-actions .icon-btn")).toHaveLength(2); // ⋯ menu + ×
   });
 
-  it("⋯ menu: Split right/down call onSplit with the pane's own leaf and direction; Close calls onClose", () => {
+  it("⋯ menu: Split right/down call onSplit with the pane's own leaf and direction; Close calls onClose", async () => {
     const { props, unmount } = renderHost();
-    fireEvent.click(within(panel("L2")).getByRole("button", { name: "Pane menu for Tab B" }));
+    // A selected menu runs §6's exit before it tells the pane to unmount it, and a bare `click`
+    // carries no pointerdown to commit that early — so each round trip waits the exit out.
+    const exited = () => act(async () => { await new Promise((r) => setTimeout(r, 200)); });
+    const openMenu = () => fireEvent.click(within(panel("L2")).getByRole("button", { name: "Pane menu for Tab B" }));
+    openMenu();
     fireEvent.click(screen.getByRole("menuitem", { name: /Split right/ }));
     expect(props.onSplit).toHaveBeenCalledExactlyOnceWith("L2", "row");
-    fireEvent.click(within(panel("L2")).getByRole("button", { name: "Pane menu for Tab B" }));
+    await exited();
+    openMenu();
     fireEvent.click(screen.getByRole("menuitem", { name: /Split down/ }));
     expect(props.onSplit).toHaveBeenLastCalledWith("L2", "col");
-    fireEvent.click(within(panel("L2")).getByRole("button", { name: "Pane menu for Tab B" }));
+    await exited();
+    openMenu();
     fireEvent.click(screen.getByRole("menuitem", { name: /Close/ }));
     expect(props.onClose).toHaveBeenCalledExactlyOnceWith("B");
+    await exited();
     unmount();
   });
 

--- a/apps/desktop/src/renderer/src/components/sidebar/SpaceSwiper.tsx
+++ b/apps/desktop/src/renderer/src/components/sidebar/SpaceSwiper.tsx
@@ -244,6 +244,8 @@ const SpaceBody = memo(function SpaceBody({ items, groups }: { items: Item[]; gr
  */
 function ArchivedSection({ items }: { items: Item[] }) {
   const [open, setOpen] = useState(false);
+  const everOpened = useRef(false);
+  everOpened.current ||= open;
   return (
     <>
       <div className="group-label group-head archived-head">
@@ -253,7 +255,19 @@ function ArchivedSection({ items }: { items: Item[] }) {
           <span className="archived-count">{items.length}</span>
         </button>
       </div>
-      {open && <ItemList items={items} variant="archived" />}
+      {/* The shelf unfolds on the tool row's technique — grid-template-rows 0fr→1fr, the only way to
+          animate to a height nobody can know in advance — which needs the rows in the DOM on both
+          sides of the flip. So they are built on first open and stay built: folding it back animates
+          too, and re-opening is instant. Built on first open rather than always, because a shelf
+          nobody has asked for should cost nothing; `inert` keeps a folded row's controls out of the
+          tab order and the accessibility tree. */}
+      {everOpened.current && (
+        <div className="archived-wrap" data-open={open || undefined}>
+          <div className="archived-clip" inert={!open || undefined}>
+            <ItemList items={items} variant="archived" />
+          </div>
+        </div>
+      )}
     </>
   );
 }

--- a/apps/desktop/src/renderer/src/components/sidebar/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/components/sidebar/sidebar.test.tsx
@@ -14,6 +14,11 @@ const RUNGS = new Set([20, 18, 16, 14, 12]);
    under jsdom) never comes into it. */
 const SIDEBAR_SOURCES = import.meta.glob("./*.tsx", { query: "?raw", import: "default", eager: true }) as Record<string, string>;
 
+/** §6's popover exit keeps a dismissed menu or picker mounted for `--dur-press` and tells its parent
+ *  at the end of it, so anything that closes one and then opens (or asserts the absence of) another
+ *  has to let the first one leave. */
+const exited = () => act(async () => { await new Promise((r) => setTimeout(r, 200)); });
+
 async function mount(api = fakeApi()) {
   const store = createAppStore(api); await store.getState().boot();
   const r = render(<StoreContext.Provider value={store}><Sidebar /></StoreContext.Provider>);
@@ -151,6 +156,7 @@ describe("Arc sidebar", () => {
     await waitFor(() => expect(screen.getByRole("button", { name: /Terminal/ })).toHaveAttribute("data-tile", "true"));
     expect(store.getState().items[0]?.pinned).toBe(true);
     // i1 is unopened (default layout is null), so Close should not even be offered here.
+    await exited();
     fireEvent.contextMenu(screen.getByRole("button", { name: /Terminal/ }));
     expect(screen.queryByRole("menuitem", { name: "Close" })).not.toBeInTheDocument();
     fireEvent.click(screen.getByRole("menuitem", { name: "Delete" }));
@@ -839,11 +845,13 @@ describe("archiving a session", () => {
     fireEvent.contextMenu(screen.getByRole("button", { name: "Terminal" }));
     expect(screen.queryByRole("menuitem", { name: "Archive" })).not.toBeInTheDocument();
     fireEvent.keyDown(document, { key: "Escape" });
+    await exited();
 
     fireEvent.contextMenu(screen.getByRole("button", { name: /^Fix the build/ }));
     fireEvent.click(screen.getByRole("menuitem", { name: "Archive" }));
     await waitFor(() => expect(store.getState().items.find((i) => i.id === "i2")?.archived).toBe(true));
     expand();
+    await exited();
     fireEvent.contextMenu(screen.getByRole("button", { name: /^Fix the build/ }));
     expect(screen.queryByRole("menuitem", { name: "Archive" })).not.toBeInTheDocument();
     fireEvent.click(screen.getByRole("menuitem", { name: "Unarchive" }));

--- a/apps/desktop/src/renderer/src/components/use-anchored-popover.ts
+++ b/apps/desktop/src/renderer/src/components/use-anchored-popover.ts
@@ -1,20 +1,41 @@
-import { useLayoutEffect, useRef, useState, type RefObject } from "react";
+import { useCallback, useLayoutEffect, useRef, useState, type RefObject } from "react";
 import { placeAnchored } from "../state/no-overlay";
 import { useBrowserRects } from "../state/store";
 
 export type PopoverPosition = { left: number; top: number; origin: string };
+export type AnchoredPopover = {
+  /** `null` until the surface has been measured. */
+  pos: PopoverPosition | null;
+  /** The exit is running: the surface is still in the DOM but is on its way out. */
+  closing: boolean;
+  /** Dismiss. Where the surface has an exit this holds it on screen for `EXIT_MS` first. */
+  close: () => void;
+};
 
 const MARGIN = 6;
+/** How long a closing surface stays in the DOM. This is the same fact as `rl-menu-out`'s duration —
+ *  a timer shorter than the animation clips the exit, a longer one parks a finished surface on
+ *  screen — so styles.test.ts pins the two together against the `--dur-press` rung. */
+const EXIT_MS = 120;
+
+const reducedMotion = (): boolean => window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false;
 
 /**
  * Placement and dismissal for a portalled surface anchored to a control — everything `Menu` and the
  * prompter's `ModelPicker` share, minus the contents and minus each one's own focus model (a menu
  * roves across its items; the picker starts in its search field).
  *
- * Returns `null` until the surface has been measured; render at `-9999` and `visibility: hidden`
+ * `pos` is `null` until the surface has been measured; render at `-9999` and `visibility: hidden`
  * until then, so the flip decision is never visible as a jump.
+ *
+ * `exit` opts the surface into §6's popover exit. React unmounts a `{open && <Popover/>}` child the
+ * instant its parent says so, which leaves no frame for an exit to run in, so the delay lives here:
+ * `close()` marks the surface closing, hands focus back, and only then tells the parent. The caller
+ * must render that state as inert and pointer-transparent — a surface that is visually gone but
+ * still hit-testable is worse than no exit at all. Surfaces that enter instantly close instantly:
+ * enter and exit are one decision per surface, not two.
  */
-export function useAnchoredPopover({ ref, anchorRef, at, align = "left", placement = "down", onClose, returnFocusRef }: {
+export function useAnchoredPopover({ ref, anchorRef, at, align = "left", placement = "down", onClose, returnFocusRef, exit = false }: {
   ref: RefObject<HTMLElement | null>;
   anchorRef?: RefObject<HTMLElement | null>;
   /** Place at a point instead of against an anchor (context menus). */
@@ -23,8 +44,11 @@ export function useAnchoredPopover({ ref, anchorRef, at, align = "left", placeme
   placement?: "down" | "up";
   onClose: () => void;
   returnFocusRef?: RefObject<HTMLElement | null>;
-}): PopoverPosition | null {
+  exit?: boolean;
+}): AnchoredPopover {
   const [pos, setPos] = useState<PopoverPosition | null>(null);
+  const [closing, setClosing] = useState(false);
+  const closingRef = useRef(false);
   // W2's no-overlay invariant, enforced in the primitive: browser view rects are avoided by every
   // anchored surface (preferred side → flip → slide along the anchor edge → complement fallback).
   // [] outside the provider, which makes placeAnchored the pre-W2 placement exactly.
@@ -33,6 +57,10 @@ export function useAnchoredPopover({ ref, anchorRef, at, align = "left", placeme
   useLayoutEffect(() => {
     const el = ref.current; if (!el) return;
     const place = () => {
+      // A closing surface is frozen where it was dismissed. Its anchor may already have gone with
+      // the action that dismissed it (a menu item that closes its own pane), and re-placing against
+      // a missing anchor would fling the surface to the window corner mid-fade.
+      if (closingRef.current) return;
       const { width, height } = el.getBoundingClientRect();
       const a = at ? { x: at.x, y: at.y, width: 0, height: 0 } : anchorRef?.current?.getBoundingClientRect();
       if (!a) { setPos({ left: MARGIN, top: MARGIN, origin: "top left" }); return; }
@@ -62,36 +90,91 @@ export function useAnchoredPopover({ ref, anchorRef, at, align = "left", placeme
     return () => ro.disconnect();
   }, [ref, at, anchorRef, align, placement, browserRects]);
 
-  // Focus restore on close. The target is captured once at mount, before any roving focus moves into
-  // the surface, so it is the trigger unless the caller overrides it.
+  // Focus restore. The target is captured once at mount, before any roving focus moves into the
+  // surface, so it is the trigger unless the caller overrides it. It runs exactly once: an exiting
+  // surface hands focus back when it is dismissed rather than when it finally unmounts, so the two
+  // paths both come through here and the second one is a no-op.
   const restore = useRef<HTMLElement | null>(null);
+  const restored = useRef(false);
+  const restoreFocus = useCallback(() => {
+    if (restored.current) return;
+    restored.current = true;
+    const target = returnFocusRef?.current ?? restore.current;
+    // The trigger may have unmounted with the surface (e.g. a menu's own Close removed the pane):
+    // fall back to the focused panel — a deliberate body-safe no-op when it isn't focusable.
+    if (target?.isConnected) target.focus?.();
+    else document.querySelector<HTMLElement>(".panel[data-focused]")?.focus?.();
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- returnFocusRef is a ref, read at call time
+  }, []);
+
+  // `onClose` is read through a ref so the exit timer, armed once, cannot fire a stale one.
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  /** Commit a running exit now. An exit is a courtesy and it stops being one the moment the user
+   *  does something else, so the next press ends it rather than waiting it out.
+   *
+   *  Called from pointerdown and keydown, and deliberately NOT from the click that follows a
+   *  pointerdown: the parent has to be told BETWEEN the two events. React then unmounts the surface
+   *  before the click toggles it back open, and the re-opened one is a fresh mount with its own
+   *  focus and its own state. Told during the click instead, the parent re-opens the very element
+   *  that is mid-exit — React reuses it, `closing` never clears, and the menu is stuck invisible and
+   *  inert forever, which is precisely the leak this feature must not introduce. */
+  const flush = useCallback(() => {
+    if (!closingRef.current || !timer.current) return;
+    clearTimeout(timer.current);
+    timer.current = null;
+    onCloseRef.current();
+  }, []);
+
+  const close = useCallback(() => {
+    if (closingRef.current) return;
+    // Reduced motion skips the hold rather than running it at zero duration. The global
+    // `animation: none !important` would otherwise leave the surface fully painted and merely
+    // unusable for the length of an exit nobody asked to see.
+    if (!exit || reducedMotion()) { onCloseRef.current(); return; }
+    closingRef.current = true;
+    setClosing(true);
+    // Focus leaves with the gesture, not with the unmount: the surface goes inert this frame, and a
+    // keystroke in the gap between the two would otherwise land on <body>.
+    restoreFocus();
+    timer.current = setTimeout(() => onCloseRef.current(), EXIT_MS);
+  }, [exit, restoreFocus]);
+
   useLayoutEffect(() => {
     restore.current = document.activeElement instanceof HTMLElement ? document.activeElement : null;
     return () => {
-      const target = returnFocusRef?.current ?? restore.current;
-      // The trigger may have unmounted with the surface (e.g. a menu's own Close removed the pane):
-      // fall back to the focused panel — a deliberate body-safe no-op when it isn't focusable.
-      if (target?.isConnected) target.focus?.();
-      else document.querySelector<HTMLElement>(".panel[data-focused]")?.focus?.();
+      // The parent may unmount the surface out from under a running exit (its pane closed, the
+      // session switched). Dropping the timer here is what keeps that from calling `onClose` on a
+      // parent that has already moved on.
+      if (timer.current) clearTimeout(timer.current);
+      restoreFocus();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps -- mount/unmount only
   }, []);
 
   useLayoutEffect(() => {
     const onDown = (e: PointerEvent) => {
+      if (closingRef.current) { flush(); return; }
       const target = e.target as Node;
       if (ref.current?.contains(target)) return;
       // The trigger lives OUTSIDE the portal, so an anchored surface would otherwise close on its own
       // trigger's pointerdown and the following click would reopen it — flicker, focus ping-pong, and
       // no way to dismiss by clicking the control again. Leave the trigger to its own toggle.
       if (anchorRef?.current?.contains(target)) return;
-      onClose();
+      close();
     };
-    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") { e.stopPropagation(); onClose(); } };
+    // A surface already on its way out must not keep swallowing Escape: the key belongs to whatever
+    // is behind it for the rest of the exit.
+    const onKey = (e: KeyboardEvent) => {
+      if (closingRef.current) { flush(); return; } // and Escape passes through: the key is the app's again
+      if (e.key !== "Escape") return;
+      e.stopPropagation(); close();
+    };
     // Deferred so the click that opened the surface doesn't immediately close it.
     const id = setTimeout(() => { window.addEventListener("pointerdown", onDown); window.addEventListener("keydown", onKey, true); }, 0);
     return () => { clearTimeout(id); window.removeEventListener("pointerdown", onDown); window.removeEventListener("keydown", onKey, true); };
-  }, [ref, onClose, anchorRef]);
+  }, [ref, close, flush, anchorRef]);
 
-  return pos;
+  return { pos, closing, close };
 }

--- a/apps/desktop/src/renderer/src/panes/documents/documents-pane.test.tsx
+++ b/apps/desktop/src/renderer/src/panes/documents/documents-pane.test.tsx
@@ -186,8 +186,14 @@ describe("DocumentsPane", () => {
  * buttons behind a text field, for a file that did not exist yet. These cover the shape that replaced
  * it — pick a kind, get a working document, rename it whenever (or never).
  */
+/** §6's popover exit keeps a dismissed menu or picker mounted for `--dur-press` and tells its parent
+ *  at the end of it, so anything that closes one and then opens (or asserts the absence of) another
+ *  has to let the first one leave. */
+const exited = () => act(async () => { await new Promise((r) => setTimeout(r, 200)); });
+
 describe("DocumentsPane — making a document", () => {
   const addMenu = async () => {
+    await exited();
     fireEvent.click(await screen.findByRole("button", { name: "Add a document" }));
   };
 

--- a/apps/desktop/src/renderer/src/panes/session/Composer.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/Composer.tsx
@@ -625,7 +625,23 @@ export function Composer({ session, status, gitInfo, onOpenDiff, draft, onDraftC
   return (
     <div className="composer-dock">
       {hero && (
-        <div className="hero-greeting">
+        /* Click the emphasised word — your name, or the space's — and the line nods back. Nothing
+           announces it, nothing reaches it by keyboard, and nothing depends on it having happened.
+           The mark goes on the element and comes off when the animation ends, so there is no state,
+           no timer and nothing to clean up. Taking it off and putting it straight back would replay
+           nothing — the browser only sees the value it holds at the end of the frame — so the read
+           of `offsetWidth` between the two forces the removal to land first. Under
+           prefers-reduced-motion the global kill means no animation runs and no `animationend`
+           arrives, which is the correct outcome: the greeting simply does not nod. */
+        <div className="hero-greeting"
+          onClick={(e) => {
+            if (!(e.target instanceof HTMLElement) || e.target.tagName !== "EM") return;
+            const line = e.currentTarget;
+            line.removeAttribute("data-nod");
+            void line.offsetWidth;
+            line.setAttribute("data-nod", "");
+          }}
+          onAnimationEnd={(e) => e.currentTarget.removeAttribute("data-nod")}>
           {greeting.map((part, i) => (part.em ? <em key={i}>{part.text}</em> : <Fragment key={i}>{part.text}</Fragment>))}
         </div>
       )}

--- a/apps/desktop/src/renderer/src/panes/session/InstallCard.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/InstallCard.tsx
@@ -45,8 +45,10 @@ export function InstallCard({ availability, onRetry, onOpenInTerminal }: {
           <div className="install-cmd">
             <code>{command}</code>
             <button className="tool-copy" aria-label="Copy command" title={copied ? "Copied" : "Copy"}
+              data-copied={copied || undefined}
               onClick={() => { void navigator.clipboard?.writeText(command); setCopied(true); }}>
-              <Icon name={copied ? "check" : "copy"} size={12} />
+              <Icon name="copy" size={12} className="copy-icon" />
+              <Icon name="check" size={12} className="copied-icon" />
             </button>
           </div>
         )}

--- a/apps/desktop/src/renderer/src/panes/session/MentionPicker.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/MentionPicker.tsx
@@ -57,7 +57,9 @@ export function MentionPicker({ skills, activeIndex, anchorRef, onPick, onHover,
   onClose: () => void;
 }) {
   const ref = useRef<HTMLDivElement>(null);
-  const pos = useAnchoredPopover({ ref, anchorRef, placement: "up", onClose });
+  // No exit, because this one is driven by typing: it opens and closes between keystrokes, and a
+  // ghost of it trailing the caret while the sentence carries on is noise rather than motion.
+  const { pos } = useAnchoredPopover({ ref, anchorRef, placement: "up", onClose });
   const active = Math.min(activeIndex, skills.length - 1);
   return createPortal(
     <div ref={ref} id="mention-list" className="mention-picker" role="listbox" aria-label="Skills"

--- a/apps/desktop/src/renderer/src/panes/session/ModelPicker.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/ModelPicker.tsx
@@ -94,8 +94,7 @@ function ModelPopover({ rows, info, anchorRef, onClose, onPick, onToggleFavorite
   overflow?: OverflowGroup[];
 }) {
   const ref = useRef<HTMLDivElement>(null);
-  const close = useCallback(() => onClose(), [onClose]);
-  const pos = useAnchoredPopover({ ref, anchorRef, placement: "up", onClose: close });
+  const { pos, closing, close } = useAnchoredPopover({ ref, anchorRef, placement: "up", onClose, exit: true });
   const [query, setQuery] = useState("");
   const [activeKey, setActiveKey] = useState<string | null>(null);
   /** The harness the user has chosen for a given row, when they have overridden the resolved one.
@@ -171,7 +170,7 @@ function ModelPopover({ rows, info, anchorRef, onClose, onPick, onToggleFavorite
     // model is `claude-fable-5-1` to the Claude CLI and `claude-fable-5-1` through Cursor's ACP only
     // by luck, and a foreign id is rejected on the wire.
     onPick(target, modelIdOn(row, target) ?? null);
-    onClose();
+    close();
   };
 
   const onKeyDown = (e: KeyboardEvent) => {
@@ -199,7 +198,8 @@ function ModelPopover({ rows, info, anchorRef, onClose, onPick, onToggleFavorite
   return createPortal(
     <div ref={ref} className="model-picker" aria-label="Model picker" role="dialog"
       style={{ position: "fixed", left: pos?.left ?? -9999, top: pos?.top ?? -9999,
-        visibility: pos ? "visible" : "hidden", transformOrigin: pos?.origin ?? "bottom left" }}>
+        visibility: pos ? "visible" : "hidden", transformOrigin: pos?.origin ?? "bottom left" }}
+      data-closing={closing || undefined} inert={closing}>
       <div className="mp-search">
         <Icon name="search" size={14} />
         {/* Autofocused because the picker opens for typing — the same bargain the command palette
@@ -282,7 +282,7 @@ function ModelPopover({ rows, info, anchorRef, onClose, onPick, onToggleFavorite
         {activeRow && route && (
           <ModelDetail row={activeRow} route={route} info={info}
             onRoute={(h) => setRoutes({ ...routes, [activeRow.key]: h })}
-            onUse={() => pick(activeRow, route)} effortItems={effortItems} overflow={overflow} onClose={onClose} />
+            onUse={() => pick(activeRow, route)} effortItems={effortItems} overflow={overflow} onClose={close} />
         )}
       </div>
     </div>,

--- a/apps/desktop/src/renderer/src/panes/session/SkillPicker.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/SkillPicker.tsx
@@ -90,7 +90,7 @@ export function SkillPicker({ skills, anchorRef, onToggle, onMention, onClose, o
   const input = useRef<HTMLInputElement>(null);
   const [query, setQuery] = useState("");
   const [active, setActive] = useState(0);
-  const pos = useAnchoredPopover({ ref, anchorRef, placement: "up", onClose });
+  const { pos } = useAnchoredPopover({ ref, anchorRef, placement: "up", onClose });
 
   const shown = useMemo(() => filterSkills(skills, query), [skills, query]);
   const groups = useMemo(() => groupSkills(shown), [shown]);

--- a/apps/desktop/src/renderer/src/panes/session/ToolCard.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/ToolCard.tsx
@@ -1,5 +1,5 @@
 import { Icon } from "@realm/ui";
-import { memo, useEffect, useRef, useState, type ReactNode } from "react";
+import { memo, useEffect, useRef, useState, type MouseEvent as ReactMouseEvent, type ReactNode } from "react";
 import type { SessionStatus } from "@realm/contracts";
 import { Spinner } from "../../components/Spinner";
 import { clip, editStat, prettyJson, toolSummary } from "./tool-summary";
@@ -61,6 +61,27 @@ function Well({ label, text, error = false, rich = null }: { label: string; text
   );
 }
 
+/**
+ * Opening a card with ⌥ held opens every card in the same transcript — Finder's gesture on a
+ * disclosure triangle, and the modifier this app already spells "the other way to do this" on a
+ * sidebar row. Nothing advertises it; a plain click is untouched.
+ *
+ * The siblings are driven through their OWN rows rather than by lifting `open` into shared state: a
+ * long transcript holds hundreds of cards, and a subscription each would be a standing cost paid by
+ * every reader who never finds this. A synthetic click carries no `altKey`, so one press cannot
+ * cascade. Only rows that DISAGREE with the target are pressed, so they end up matching the card you
+ * opened instead of each flipping to its own opposite.
+ *
+ * Returns `next` so the caller's own state moves whether or not the modifier was held.
+ */
+function expand(e: ReactMouseEvent<HTMLButtonElement>, next: boolean): boolean {
+  if (!e.altKey) return next;
+  const self = e.currentTarget;
+  for (const row of self.closest(".transcript-col")?.querySelectorAll<HTMLButtonElement>(".tool-row") ?? [])
+    if (row !== self && (row.getAttribute("aria-expanded") === "true") !== next) row.click();
+  return next;
+}
+
 /** A tool call the agent made: BUI ThinkingState's coding-row shape (Plan 9 W2) — a leading status
  *  glyph whose spinner→muted-check progression is the block's REAL settled state (result present),
  *  never a clock; the tool name; the target as a mono chip (ToolChips' chip language); measured
@@ -99,7 +120,7 @@ export const ToolCard = memo(function ToolCard({ block, sessionStatus, enter = f
   const work = state === "running" ? mediaWorkFor(block.name, block.input) : null;
   return (
     <div className="tool-card" data-state={state} data-open={open || undefined} data-enter={enter || undefined}>
-      <button className="tool-row" aria-expanded={open} aria-label={`${block.name} tool call`} onClick={() => setOpen((o) => !o)}>
+      <button className="tool-row" aria-expanded={open} aria-label={`${block.name} tool call`} onClick={(e) => setOpen(expand(e, !open))}>
         <span className="tool-status" aria-label={state === "running" ? "running" : state === "ok" ? "done" : state === "error" ? "failed" : "no result"}>
           {/* 16, not the 14 the settled glyphs use: the orb fills the status slot, and 40 dots at
               0.12–1 opacity carry far less weight than a 1.5px stroke, so it reads lighter even so. */}

--- a/apps/desktop/src/renderer/src/panes/session/hero-greeting.test.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/hero-greeting.test.tsx
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { StoreContext, createAppStore } from "../../state/store";
+import { fakeApi, item, session } from "../../state/store.test-fakes";
+import { SessionPane } from "./SessionPane";
+
+/**
+ * The greeting nods when its emphasised word is clicked. `greeting.test.ts` proves which sentence a
+ * session gets; this proves the one unadvertised thing the line does, and — the part that actually
+ * matters for something nobody is told about — that it stays out of the way: it answers only to the
+ * emphasised word, it leaves no mark behind once it has run, and it is reachable by nothing else.
+ *
+ * What the animation LOOKS like is not assertable here (jsdom has no animation clock); §6's shared
+ * `prefers-reduced-motion` kill is what takes the motion away, and styles.test.ts pins both.
+ */
+async function mountHero() {
+  const it0 = item("i9", "s1", { kind: "session", refId: "se1", title: "s" });
+  const api = fakeApi({
+    sessions: [session("se1", "s1", { status: "idle", agentKind: "fake" })],
+    items: { s1: [it0] },
+  });
+  const store = createAppStore(api);
+  await store.getState().boot();
+  // No events anywhere: an empty transcript is what puts the prompter in its hero state, which is
+  // the only state the greeting exists in.
+  store.setState({ sessionStatus: { se1: "idle" } });
+  render(<StoreContext.Provider value={store}><SessionPane item={it0} visible /></StoreContext.Provider>);
+  return screen.getByText((_, el) => el?.className === "hero-greeting") as HTMLElement;
+}
+
+describe("the hero greeting nods back", () => {
+  it("marks the line when the emphasised word is clicked, and clears the mark when the nod ends", async () => {
+    const line = await mountHero();
+    const em = line.querySelector("em")!;
+    expect(em).toBeInTheDocument(); // every variant emphasises the space or the person
+    expect(line).not.toHaveAttribute("data-nod");
+    fireEvent.click(em);
+    expect(line).toHaveAttribute("data-nod");
+    // Nothing survives the flourish: no state, no timer, and nothing for a later assertion to trip on.
+    fireEvent.animationEnd(line);
+    expect(line).not.toHaveAttribute("data-nod");
+  });
+
+  it("ignores a click on the rest of the line — the plain words are not a control", async () => {
+    const line = await mountHero();
+    fireEvent.click(line);
+    expect(line).not.toHaveAttribute("data-nod");
+  });
+
+  it("re-arms, so the second click nods as well as the first", async () => {
+    // The mark has to come OFF before it goes back on: re-adding an attribute the element already
+    // carries changes nothing, and the animation would play once and never again.
+    const line = await mountHero();
+    const em = line.querySelector("em")!;
+    fireEvent.click(em);
+    fireEvent.animationEnd(line);
+    fireEvent.click(em);
+    expect(line).toHaveAttribute("data-nod");
+  });
+});

--- a/apps/desktop/src/renderer/src/panes/session/media/MediaView.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/media/MediaView.tsx
@@ -87,8 +87,13 @@ function VideoPlayer({ file, autoFocus = false, onExpand }: { file: MediaFile; a
         </button>
       )}
       <div className="media-controls">
+        {/* §6 icon swap: the transport is one control whose glyph turns over, so both stay in the DOM
+            and cross-fade. A ternary replaces the element instead, and gets no transition at all. */}
         <button type="button" className="media-btn" aria-label={playing ? "Pause" : "Play"} onClick={toggle}>
-          <Icon name={playing ? "pause" : "play"} size={13} />
+          <span className="icon-swap" data-on={playing || undefined}>
+            <Icon name="play" size={13} className="swap-off" />
+            <Icon name="pause" size={13} className="swap-on" />
+          </span>
         </button>
         <span className="media-time">{formatTime(time)}</span>
         <input
@@ -101,7 +106,10 @@ function VideoPlayer({ file, autoFocus = false, onExpand }: { file: MediaFile; a
         />
         <span className="media-time media-duration">{formatTime(duration)}</span>
         <button type="button" className="media-btn" aria-label={muted ? "Unmute" : "Mute"} aria-pressed={muted} onClick={() => setMuted((m) => !m)}>
-          <Icon name={muted ? "volumeOff" : "volumeOn"} size={13} />
+          <span className="icon-swap" data-on={muted || undefined}>
+            <Icon name="volumeOn" size={13} className="swap-off" />
+            <Icon name="volumeOff" size={13} className="swap-on" />
+          </span>
         </button>
         {onExpand && (
           <button type="button" className="media-btn" aria-label="Open larger" onClick={onExpand}>

--- a/apps/desktop/src/renderer/src/panes/session/session-pane.test.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/session-pane.test.tsx
@@ -36,6 +36,11 @@ async function mountKind(agentKind: "codex" | "acp:cursor") {
 /** Opens the prompter's combined model picker (agent + model in one popover). */
 const openPicker = () => fireEvent.click(screen.getByRole("button", { name: "Model" }));
 
+/** §6's popover exit keeps a dismissed menu or picker mounted for `--dur-press` and tells its parent
+ *  at the end of it, so anything that closes one and then opens (or asserts the absence of) another
+ *  has to let the first one leave. */
+const exited = () => act(async () => { await new Promise((r) => setTimeout(r, 200)); });
+
 describe("SessionPane", () => {
   it("renders transcript blocks, shows permission card, and sends composer text", async () => {
     const { api } = await mount();
@@ -173,6 +178,7 @@ describe("SessionPane", () => {
     expect(chip).not.toHaveAttribute("data-warning");
     // Plan is no longer one of these: it is its own axis, on its own chip.
     expect(screen.queryByRole("menuitemcheckbox", { name: "Plan" })).toBeNull();
+    await exited();
     fireEvent.click(chip);
     fireEvent.click(screen.getByRole("menuitemcheckbox", { name: "Full access" }));
     fireEvent.click(screen.getByRole("button", { name: "Allow everything? Confirm" }));
@@ -249,6 +255,7 @@ describe("SessionPane", () => {
     await waitFor(() => expect(store.getState().sessions.se1?.effort).toBe("high"));
     expect(store.getState().sessions.se1?.model).toBeNull(); // the effort edit set effort, not model
     expect(store.getState().sessions.se1?.permissionMode).toBe("default"); // …and not permission either
+    await exited();
     expect(screen.queryByRole("dialog", { name: "Model picker" })).toBeNull(); // picking closes the picker
     expect(document.querySelector(".model-chip .chip-effort")).toHaveTextContent("High"); // the suffix wears it
   });
@@ -681,6 +688,7 @@ describe("control-row rework (prompter rework atop Ara refresh §3)", () => {
       const perms = screen.getByRole("group", { name: "Permissions" });
       fireEvent.click(within(perms).getByRole("button", { name: "Accept edits" }));
       await waitFor(() => expect(store.getState().sessions.se1?.permissionMode).toBe("acceptEdits"));
+      await exited();
       expect(screen.queryByRole("dialog", { name: "Model picker" })).toBeNull(); // picking closes the menu
     });
 
@@ -881,7 +889,8 @@ async function mountKindFresh(agentKind: "codex" | "acp:cursor") {
 describe("prompter mode chip (Build / Plan)", () => {
   const modeChip = () => screen.getByRole("button", { name: "Mode" });
   const permissionChip = () => screen.queryByRole("button", { name: "Permission mode" });
-  const setMode = (label: "Build" | "Plan") => {
+  const setMode = async (label: "Build" | "Plan") => {
+    await exited();
     fireEvent.click(modeChip());
     fireEvent.click(screen.getByRole("menuitemcheckbox", { name: label }));
   };
@@ -889,7 +898,7 @@ describe("prompter mode chip (Build / Plan)", () => {
   it("starts on Build and moves the session onto the plan permission mode", async () => {
     const { store } = await mountFresh();
     expect(modeChip()).toHaveTextContent("Build");
-    setMode("Plan");
+    await setMode("Plan");
     await waitFor(() => expect(store.getState().sessions.se1?.permissionMode).toBe("plan"));
     expect(modeChip()).toHaveTextContent("Plan");
   });
@@ -899,9 +908,9 @@ describe("prompter mode chip (Build / Plan)", () => {
     // would otherwise silently demote Full access to Ask.
     const { store } = await mountFresh({ permissionMode: "bypassPermissions" });
     expect(permissionChip()).toHaveTextContent("Full access");
-    setMode("Plan");
+    await setMode("Plan");
     await waitFor(() => expect(store.getState().sessions.se1?.permissionMode).toBe("plan"));
-    setMode("Build");
+    await setMode("Build");
     await waitFor(() => expect(store.getState().sessions.se1?.permissionMode).toBe("bypassPermissions"));
     expect(permissionChip()).toHaveTextContent("Full access");
     expect(store.getState().planReturn.se1).toBeUndefined(); // the park is spent, not left behind
@@ -909,17 +918,17 @@ describe("prompter mode chip (Build / Plan)", () => {
 
   it("survives a pane remount — the parked mode lives in the store, not the component", async () => {
     const { store, unmount } = await mountFresh({ permissionMode: "acceptEdits" });
-    setMode("Plan");
+    await setMode("Plan");
     await waitFor(() => expect(store.getState().sessions.se1?.permissionMode).toBe("plan"));
     unmount();
     render(<StoreContext.Provider value={store}><SessionPane item={item("i9", "s1", { kind: "session", refId: "se1", title: "Claude session" })} visible /></StoreContext.Provider>);
-    setMode("Build");
+    await setMode("Build");
     await waitFor(() => expect(store.getState().sessions.se1?.permissionMode).toBe("acceptEdits"));
   });
 
   it("names what Build will restore while in Plan, and stops offering a picker that would do nothing", async () => {
     const { store } = await mountFresh({ permissionMode: "acceptEdits" });
-    setMode("Plan");
+    await setMode("Plan");
     await waitFor(() => expect(store.getState().sessions.se1?.permissionMode).toBe("plan"));
     // Plan is read-only regardless of permission mode, so the control is a label, not a menu.
     expect(permissionChip()).toBeNull();
@@ -1056,6 +1065,7 @@ describe("ACP mode chip — per-session modes (Plan 14 W3)", () => {
     await waitFor(() => expect(store.getState().sessions.se1?.permissionMode).toBe("plan"));
     expect(store.getState().planReturn.se1).toBeUndefined(); // no park for an agent with no permission axis
     expect(screen.getByRole("button", { name: "Mode" })).toHaveTextContent("Plan");
+    await exited();
     fireEvent.click(screen.getByRole("button", { name: "Mode" }));
     fireEvent.click(screen.getByRole("menuitemcheckbox", { name: "Build" }));
     await waitFor(() => expect(store.getState().sessions.se1?.permissionMode).toBe("default"));
@@ -1280,6 +1290,7 @@ describe("prompter model picker", () => {
       openPicker();
       fireEvent.click(screen.getByRole("option", { name: /gpt-5.3-codex/ }));
       await waitFor(() => expect(store.getState().sessions.se1?.model).toBe("gpt-5.3-codex[reasoning=medium,fast=false]"));
+      await exited();
       openPicker();
       // "Auto" is a REAL id in Cursor's catalog (set_model accepts `default[]`, rejects `auto`):
       // picking it transmits that id — it is never rewritten to null or to a literal "auto".

--- a/apps/desktop/src/renderer/src/panes/session/tool-card.test.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/tool-card.test.tsx
@@ -16,6 +16,48 @@ const resultWell = () => document.querySelector<HTMLElement>(".tool-section:last
 
 afterEach(() => cleanup());
 
+/** ⌥-click on a disclosure, Finder's gesture, applied to the ledger. It is unadvertised, so the
+ *  thing to hold is that it stays out of the way: a plain click must be exactly what it was, and one
+ *  press must not cascade into a second round of presses. */
+describe("⌥-click opens the whole ledger", () => {
+  // Prose between the calls, because a run of GROUP_MIN folds into a ToolGroup and the cards inside a
+  // closed one are not rendered at all. Three cards standing on their own is the shape under test.
+  const three = (): TranscriptModel => ({
+    blocks: (["a", "b", "c"].flatMap((id, i) => [
+      { kind: "tool", toolUseId: id, name: "Bash", input: { command: id }, result: { content: id, isError: false }, ts: i * 2 },
+      { kind: "assistant", messageId: `m${i}`, text: "and then", streaming: false, ts: i * 2 + 1 },
+    ]) as Block[]),
+    pendingPermissions: [], usage: { costUsd: 0, inputTokens: 0, outputTokens: 0, numTurns: 0 }, init: null, run: null,
+  });
+  const rows = () => screen.getAllByRole("button", { name: /tool call/ });
+  const openStates = () => rows().map((r) => r.getAttribute("aria-expanded"));
+
+  it("a plain click still opens only the card it landed on", () => {
+    render(<Transcript transcript={three()} sessionStatus="idle" onDecide={() => {}} />);
+    fireEvent.click(rows()[0]!);
+    expect(openStates()).toEqual(["true", "false", "false"]);
+  });
+
+  it("⌥-click carries every other card to the SAME state, rather than flipping each to its own", () => {
+    render(<Transcript transcript={three()} sessionStatus="idle" onDecide={() => {}} />);
+    fireEvent.click(rows()[1]!); // one card already open, so a blind toggle-all would close it
+    fireEvent.click(rows()[0]!, { altKey: true });
+    expect(openStates()).toEqual(["true", "true", "true"]);
+    fireEvent.click(rows()[0]!, { altKey: true });
+    expect(openStates()).toEqual(["false", "false", "false"]);
+  });
+
+  it("does not cascade: the clicks it sends carry no modifier of their own", () => {
+    // Each synthetic press re-enters the same handler, so a press that inherited `altKey` would send
+    // its own round — quadratic on a transcript that runs to hundreds of cards.
+    render(<Transcript transcript={three()} sessionStatus="idle" onDecide={() => {}} />);
+    const presses = vi.spyOn(HTMLElement.prototype, "click");
+    fireEvent.click(rows()[0]!, { altKey: true });
+    expect(presses).toHaveBeenCalledTimes(2); // the two siblings, and nothing they went on to press
+    presses.mockRestore();
+  });
+});
+
 describe("ToolCard output clamp (A-M2)", () => {
   it("a result at exactly the clamp limit renders in full with no expander", () => {
     mount("x".repeat(RESULT_CLAMP));

--- a/apps/desktop/src/renderer/src/panes/settings/SettingsPage.tsx
+++ b/apps/desktop/src/renderer/src/panes/settings/SettingsPage.tsx
@@ -83,8 +83,10 @@ function CommandCopy({ command }: { command: string }) {
     <div className="install-cmd">
       <code>{command}</code>
       <button className="tool-copy" aria-label="Copy command" title={copied ? "Copied" : "Copy"}
+        data-copied={copied || undefined}
         onClick={() => { void navigator.clipboard?.writeText(command); setCopied(true); }}>
-        <Icon name={copied ? "check" : "copy"} size={12} />
+        <Icon name="copy" size={12} className="copy-icon" />
+        <Icon name="check" size={12} className="copied-icon" />
       </button>
     </div>
   );

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -244,6 +244,12 @@ kbd { font: 11px var(--font-mono); }
 .pill { font-size: 11px; padding: 2px 8px; border-radius: 999px; background: var(--inset); color: var(--ink-2); } /* W3: StatusPill neutral */
 .icon-btn { display: grid; place-items: center; width: 28px; height: 28px; border-radius: var(--r-ctl); color: var(--rl-text-dim); }
 .icon-btn:hover { background: var(--rl-hover); color: var(--rl-text-bright); }
+/* A toggle whose glyph does NOT change has to say so with its fill, and these had no on-state at all:
+   the rich-text toolbar's Bold and the terminal drawer's ⌘J looked identical pressed and unpressed.
+   One rung past hover, so "on" always reads as more than "under the pointer" — which is also why it
+   sits after the hover rule and wins over it. It moves on the hover transition the button already
+   carries (§6), so turning a toggle on settles rather than snaps. */
+.icon-btn[aria-pressed="true"] { background: var(--hover-2); color: var(--rl-text-bright); }
 /* Hit-target extension (V-F8): the visual button stays small; the click target grows 6px each way.
    .tool-copy joins the list — its 20px box sits alone at its row's right edge, so the overhang
    never crosses another interactive element. */
@@ -1123,11 +1129,9 @@ button.panel-title:hover { background: var(--rl-hover); }
 .tool-body { border-top: 1px solid var(--rl-hairline); padding: 10px 12px; display: flex; flex-direction: column; gap: 8px;
   opacity: 0; transition: opacity var(--dur-press) ease; }
 .tool-section { display: flex; flex-direction: column; }
-/* Copy ✓ (§6 icon swap): both glyphs stacked in one grid cell, cross-fading with scale + blur. */
-.tool-copy .copy-icon, .tool-copy .copied-icon { grid-area: 1 / 1;
-  transition: opacity var(--dur-swap) var(--ease-out-strong), transform var(--dur-swap) var(--ease-out-strong), filter var(--dur-swap) var(--ease-out-strong); }
+/* Copy ✓ rides §6's icon swap (the shared rule down in the motion block); the tick's colour is the
+   only part of it that belongs to this button. */
 .tool-copy .copied-icon { color: var(--rl-success); }
-.tool-copy:not([data-copied]) .copied-icon, .tool-copy[data-copied] .copy-icon { opacity: 0; transform: scale(.25); filter: blur(4px); }
 .tool-label { display: flex; align-items: center; font-size: 10.5px; text-transform: uppercase; letter-spacing: .06em; color: var(--rl-text-dim); margin-bottom: 4px; }
 .tool-copy { margin-left: auto; display: grid; place-items: center; width: 20px; height: 20px; border-radius: var(--r-chip); color: var(--rl-text-dim); }
 .tool-copy:hover { background: var(--rl-hover); color: var(--rl-text-bright); }
@@ -1637,17 +1641,15 @@ button.panel-title:hover { background: var(--rl-hover); }
 .composer-drop-hint { position: absolute; inset: 0; display: grid; place-items: center; pointer-events: none;
   border-radius: calc(var(--r-float) + 4px); corner-shape: squircle; background: color-mix(in srgb, var(--rl-raised) 82%, transparent);
   font-size: 12px; font-weight: var(--fw-label); color: var(--rl-text-bright); }
-/* Send↔stop morph (§6; Ara refresh §2 sizes it up to 32px): accent circle; both icons in the DOM,
-   cross-fading 160ms with opacity + scale .25→1 + 4px blur. data-state picks which one is up.
+/* Send↔stop morph (§6): accent circle at Ara refresh §2's 32px, wearing the shared icon swap in the
+   motion block — both icons in the DOM, `data-state` picking which one is up.
    Plan 9 W3: the circle wears BUI Button's accent treatment — inset top highlight, accent-ink on
    hover — and PromptBar's disabled send (line-strong fill, ink-2 glyph) replaces the bare fade. */
 .composer-send { position: relative; display: grid; place-items: center; width: 32px; height: 32px; border-radius: 50%;
   background: var(--rl-accent); color: var(--rl-accent-contrast); box-shadow: var(--fill-bevel); flex: none; }
 .composer-send:hover:not(:disabled) { background: var(--accent-ink); }
 .composer-send:disabled { background: var(--line-strong); color: var(--ink-2); box-shadow: none; opacity: 1; }
-.composer-send svg { grid-area: 1 / 1;
-  transition: opacity var(--dur-swap) var(--ease-out-strong), transform var(--dur-swap) var(--ease-out-strong), filter var(--dur-swap) var(--ease-out-strong); }
-.composer-send[data-state="send"] .stop-icon, .composer-send[data-state="stop"] .send-icon { opacity: 0; transform: scale(.25); filter: blur(4px); }
+
 /* ── Under-strip (§4 + Plan 12 W1): machine label + workspace selector, one size quieter than the
    control row (11px on faint vs 12px on dim), on a frame fill sliding out from beneath the card
    (z-index 1 on .composer keeps the card on top). Drawn unconditionally — where a session runs is
@@ -1863,6 +1865,22 @@ button.panel-title:hover { background: var(--rl-hover); }
    everything" that covers the window, so it enters on the sheet's own timings rather than snapping. */
 .spaces-overview { animation: rl-sheet-in var(--dur-slow) var(--ease-out-strong); }
 .spaces-backdrop { animation: rl-fade-in var(--dur-swap) var(--ease-out-strong); }
+
+/* Icon swap (§6): a control whose GLYPH carries its state keeps both glyphs in the DOM, stacked in
+   one grid cell, and turns them over with opacity + scale .25 + a 4px blur on the swap rung. Written
+   once, because it was written twice and skipped twice: the copy tick and the send↔stop morph each
+   carried a copy, while Settings' and the install card's copy buttons — which match `.tool-copy` and
+   were therefore already paying for the rule — swapped their glyph with a bare ternary and got no
+   transition at all, there being nothing named to reach for. The scale-into-the-centre is what makes
+   it read as one glyph turning over rather than two crossing past each other, and the control keeps
+   ONE glyph box and ONE accessible name throughout: a swap is a change of state, not of control. */
+.icon-swap { display: grid; place-items: center; }
+.icon-swap > *, .tool-copy .copy-icon, .tool-copy .copied-icon, .composer-send svg { grid-area: 1 / 1;
+  transition: opacity var(--dur-swap) var(--ease-out-strong), transform var(--dur-swap) var(--ease-out-strong), filter var(--dur-swap) var(--ease-out-strong); }
+.icon-swap:not([data-on]) .swap-on, .icon-swap[data-on] .swap-off,
+.tool-copy:not([data-copied]) .copied-icon, .tool-copy[data-copied] .copy-icon,
+.composer-send[data-state="send"] .stop-icon, .composer-send[data-state="stop"] .send-icon {
+  opacity: 0; transform: scale(.25); filter: blur(4px); }
 
 /* Hover fills (§6): 100ms `ease`, background (and the text colour riding along with it) only —
    never `all`, never geometry. */

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -1081,11 +1081,17 @@ button.panel-title:hover { background: var(--rl-hover); }
 .tool-stat-add { color: var(--green); }
 .tool-stat-del { color: var(--red); }
 
-/* §6 tool-row expand: height animates via grid-template-rows 0fr→1fr over 200ms, content fades at
-   120ms. .tool-body-clip is the overflow container the 0fr row needs to clip against. */
-.tool-body-wrap { display: grid; grid-template-rows: 0fr; transition: grid-template-rows var(--dur-base) var(--ease-in-out-strong); }
-.tool-card[data-open] > .tool-body-wrap { grid-template-rows: 1fr; }
-.tool-body-clip { overflow: hidden; min-height: 0; }
+/* §6 disclosure expand: height animates via grid-template-rows 0fr→1fr over 200ms — the one rung
+   for a box changing SIZE, and the one technique that works when the content's height is unknowable
+   in advance. `.tool-body-clip` is the overflow container the 0fr row needs to clip against; the
+   tool row's content also fades in at 120ms behind it. The sidebar's archived shelf shares this
+   rule rather than reaching for max-height, which would have to guess a number and would ease
+   against a height the list does not have.
+   The tool card's half addresses DIRECT children: a card now contains its sub-agent's cards, and a
+   descendant selector would have opening the parent unfold every body beneath it. */
+.tool-body-wrap, .archived-wrap { display: grid; grid-template-rows: 0fr; transition: grid-template-rows var(--dur-base) var(--ease-in-out-strong); }
+.tool-card[data-open] > .tool-body-wrap, .archived-wrap[data-open] { grid-template-rows: 1fr; }
+.tool-body-clip, .archived-clip { overflow: hidden; min-height: 0; }
 .tool-card[data-open] > .tool-body-wrap .tool-body { opacity: 1; }
 
 /* Grouped runs (§2.8/§5) wear BUI ThinkingState's header + trace (Plan 9 W2): the collapsed row is

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -1823,6 +1823,16 @@ button.panel-title:hover { background: var(--rl-hover); }
    transform-origin to the corner the menu grew from, so it appears to unfold out of its trigger. */
 .menu, .model-picker { animation: rl-menu-in var(--dur-pop) var(--ease-out-strong); }
 @keyframes rl-menu-in { from { opacity: 0; transform: scale(.97); } to { opacity: 1; transform: none; } }
+/* …and back into it. The exit reverses the enter on `--dur-press`, the rung for a control resolving
+   inside the gesture that dismissed it — a popover leaving should never take longer than it took to
+   arrive. `use-anchored-popover.ts` holds the surface in the DOM for exactly that rung and marks it
+   `inert`; `pointer-events: none` is the second lock, for the frame between the paint and the
+   attribute. `forwards` matters: without it a timer that lands a frame late flashes the surface back
+   to full opacity on its way out. Enter and exit are one decision, so this selector list and the
+   one above it are the same list — the pickers that appear instantly also vanish instantly. */
+.menu[data-closing], .model-picker[data-closing], .icon-picker[data-closing] {
+  animation: rl-menu-out var(--dur-press) var(--ease-out-strong) forwards; pointer-events: none; }
+@keyframes rl-menu-out { from { opacity: 1; transform: none; } to { opacity: 0; transform: scale(.97); } }
 
 /* Sheets (§6): enter 240ms, scale .96 + fade, origin center; the scrim fades on its own at 160ms.
    One rule for every sheet — W4b's `.sheet.onboarding` carve-out is gone. */

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -1430,6 +1430,12 @@ button.panel-title:hover { background: var(--rl-hover); }
 .hero-greeting { position: absolute; bottom: calc(100% + 20px); left: 0; right: 0; text-align: center;
   font-size: 30px; font-weight: var(--fw-title); letter-spacing: -0.02em; color: var(--rl-text-bright); text-wrap: balance; }
 .hero-greeting em { font-style: normal; }
+/* The greeting nods when its emphasised word is clicked (Composer.tsx sets the mark). Pivoting on
+   the baseline, so the line dips on the ruler it sits on rather than swinging around its middle;
+   the whole line moves rather than the word alone, because a transform needs a block box and giving
+   the inline <em> one would stop a long space name wrapping. */
+.hero-greeting[data-nod] { animation: rl-nod var(--dur-move) var(--ease-in-out-strong); transform-origin: 50% 100%; }
+@keyframes rl-nod { 45% { transform: rotate(-1.5deg) translateY(2px); } to { transform: none; } }
 
 /* Suggested prompts (Ara refresh §3): a single-column LIST at full prompter width under the card —
    transparent rows, hover fill, one 14px title line behind a faint leading glyph. */

--- a/apps/desktop/src/renderer/src/styles.test.ts
+++ b/apps/desktop/src/renderer/src/styles.test.ts
@@ -272,6 +272,15 @@ describe("§6 motion table", () => {
     expect(bodiesFor('.strip-badge[data-status="waiting_permission"]').join(" ")).toContain("rl-pulse 0.9s ease-in-out infinite");
   });
 
+  it("the greeting's nod is on the ladder like everything else, and the preference takes it away", () => {
+    // An unadvertised flourish is still motion, and gets no exemption from either rule: it reaches
+    // for a rung rather than inventing a tempo, and it is an ordinary element rule, so the global
+    // `* { animation: none }` reaches it without the pseudo-element carve-out the ping needed.
+    expect(bodiesFor(".hero-greeting[data-nod]").join(" ")).toContain(`animation: rl-nod ${dur("--dur-move")} var(--ease-in-out-strong)`);
+    expect(blockAfter("@keyframes rl-nod")).toContain("transform: none");
+    expect(RULES.some((r) => r.selectors.some((sel) => sel.includes("::") && sel.includes("hero-greeting")))).toBe(false);
+  });
+
   it("`will-change` is reserved for the swiper track (§6 performance note)", () => {
     const owners = RULES.filter((r) => r.body.includes("will-change")).flatMap((r) => r.selectors);
     expect(owners).toEqual([".swiper-track"]);

--- a/apps/desktop/src/renderer/src/styles.test.ts
+++ b/apps/desktop/src/renderer/src/styles.test.ts
@@ -104,6 +104,32 @@ describe("§6 motion table", () => {
     expect(blockAfter("@keyframes rl-menu-in")).toContain("scale(.97)");
   });
 
+  it("popovers leave the way they arrived: the exit reverses the enter on the press rung, and holds nothing behind", () => {
+    for (const sel of [".menu[data-closing]", ".model-picker[data-closing]", ".icon-picker[data-closing]"]) {
+      const body = bodiesFor(sel).join(" ");
+      expect(body, sel).toContain(`animation: rl-menu-out ${dur("--dur-press")} var(--ease-out-strong) forwards`);
+      // A surface that is on its way out must not still be catching clicks. `inert` is the real
+      // guard (Menu.tsx sets it) — this is the half that holds for the frame before the attribute.
+      expect(body, sel).toContain("pointer-events: none");
+    }
+    // The exit is the enter played backwards, not a second idea about what a popover does.
+    expect(blockAfter("@keyframes rl-menu-out")).toContain("scale(.97)");
+    // No half-pairs. A surface that only animates while you are trying to get rid of it is worse
+    // than one that never animates, so an exit may only exist where the matching enter already does
+    // — which rules the @-mention typeahead and the skill picker out, both of which appear instantly.
+    const listOf = (decl: string) => RULES.filter((r) => r.body.includes(decl)).flatMap((r) => r.selectors);
+    const enters = new Set(listOf("rl-menu-in"));
+    for (const sel of listOf("rl-menu-out")) expect(enters, sel).toContain(sel.replace("[data-closing]", ""));
+  });
+
+  it("the DOM hold and the CSS exit are the same number", () => {
+    // `use-anchored-popover.ts` keeps a dismissed popover mounted on a timer; the stylesheet fades it
+    // on an animation. Nothing in either file can notice the two drifting apart — a short timer clips
+    // the fade, a long one parks a finished surface on screen — so they are pinned to each other here.
+    const hook = readFileSync(repoFile("apps/desktop/src/renderer/src/components/use-anchored-popover.ts"), "utf8");
+    expect(Number(hook.match(/const EXIT_MS = (\d+);/)?.[1])).toBe(LADDER["--dur-press"]);
+  });
+
   it("the model picker is a popover and enters on the same rule as menus, not one of its own", () => {
     // It shares `.menu`'s declaration rather than carrying a copy: §6 gives every popover one timing,
     // and a second animation here is how the prompter's picker drifts away from every other surface.

--- a/apps/desktop/src/renderer/src/styles.test.ts
+++ b/apps/desktop/src/renderer/src/styles.test.ts
@@ -178,6 +178,19 @@ describe("§6 motion table", () => {
     expect(bodiesFor(".tool-body").join(" ")).toContain(`transition: opacity ${dur("--dur-press")} ease`);
   });
 
+  it("every disclosure in the app opens the same way — one rule, never a second guess at max-height", () => {
+    // The sidebar's archived shelf rides the tool row's declaration rather than carrying a copy.
+    // max-height is the alternative, and it is the wrong one twice over: the number has to be
+    // guessed, and the easing then runs against a height the content does not have, so a short list
+    // snaps and a long one is clipped.
+    for (const sel of [".archived-wrap", ".tool-body-wrap"])
+      expect(bodiesFor(sel).join(" "), sel).toContain(`transition: grid-template-rows ${dur("--dur-base")} var(--ease-in-out-strong)`);
+    expect(bodiesFor(".archived-wrap[data-open]").join(" ")).toContain("grid-template-rows: 1fr");
+    // 0fr only clips against an overflow container; without it the folded rows spill up the sidebar.
+    expect(bodiesFor(".archived-clip").join(" ")).toContain("overflow: hidden");
+    expect(css, "no disclosure may animate max-height").not.toMatch(/transition:[^;]*max-height/);
+  });
+
   it("the copy ✓ swap uses the same 160ms opacity/scale/blur cross-fade as send↔stop", () => {
     const swap = bodiesFor(".tool-copy .copy-icon").join(" ");
     for (const prop of ["opacity", "transform", "filter"]) expect(swap, prop).toContain(`${prop} ${dur("--dur-swap")}`);

--- a/apps/desktop/src/renderer/src/styles.test.ts
+++ b/apps/desktop/src/renderer/src/styles.test.ts
@@ -191,6 +191,33 @@ describe("§6 motion table", () => {
     expect(css, "no disclosure may animate max-height").not.toMatch(/transition:[^;]*max-height/);
   });
 
+  it("every glyph that carries a state turns over on ONE rule — no surface writes the swap again", () => {
+    // The two that had their own copy of it are now comma-separated parts of the shared one, which
+    // is what lets a third control (the media transport) reach for `.icon-swap` instead of writing
+    // a fourth. Anything declaring the cross-fade outside this pair of rules is a copy coming back.
+    const swapRules = RULES.filter((r) => r.body.includes("filter") && r.body.includes(dur("--dur-swap")) && r.body.includes("grid-area"));
+    expect(swapRules).toHaveLength(1);
+    expect(swapRules[0]!.selectors).toContain(".icon-swap > *");
+    const down = RULES.filter((r) => r.body.includes("blur(4px)") && r.body.includes("scale(.25)"));
+    expect(down).toHaveLength(1);
+    // `.icon-swap` reads its state off the CONTAINER, so a control adopting it needs no new CSS —
+    // just the two glyphs and a `data-on`.
+    expect(down[0]!.selectors).toEqual(expect.arrayContaining([".icon-swap:not([data-on]) .swap-on", ".icon-swap[data-on] .swap-off"]));
+  });
+
+  it("an icon button can finally show that it is ON, one rung past hover", () => {
+    // Bold, Italic, and the terminal drawer's ⌘J are `.icon-btn[aria-pressed]` and had no pressed
+    // treatment of any kind — a toggle you could not tell the state of. The fill is the state (the
+    // glyph does not change), so it has to sit ABOVE the hover fill or "on" and "under the pointer"
+    // would be the same picture.
+    const on = bodiesFor('.icon-btn[aria-pressed="true"]').join(" ");
+    expect(on).toContain("background: var(--hover-2)");
+    expect(bodiesFor(".icon-btn:hover").join(" ")).toContain("background: var(--rl-hover)");
+    // …and it moves on the hover rung the button already carries — §6 gives it no rule of its own.
+    expect(on).not.toContain("transition");
+    expect(on).not.toContain("transform"); // hover and state are colour; geometry is the press alone
+  });
+
   it("the copy ✓ swap uses the same 160ms opacity/scale/blur cross-fade as send↔stop", () => {
     const swap = bodiesFor(".tool-copy .copy-icon").join(" ");
     for (const prop of ["opacity", "transform", "filter"]) expect(swap, prop).toContain(`${prop} ${dur("--dur-swap")}`);


### PR DESCRIPTION
Stacked on #27.

**Exits.** Menus and pickers had an enter animation and no exit at all, because React unmounts them immediately. The deferral now lives in `useAnchoredPopover`, so no mount site changed: `close()` marks the surface closing, hands focus back, and tells the parent one `--dur-press` later.

Four things make that a deferral rather than a leak. The fading surface is `inert` and pointer-transparent, so the app behind stays reachable by pointer, keyboard and AT. Focus returns on the *gesture*, not the unmount — otherwise keystrokes land on `<body>` for 120ms. Placement freezes while closing, because a menu item that closes its own pane takes the anchor with it and the fallback would fling the surface to the window corner mid-fade.

And the next pointerdown or keydown commits the exit outright — deliberately **not** the click that follows a pointerdown. That version got built first, and instrumentation caught it: told during the click, the parent re-opens the very element that is mid-exit, React reuses it, `closing` never clears, and you get a menu stuck invisible and inert forever. The parent has to be told *between* pointerdown and click so the remount is real.

Reduced motion skips the hold entirely — no closing state, no timer — rather than running it at zero.

Proved by `popover-exit-live.mjs`, 15 checks: `getAnimations()` shows `rl-menu-out` actually playing on the compositor; `elementFromPoint` through the middle of the fade lands on the app; the menu doesn't travel; it is gone after a settle; ten open/close cycles faster than the exit never stack two. The check carries its own negative controls — it plants a leaked menu and confirms the same predicate counts it, and it moves a menu to confirm the no-travel assertion can fail — so a pass is not vacuous.

**Disclosures.** The archived shelf shares the tool row's `grid-template-rows` rule rather than reaching for `max-height`, which would have to guess a number and would ease against a height the list does not have.

**Icon buttons.** The swap is hoisted to one idiom, and `aria-pressed` buttons get an on-state they did not have — Bold, Italic, the three headings and ⌘J looked identical pressed and unpressed.

Left still on purpose: hover stays colour-only and press stays `.97`. The `@`-mention typeahead gets no exit, since it opens and closes between keystrokes and a ghost trailing the caret is noise. `.skill-picker` and `.mention-picker` have no enter, so they get no exit — enter and exit are one decision per surface, and an exit without an enter only animates while you are trying to get rid of something. Focus/unfocus-pane and browser stop/reload keep their element swap, because they are two verbs with two accessible names and cross-fading them means one control whose name changes under a screen reader mid-fade.

No animation library was added; nothing here needed one.

**Two easter eggs.** ⌥-click a tool card's disclosure opens every card in the transcript — Finder's gesture, and ⌥ is already this app's "the other way to do this". Siblings are driven through their own rows rather than lifting `open` into shared state, because a transcript holds hundreds of cards and a subscription each is a standing cost paid by everyone who never finds it; synthetic clicks carry no `altKey`, so one press cannot cascade. And clicking the emphasised word in the hero greeting makes the line nod — no state, no timer, the mark comes off on `animationend`. Both sit under the existing reduced-motion kill with no carve-out.

One behaviour change worth knowing: ten tests across four files now wait for a menu to leave before opening the next one. `onClose` is genuinely later now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)