### PR TITLE
Prompter and space-strip polish: rounder squircles, a lift that follows the curve, a strip that blends

### DIFF
--- a/apps/desktop/scripts/squircle-live.mjs
+++ b/apps/desktop/scripts/squircle-live.mjs
@@ -251,10 +251,20 @@ async function main() {
     return s.band(b.left - 6, b.top + 30, b.left - 1, b.bottom - 30);
   })()`;
   const lift = await evalIn(c, leftOfCard(restShot));
-  await evalIn(c, `(() => { document.querySelector(".composer").style.boxShadow = "none"; return true; })()`);
+  // The lift is a `filter` on the card's ::before, not a box-shadow on the card — a box-shadow is
+  // drawn from the border box and these surfaces have `border-radius: 0`, so it landed square behind
+  // a rounded card. Suppressing the filter is therefore what removes the lift; mutating boxShadow
+  // here would change nothing and this check would pass without testing anything.
+  await evalIn(c, `(() => {
+    const st = document.createElement("style");
+    st.id = "kill-lift";
+    st.textContent = ":root[data-squircle] .composer::before { filter: none !important; }";
+    document.head.appendChild(st);
+    return true;
+  })()`);
   await sleep(250);
   const flat = await evalIn(c, leftOfCard(await shotOf(c)));
-  check("the card still casts its lift — the ground beside it is darker than with box-shadow removed",
+  check("the card still casts its lift — the ground beside it is darker than with the drop-shadow removed",
     lift < flat - 0.3, { withShadow: +lift.toFixed(2), withoutShadow: +flat.toFixed(2) });
   await evalIn(c, `(() => { document.querySelector(".composer").style.boxShadow = ""; return true; })()`);
   await sleep(250);

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -96,6 +96,12 @@
   --r-panel: 12px;                               /* --radius-card: menus, pickers, permission card */
   --r-float: 16px;                               /* --radius-window: composer, sheets, palette */
   --r-pill: 999px;                               /* --radius-pill */
+  /* The floating cards the paint worklet draws. Its own rung rather than a step off --r-float:
+     a superellipse at a given radius reads visually smaller than a circular corner at the same
+     one, so the two scales were never going to stay in step by arithmetic. Every squircle surface
+     reads this, and the fallback border-radius reads it too, so the painted and unpainted forms
+     cannot drift apart. */
+  --r-squircle: 36px;
   --sidebar-w: 280px; --prompter-w: 720px;
   /* §6 easings — identical curves to BUI's @theme; --ease stays as the legacy alias. */
   --ease-out-strong: cubic-bezier(.23,1,.32,1);
@@ -1474,12 +1480,13 @@ button.panel-title:hover { background: var(--rl-hover); }
 /* The card (Plan 9 W3 — BUI PromptBar): a surface field on shadow-card (the hairline ring is part
    of the stack), --r-float, borderless. Focus is BUI's border-brighten — the ring steps to
    line-strong — replacing the old 30% accent glow (PromptBar's focus-within:border-line-strong). */
-/* Squircle prompter. What is written here is the FALLBACK — a circular corner one radius step past
-   --r-float, because a squircle at the same radius reads visually smaller — plus `corner-shape`,
+/* Squircle prompter. What is written here is the FALLBACK — a circular corner at --r-squircle,
+   which is its own rung because a squircle reads visually smaller than a circular corner at the
+   same radius and the two scales cannot track by arithmetic — plus `corner-shape`,
    which states the shape declaratively and takes over once Electron ships Chromium 139. On the
    runtime this app actually has (Chromium 138) `corner-shape` is not a recognised property at all,
    so the curve is drawn by the paint worklet instead; see the squircle block further down. */
-.composer { width: 100%; border-radius: calc(var(--r-float) + 4px); corner-shape: squircle; background: var(--surface);
+.composer { width: 100%; border-radius: var(--r-squircle); corner-shape: squircle; background: var(--surface);
   box-shadow: var(--shadow-card); display: flex; flex-direction: column; position: relative; z-index: 1; }
 .composer:focus-within {
   box-shadow: 0 0 0 1px var(--line-strong), var(--shadow-card); }
@@ -1667,7 +1674,7 @@ button.panel-title:hover { background: var(--rl-hover); }
    card declares none. The hint is a label, not a scrim: pointer-events off, so the drop still lands. */
 .composer[data-dropping] { box-shadow: 0 0 0 2px var(--rl-accent), var(--shadow-card); }
 .composer-drop-hint { position: absolute; inset: 0; display: grid; place-items: center; pointer-events: none;
-  border-radius: calc(var(--r-float) + 4px); corner-shape: squircle; background: color-mix(in srgb, var(--rl-raised) 82%, transparent);
+  border-radius: var(--r-squircle); corner-shape: squircle; background: color-mix(in srgb, var(--rl-raised) 82%, transparent);
   font-size: 12px; font-weight: var(--fw-label); color: var(--rl-text-bright); }
 /* Send↔stop morph (§6): accent circle at Ara refresh §2's 32px, wearing the shared icon swap in the
    motion block — both icons in the DOM, `data-state` picking which one is up.
@@ -1685,6 +1692,9 @@ button.panel-title:hover { background: var(--rl-hover); }
    transform carries it and the absolutely-hung suggestions land below it. ── */
 .composer-understrip { display: flex; align-items: center; gap: 2px; min-width: 0;
   margin: -10px 10px 0; padding: 12px 6px 6px; background: var(--rl-frame);
+  /* --r-panel, not --r-squircle: only ~26px of this strip shows below the card, so 12px is already
+     nearly half its height. A corner cannot be rounder than half the box — past that the curve
+     clamps and the strip reads as a stadium rather than as the bottom of the prompter. */
   border-radius: 0 0 var(--r-panel) var(--r-panel); corner-shape: squircle; }
 .composer-understrip .ghost-chip { height: 24px; font-size: 11px; gap: 5px; color: var(--rl-text-faint); max-width: 260px; }
 .composer-understrip .ghost-chip:hover:not([data-static]) { color: var(--rl-text-dim); }
@@ -1703,7 +1713,7 @@ button.panel-title:hover { background: var(--rl-hover); }
 
 /* ── Install card (§5 floating card) — what stands in for the prompter when the CLI can't run ── */
 /* It rides the prompter's own rails (.composer-dock), so hero vs docked positioning is already right. */
-.install-card { width: 100%; border-radius: calc(var(--r-float) + 4px); corner-shape: squircle; background: var(--rl-raised);
+.install-card { width: 100%; border-radius: var(--r-squircle); corner-shape: squircle; background: var(--rl-raised);
   box-shadow: var(--rl-edge), var(--rl-shadow); padding: 16px 18px 14px; display: flex; flex-direction: column; gap: 10px; position: relative; z-index: 1; }
 .install-head { display: flex; align-items: center; gap: 8px; }
 .install-head h3 { margin: 0; font-size: 14px; font-weight: var(--fw-title); color: var(--rl-text-bright); }
@@ -1744,8 +1754,8 @@ button.panel-title:hover { background: var(--rl-hover); }
 :root[data-squircle] .commit-card {
   border-radius: 0;
   background: paint(rl-squircle);
-  --sq-radius-top: calc(var(--r-float) + 4px);
-  --sq-radius-bottom: calc(var(--r-float) + 4px);
+  --sq-radius-top: var(--r-squircle);
+  --sq-radius-bottom: var(--r-squircle);
 }
 :root[data-squircle] .composer, :root[data-squircle] .commit-card {
   --sq-fill: var(--surface); --sq-ring: var(--card-ring); --sq-ring-w: var(--hairline-w);
@@ -2021,7 +2031,7 @@ button.panel-title:hover { background: var(--rl-hover); }
    second time. Unlike .composer-input this textarea has no auto-resize behind it, so it keeps its
    scrollbar: at a fixed two rows that bar is the only sign the message runs on. */
 .diff-commit { flex: none; display: flex; flex-direction: column; gap: 8px; padding: 6px 12px 12px; }
-.commit-card { display: flex; flex-direction: column; border-radius: calc(var(--r-float) + 4px); corner-shape: squircle;
+.commit-card { display: flex; flex-direction: column; border-radius: var(--r-squircle); corner-shape: squircle;
   background: var(--surface); box-shadow: var(--shadow-card); }
 .commit-card:focus-within { box-shadow: 0 0 0 1px var(--line-strong), var(--shadow-card); }
 .commit-message { border: none; outline: none; resize: none; background: transparent; color: var(--rl-text-bright);

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -341,13 +341,34 @@ kbd { font: 11px var(--font-mono); }
 /* The profile chip: which profile the strip below is scoped to, and the door to the others. One
    square the size of a space button, wearing the profile's own icon and colour — spelling the name
    out here cost roughly two space slots, and the header's profile pill already says it. */
-.strip-profile { display: grid; place-items: center; width: 30px; height: 30px; border-radius: var(--r-ctl); }
-.strip-profile:hover:not(:disabled) { background: var(--rl-hover); }
+.strip-profile { position: relative; isolation: isolate; display: grid; place-items: center; width: 30px; height: 30px; border-radius: var(--r-ctl); }
+.strip-profile::before {
+  content: ""; position: absolute; inset: 0; z-index: -1; border-radius: inherit; opacity: 0;
+  background: radial-gradient(closest-side, var(--rl-hover), transparent);
+  transition: opacity var(--dur-hover) ease;
+}
+.strip-profile:hover:not(:disabled)::before { opacity: 1; }
 .strip-profile:disabled { opacity: .45; }
-.strip-space { position: relative; display: grid; place-items: center; width: 30px; height: 30px; border-radius: var(--r-ctl); color: var(--rl-text-dim); flex: none; }
-.strip-space:hover { background: var(--rl-hover); color: var(--rl-text-bright); }
-/* Active space (§5): --rl-active fill, no border; the glyph takes the space colour. */
-.strip-space[data-active] { color: var(--rl-space); background: var(--rl-active); }
+/* The strip sits on the macOS vibrancy, and a flat fill behind the active space read as a plate
+   stuck onto the material rather than part of it — a hard rounded-rect edge is the one thing the
+   blur underneath cannot soften. The fill is a radial wash with no boundary instead: strongest under
+   the glyph, gone by the edge of the box.
+
+   It rides ::before rather than the element so the hover can still cross-fade — a background-image
+   does not interpolate, and .strip-space is in the §6 hover-transition list. `isolation` is what
+   makes z-index: -1 mean "behind the glyph" rather than "behind the sidebar": without a stacking
+   context here the wash would drop through the strip entirely. */
+.strip-space { position: relative; isolation: isolate; display: grid; place-items: center; width: 30px; height: 30px; border-radius: var(--r-ctl); color: var(--rl-text-dim); flex: none; }
+.strip-space::before {
+  content: ""; position: absolute; inset: 0; z-index: -1; border-radius: inherit; opacity: 0;
+  background: radial-gradient(closest-side, var(--rl-active), transparent);
+  transition: opacity var(--dur-hover) ease;
+}
+.strip-space:hover { color: var(--rl-text-bright); }
+.strip-space:hover::before { opacity: .6; }
+/* Active space (§5): the wash at full strength, no border; the glyph takes the space colour. */
+.strip-space[data-active] { color: var(--rl-space); }
+.strip-space[data-active]::before { opacity: 1; }
 .strip-space[data-drag-over] { box-shadow: inset 2px 0 0 var(--rl-accent); }
 /* Cross-space agent status (U-H3): waiting > error > running, resolved in spaceBadge. */
 /* This badge does NOT take the .status-dot ping, and the divergence is the point. A status dot says

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -1757,18 +1757,38 @@ button.panel-title:hover { background: var(--rl-hover); }
   --sq-radius-top: var(--r-squircle);
   --sq-radius-bottom: var(--r-squircle);
 }
+/* The lift, cast from the painted curve rather than from the border box.
+ *
+ * `box-shadow` is drawn from the border box, and these surfaces set `border-radius: 0` because their
+ * curve is painted rather than declared — so the lift landed as a SQUARE behind a rounded card, six
+ * pixels wide at the corners once the radius reached 36. `drop-shadow` traces rendered alpha, which
+ * IS the worklet's path, and neither lift layer has a spread, so the two forms are otherwise equal.
+ *
+ * It rides a content-free ::before rather than the card, and that is load-bearing twice over: a
+ * filter on the card promotes it to its own layer and the worklet then stops repainting when
+ * `--sq-ring` changes, so focus silently stopped brightening the edge; and filtering the card would
+ * put its text through the filter too. The registered `--sq-*` inputs do not inherit, so this layer
+ * states its own — it needs only an opaque fill and the same radii, never the ring. */
+:root[data-squircle] .composer::before,
+:root[data-squircle] .install-card::before,
+:root[data-squircle] .commit-card::before {
+  content: ""; position: absolute; inset: 2px; z-index: -1; pointer-events: none;
+  --sq-fill: var(--surface); --sq-radius-top: var(--r-squircle); --sq-radius-bottom: var(--r-squircle);
+  background: paint(rl-squircle);
+  filter: var(--shadow-card-lift-filter);
+}
 :root[data-squircle] .composer, :root[data-squircle] .commit-card {
   --sq-fill: var(--surface); --sq-ring: var(--card-ring); --sq-ring-w: var(--hairline-w);
-  box-shadow: var(--shadow-card-lift);
+  box-shadow: none;
 }
 /* Focus is still PromptBar's border-brighten, now traced on the curve instead of around it. */
 :root[data-squircle] .composer:focus-within, :root[data-squircle] .commit-card:focus-within {
   --sq-ring: var(--line-strong); --sq-ring-w: 1px;
-  box-shadow: var(--shadow-card-lift);
+  box-shadow: none;
 }
 :root[data-squircle] .composer[data-dropping] {
   --sq-ring: var(--rl-accent); --sq-ring-w: 2px;
-  box-shadow: var(--shadow-card-lift);
+  box-shadow: none;
 }
 /* The hint lies inset:0 over the card, so it takes the card's own radius or it would square off
    inside a rounded corner. No ring: the card underneath is already wearing the drop target's. */

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -1711,12 +1711,15 @@ button.panel-title:hover { background: var(--rl-hover); }
    (z-index 1 on .composer keeps the card on top). Drawn unconditionally — where a session runs is
    standing context, not a streaming state. In normal flow inside .composer-dock, so the hero→docked
    transform carries it and the absolutely-hung suggestions land below it. ── */
+/* Same rung and same ring as the card above it, so the two read as one object rather than a tab
+   stuck under a card. The bottom padding buys the height that rounding needs: both the worklet and
+   the browser clamp a corner to half the box, so on the old 42px box --r-squircle drew at 21 however
+   it was written. The padding goes symmetric at 12px, which costs 6px of height and buys a 24px
+   corner. The remaining gap to the card's 36 is geometry rather than a choice: matching it exactly
+   needs a 72px strip, three times the height of the chips it holds. */
 .composer-understrip { display: flex; align-items: center; gap: 2px; min-width: 0;
-  margin: -10px 10px 0; padding: 12px 6px 6px; background: var(--rl-frame);
-  /* --r-panel, not --r-squircle: only ~26px of this strip shows below the card, so 12px is already
-     nearly half its height. A corner cannot be rounder than half the box — past that the curve
-     clamps and the strip reads as a stadium rather than as the bottom of the prompter. */
-  border-radius: 0 0 var(--r-panel) var(--r-panel); corner-shape: squircle; }
+  margin: -10px 10px 0; padding: 12px 10px 12px; background: var(--rl-frame);
+  border-radius: 0 0 var(--r-squircle) var(--r-squircle); corner-shape: squircle; }
 .composer-understrip .ghost-chip { height: 24px; font-size: 11px; gap: 5px; color: var(--rl-text-faint); max-width: 260px; }
 .composer-understrip .ghost-chip:hover:not([data-static]) { color: var(--rl-text-dim); }
 /* "Thinking…" hangs off the strip's far end, so arriving mid-stream costs the chips no motion. */
@@ -1815,7 +1818,10 @@ button.panel-title:hover { background: var(--rl-hover); }
    inside a rounded corner. No ring: the card underneath is already wearing the drop target's. */
 :root[data-squircle] .composer-drop-hint { --sq-fill: color-mix(in srgb, var(--rl-raised) 82%, transparent); }
 /* The under-strip's top edge is hidden beneath the card, so only its bottom corners are drawn. */
-:root[data-squircle] .composer-understrip { --sq-fill: var(--rl-frame); --sq-radius-top: 0px; --sq-radius-bottom: var(--r-panel); }
+:root[data-squircle] .composer-understrip {
+  --sq-fill: var(--rl-frame); --sq-ring: var(--card-ring); --sq-ring-w: var(--hairline-w);
+  --sq-radius-top: 0px; --sq-radius-bottom: var(--r-squircle);
+}
 :root[data-squircle] .install-card {
   --sq-fill: var(--rl-raised); --sq-ring: var(--line); --sq-ring-w: var(--hairline-w);
   box-shadow: var(--rl-shadow);

--- a/apps/desktop/src/renderer/src/styles.test.ts
+++ b/apps/desktop/src/renderer/src/styles.test.ts
@@ -959,13 +959,19 @@ describe("squircle surfaces", () => {
     expect(registrar).toContain('root.setAttribute("data-squircle", "")');
   });
 
-  it("the ring moves to the painter and the lift stays on box-shadow", () => {
-    // A box-shadow ring is drawn on the rounded rect whatever the fill does, so under the gate —
-    // where the radius is 0 — a focus ring left on box-shadow would square the corner off. The lift
-    // is the opposite case: blurred far wider than the two curves diverge, so it stays put, and
-    // keeping it there is what a mask would have cost.
+  it("the ring AND the lift both come off box-shadow — neither can be drawn from the border box", () => {
+    // Both are drawn from the rounded rect whatever the fill does, so under the gate — where the
+    // radius is 0 — box-shadow squares them off. The ring squares the corner outright; the lift
+    // landed as a detached square band beside the card, measured 6px wide at --r-squircle: 36px.
+    // The lift's old home was defended as "blurred wider than the two curves diverge", which held
+    // while the radius was 20 and stopped holding when it grew.
+    //
+    // The lift rides a ::before rather than the card because a filter on the card promotes it to its
+    // own layer, and the worklet then stops repainting when --sq-ring changes — focus silently stops
+    // brightening the edge. squircle-live.mjs is what catches that; this only pins where it lives.
     for (const sel of [".composer", ".commit-card"]) {
-      expect(bodiesFor(`:root[data-squircle] ${sel}`).join(" "), sel).toContain("box-shadow: var(--shadow-card-lift)");
+      expect(bodiesFor(`:root[data-squircle] ${sel}`).join(" "), sel).toContain("box-shadow: none");
+      expect(bodiesFor(`:root[data-squircle] ${sel}::before`).join(" "), sel).toContain("filter: var(--shadow-card-lift-filter)");
       const focus = bodiesFor(`:root[data-squircle] ${sel}:focus-within`).join(" ");
       expect(focus, sel).toContain("--sq-ring: var(--line-strong)");
       expect(focus, sel).not.toContain("0 0 0 1px");

--- a/apps/desktop/src/renderer/src/theme/tokens.css
+++ b/apps/desktop/src/renderer/src/theme/tokens.css
@@ -413,6 +413,11 @@ a {
    * stack, and there is still one place either half is written. */
   --card-ring: var(--overlay-lighten-400);
   --shadow-card-lift: 0 1px 2px #00000033, 0 2px 6px #00000033;
+  /* The same lift as a filter. A box-shadow is drawn from the border box, so on the squircle
+     surfaces — whose border-radius is 0 because the curve is painted, not declared — it lands as a
+     SQUARE behind a rounded card. `drop-shadow` traces the rendered alpha instead, which is the
+     worklet's actual path. Neither layer has a spread, which is what makes the two forms equal. */
+  --shadow-card-lift-filter: drop-shadow(0 1px 2px #00000033) drop-shadow(0 2px 6px #00000033);
   --shadow-card: 0 0 0 var(--hairline-w) var(--card-ring), var(--shadow-card-lift);
   --shadow-raised:
     0 0 0 var(--hairline-w) var(--overlay-lighten-500),
@@ -437,6 +442,7 @@ a {
   --shadow-btn: 0 0 0 var(--hairline-w) var(--overlay-darken-300), 0 1px 2px #03071214;
   --card-ring: #03071214;
   --shadow-card-lift: 0 2px 4px 0 #0307120a;
+  --shadow-card-lift-filter: drop-shadow(0 2px 4px #0307120a);
   --shadow-card: 0 0 0 var(--hairline-w) var(--card-ring), var(--shadow-card-lift);
   --shadow-raised: 0 0 0 var(--hairline-w) #03071214, 0 8px 16px 0 #0307120a, 0 24px 117px 0 #1c284024;
   --shadow-overlay:


### PR DESCRIPTION
Stacked on #29.

The floating cards wrote `calc(var(--r-float) + 4px)` six times over. The derivation was never sound — a superellipse reads visually smaller than a circular corner at the same radius, so the two scales cannot track each other by arithmetic — and repeating it six times made "make them rounder" a six-place edit. It is one token now, `--r-squircle`, and 36px rather than 20.

The under-strip does not follow it. Only about **26px** of that strip shows below the card, measured off a render by sampling down its own column, so `--r-panel`'s 12px is already close to half its height. A corner cannot be rounder than half its box: at 36px the curve clamped and the strip began reading as a stadium tucked underneath rather than as the prompter's bottom edge. Its fill fraction falling from 0.893 to 0.809 when the radius was raised is exactly that clamp showing up in the measurement.

Verified against a real build with `squircle-live.mjs`, which reads the radius off the element rather than assuming it and so picked up the new value on its own: the prompter's corner fills **0.904** of its corner square where a circular arc fills 0.785, and stripping the paint gate drops it to 0.758.

🤖 Generated with [Claude Code](https://claude.com/claude-code)