### PR TITLE
Centre a page's column in its pane instead of parking it at the left edge

### DIFF
--- a/apps/desktop/scripts/chip-hover-live.mjs
+++ b/apps/desktop/scripts/chip-hover-live.mjs
@@ -187,16 +187,22 @@ async function main() {
   await sleep(300);
 
   // ── 2. Hover lights the chip and moves nothing ─────────────────────────
+  const lit = () => evalIn(c, `document.querySelector('.ch-element').hasAttribute('data-hot')`);
+  /** A move to where the pointer already is may never be delivered, so every hover starts off the run. */
+  const settles = async (want) => {
+    for (let i = 0; i < 20; i++) { if ((await lit()) === want) return true; await sleep(100); }
+    return false;
+  };
+
+  await moveTo(c, rest.x - 60, mid.y);
   const before = await evalIn(c, CHIP_RECT);
   await moveTo(c, mid.x, mid.y);
-  const hotOn = await evalIn(c, `document.querySelector('.ch-element').hasAttribute('data-hot')`);
+  check("the pointer lights the chip it is over", await settles(true));
   const during = await evalIn(c, CHIP_RECT);
-  check("the pointer lights the chip it is over", hotOn === true);
   check("lighting it moves no glyph", JSON.stringify(before) === JSON.stringify(during), { before, during });
 
   await moveTo(c, rest.x + rest.w + 60, mid.y);
-  const hotOff = await evalIn(c, `document.querySelector('.ch-element').hasAttribute('data-hot')`);
-  check("the light goes out when the pointer leaves the run", hotOff === false);
+  check("the light goes out when the pointer leaves the run", await settles(false));
 
   // The mutant for the measurement: give the hover state a padding — the exact class of change the
   // stylesheet guardrail exists to forbid — and confirm the box really does move when one is added.
@@ -205,7 +211,9 @@ async function main() {
     s.textContent = '.ch-element[data-hot] { padding: 2px; }';
     document.head.append(s);
     return true; })()`);
+  await moveTo(c, rest.x - 60, mid.y);
   await moveTo(c, mid.x, mid.y);
+  await settles(true);
   const mutated = await evalIn(c, CHIP_RECT);
   check("the mutant reproduces the drift (a padded hover state moves the run)",
     JSON.stringify(before) !== JSON.stringify(mutated), { before, mutated });

--- a/apps/desktop/scripts/chip-hover-live.mjs
+++ b/apps/desktop/scripts/chip-hover-live.mjs
@@ -1,0 +1,223 @@
+/**
+ * Live check for chip interaction in the prompter (run with: node apps/desktop/scripts/chip-hover-live.mjs)
+ *
+ * Boots the REAL app on a scratch REALM_HOME and proves the two things the jsdom tests cannot,
+ * because both need glyphs that have actually been laid out:
+ *
+ *   1. A real click on the painted pill selects the whole token. The composer never looks at where
+ *      the click was — it reads `selectionStart`, which the browser resolved from the point using the
+ *      TEXTAREA's metrics, while the pill the user aimed at was drawn by the MIRROR. The two agreeing
+ *      is the mirror's whole premise, and this is the only place it can be observed.
+ *   2. The hover affordance does not move a glyph. The stylesheet guardrail in `styles.test.ts` can
+ *      only check which properties are written; this measures the run's box with the state on and off.
+ *
+ * Each is paired with a mutant applied at runtime, so a passing measurement cannot be vacuous.
+ *
+ * Ports: env-overridable. Touches only a scratch dir; kills only the process it started.
+ */
+import { spawn } from "node:child_process";
+import { connect } from "node:net";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
+const CDP_PORT = Number(process.env.LIVE_CDP_PORT ?? 9341), SERVER_PORT = Number(process.env.LIVE_SERVER_PORT ?? 8907);
+const scratch = fs.mkdtempSync(path.join(os.tmpdir(), "realm-chip-live-"));
+let electron = null;
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+async function portFree(port) {
+  return new Promise((resolve) => {
+    const s = connect({ port, host: "127.0.0.1" });
+    s.once("connect", () => { s.destroy(); resolve(false); });
+    s.once("error", () => resolve(true));
+  });
+}
+
+async function until(fn, ms, tag) {
+  const t0 = Date.now();
+  for (;;) {
+    const v = await fn();
+    if (v) return v;
+    if (Date.now() - t0 > ms) throw new Error(`timeout:${tag}`);
+    await sleep(150);
+  }
+}
+
+function cdp(wsUrl) {
+  const ws = new WebSocket(wsUrl);
+  let id = 0;
+  const pending = new Map();
+  const events = [];
+  const ready = new Promise((res) => ws.addEventListener("open", res));
+  ws.addEventListener("message", (m) => {
+    const msg = JSON.parse(m.data);
+    if (msg.id !== undefined) pending.get(msg.id)?.(msg);
+    else if (msg.method === "Runtime.consoleAPICalled" && msg.params.type === "error") {
+      events.push(msg.params.args.map((a) => a.value ?? a.description ?? "").join(" "));
+    }
+  });
+  return {
+    ready, events,
+    send: (method, params) => new Promise((res, rej) => {
+      const i = ++id;
+      pending.set(i, (msg) => (msg.error ? rej(new Error(msg.error.message)) : res(msg.result)));
+      ws.send(JSON.stringify({ id: i, method, params }));
+    }),
+    close: () => ws.close(),
+  };
+}
+
+const HELPERS = `
+window.__live = window.__live ?? {
+  setInput(el, value) {
+    const proto = el instanceof HTMLTextAreaElement ? HTMLTextAreaElement.prototype : HTMLInputElement.prototype;
+    const set = Object.getOwnPropertyDescriptor(proto, "value").set;
+    set.call(el, value); el.dispatchEvent(new Event("input", { bubbles: true }));
+  },
+};
+void 0`;
+
+async function evalIn(c, expr) {
+  const r = await c.send("Runtime.evaluate", { expression: HELPERS + ";\n" + expr, awaitPromise: true, returnByValue: true });
+  if (r.exceptionDetails) throw new Error(`page exception: ${r.exceptionDetails.exception?.description ?? r.exceptionDetails.text}`);
+  return r.result.value;
+}
+
+const check = (name, cond, detail) => {
+  if (!cond) process.exitCode = 1;
+  console.log(`${cond ? "PASS" : "FAIL"} ${name}${detail !== undefined ? " " + JSON.stringify(detail) : ""}`);
+};
+
+const DRAFT = 'make @[button "Sign in"] blue';
+const CHIP = { start: DRAFT.indexOf("@["), end: DRAFT.indexOf("]") + 1 };
+
+/** The painted run's box, rounded to a tenth of a pixel — enough to catch a 1px border. */
+const CHIP_RECT = `(() => {
+  const r = document.querySelector('.ch-element').getBoundingClientRect();
+  return { x: Math.round(r.x * 10) / 10, y: Math.round(r.y * 10) / 10, w: Math.round(r.width * 10) / 10, h: Math.round(r.height * 10) / 10 };
+})()`;
+
+async function clickAt(c, x, y) {
+  for (const type of ["mousePressed", "mouseReleased"]) {
+    await c.send("Input.dispatchMouseEvent", { type, x, y, button: "left", clickCount: 1, buttons: type === "mousePressed" ? 1 : 0 });
+  }
+  await sleep(120);
+}
+
+async function moveTo(c, x, y) {
+  await c.send("Input.dispatchMouseEvent", { type: "mouseMoved", x, y, buttons: 0 });
+  await sleep(120);
+}
+
+async function main() {
+  for (const p of [CDP_PORT, SERVER_PORT]) {
+    if (!(await portFree(p))) throw new Error(`port ${p} is in use — refusing to run`);
+  }
+
+  const wrapper = path.join(scratch, "wrapper.mjs");
+  fs.writeFileSync(wrapper, [
+    'import { app } from "electron";',
+    'app.setPath("userData", process.env.LIVE_USER_DATA);',
+    "await import(process.env.LIVE_MAIN);",
+  ].join("\n"));
+  const electronBin = process.platform === "darwin"
+    ? path.join(repoRoot, "node_modules/.pnpm/electron@37.10.3/node_modules/electron/dist/Electron.app/Contents/MacOS/Electron")
+    : path.join(repoRoot, "apps/desktop/node_modules/.bin/electron");
+  electron = spawn(electronBin, [wrapper], {
+    env: {
+      ...process.env,
+      REALM_HOME: path.join(scratch, "home"),
+      REALM_PORT: String(SERVER_PORT),
+      REALM_DEVTOOLS_PORT: String(CDP_PORT),
+      REALM_SERVER_ENTRY: path.join(repoRoot, "apps/server/dist/main.js"),
+      LIVE_USER_DATA: path.join(scratch, "userData"),
+      LIVE_MAIN: path.join(repoRoot, "apps/desktop/out/main/index.js"),
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  electron.stderr.on("data", () => {}); electron.stdout.on("data", () => {});
+
+  const targets = () => fetch(`http://127.0.0.1:${CDP_PORT}/json/list`).then((r) => r.json()).catch(() => []);
+  const rendererTarget = await until(async () => (await targets()).find((t) => t.type === "page" && t.url.startsWith("file://")), 30000, "renderer target");
+  const c = cdp(rendererTarget.webSocketDebuggerUrl);
+  await c.ready;
+  await c.send("Runtime.enable");
+  await c.send("Page.enable");
+
+  await until(() => evalIn(c, `!!document.querySelector('.onboarding input:not([type=radio])')`), 20000, "onboarding");
+  await evalIn(c, `(() => {
+    const input = document.querySelector('.onboarding input:not([type=radio])');
+    __live.setInput(input, "Live");
+    input.closest("form").requestSubmit();
+    return true; })()`);
+  await until(() => evalIn(c, `!!document.querySelector('.composer')`), 20000, "composer");
+
+  await c.send("Emulation.setDeviceMetricsOverride", { width: 1100, height: 800, deviceScaleFactor: 1, mobile: false });
+  await sleep(400);
+  await evalIn(c, `(() => { __live.setInput(document.querySelector('.composer-input'), ${JSON.stringify(DRAFT)}); return true; })()`);
+  await sleep(400);
+
+  const rest = await evalIn(c, CHIP_RECT);
+  check("the chip run is laid out with a real box", rest && rest.w > 40 && rest.h > 10, rest);
+
+  // ── 1. A real click on the pill selects the token ───────────────────────
+  const mid = { x: rest.x + rest.w / 2, y: rest.y + rest.h / 2 };
+  await clickAt(c, mid.x, mid.y);
+  const onChip = await evalIn(c, `(() => { const t = document.querySelector('.composer-input'); return [t.selectionStart, t.selectionEnd]; })()`);
+  check("a click on the painted pill selects the whole token", onChip[0] === CHIP.start && onChip[1] === CHIP.end, { got: onChip, want: [CHIP.start, CHIP.end] });
+
+  // The mutant for the click: the same gesture aimed at the prose after the chip. If THAT selected
+  // the token too, the check above would be measuring nothing.
+  await clickAt(c, rest.x + rest.w + 20, mid.y);
+  const offChip = await evalIn(c, `(() => { const t = document.querySelector('.composer-input'); return [t.selectionStart, t.selectionEnd]; })()`);
+  check("a click in the prose beside it leaves an ordinary caret", offChip[0] === offChip[1] && offChip[0] > CHIP.end, { got: offChip });
+
+  // What the selection buys: the browser's own Backspace, with no handler involved, takes the token.
+  await clickAt(c, mid.x, mid.y);
+  await c.send("Input.dispatchKeyEvent", { type: "keyDown", key: "Backspace", code: "Backspace", windowsVirtualKeyCode: 8, nativeVirtualKeyCode: 8 });
+  await c.send("Input.dispatchKeyEvent", { type: "keyUp", key: "Backspace", code: "Backspace", windowsVirtualKeyCode: 8, nativeVirtualKeyCode: 8 });
+  await sleep(250);
+  const afterDelete = await evalIn(c, `document.querySelector('.composer-input').value`);
+  check("one Backspace on the selected chip removes the whole token", afterDelete === "make  blue", { value: afterDelete });
+
+  await evalIn(c, `(() => { __live.setInput(document.querySelector('.composer-input'), ${JSON.stringify(DRAFT)}); return true; })()`);
+  await sleep(300);
+
+  // ── 2. Hover lights the chip and moves nothing ─────────────────────────
+  const before = await evalIn(c, CHIP_RECT);
+  await moveTo(c, mid.x, mid.y);
+  const hotOn = await evalIn(c, `document.querySelector('.ch-element').hasAttribute('data-hot')`);
+  const during = await evalIn(c, CHIP_RECT);
+  check("the pointer lights the chip it is over", hotOn === true);
+  check("lighting it moves no glyph", JSON.stringify(before) === JSON.stringify(during), { before, during });
+
+  await moveTo(c, rest.x + rest.w + 60, mid.y);
+  const hotOff = await evalIn(c, `document.querySelector('.ch-element').hasAttribute('data-hot')`);
+  check("the light goes out when the pointer leaves the run", hotOff === false);
+
+  // The mutant for the measurement: give the hover state a padding — the exact class of change the
+  // stylesheet guardrail exists to forbid — and confirm the box really does move when one is added.
+  await evalIn(c, `(() => {
+    const s = document.createElement('style');
+    s.textContent = '.ch-element[data-hot] { padding: 2px; }';
+    document.head.append(s);
+    return true; })()`);
+  await moveTo(c, mid.x, mid.y);
+  const mutated = await evalIn(c, CHIP_RECT);
+  check("the mutant reproduces the drift (a padded hover state moves the run)",
+    JSON.stringify(before) !== JSON.stringify(mutated), { before, mutated });
+
+  const errs = c.events.filter((e) => !e.includes("Autofill"));
+  check("no renderer console errors", errs.length === 0, errs.slice(0, 5));
+  c.close();
+}
+
+main()
+  .catch((e) => { console.error("ERROR", e.message); process.exitCode = 1; })
+  .finally(() => {
+    electron?.kill("SIGTERM");
+    setTimeout(() => { electron?.kill("SIGKILL"); fs.rmSync(scratch, { recursive: true, force: true }); process.exit(process.exitCode ?? 0); }, 1200);
+  });

--- a/apps/desktop/scripts/page-measure-live.mjs
+++ b/apps/desktop/scripts/page-measure-live.mjs
@@ -1,0 +1,446 @@
+/**
+ * Live check for the page panes' measure (run with: node apps/desktop/scripts/page-measure-live.mjs)
+ *
+ * Boots the REAL app on a scratch REALM_HOME and measures where a page's parts actually land: the
+ * head's glyph, the rail, the reading column, and the notifications split, at pane widths from 340
+ * to ~1500. Alignment is the one property jsdom cannot hold an opinion about — it has no layout, so
+ * `max-width` and `margin-inline: auto` are to it just two declarations that parse.
+ *
+ * The pane, not the window, is the thing being swept: `.page` is an inline-size container and a page
+ * is as likely to be a third of a split as it is to be the whole screen. Widths below are WINDOW
+ * widths; every assertion is against the measured `.page` rect.
+ *
+ * The second half is the scrollbar report: whether a track is painted in either mode. That is a
+ * question about composited pixels, so it is answered by sampling the screenshot down the gutter of
+ * a scroller that is actually overflowing, not by reading the stylesheet.
+ *
+ * Ports: env-overridable. Touches only a scratch dir; kills only the process it started.
+ */
+import { spawn } from "node:child_process";
+import { connect } from "node:net";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
+const CDP_PORT = Number(process.env.LIVE_CDP_PORT ?? 9347), SERVER_PORT = Number(process.env.LIVE_SERVER_PORT ?? 8913);
+const scratch = fs.mkdtempSync(path.join(os.tmpdir(), "realm-page-measure-"));
+let electron = null;
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+/** Window widths. The sidebar takes 280 of each, so the pane sweeps ~340…~1520 — across the 640px
+ *  narrow breakpoint, the notifications page's 760, and both sides of every measure. */
+const WIDTHS = [1800, 1400, 1200, 1000, 860, 700, 620];
+
+/** `scrollbar-color`'s second value is the track. Chromium serialises the computed value, so the
+ *  authored `transparent` comes back as a zero-alpha colour and never as the keyword. */
+const TRACKLESS = /\brgba\(0, 0, 0, 0\)\s*$/;
+
+async function portFree(port) {
+  return new Promise((resolve) => {
+    const s = connect({ port, host: "127.0.0.1" });
+    s.once("connect", () => { s.destroy(); resolve(false); });
+    s.once("error", () => resolve(true));
+  });
+}
+
+async function until(fn, ms, tag) {
+  const t0 = Date.now();
+  for (;;) {
+    const v = await fn();
+    if (v) return v;
+    if (Date.now() - t0 > ms) throw new Error(`timeout:${tag}`);
+    await sleep(150);
+  }
+}
+
+function cdp(wsUrl) {
+  const ws = new WebSocket(wsUrl);
+  let id = 0;
+  const pending = new Map();
+  const events = [];
+  const ready = new Promise((res) => ws.addEventListener("open", res));
+  ws.addEventListener("message", (m) => {
+    const msg = JSON.parse(m.data);
+    if (msg.id !== undefined) pending.get(msg.id)?.(msg);
+    else if (msg.method === "Runtime.consoleAPICalled" && msg.params.type === "error") {
+      events.push(msg.params.args.map((a) => a.value ?? a.description ?? "").join(" "));
+    }
+  });
+  return {
+    ready, events,
+    send: (method, params) => new Promise((res, rej) => {
+      const i = ++id;
+      pending.set(i, (msg) => (msg.error ? rej(new Error(msg.error.message)) : res(msg.result)));
+      ws.send(JSON.stringify({ id: i, method, params }));
+    }),
+    close: () => ws.close(),
+  };
+}
+
+function rpc(port) {
+  const ws = new WebSocket(`ws://127.0.0.1:${port}`);
+  let id = 0;
+  const pending = new Map();
+  const ready = new Promise((res) => ws.addEventListener("open", res));
+  ws.addEventListener("message", (m) => {
+    const msg = JSON.parse(m.data);
+    if (msg.id !== undefined) pending.get(msg.id)?.(msg);
+  });
+  return {
+    ready,
+    call: (method, params) => new Promise((res, rej) => {
+      const i = String(++id);
+      pending.set(i, (msg) => (msg.ok ? res(msg.result) : rej(new Error(`${method}: ${msg.error?.message}`))));
+      ws.send(JSON.stringify({ id: i, method, params }));
+    }),
+    close: () => ws.close(),
+  };
+}
+
+const HELPERS = `
+window.__live = window.__live ?? {
+  /** Click a sidebar destination by its label, and wait for its page to be the one on screen. */
+  async destination(label) {
+    const row = [...document.querySelectorAll('.sb-destinations .dest-row')].find((b) => b.textContent.trim().startsWith(label));
+    if (!row) throw new Error('no destination: ' + label);
+    row.click();
+    for (let i = 0; i < 60; i++) {
+      if (document.querySelector('.page')) return true;
+      await new Promise((r) => setTimeout(r, 25));
+    }
+    throw new Error('destination did not open: ' + label);
+  },
+  /** Run a command palette entry by its visible label. Profile and space pages have no sidebar row —
+   *  the palette is how a user reaches them. */
+  async palette(label) {
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'k', metaKey: true, bubbles: true }));
+    for (let i = 0; i < 60 && !document.querySelector('.palette input'); i++) await new Promise((r) => setTimeout(r, 25));
+    const input = document.querySelector('.palette input');
+    if (!input) throw new Error('the palette did not open');
+    Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value').set.call(input, label);
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    for (let i = 0; i < 80; i++) {
+      const hit = [...document.querySelectorAll('.palette-list [role=option]')]
+        .find((o) => o.querySelector('.palette-label')?.textContent.trim() === label);
+      if (hit) { hit.click(); return true; }
+      await new Promise((r) => setTimeout(r, 25));
+    }
+    throw new Error('no palette entry: ' + label);
+  },
+  async menu(label) {
+    document.querySelector('[aria-label="Space menu"]').click();
+    for (let i = 0; i < 40 && !document.querySelector('[role="menu"]'); i++) await new Promise((r) => setTimeout(r, 25));
+    const hit = [...document.querySelectorAll('[role="menu"] button')].find((b) => b.textContent.trim() === label);
+    if (!hit) { document.querySelector('[role="menu"]')?.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true })); throw new Error('no menu item: ' + label); }
+    hit.click();
+    return true;
+  },
+  box(e) { if (!e) return null; const r = e.getBoundingClientRect();
+    return { l: Math.round(r.left), r: Math.round(r.right), t: Math.round(r.top), w: Math.round(r.width), h: Math.round(r.height) }; },
+  /** The horizontal extent of a band's visible children — what the eye reads as the column's edges.
+   *  The band ELEMENT is full-bleed today and would report itself centred either way. */
+  span(el) {
+    if (!el) return null;
+    const rs = [...el.children].map((c) => c.getBoundingClientRect()).filter((r) => r.width > 0);
+    if (!rs.length) return null;
+    return { l: Math.round(Math.min(...rs.map((r) => r.left))), r: Math.round(Math.max(...rs.map((r) => r.right))) };
+  },
+  page() {
+    const page = document.querySelector('.page');
+    if (!page) return null;
+    const q = (s) => this.box(page.querySelector(s));
+    const head = page.querySelector('.page-head'), body = page.querySelector('.page-body');
+    const headSpan = this.span(head), bodySpan = this.span(body);
+    const p = this.box(page);
+    const band = bodySpan && headSpan
+      ? { l: Math.min(headSpan.l, bodySpan.l), r: Math.max(headSpan.r, bodySpan.r) } : null;
+    return {
+      page: p, head: this.box(head), body: this.box(body), headSpan, bodySpan,
+      rail: q('.page-rail'), content: q('.page-content'), split: q('.notif-split'), chips: this.span(page.querySelector('.profile-spaces')),
+      list: q('.notif-list'), detail: q('.notif-detail'), lens: q('.task-lens'), lensDetail: q('.task-detail'),
+      gaps: band ? { left: band.l - p.l, right: p.r - band.r } : null,
+    };
+  },
+  /** Any CSS colour as the sRGB triple the compositor will paint, via the compositor itself. */
+  srgb(color) {
+    const g = (this._cv ??= document.createElement('canvas').getContext('2d', { willReadFrequently: true }));
+    g.clearRect(0, 0, 1, 1); g.fillStyle = color; g.fillRect(0, 0, 1, 1);
+    return [...g.getImageData(0, 0, 1, 1).data].slice(0, 3).join(',');
+  },
+  /** A scroller that is actually overflowing, with the gutter its bar reserves. A gutter of 0 means
+   *  the platform is drawing overlay bars, which paint no track at all. The ground is the page's own
+   *  colour and not a pixel read from inside the scroller — that lands on a row, not on the page. */
+  scroller(sel) {
+    const e = document.querySelector(sel);
+    if (!e) return null;
+    const cs = getComputedStyle(e);
+    const r = e.getBoundingClientRect();
+    return { sel, gutter: e.offsetWidth - e.clientWidth, overflow: e.scrollHeight - e.clientHeight,
+      scrollTop: e.scrollTop, width: cs.scrollbarWidth, color: cs.scrollbarColor,
+      ground: this.srgb(getComputedStyle(e.closest('.page')).backgroundColor),
+      box: { l: Math.round(r.left), r: Math.round(r.right), t: Math.round(r.top), b: Math.round(r.bottom) } };
+  },
+  /** Pixels down the gutter of a scroller, read out of the screenshot the compositor produced. */
+  async gutterPixels(b64, box, gutter) {
+    const img = new Image();
+    img.src = 'data:image/png;base64,' + b64;
+    await img.decode();
+    const cv = document.createElement('canvas');
+    cv.width = img.width; cv.height = img.height;
+    cv.getContext('2d').drawImage(img, 0, 0);
+    const g = cv.getContext('2d');
+    const x = Math.round(box.r - gutter / 2);
+    const out = [];
+    for (let i = 1; i < 40; i++) {
+      const y = Math.round(box.t + ((box.b - box.t) * i) / 40);
+      out.push([...g.getImageData(x, y, 1, 1).data].slice(0, 3).join(','));
+    }
+    return out;
+  },
+};
+`;
+
+async function evalIn(c, expr) {
+  const r = await c.send("Runtime.evaluate", { expression: `${HELPERS};\n${expr}`, awaitPromise: true, returnByValue: true });
+  if (r.exceptionDetails) throw new Error(`page exception: ${r.exceptionDetails.exception?.description ?? r.exceptionDetails.text}`);
+  return r.result.value;
+}
+
+const check = (name, cond, detail) => {
+  if (!cond) process.exitCode = 1;
+  console.log(`${cond ? "PASS" : "FAIL"} ${name}${detail !== undefined ? " " + JSON.stringify(detail) : ""}`);
+};
+
+async function shot(c, tag) {
+  const s = await c.send("Page.captureScreenshot", { format: "png" });
+  const out = path.join(os.tmpdir(), `realm-page-${tag}.png`);
+  fs.writeFileSync(out, Buffer.from(s.data, "base64"));
+  console.log(`SCREENSHOT ${tag} ${out}`);
+  return s.data;
+}
+
+/** The composited proof that no track is drawn: every pixel down the scroller's gutter is either the
+ *  page's own ground or the thumb, and nothing else. A gutter of 0 means the platform is drawing
+ *  overlay bars, which have no track to draw. */
+async function gutter(c, mode, s, b64) {
+  const tag = mode.toLowerCase();
+  if (!s || s.gutter <= 0) {
+    console.log(`  NOTE ${tag} ${s?.sel}: overlay scrollbars (gutter 0) — there is no track to paint.`);
+    return;
+  }
+  const samples = await evalIn(c, `__live.gutterPixels(${JSON.stringify(b64)}, ${JSON.stringify(s.box)}, ${s.gutter})`);
+  /* Within a channel of the ground: the canvas fill the ground is read through and the composited
+     screenshot round the last bit differently in light mode. A track would be off by far more — the
+     thumb, the thing that is SUPPOSED to differ, is 14 away. */
+  const near = (p) => p.split(",").every((v, i) => Math.abs(Number(v) - Number(s.ground.split(",")[i])) <= 2);
+  const onGround = samples.filter(near).length;
+  check(`${tag}: no track down ${s.sel}'s gutter — only the thumb differs from the page`,
+    onGround > 0 && [...new Set(samples)].length <= 2,
+    { ground: s.ground, matching: onGround, of: samples.length, distinct: [...new Set(samples)] });
+}
+
+/** Sweep one page across the widths, report the measured rects, and leave a shot of the widest —
+ *  the width the complaint was about, and the one a number cannot settle. */
+async function sweep(c, label, tag) {
+  const rows = [];
+  for (const width of WIDTHS) {
+    await c.send("Emulation.setDeviceMetricsOverride", { width, height: 900, deviceScaleFactor: 1, mobile: false });
+    await sleep(250);
+    rows.push({ width, ...(await evalIn(c, `__live.page()`)) });
+  }
+  console.log(`\n── ${label} ───────────────────────────────────────────────`);
+  for (const r of rows) {
+    console.log(`  pane ${String(r.page.w).padStart(4)}  gaps L${String(r.gaps?.left ?? "-").padStart(4)} R${String(r.gaps?.right ?? "-").padStart(4)}` +
+      `  head[${r.headSpan?.l},${r.headSpan?.r}] body[${r.bodySpan?.l},${r.bodySpan?.r}]` +
+      (r.rail ? `  rail w${r.rail.w}@${r.rail.l}` : "") +
+      (r.content ? `  content w${r.content.w}@${r.content.l}` : "") +
+      (r.list ? `  list w${r.list.w}@${r.list.l} detail w${r.detail?.w}@${r.detail?.l}` : ""));
+  }
+  if (tag) {
+    await c.send("Emulation.setDeviceMetricsOverride", { width: WIDTHS[0], height: 900, deviceScaleFactor: 1, mobile: false });
+    await sleep(250);
+    await shot(c, tag);
+  }
+  return rows;
+}
+
+async function main() {
+  for (const p of [CDP_PORT, SERVER_PORT]) {
+    if (!(await portFree(p))) throw new Error(`port ${p} is in use — refusing to run`);
+  }
+
+  const wrapper = path.join(scratch, "wrapper.mjs");
+  fs.writeFileSync(wrapper, [
+    'import { app } from "electron";',
+    'app.setPath("userData", process.env.LIVE_USER_DATA);',
+    "await import(process.env.LIVE_MAIN);",
+  ].join("\n"));
+  const electronBin = process.platform === "darwin"
+    ? path.join(repoRoot, "node_modules/.pnpm/electron@37.10.3/node_modules/electron/dist/Electron.app/Contents/MacOS/Electron")
+    : path.join(repoRoot, "apps/desktop/node_modules/.bin/electron");
+  electron = spawn(electronBin, [wrapper], {
+    env: {
+      ...process.env,
+      REALM_HOME: path.join(scratch, "home"),
+      REALM_ENABLE_FAKE_AGENT: "1",
+      REALM_PORT: String(SERVER_PORT),
+      REALM_DEVTOOLS_PORT: String(CDP_PORT),
+      REALM_SERVER_ENTRY: path.join(repoRoot, "apps/server/dist/main.js"),
+      LIVE_USER_DATA: path.join(scratch, "userData"),
+      LIVE_MAIN: path.join(repoRoot, "apps/desktop/out/main/index.js"),
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  electron.stderr.on("data", () => {}); electron.stdout.on("data", () => {});
+
+  const targets = () => fetch(`http://127.0.0.1:${CDP_PORT}/json/list`).then((r) => r.json()).catch(() => []);
+  const rendererTarget = await until(async () => (await targets()).find((t) => t.type === "page" && t.url.startsWith("file://")), 30000, "renderer target");
+  const c = cdp(rendererTarget.webSocketDebuggerUrl);
+  await c.ready;
+  await c.send("Runtime.enable");
+  await c.send("Page.enable");
+
+  await until(() => evalIn(c, `!!document.querySelector('.onboarding input:not([type=radio])')`), 20000, "onboarding");
+  await evalIn(c, `(() => {
+    const input = document.querySelector('.onboarding input:not([type=radio])');
+    const set = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value').set;
+    set.call(input, 'Live'); input.dispatchEvent(new Event('input', { bubbles: true }));
+    input.closest('form').requestSubmit();
+    return true; })()`);
+  await until(() => evalIn(c, `!!document.querySelector('.composer')`), 20000, "composer");
+
+  /* A feed with rows in it. `session_done` is the notification a finished turn raises, and the fake
+     agent finishes one immediately — the page's empty state would measure a single paragraph and
+     say nothing about the split. */
+  const api = rpc(SERVER_PORT);
+  await api.ready;
+  const first = (await until(async () => {
+    const all = await api.call("sessions.listAll", {});
+    return all.length ? all : null;
+  }, 15000, "a session"))[0];
+  const spaceId = first.spaceId;
+  const TITLES = ["Rename the pane group", "Port the importer", "Trim the transcript", "Fix the diff gutter",
+    "Teach the rail to wrap", "Drop the dead migration", "Seed the scratch repo", "Re-probe the engines",
+    "Widen the commit field", "Collapse the sidebar"];
+  for (const title of TITLES) {
+    const made = await api.call("sessions.create", { spaceId, agentKind: "fake", title });
+    await api.call("sessions.send", { id: made.session.id, text: "hello", attachments: [], mentions: [] });
+  }
+  await api.call("sessions.setAgent", { id: first.id, agentKind: "fake" });
+  await api.call("sessions.send", { id: first.id, text: "hello", attachments: [], mentions: [] });
+  await until(() => evalIn(c, `(window.__realmUnread ?? 0) >= 0 && !!document.querySelector('.sb-destinations')`), 10000, "the sidebar");
+  await sleep(2500);
+
+  /* ── Settings: rail + reading column ─────────────────────────────────────────────────────── */
+  await evalIn(c, `__live.destination('Settings')`);
+  await sleep(500);
+  const settings = await sweep(c, "Settings", "wide-settings");
+
+  const wide = settings.filter((r) => r.page.w >= 1000);
+  check("settings: the column is centred in the pane — equal air on both sides",
+    wide.every((r) => Math.abs(r.gaps.left - r.gaps.right) <= 1),
+    wide.map((r) => ({ pane: r.page.w, l: r.gaps.left, r: r.gaps.right })));
+  check("settings: the head sits over the column it introduces, not off at the pane's left edge",
+    wide.every((r) => Math.abs(r.headSpan.l - r.bodySpan.l) <= 1),
+    wide.map((r) => ({ pane: r.page.w, head: r.headSpan.l, body: r.bodySpan.l })));
+  check("settings: the reading column keeps its 720px measure at every width",
+    settings.every((r) => r.content.w <= 720), settings.map((r) => ({ pane: r.page.w, content: r.content.w })));
+  check("settings: the rail stays beside the column at the body's own 20px gap",
+    settings.filter((r) => r.page.w > 640).every((r) => r.content.l - r.rail.r === 20),
+    settings.map((r) => ({ pane: r.page.w, gap: r.content.l - r.rail.r })));
+  const narrow = settings.filter((r) => r.page.w <= 640);
+  check("settings: a narrow pane is spent on content, not on margins — the column stays full-bleed",
+    narrow.length > 0 && narrow.every((r) => r.gaps.left <= 16),
+    narrow.map((r) => ({ pane: r.page.w, l: r.gaps.left })));
+
+  /* ── Notifications: a two-column split, not a form ───────────────────────────────────────── */
+  await evalIn(c, `__live.destination('Notifications')`);
+  await sleep(500);
+  const notifs = await sweep(c, "Notifications", "wide-notifications");
+  check("notifications: the feed has rows to lay out", notifs.every((r) => r.list && r.detail),
+    notifs.map((r) => ({ pane: r.page.w, list: !!r.list })));
+  const nWide = notifs.filter((r) => r.page.w >= 1200);
+  check("notifications: the split is centred as one unit",
+    nWide.length > 0 && nWide.every((r) => Math.abs(r.gaps.left - r.gaps.right) <= 1),
+    nWide.map((r) => ({ pane: r.page.w, l: r.gaps.left, r: r.gaps.right })));
+  check("notifications: both columns stay readable — the detail never falls under the list's width",
+    notifs.filter((r) => r.page.w > 760).every((r) => r.detail.w >= 300),
+    notifs.map((r) => ({ pane: r.page.w, list: r.list?.w, detail: r.detail?.w })));
+  const nStack = notifs.filter((r) => r.page.w <= 760);
+  check("notifications: under 760 of pane the columns stack and the page is full-bleed again",
+    nStack.length > 0 && nStack.every((r) => r.detail.t > r.list.t && r.gaps.left <= 24),
+    nStack.map((r) => ({ pane: r.page.w, listTop: r.list?.t, detailTop: r.detail?.t, l: r.gaps.left })));
+
+  /* ── The other three shapes on the same shell ────────────────────────────────────────────── */
+  await evalIn(c, `__live.destination('Connections')`);
+  await sleep(500);
+  const conns = await sweep(c, "Connections (no rail)", "wide-connections");
+  check("connections: a page with no rail centres the column it does have",
+    conns.filter((r) => r.page.w >= 1000).every((r) => Math.abs(r.gaps.left - r.gaps.right) <= 1),
+    conns.map((r) => ({ pane: r.page.w, l: r.gaps.left, r: r.gaps.right })));
+
+  await evalIn(c, `__live.palette('Open profile')`);
+  await until(() => evalIn(c, `!!document.querySelector('.profile-page-pane')`), 10000, "the profile page");
+  await sleep(500);
+  const profile = await sweep(c, "Profile", "wide-profile");
+  check("profile: the space chips share the column, rather than starting at the pane's edge",
+    profile.every((r) => Math.abs(r.chips.l - r.bodySpan.l) <= 1),
+    profile.map((r) => ({ pane: r.page.w, chips: r.chips?.l, body: r.bodySpan?.l })));
+
+  await evalIn(c, `__live.palette('Open space')`);
+  await until(() => evalIn(c, `!!document.querySelector('.space-page-pane')`), 10000, "the space page");
+  await sleep(500);
+  const general = await sweep(c, "Space · General", "wide-space-general");
+  await evalIn(c, `(() => { [...document.querySelectorAll('.page-rail .settings-tab')].find((l) => l.textContent.trim() === 'Tasks').querySelector('input').click(); return true; })()`);
+  await until(() => evalIn(c, `!!document.querySelector('.task-lens')`), 10000, "the tasks lens");
+  await sleep(500);
+  const tasks = await sweep(c, "Space · Tasks lens", "wide-tasks");
+  check("space: switching to the Tasks tab widens the page — the head and rail move with it",
+    general[0].gaps.left > tasks[0].gaps.left,
+    { general: general[0].gaps.left, tasks: tasks[0].gaps.left });
+  check("tasks: the lens still opts out of the reading measure — it is wider than 720 where there is room",
+    tasks.filter((r) => r.page.w >= 1400).every((r) => r.content.w > 720),
+    tasks.map((r) => ({ pane: r.page.w, content: r.content?.w, lens: r.lens?.w })));
+  check("tasks: the lens keeps room for a list AND a 340px panel beside it, which 720 would not leave",
+    tasks.filter((r) => r.page.w >= 1400).every((r) => r.lens.w >= 1000),
+    tasks.map((r) => ({ pane: r.page.w, lens: r.lens?.w })));
+
+  /* ── Scrollbars, in both modes, on a scroller that is actually overflowing ───────────────── */
+  await evalIn(c, `__live.destination('Settings')`);
+  await sleep(400);
+  await c.send("Emulation.setDeviceMetricsOverride", { width: 1400, height: 620, deviceScaleFactor: 1, mobile: false });
+  await sleep(400);
+  for (const mode of ["Dark", "Light"]) {
+    await evalIn(c, `__live.menu(${JSON.stringify(`Theme: ${mode}`)})`);
+    await sleep(500);
+    const s = await evalIn(c, `__live.scroller('.page-content')`);
+    check(`${mode.toLowerCase()}: the settings column is genuinely overflowing, so there is a bar to judge`,
+      s && s.overflow > 40, s);
+    check(`${mode.toLowerCase()}: the track is transparent — the thumb is the only thing the bar paints`,
+      TRACKLESS.test(s.color) && s.width === "thin", { color: s.color, width: s.width, gutter: s.gutter });
+    await gutter(c, mode, s, await shot(c, `settings-${mode.toLowerCase()}`));
+
+    await evalIn(c, `__live.destination('Notifications')`);
+    await sleep(400);
+    const n = await evalIn(c, `__live.scroller('.notif-list')`);
+    check(`${mode.toLowerCase()}: the notifications list is overflowing too, and its bar is the same thin one`,
+      n && n.overflow > 40 && TRACKLESS.test(n.color) && n.width === "thin", n);
+    await gutter(c, mode, n, await shot(c, `notifications-${mode.toLowerCase()}`));
+    await evalIn(c, `__live.destination('Settings')`);
+    await sleep(300);
+  }
+
+  const errs = c.events.filter((e) => !e.includes("Autofill"));
+  check("no renderer console errors", errs.length === 0, errs.slice(0, 5));
+  api.close();
+  c.close();
+}
+
+main()
+  .catch((e) => { console.error("ERROR", e.message); process.exitCode = 1; })
+  .finally(() => {
+    electron?.kill("SIGTERM");
+    setTimeout(() => { electron?.kill("SIGKILL"); fs.rmSync(scratch, { recursive: true, force: true }); process.exit(process.exitCode ?? 0); }, 1200);
+  });

--- a/apps/desktop/src/renderer/src/panes/notifications/notifications-page.test.tsx
+++ b/apps/desktop/src/renderer/src/panes/notifications/notifications-page.test.tsx
@@ -48,6 +48,15 @@ describe("the Notifications page (Plan 12 W5)", () => {
     expect(within(old).queryByLabelText("Unread")).toBeNull();
   });
 
+  it("the page body IS the split, which is how the page earns a measure wide enough for two columns", async () => {
+    // styles.css caps `.page:has(.notif-split)` alongside the rail pages rather than at the bare
+    // 720px reading column, because the list alone claims 480 of it. Rename the class and the detail
+    // silently becomes a gutter too narrow for a title.
+    const { container } = await mount({ notifications: [notification("n1", { title: "a row" })] });
+    await waitFor(() => expect(screen.getByText("a row")).toBeInTheDocument());
+    expect(container.querySelector(".page > .page-body")).toHaveClass("notif-split");
+  });
+
   it("shows a quiet, honest empty state", async () => {
     await mount();
     await waitFor(() => expect(screen.getByText(/Nothing has needed you/)).toBeInTheDocument());

--- a/apps/desktop/src/renderer/src/panes/profile/profile-page.test.tsx
+++ b/apps/desktop/src/renderer/src/panes/profile/profile-page.test.tsx
@@ -32,6 +32,14 @@ describe("ProfilePage · header", () => {
     await waitFor(() => expect(store.getState().activeSpaceId).toBe("s3"));
   });
 
+  it("the chip strip is a BAND of the page, a sibling of the head and the body", async () => {
+    // It takes the page's measure and gutter from the band rule in styles.css, which reaches it only
+    // as a direct child of `.page`. Nested inside the head or the body it would take the gutter
+    // twice and sit 24px inside the column every other band starts at.
+    const { container } = await mount();
+    expect(container.querySelector(".page > .profile-spaces")).toBe(screen.getByLabelText("Spaces of Work"));
+  });
+
   it("derives the profile LIVE from the item's space — a space moved between profiles moves the page's subject", async () => {
     const { store } = await mount();
     expect(screen.getByRole("heading", { name: "Work" })).toBeInTheDocument();

--- a/apps/desktop/src/renderer/src/panes/session/Composer.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/Composer.tsx
@@ -10,7 +10,7 @@ import { SkillPicker } from "./SkillPicker";
 import { ModelPicker, formatEffort, type OverflowGroup } from "./ModelPicker";
 import { SUGGESTIONS } from "./suggestions";
 import { heroGreeting } from "./greeting";
-import { chipAround, chipSpans, continueList, deleteChipAt, highlightSegments, indentList, stepOverChip, toggleList, type DraftEdit } from "./draft-format";
+import { chipAround, chipSpans, continueList, deleteChipAt, highlightSegments, indentList, isChipKind, stepOverChip, toggleList, type DraftEdit } from "./draft-format";
 import { AttachmentTile } from "./AttachmentTile";
 
 // ~10 lines of 15px/1.55 plus the vertical padding (Ara refresh §1 raises the input to 15px; §4:
@@ -419,6 +419,27 @@ export function Composer({ session, status, gitInfo, onOpenDiff, draft, onDraftC
      already resolved the point to a caret by the time `click` fires, and `selectionStart` is that same
      answer in the coordinate system the chips are already in. */
   const chips = useMemo(() => chipSpans(segments), [segments]);
+  /** Where each painted run begins, so a chip span can carry its own draft offset as an attribute. */
+  const segStarts = useMemo(() => { const out: number[] = []; let at = 0; for (const s of segments) { out.push(at); at += s.text.length; } return out; }, [segments]);
+  /** The chip under the pointer, by start offset. Hover is the one thing here that cannot be answered
+   *  in offsets — there is no selection to read — so it is also the one place the composer asks the
+   *  mirror for real geometry. Asking the runs for their own boxes is cheaper and far more predictable
+   *  than a caret-from-point API: the mirror takes no pointer events, so nothing else has to change. */
+  const [hotChip, setHotChip] = useState<number | null>(null);
+  const onHoverChip = (e: ReactMouseEvent<HTMLTextAreaElement>) => {
+    const m = hl.current;
+    let hit: number | null = null;
+    if (m && chips.length > 0) {
+      for (const el of m.querySelectorAll<HTMLElement>("[data-chip]")) {
+        // A run that wraps has one box per line; the pointer is in the chip if it is in any of them.
+        for (const r of el.getClientRects()) {
+          if (e.clientX >= r.left && e.clientX < r.right && e.clientY >= r.top && e.clientY < r.bottom) { hit = Number(el.dataset.chip); break; }
+        }
+        if (hit !== null) break;
+      }
+    }
+    if (hit !== hotChip) setHotChip(hit);
+  };
 
   useLayoutEffect(() => {
     const el = ta.current; if (!el) return;
@@ -705,7 +726,11 @@ export function Composer({ session, status, gitInfo, onOpenDiff, draft, onDraftC
             aria-hidden on the mirror: it is a duplicate of text the textarea already exposes. */}
         <div className="composer-editor">
           <div ref={hl} className="composer-highlight" aria-hidden="true">
-            {segments.map((s, i) => (s.kind ? <span key={i} className={`ch-${s.kind}`}>{s.text}</span> : s.text))}
+            {segments.map((s, i) => (s.kind
+              ? <span key={i} className={`ch-${s.kind}`}
+                  data-chip={isChipKind(s.kind) ? segStarts[i] : undefined}
+                  data-hot={(isChipKind(s.kind) && segStarts[i] === hotChip) || undefined}>{s.text}</span>
+              : s.text))}
             {/* A draft ending in a newline: the block would drop that last empty line, and the mirror
                 would sit one line short of the textarea from there down. */}
             {draft.endsWith("\n") && "\n"}
@@ -722,9 +747,9 @@ export function Composer({ session, status, gitInfo, onOpenDiff, draft, onDraftC
             </div>
           )}
           <textarea ref={ta} className="composer-input" aria-label="Message" placeholder={hint ? "" : `Ask ${AGENT_META[kind].label} anything…`} rows={1}
-            value={draft} onChange={(e) => { onDraftChange(e.target.value); setCaret(e.target.selectionStart ?? e.target.value.length); setMentionActive(0); }}
+            value={draft} onChange={(e) => { onDraftChange(e.target.value); setCaret(e.target.selectionStart ?? e.target.value.length); setMentionActive(0); setHotChip(null); }}
             onSelect={(e) => setCaret(e.currentTarget.selectionStart ?? 0)}
-            onClick={onClickChip}
+            onClick={onClickChip} onMouseMove={onHoverChip} onMouseLeave={() => setHotChip(null)}
             onKeyDown={onKeyDown} onPaste={onPaste} onScroll={syncScroll}
             aria-describedby={hint ? hintId : undefined}
             aria-controls={mentionOpen ? "mention-list" : undefined}

--- a/apps/desktop/src/renderer/src/panes/session/Composer.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/Composer.tsx
@@ -1,6 +1,6 @@
 import { AGENT_META, AGENT_SUPPORTS_ASK_MODE, AGENT_SUPPORTS_PERMISSION_MODES, DEFAULT_MODEL_LABEL, SELECTABLE_AGENT_KINDS, AGENT_SUPPORTS_PLAN_MODE, EFFORT_LEVELS, PERMISSION_MODES, SESSION_MODES, acpAskMode, acpPlanMode, sessionModeOf, attachmentDisposition, attachmentNote, attachmentSummary, formatAttachmentSize, type AcpSessionMode, type AgentKind, type Environment, type GitInfo, type McpServer, type ModelInfo, type Session, type SessionMode, type SessionStatus, type Skill } from "@realm/contracts";
 import { Icon, type IconName } from "@realm/ui";
-import { Fragment, useEffect, useLayoutEffect, useMemo, useRef, useState, type ClipboardEvent, type DragEvent, type KeyboardEvent, type ReactNode, type RefObject } from "react";
+import { Fragment, useEffect, useLayoutEffect, useMemo, useRef, useState, type ClipboardEvent, type DragEvent, type KeyboardEvent, type MouseEvent as ReactMouseEvent, type ReactNode, type RefObject } from "react";
 import { Menu, type MenuItem } from "../../components/Menu";
 import type { AgentProbe, PickedAttachment, SessionOptions, SubmitKey } from "../../state/store";
 import { agentAvailability, availabilityNote } from "../../state/agent-availability";
@@ -10,7 +10,7 @@ import { SkillPicker } from "./SkillPicker";
 import { ModelPicker, formatEffort, type OverflowGroup } from "./ModelPicker";
 import { SUGGESTIONS } from "./suggestions";
 import { heroGreeting } from "./greeting";
-import { continueList, deleteElementChipBefore, highlightSegments, indentList, toggleList, type DraftEdit } from "./draft-format";
+import { chipAround, chipSpans, continueList, deleteChipAt, highlightSegments, indentList, stepOverChip, toggleList, type DraftEdit } from "./draft-format";
 import { AttachmentTile } from "./AttachmentTile";
 
 // ~10 lines of 15px/1.55 plus the vertical padding (Ara refresh §1 raises the input to 15px; §4:
@@ -414,6 +414,11 @@ export function Composer({ session, status, gitInfo, onOpenDiff, draft, onDraftC
   // Coloured as a mention only if `scanMentions` resolves it — the same call the server re-runs on the
   // sent text. Stale ids get the warning tone the note below the card already explains.
   const segments = useMemo(() => highlightSegments(draft, liveMentionIds, staleMentions), [draft, liveMentionIds, staleMentions]);
+  /* Chip geometry, in draft offsets rather than pixels. The mirror is behind the textarea and takes no
+     pointer events, so a click never reaches a painted run — but it does not have to: the browser has
+     already resolved the point to a caret by the time `click` fires, and `selectionStart` is that same
+     answer in the coordinate system the chips are already in. */
+  const chips = useMemo(() => chipSpans(segments), [segments]);
 
   useLayoutEffect(() => {
     const el = ta.current; if (!el) return;
@@ -510,17 +515,47 @@ export function Composer({ session, status, gitInfo, onOpenDiff, draft, onDraftC
     pendingSel.current = { start: edit.start, end: edit.end };
   };
 
+  /**
+   * A click that lands inside a chip takes the whole token instead of dropping a caret into the
+   * middle of one.
+   *
+   * Both kinds, unlike ⌫ and ←: a click is AIMED. Nobody clicks the third character of `@mac` on the
+   * way to somewhere else, whereas the caret arrives there constantly just by moving. Aiming at the
+   * pill is the user saying "that thing", and from a selection everything else is already free —
+   * typing replaces it, ⌫ removes it, and the selection says so on screen.
+   *
+   * A drag is left alone: a range the user drew by hand is more specific than anything guessable from
+   * it. The caret lands at the token's start rather than its end so that selecting `@mac` does not
+   * also reopen the mention picker over the token it just selected.
+   */
+  const onClickChip = (e: ReactMouseEvent<HTMLTextAreaElement>) => {
+    const el = e.currentTarget;
+    if (el.selectionStart !== el.selectionEnd) return;
+    const chip = chipAround(chips, el.selectionStart);
+    if (!chip) return;
+    el.setSelectionRange(chip.start, chip.end);
+    setCaret(chip.start);
+  };
+
   const onKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
     // ⌘/Ctrl+Enter sends even while the picker is open — the send gesture never changes meaning.
     // Shift is deliberately excluded AND untouched: ⌘⇧↩ is dispatch (Plan 13 W2), bound at the
     // window level in hotkeys.ts — consuming it here would turn dispatch into a plain send.
     if (e.key === "Enter" && (e.metaKey || e.ctrlKey) && !e.shiftKey) { e.preventDefault(); send(); return; }
-    // Backspace behind an element chip takes the whole token (see `deleteElementChipBefore` for why
+    // ⌫ behind and ⌦ in front of an element chip take the whole token (see `deleteChipAt` for why
     // only that kind). A collapsed selection and no modifiers: ⌥⌫ and a live selection are the user
     // already being specific, and guessing wider destroys text they can no longer see.
-    if (e.key === "Backspace" && !e.metaKey && !e.ctrlKey && !e.altKey && e.currentTarget.selectionStart === e.currentTarget.selectionEnd) {
-      const edit = deleteElementChipBefore(draft, e.currentTarget.selectionStart ?? 0);
+    if ((e.key === "Backspace" || e.key === "Delete") && !e.metaKey && !e.ctrlKey && !e.altKey && e.currentTarget.selectionStart === e.currentTarget.selectionEnd) {
+      const edit = deleteChipAt(chips, draft, e.currentTarget.selectionStart ?? 0, e.key === "Backspace" ? -1 : 1);
       if (edit) { e.preventDefault(); applyEdit(edit); return; }
+    }
+    // ←/→ cross an element chip in one press. Bare arrows only: ⌥← and ⌘← already have widths of their
+    // own, and ⇧← is the user drawing a range by hand, which is precisely when a 19-character jump is
+    // the wrong help. A live selection collapses to its edge first, the way it does everywhere else.
+    if ((e.key === "ArrowLeft" || e.key === "ArrowRight") && !e.metaKey && !e.ctrlKey && !e.altKey && !e.shiftKey
+      && e.currentTarget.selectionStart === e.currentTarget.selectionEnd) {
+      const to = stepOverChip(chips, e.currentTarget.selectionStart ?? 0, e.key === "ArrowRight" ? 1 : -1);
+      if (to !== null) { e.preventDefault(); e.currentTarget.setSelectionRange(to, to); setCaret(to); return; }
     }
     // ⌘⇧8 bulleted / ⌘⇧7 numbered — the shortcuts these have everywhere else. Keyed off `code`, not
     // `key`: with Shift down the digit row reports "*" and "&", and those differ by layout.
@@ -689,6 +724,7 @@ export function Composer({ session, status, gitInfo, onOpenDiff, draft, onDraftC
           <textarea ref={ta} className="composer-input" aria-label="Message" placeholder={hint ? "" : `Ask ${AGENT_META[kind].label} anything…`} rows={1}
             value={draft} onChange={(e) => { onDraftChange(e.target.value); setCaret(e.target.selectionStart ?? e.target.value.length); setMentionActive(0); }}
             onSelect={(e) => setCaret(e.currentTarget.selectionStart ?? 0)}
+            onClick={onClickChip}
             onKeyDown={onKeyDown} onPaste={onPaste} onScroll={syncScroll}
             aria-describedby={hint ? hintId : undefined}
             aria-controls={mentionOpen ? "mention-list" : undefined}

--- a/apps/desktop/src/renderer/src/panes/session/Composer.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/Composer.tsx
@@ -421,11 +421,12 @@ export function Composer({ session, status, gitInfo, onOpenDiff, draft, onDraftC
   const chips = useMemo(() => chipSpans(segments), [segments]);
   /** Where each painted run begins, so a chip span can carry its own draft offset as an attribute. */
   const segStarts = useMemo(() => { const out: number[] = []; let at = 0; for (const s of segments) { out.push(at); at += s.text.length; } return out; }, [segments]);
-  /** The chip under the pointer, by start offset. Hover is the one thing here that cannot be answered
-   *  in offsets — there is no selection to read — so it is also the one place the composer asks the
-   *  mirror for real geometry. Asking the runs for their own boxes is cheaper and far more predictable
-   *  than a caret-from-point API: the mirror takes no pointer events, so nothing else has to change. */
+  /** The chip under the pointer, by start offset. */
   const [hotChip, setHotChip] = useState<number | null>(null);
+  /* Hover is the one chip gesture with no selection behind it to read, so it is the one place the
+     composer needs real geometry — and it takes it from the mirror's own runs rather than from a
+     caret-from-point API, which would have to guess which layer the point belongs to. Nothing else
+     changes: the runs are measured, never hit-tested, so the mirror keeps taking no pointer events. */
   const onHoverChip = (e: ReactMouseEvent<HTMLTextAreaElement>) => {
     const m = hl.current;
     let hit: number | null = null;

--- a/apps/desktop/src/renderer/src/panes/session/composer-richtext.test.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/composer-richtext.test.tsx
@@ -199,3 +199,136 @@ describe("list authoring in the prompter", () => {
     expect(painted()).toEqual([["ch-marker", "1."], ["ch-marker", "2."]]);
   });
 });
+
+/**
+ * Chips that behave like chips, without the composer ever leaving the textarea.
+ *
+ * Nothing here needs a pixel. The browser resolves a click to a character offset before `click`
+ * fires, so `selectionStart` is the pointer already expressed in the coordinates the chips live in —
+ * which is what these tests set by hand, exactly as the browser would have.
+ */
+describe("chip interaction in the prompter", () => {
+  /** A click landing at the offset the browser would have resolved the point to. */
+  const clickAt = (at: number) => { box().setSelectionRange(at, at); fireEvent.click(box()); };
+  const sel = () => [box().selectionStart, box().selectionEnd];
+  const picker = () => document.getElementById("mention-list");
+
+  it("clicking inside an element chip selects the whole token", async () => {
+    await mount();
+    typeAt('make @[button "Sign in"] blue');
+    clickAt(12); // in the middle of the label
+    expect(sel()).toEqual([5, 24]);
+  });
+
+  /* The selection IS the interaction: from here the browser's own Backspace takes the token, and so
+     does the next character typed. The composer deliberately does not consume the key. */
+  it("hands the selected chip to the browser's own editing, rather than claiming the key", async () => {
+    await mount();
+    typeAt('make @[button "Sign in"] blue');
+    clickAt(12);
+    expect(fireEvent.keyDown(box(), { key: "Backspace" })).toBe(true);
+    expect(sel()).toEqual([5, 24]);
+  });
+
+  it("clicking inside a mention selects it too — a click is aimed, unlike a caret arriving by arrow", async () => {
+    await mount();
+    typeAt("see @mac now");
+    clickAt(6);
+    expect(sel()).toEqual([4, 8]);
+    // The caret lands at the token's start, so selecting a mention does not reopen the picker over it.
+    expect(picker()).toBeNull();
+  });
+
+  it("leaves the trailing edge alone, which is how `@mac` becomes `@mac-cli`", async () => {
+    await mount();
+    typeAt("see @mac");
+    clickAt(8);
+    expect(sel()).toEqual([8, 8]);
+    await waitFor(() => expect(picker()).not.toBeNull());
+  });
+
+  it("leaves a caret in plain text exactly where the click put it", async () => {
+    await mount();
+    typeAt("see @mac now");
+    clickAt(1);
+    expect(sel()).toEqual([1, 1]);
+  });
+
+  /* A range the user drew by hand is more specific than anything guessable from it. */
+  it("never widens a drag-selection to a chip", async () => {
+    await mount();
+    typeAt('make @[button "Sign in"] blue');
+    box().setSelectionRange(10, 14);
+    fireEvent.click(box());
+    expect(sel()).toEqual([10, 14]);
+  });
+
+  it("crosses an element chip in one arrow press, in both directions", async () => {
+    await mount();
+    typeAt('make @[button "Sign in"] blue', 5);
+    expect(fireEvent.keyDown(box(), { key: "ArrowRight" })).toBe(false); // consumed
+    expect(sel()).toEqual([24, 24]);
+    expect(fireEvent.keyDown(box(), { key: "ArrowLeft" })).toBe(false);
+    expect(sel()).toEqual([5, 5]);
+  });
+
+  it("leaves the arrow alone at a mention, and whenever a modifier is down", async () => {
+    await mount();
+    typeAt("see @mac now", 4);
+    expect(fireEvent.keyDown(box(), { key: "ArrowRight" })).toBe(true);
+    typeAt('make @[button "Sign in"] blue', 5);
+    for (const mod of [{ shiftKey: true }, { altKey: true }, { metaKey: true }])
+      expect(fireEvent.keyDown(box(), { key: "ArrowRight", ...mod }), JSON.stringify(mod)).toBe(true);
+    expect(sel()).toEqual([5, 5]);
+  });
+
+  it("Delete in front of an element chip takes the whole token", async () => {
+    const { store } = await mount();
+    typeAt('make @[button "Sign in"] blue', 5);
+    fireEvent.keyDown(box(), { key: "Delete" });
+    expect(store.getState().drafts.se1).toBe("make  blue");
+  });
+
+  it("leaves Delete alone in front of a mention", async () => {
+    const { store } = await mount();
+    typeAt("see @mac now", 4);
+    expect(fireEvent.keyDown(box(), { key: "Delete" })).toBe(true);
+    expect(store.getState().drafts.se1).toBe("see @mac now");
+  });
+
+  /* The whole point of doing this with offsets: selecting a chip is a selection and nothing else, so
+     the bytes that leave are the bytes that were typed. */
+  it("changes nothing about what is sent when a chip has been selected by click", async () => {
+    const { api } = await mount();
+    typeAt("see @mac now");
+    clickAt(6);
+    fireEvent.keyDown(box(), { key: "Enter", metaKey: true });
+    await waitFor(() => expect(api.sent).toHaveLength(1));
+    expect(api.sent[0]).toEqual({ id: "se1", text: "see @mac now", attachments: [], mentions: ["mac"] });
+  });
+
+  it("changes nothing about what is sent when a chip has been stepped over", async () => {
+    const { api, store } = await mount();
+    store.getState().addElementChip("se1", {
+      ref: 7, url: "https://example.com/login", title: "Sign in", rect: { x: 0, y: 0, w: 1, h: 1 },
+      selector: "#submit", tag: "button", role: "button", name: "Sign in",
+      text: "Sign in", html: '<button id="submit">Sign in</button>',
+    });
+    typeAt(`${store.getState().drafts.se1}make it blue`, 0);
+    fireEvent.keyDown(box(), { key: "ArrowRight" });
+    expect(sel()).toEqual([19, 19]);
+    fireEvent.keyDown(box(), { key: "Enter", metaKey: true });
+    await waitFor(() => expect(api.sent).toHaveLength(1));
+    expect(api.sent[0]!.text).toBe('@[button "Sign in"] make it blue');
+  });
+
+  /* A token the mirror painted as code was never shown as a pill, and a gesture may not act on a
+     promise the screen did not make. */
+  it("does nothing to a token that is not painted as a chip", async () => {
+    await mount();
+    typeAt("run `@[button]` twice");
+    clickAt(8);
+    expect(sel()).toEqual([8, 8]);
+    expect(fireEvent.keyDown(box(), { key: "ArrowRight" })).toBe(true);
+  });
+});

--- a/apps/desktop/src/renderer/src/panes/session/composer-richtext.test.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/composer-richtext.test.tsx
@@ -332,3 +332,67 @@ describe("chip interaction in the prompter", () => {
     expect(fireEvent.keyDown(box(), { key: "ArrowRight" })).toBe(true);
   });
 });
+
+/**
+ * Hover is the one chip gesture that cannot be answered in offsets — there is no selection to read —
+ * so the composer asks the mirror's runs for their own boxes. jsdom has no layout, so the runs are
+ * handed the boxes they would have had; what is under test is the mapping from a point to a chip and
+ * the attribute it drives, not the browser's measurement of a glyph.
+ */
+describe("the chip under the pointer", () => {
+  const chipEls = () => Array.from(mirror().querySelectorAll<HTMLElement>("[data-chip]"));
+  const layOut = (...boxes: [number, number][]) => chipEls().forEach((el, i) => {
+    const [left, right] = boxes[i]!;
+    el.getClientRects = () => [{ left, right, top: 0, bottom: 20 }] as unknown as DOMRectList;
+  });
+  const at = (x: number) => fireEvent.mouseMove(box(), { clientX: x, clientY: 10 });
+  const hot = () => chipEls().filter((el) => el.hasAttribute("data-hot")).map((el) => el.textContent);
+
+  it("carries each chip's draft offset, and hangs it on nothing else", async () => {
+    await mount();
+    typeAt("see @mac in `code` now");
+    expect(chipEls().map((el) => [el.dataset.chip, el.textContent])).toEqual([["4", "@mac"]]);
+  });
+
+  it("lights the run the pointer is inside, and only that one", async () => {
+    await mount();
+    typeAt("@[a] @[bb]");
+    layOut([0, 40], [50, 100]);
+    at(70);
+    expect(hot()).toEqual(["@[bb]"]);
+    at(20);
+    expect(hot()).toEqual(["@[a]"]);
+  });
+
+  it("lights nothing in the prose between two chips", async () => {
+    await mount();
+    typeAt("@[a] @[bb]");
+    layOut([0, 40], [50, 100]);
+    at(70);
+    at(45);
+    expect(hot()).toEqual([]);
+  });
+
+  it("goes out when the pointer leaves the box", async () => {
+    await mount();
+    typeAt("@[a]");
+    layOut([0, 40]);
+    at(20);
+    expect(hot()).toEqual(["@[a]"]);
+    fireEvent.mouseLeave(box());
+    expect(hot()).toEqual([]);
+  });
+
+  /* Typing shifts every chip after the caret, and the pointer has not moved. Two chips five
+     characters apart and a five-character insertion put a DIFFERENT chip on the offset that was lit,
+     so without the reset the light would jump to a run the pointer is nowhere near. */
+  it("goes out on the next keystroke, rather than following the offset onto another chip", async () => {
+    await mount();
+    typeAt("@[a] @[bb]");
+    layOut([0, 40], [50, 100]);
+    at(70);
+    expect(hot()).toEqual(["@[bb]"]);
+    typeAt("hello@[a] @[bb]"); // `@[a]` now begins where `@[bb]` did
+    expect(hot()).toEqual([]);
+  });
+});

--- a/apps/desktop/src/renderer/src/panes/session/draft-format.test.ts
+++ b/apps/desktop/src/renderer/src/panes/session/draft-format.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { scanMentions, stripMentionAts } from "@realm/contracts";
-import { continueList, deleteElementChipBefore, highlightSegments, indentList, listItemAt, toggleList, type Segment } from "./draft-format";
+import { chipAround, chipSpans, continueList, deleteChipAt, highlightSegments, indentList, listItemAt, stepOverChip, toggleList, type Segment } from "./draft-format";
 
 /** A compact readout of the runs that carry a class — plain text is the uninteresting majority. */
 const painted = (segs: Segment[]) => segs.filter((s) => s.kind).map((s) => [s.kind, s.text]);
@@ -215,31 +215,123 @@ describe("toggleList — ⌘⇧8 / ⌘⇧7", () => {
   });
 });
 
-describe("deleteElementChipBefore", () => {
+/** The chips of a draft, exactly as the composer derives them: off the painted segments. */
+const spans = (text: string, ids: string[] = ["mac"]) => chipSpans(highlightSegments(text, ids));
+
+describe("chipSpans — what the mirror paints is what a gesture can take", () => {
+  it("bounds each chip token, brackets and `@` included", () => {
+    expect(spans('use @mac on @[button "Go"] now')).toEqual([
+      { kind: "mention", start: 4, end: 8 },
+      { kind: "element", start: 12, end: 26 },
+    ]);
+  });
+
+  it("carries a stale mention, which is painted as a token and so must behave as one", () => {
+    expect(chipSpans(highlightSegments("@gone", [], ["gone"]))).toEqual([{ kind: "mention-stale", start: 0, end: 5 }]);
+  });
+
+  /* The reason these come from the segments and not from a second `scanChips` call: a token that
+     lost an overlap is not on screen as a pill, and a gesture that took it anyway would be acting on
+     something the user was never shown. */
+  it("is not a chip where the mirror painted something else", () => {
+    expect(spans("use `@mac` here")).toEqual([]);
+    expect(spans("https://x.dev/@mac")).toEqual([]);
+  });
+
+  it("leaves nothing to interact with in a draft that has no chips", () => {
+    expect(spans("plain words @nonesuch")).toEqual([]);
+  });
+});
+
+describe("chipAround — a click aimed at a chip", () => {
+  const draft = 'make @[button "Sign in"] blue';
+  const chip = spans(draft)[0]!;
+
+  it("takes the whole token from anywhere among its glyphs", () => {
+    for (const pos of [chip.start + 1, chip.start + 7, chip.end - 1])
+      expect(chipAround(spans(draft), pos), String(pos)).toEqual(chip);
+  });
+
+  /* The edges are where an ordinary caret has to stay reachable — `@mac|` is how a hand gets to
+     `@mac-cli`, and the position before a chip is how it types a word in front of one. */
+  it("leaves both edges alone, so a caret can still be placed against a chip", () => {
+    for (const pos of [chip.start, chip.end, 0, draft.length])
+      expect(chipAround(spans(draft), pos), String(pos)).toBeNull();
+  });
+
+  it("takes a mention too — clicking one is aimed, unlike arriving in it by arrow", () => {
+    expect(chipAround(spans("use @mac now"), 6)).toEqual({ kind: "mention", start: 4, end: 8 });
+  });
+
+  it("picks the chip the caret is in when a draft holds several", () => {
+    expect(chipAround(spans("@[a] @[bb]"), 7)).toEqual({ kind: "element", start: 5, end: 10 });
+  });
+});
+
+describe("stepOverChip — one press crosses an element chip", () => {
+  const draft = 'make @[button "Sign in"] blue';
+  const [start, end] = [5, 24];
+
+  it("jumps the token from either side", () => {
+    expect(stepOverChip(spans(draft), start, 1)).toBe(end);
+    expect(stepOverChip(spans(draft), end, -1)).toBe(start);
+  });
+
+  it("does not jump backwards out of a chip the caret is about to enter", () => {
+    expect(stepOverChip(spans(draft), start, -1)).toBeNull();
+    expect(stepOverChip(spans(draft), end, 1)).toBeNull();
+  });
+
+  it("leaves the key alone everywhere else, including inside the token", () => {
+    for (const pos of [0, 4, 6, 12, 25, draft.length])
+      expect(stepOverChip(spans(draft), pos, 1), String(pos)).toBeNull();
+  });
+
+  /* A mention is four characters a hand walks INTO on purpose. A mention that could not be entered
+     would be a mention that could not be corrected. */
+  it("never steps over a mention", () => {
+    expect(stepOverChip(spans("use @mac now"), 4, 1)).toBeNull();
+    expect(stepOverChip(spans("use @mac now"), 8, -1)).toBeNull();
+  });
+});
+
+describe("deleteChipAt", () => {
   const draft = 'make @[button "Sign in"] blue';
   const chipEnd = draft.indexOf("]") + 1;
 
   it("takes the whole token when the caret sits at its trailing edge", () => {
-    expect(deleteElementChipBefore(draft, chipEnd)).toEqual({ text: "make  blue", start: 5, end: 5 });
+    expect(deleteChipAt(spans(draft), draft, chipEnd, -1)).toEqual({ text: "make  blue", start: 5, end: 5 });
+  });
+
+  it("takes it forwards too, from the leading edge", () => {
+    expect(deleteChipAt(spans(draft), draft, 5, 1)).toEqual({ text: "make  blue", start: 5, end: 5 });
   });
 
   it("leaves the caret where the chip was, so the next keystroke lands in its place", () => {
-    const edit = deleteElementChipBefore(draft, chipEnd)!;
+    const edit = deleteChipAt(spans(draft), draft, chipEnd, -1)!;
     expect(edit.text.slice(0, edit.start)).toBe("make ");
   });
 
   it("does nothing anywhere else in the token, or in the prose around it", () => {
     for (const caret of [0, 5, 6, chipEnd - 1, chipEnd + 1, draft.length])
-      expect(deleteElementChipBefore(draft, caret), String(caret)).toBeNull();
+      expect(deleteChipAt(spans(draft), draft, caret, -1), String(caret)).toBeNull();
   });
 
   it("does nothing to a mention — a hand types straight through `@mac` on its way to `@mac-cli`", () => {
-    expect(deleteElementChipBefore("use @mac", 8)).toBeNull();
+    expect(deleteChipAt(spans("use @mac"), "use @mac", 8, -1)).toBeNull();
+    expect(deleteChipAt(spans("use @mac"), "use @mac", 4, 1)).toBeNull();
   });
 
   it("picks the chip that actually ends at the caret when a draft holds several", () => {
     const two = "@[a] @[bb]";
-    expect(deleteElementChipBefore(two, two.length)).toEqual({ text: "@[a] ", start: 5, end: 5 });
-    expect(deleteElementChipBefore(two, 4)).toEqual({ text: " @[bb]", start: 0, end: 0 });
+    expect(deleteChipAt(spans(two), two, two.length, -1)).toEqual({ text: "@[a] ", start: 5, end: 5 });
+    expect(deleteChipAt(spans(two), two, 4, -1)).toEqual({ text: " @[bb]", start: 0, end: 0 });
+  });
+
+  /* The token is inside a code span, so the mirror drew backticked code and no pill at all. One
+     keystroke may not delete nineteen characters the user was never told were one thing. */
+  it("does nothing to a token the mirror did not paint as a chip", () => {
+    const code = "`@[button]`";
+    expect(deleteChipAt(spans(code), code, code.length - 1, -1)).toBeNull();
   });
 });

--- a/apps/desktop/src/renderer/src/panes/session/draft-format.ts
+++ b/apps/desktop/src/renderer/src/panes/session/draft-format.ts
@@ -258,10 +258,61 @@ export function toggleList(text: string, selStart: number, selEnd: number, order
   return { text: out + text.slice(prev), start, end: Math.max(start, selEnd + endShift) };
 }
 
-// ── Chip editing ───────────────────────────────────────────────────────────
+// ── Chip interaction ───────────────────────────────────────────────────────
+
+/** Where one painted chip sits in the draft. `start`/`end` bound the whole token, `@` included. */
+export type ChipSpan = { kind: SegmentKind; start: number; end: number };
+
+/** The segment kinds that NAME something rather than format something — the runs the mirror draws as
+ *  a pill, and therefore the runs a gesture may take whole. */
+const CHIP_KINDS: readonly SegmentKind[] = ["mention", "mention-stale", "element"];
 
 /**
- * Backspace at the trailing edge of an element chip deletes the whole token.
+ * Every chip in the draft, as offsets, read off the SAME segments the mirror paints.
+ *
+ * Deriving from the segments rather than re-scanning is what keeps "looks like a chip" and "behaves
+ * like a chip" one set instead of two: `highlightSegments` drops a token that loses an overlap, so
+ * `@mac` inside backticks paints as code — and a click there must place an ordinary caret, because a
+ * pill is the only thing on screen promising otherwise.
+ */
+export function chipSpans(segments: readonly Segment[]): ChipSpan[] {
+  const out: ChipSpan[] = [];
+  let at = 0;
+  for (const s of segments) {
+    if (s.kind && CHIP_KINDS.includes(s.kind)) out.push({ kind: s.kind, start: at, end: at + s.text.length });
+    at += s.text.length;
+  }
+  return out;
+}
+
+/**
+ * The chip a caret at `pos` landed INSIDE — strictly inside, both edges excluded.
+ *
+ * The edges are where an ordinary caret has to stay reachable: clicking just past `@mac` is how a
+ * hand gets to `@mac-cli`, and clicking just before a chip is how it types a word in front of one.
+ * Only a click aimed at the glyphs themselves means "this token".
+ */
+export function chipAround(spans: readonly ChipSpan[], pos: number): ChipSpan | null {
+  return spans.find((c) => pos > c.start && pos < c.end) ?? null;
+}
+
+/**
+ * Where ←/→ lands when the step would otherwise walk into an element chip, or null to leave the key
+ * alone.
+ *
+ * Element chips only, and it is the same asymmetry the atomic delete below draws. Nineteen presses to
+ * cross `@[button "Sign in"]` is the caret pretending a token is a sentence; `@mac` is four characters
+ * that a hand walks INTO on purpose, to make it `@mac-cli` or to fix the word in front of it, and a
+ * mention that could not be entered would be a mention that could not be corrected.
+ */
+export function stepOverChip(spans: readonly ChipSpan[], caret: number, dir: -1 | 1): number | null {
+  const chip = spans.find((c) => c.kind === "element" && (dir === 1 ? c.start === caret : c.end === caret));
+  return chip ? (dir === 1 ? chip.end : chip.start) : null;
+}
+
+/**
+ * Backspace at an element chip's trailing edge (`dir` -1) or Delete at its leading edge (+1) takes the
+ * whole token.
  *
  * Element chips only, and the asymmetry is the point. `@[button "Sign in"]` is syntax the user never
  * types through: `@[` is not something a hand produces by accident, and half of it — `@[button "Sign`
@@ -272,8 +323,8 @@ export function toggleList(text: string, selStart: number, selEnd: number, order
  * Null for everything else, including a non-empty selection: a selection is already the user saying
  * exactly what to delete, and overriding it would be the editor arguing.
  */
-export function deleteElementChipBefore(text: string, caret: number): DraftEdit | null {
-  const chip = scanElementChips(text).find((c) => c.end === caret);
+export function deleteChipAt(spans: readonly ChipSpan[], text: string, caret: number, dir: -1 | 1): DraftEdit | null {
+  const chip = spans.find((c) => c.kind === "element" && (dir === -1 ? c.end === caret : c.start === caret));
   if (!chip) return null;
   return { text: text.slice(0, chip.start) + text.slice(chip.end), start: chip.start, end: chip.start };
 }

--- a/apps/desktop/src/renderer/src/panes/session/draft-format.ts
+++ b/apps/desktop/src/renderer/src/panes/session/draft-format.ts
@@ -267,6 +267,10 @@ export type ChipSpan = { kind: SegmentKind; start: number; end: number };
  *  a pill, and therefore the runs a gesture may take whole. */
 const CHIP_KINDS: readonly SegmentKind[] = ["mention", "mention-stale", "element"];
 
+/** Whether a painted run is a chip. The mirror asks this to decide which spans carry the offset a
+ *  pointer is matched against, so it and `chipSpans` can never disagree about what a chip is. */
+export const isChipKind = (kind: SegmentKind | null): boolean => kind !== null && CHIP_KINDS.includes(kind);
+
 /**
  * Every chip in the draft, as offsets, read off the SAME segments the mirror paints.
  *
@@ -279,7 +283,7 @@ export function chipSpans(segments: readonly Segment[]): ChipSpan[] {
   const out: ChipSpan[] = [];
   let at = 0;
   for (const s of segments) {
-    if (s.kind && CHIP_KINDS.includes(s.kind)) out.push({ kind: s.kind, start: at, end: at + s.text.length });
+    if (isChipKind(s.kind)) out.push({ kind: s.kind!, start: at, end: at + s.text.length });
     at += s.text.length;
   }
   return out;

--- a/apps/desktop/src/renderer/src/panes/session/draft-format.ts
+++ b/apps/desktop/src/renderer/src/panes/session/draft-format.ts
@@ -269,7 +269,7 @@ const CHIP_KINDS: readonly SegmentKind[] = ["mention", "mention-stale", "element
 
 /** Whether a painted run is a chip. The mirror asks this to decide which spans carry the offset a
  *  pointer is matched against, so it and `chipSpans` can never disagree about what a chip is. */
-export const isChipKind = (kind: SegmentKind | null): boolean => kind !== null && CHIP_KINDS.includes(kind);
+export const isChipKind = (kind: SegmentKind | null): kind is SegmentKind => kind !== null && CHIP_KINDS.includes(kind);
 
 /**
  * Every chip in the draft, as offsets, read off the SAME segments the mirror paints.
@@ -283,7 +283,7 @@ export function chipSpans(segments: readonly Segment[]): ChipSpan[] {
   const out: ChipSpan[] = [];
   let at = 0;
   for (const s of segments) {
-    if (isChipKind(s.kind)) out.push({ kind: s.kind!, start: at, end: at + s.text.length });
+    if (isChipKind(s.kind)) out.push({ kind: s.kind, start: at, end: at + s.text.length });
     at += s.text.length;
   }
   return out;
@@ -293,7 +293,7 @@ export function chipSpans(segments: readonly Segment[]): ChipSpan[] {
  * The chip a caret at `pos` landed INSIDE — strictly inside, both edges excluded.
  *
  * The edges are where an ordinary caret has to stay reachable: clicking just past `@mac` is how a
- * hand gets to `@mac-cli`, and clicking just before a chip is how it types a word in front of one.
+ * hand gets to `@mac-cli`, and clicking just before a chip is how a hand types a word in front of one.
  * Only a click aimed at the glyphs themselves means "this token".
  */
 export function chipAround(spans: readonly ChipSpan[], pos: number): ChipSpan | null {
@@ -304,7 +304,7 @@ export function chipAround(spans: readonly ChipSpan[], pos: number): ChipSpan | 
  * Where ←/→ lands when the step would otherwise walk into an element chip, or null to leave the key
  * alone.
  *
- * Element chips only, and it is the same asymmetry the atomic delete below draws. Nineteen presses to
+ * Element chips only, the same asymmetry the atomic delete below makes. Nineteen presses to
  * cross `@[button "Sign in"]` is the caret pretending a token is a sentence; `@mac` is four characters
  * that a hand walks INTO on purpose, to make it `@mac-cli` or to fix the word in front of it, and a
  * mention that could not be entered would be a mention that could not be corrected.

--- a/apps/desktop/src/renderer/src/panes/settings/settings-page.test.tsx
+++ b/apps/desktop/src/renderer/src/panes/settings/settings-page.test.tsx
@@ -47,6 +47,16 @@ describe("the Settings page (Plan 12 W6)", () => {
     }
   });
 
+  it("the tabs ARE the page's rail, which is what widens the page's measure to hold them", async () => {
+    // styles.css caps `.page:has(.page-rail)` at the rail plus the reading column, and every other
+    // page at the column alone. Rename the class here and the whole page narrows by 200px with
+    // nothing in the stylesheet to say why.
+    const { container } = await mount();
+    const rail = container.querySelector(".page > .page-body > .page-rail");
+    expect(rail).not.toBeNull();
+    expect(within(rail as HTMLElement).getByRole("radio", { name: "Engines" })).toBeInTheDocument();
+  });
+
   it("opens the Usage tab without the rest of Settings paying for it", async () => {
     // The panel reads a whole time range on mount, so it must not run for someone who came here to
     // check an engine version — which is what tabbing rather than stacking buys.

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -2252,6 +2252,22 @@ button.panel-title:hover { background: var(--rl-hover); }
    with three panes open: the Sessions tab was overflowing by 179px and the Tasks lens by 247px,
    which put the run detail panel's Approve/Decline under the session pane. jsdom has no layout, so
    no test in the suite could see it. */
+/* ——— The measure. A page is a column of content in a pane that is routinely twice as wide as the
+   column wants to be. Head, rail and content are therefore centred TOGETHER, as one block: centring
+   the content alone would leave the title at the pane's left edge introducing a form in the middle,
+   and centring it in the space BESIDE the rail would put the rail outside the thing it belongs to.
+   The number is what the page's own parts add up to, so below it nothing moves and above it the
+   surplus becomes equal margins rather than a right-hand void. */
+.page { --page-measure: 768px; }                                 /* 24px gutter + 720px column + 24px */
+.page:has(.page-rail, .notif-split) { --page-measure: 968px; }   /* + the 180px rail and its 20px gap */
+.page:has(.page-content[data-wide]) { --page-measure: 1348px; }  /* the Tasks lens's own 1100px cap */
+/* `width: 100%` is load-bearing: an auto cross-axis margin switches off a flex item's stretch, so
+   without it each band would shrink to fit its own longest line instead of filling the cap. */
+.page-head, .page-body, .profile-spaces { width: 100%; max-width: var(--page-measure); margin-inline: auto; }
+/* The profile page's chip strip is a third band between the head and the body, so its gutter is
+   stated here rather than with its own look — after the narrow block below, it could not be
+   overridden there (a container query carries no extra specificity). */
+.profile-spaces { padding-inline: 24px; }
 .page-head { flex: none; display: flex; align-items: center; gap: 12px; padding: 20px 24px 14px; }
 .page-glyph { flex: none; display: grid; place-items: center; width: 36px; height: 36px; border-radius: var(--r-ctl);
   background: color-mix(in srgb, currentColor 14%, transparent); }
@@ -2291,6 +2307,7 @@ button.panel-title:hover { background: var(--rl-hover); }
     overflow-x: auto; overscroll-behavior-x: contain; scrollbar-width: none; }
   .page-rail .settings-tab { white-space: nowrap; }
   .page-content { max-width: none; padding-right: 0; }
+  .profile-spaces { padding-inline: 16px; }
   /* The `1fr auto` row grid, stood up: the actions keep their own width and the path/name column
      gets all of it back. */
   .env-row { grid-template-columns: minmax(0, 1fr); }
@@ -2389,7 +2406,9 @@ button.panel-title:hover { background: var(--rl-hover); }
 .task-attempt-outcome[data-outcome="failed"], .task-attempt-outcome[data-outcome="expired"] { color: var(--rl-danger); }
 
 /* The profile page's space chips (Plan 14 W2): the profile's spaces as jump targets, under the head. */
-.profile-spaces { display: flex; flex-wrap: wrap; gap: 6px; margin: 2px 0 10px; }
+/* The inline margin is left to the band rule up in the page section — a `margin` shorthand here
+   would zero the auto that centres it. */
+.profile-spaces { display: flex; flex-wrap: wrap; gap: 6px; margin-block: 2px 10px; }
 .profile-chip { display: inline-flex; align-items: center; gap: 5px; padding: 3px 10px; font-size: 12px;
   border: 1px solid var(--rl-line-strong); border-radius: 999px; background: none; color: var(--rl-text-dim); cursor: pointer; }
 .profile-chip:hover { background: var(--rl-hover); color: var(--rl-text-bright); }
@@ -2413,11 +2432,11 @@ button.panel-title:hover { background: var(--rl-hover); }
 /* ——— Plan 12 W5: the Notifications page. Quiet feed rows on the page pattern; unread is a dot and a
    brighter title, never a wash. The inline permission card is the session pane's own component. ——— */
 .notifications-page-pane .page-head { align-items: flex-start; }
-/* The feed is SCANNED, not read: it takes the whole pane instead of the ~720px reading column the
-   other destination pages cap themselves at (there is no `.page-content` here at all), and spends
-   the width on a second column. It answers to the PANE's width and not the window's — `.page` is the
-   inline-size container every page shares — because this page is as likely to be half of a split as
-   it is to be the whole screen. */
+/* The feed is SCANNED, not read: it spends its width on a second column instead of the ~720px
+   reading column the other destination pages cap themselves at (there is no `.page-content` here at
+   all), which is why it shares the rail pages' measure rather than the bare column's. It answers
+   to the PANE's width and not the window's — `.page` is the inline-size container every page shares
+   — because this page is as likely to be half of a split as it is to be the whole screen. */
 .notif-split { gap: 0; }
 .notif-list { flex: 1 1 380px; min-width: 0; max-width: 480px; overflow-y: auto; padding-right: 16px; }
 .notif-detail { flex: 2 1 0; min-width: 0; overflow-y: auto; padding-left: 20px; border-left: 1px solid var(--rl-hairline); }

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -1595,6 +1595,16 @@ button.panel-title:hover { background: var(--rl-hover); }
 /* Declared but no longer resolvable: the `@` goes as plain text. Same warning tone as the note the
    card already shows under it, so the two read as one statement about the same token. */
 .ch-mention-stale { color: var(--rl-warning); background: color-mix(in srgb, var(--rl-warning) 12%, transparent); border-radius: 3px; text-decoration: underline dotted; text-underline-offset: 2px; }
+/* A chip a click will take whole says so under the pointer. Everything that normally reads as "this
+   is a target" — a border, padding, a cursor over a hit area — is either a metric this layer may not
+   have or unreachable from a layer that takes no pointer events, so the affordance is a lift in the
+   tint the chip already wears. `data-hot` is set by Composer.tsx from the textarea above. */
+.ch-mention[data-hot] { background: color-mix(in srgb, var(--rl-accent) 26%, transparent);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--rl-accent) 26%, transparent); }
+.ch-element[data-hot] { background: var(--rl-hover); box-shadow: 0 0 0 2px var(--rl-hover), inset 0 0 0 1px var(--rl-line-strong); }
+/* No pill of its own at rest and none on hover: a run that grew a ring only under the pointer would
+   read as an element chip, and this one is going out as plain text. */
+.ch-mention-stale[data-hot] { background: color-mix(in srgb, var(--rl-warning) 24%, transparent); }
 .ch-marker { color: var(--rl-accent); }
 .ch-punct { color: var(--rl-text-faint); }
 .ch-code { color: var(--rl-text-bright); background: var(--inset); border-radius: 3px; }

--- a/apps/desktop/src/renderer/src/styles.test.ts
+++ b/apps/desktop/src/renderer/src/styles.test.ts
@@ -1204,6 +1204,94 @@ describe("row and control layout", () => {
   });
 });
 
+/** The page measure. Where a column actually LANDS is settled by scripts/page-measure-live.mjs, which
+ *  measures the real rects at seven pane widths — jsdom has no layout, so to it `margin-inline: auto`
+ *  is a declaration that parses and nothing more. What is checkable here is the arithmetic: that each
+ *  page shape is capped at what that shape's own parts add up to, read from the rules that state
+ *  those parts, so a drift in either place fails. */
+describe("the page measure", () => {
+  /** A declaration from the first rule that states it for `sel` — the base rule, which the narrow
+   *  container block further down the file overrides rather than replaces. */
+  function decl(sel: string, prop: string): string {
+    for (const body of bodiesFor(sel)) {
+      const m = body.match(new RegExp(`(?:^|;\\s*)${prop}:\\s*([^;]+)`));
+      if (m) return m[1]!.trim();
+    }
+    throw new Error(`no ${prop} on ${sel}`);
+  }
+  const px = (v: string): number => Number(v.match(/(\d+(?:\.\d+)?)px/)?.[1] ?? NaN);
+
+  const GUTTER = px(decl(".page-body", "padding").split(" ")[1]!);
+  const GAP = px(decl(".page-body", "gap"));
+  const RAIL = px(decl(".page-rail", "width"));
+  const COLUMN = px(decl(".page-content", "max-width"));
+  const LENS = px(decl(".task-lens", "max-width"));
+
+  /** Every `--page-measure` in the stylesheet, by the selector that sets it. */
+  const MEASURES = new Map(RULES
+    .filter((r) => /--page-measure:/.test(r.body))
+    .map((r) => [r.selectors.join(", "), px(r.body.match(/--page-measure:\s*([^;]+)/)![1]!)]));
+  const measure = (sel: string): number => {
+    expect(MEASURES.get(sel), `no --page-measure on \`${sel}\``).toBeGreaterThan(0);
+    return MEASURES.get(sel)!;
+  };
+
+  it("head, rail and content are ONE centred block — the title stays over the column it introduces", () => {
+    // The mutant: drop `.page-head` from this rule. The form centres itself in the pane and the title
+    // that names it stays at the pane's left edge, introducing nothing.
+    const band = RULES.filter((r) => r.selectors.includes(".page-head") && r.body.includes("margin-inline: auto"));
+    expect(band).toHaveLength(1);
+    for (const sel of [".page-body", ".profile-spaces"]) expect(band[0]!.selectors).toContain(sel);
+    // The load-bearing one: an auto cross-axis margin switches a flex item's stretch OFF, so without
+    // an explicit width each band shrinks to fit its own longest line instead of filling the cap.
+    expect(band[0]!.body).toContain("width: 100%");
+    expect(band[0]!.body).toContain("max-width: var(--page-measure)");
+  });
+
+  it("each shape is capped at what ITS parts add up to, never at a number typed in twice", () => {
+    // Bare column, column beside the rail, and the Tasks lens beside the rail. Change `.page-rail`'s
+    // width or `.page-content`'s measure and the cap that no longer matches fails here.
+    expect(measure(".page")).toBe(GUTTER * 2 + COLUMN);
+    expect(measure(".page:has(.page-rail, .notif-split)")).toBe(GUTTER * 2 + RAIL + GAP + COLUMN);
+    expect(measure(".page:has(.page-content[data-wide])")).toBe(GUTTER * 2 + RAIL + GAP + LENS);
+  });
+
+  it("the Tasks tab, which matches two of them, takes the wider", () => {
+    // The space page has a rail AND a wide content, so both selectors hit it; `[data-wide]` is what
+    // makes the wider one win. Losing that is a lens squeezed into the reading measure.
+    expect(measure(".page:has(.page-content[data-wide])"))
+      .toBeGreaterThan(measure(".page:has(.page-rail, .notif-split)"));
+  });
+
+  it("the notifications split shares the rail pages' cap, because 720 leaves it no second column", () => {
+    // The mutant: let it fall through to the bare default. The list alone claims 480, so the detail
+    // becomes the ~220px gutter that could not hold a title — the failure the 760px stacking
+    // threshold exists to avoid, reintroduced above that threshold where stacking cannot save it.
+    const detail = measure(".page:has(.page-rail, .notif-split)") - GUTTER * 2
+      - px(decl(".notif-list", "max-width")) - px(decl(".notif-detail", "padding-left"));
+    expect(detail).toBeGreaterThan(300);
+  });
+
+  it("no cap can bind inside the narrow pass, so the two never fight", () => {
+    // Every measure is wider than the widest pane the responsive rules claim (the notifications
+    // split's 760). Below them a page is full-bleed and the cap is inert; above them nothing
+    // re-flows. A measure that fell between would centre a page that was busy standing itself up.
+    for (const [sel, value] of MEASURES) expect(value, sel).toBeGreaterThan(760);
+  });
+
+  it("the profile page's chip strip is a band of the page, and can still shed its gutter when narrow", () => {
+    // Its own rule sits BELOW the narrow block. Stated there, `padding-inline: 24px` would beat the
+    // query's 16px — a container query carries no extra specificity — and the chips would hang past
+    // the head at every narrow width.
+    const base = css.indexOf(".profile-spaces { padding-inline: 24px");
+    const narrow = css.indexOf(".profile-spaces { padding-inline: 16px");
+    expect(base).toBeGreaterThan(-1);
+    expect(narrow).toBeGreaterThan(base);
+    // A `margin` shorthand anywhere would zero the auto that centres it.
+    for (const body of bodiesFor(".profile-spaces")) expect(body, body).not.toMatch(/(^|;\s*)margin:/);
+  });
+});
+
 /** A pane is not a window: `minSize={10}` in PaneHost means a leaf can be a tenth of the host, and a
  *  three-way split routinely leaves one under 300px. These assert the two halves of the fix — the
  *  flex minimums that stop a pane sizing itself to its WIDEST child (and being clipped by

--- a/apps/desktop/src/renderer/src/styles.test.ts
+++ b/apps/desktop/src/renderer/src/styles.test.ts
@@ -331,7 +331,9 @@ describe("Ara refresh §3/§4 geometry", () => {
    * a pill possible: both paint outside the run's box without the box growing.
    */
   it("no chip run changes a metric — the caret under the mirror belongs to the textarea", () => {
-    const chips = RULES.filter((r) => r.selectors.some((sel) => /^\.ch-[a-z-]+$/.test(sel)));
+    // Any rule that reaches a `.ch-*` run at all, not just the bare class: a hover or a state
+    // variant paints the same glyphs on the same layer and is under exactly the same rule.
+    const chips = RULES.filter((r) => r.selectors.some((sel) => /\.ch-[a-z-]+/.test(sel)));
     expect(chips.length, "no .ch-* rules in styles.css").toBeGreaterThan(0);
     for (const rule of chips) {
       for (const decl of rule.body.split(";").map((d) => d.trim()).filter(Boolean)) {
@@ -340,6 +342,14 @@ describe("Ara refresh §3/§4 geometry", () => {
           `${rule.selectors.join(",")} { ${decl} }`).toContain(prop);
       }
     }
+  });
+
+  it("a hovered chip is the same chip lifted, never a new shape", () => {
+    expect(bodiesFor(".ch-element[data-hot]").join(" ")).toContain("background: var(--rl-hover)");
+    expect(bodiesFor(".ch-mention[data-hot]").join(" ")).toContain("var(--rl-accent) 26%");
+    // At rest this run wears no pill, and growing one under the pointer would read as an element
+    // chip — a token that resolves to nothing dressing up as one that resolves to something.
+    expect(bodiesFor(".ch-mention-stale[data-hot]").join(" ")).not.toContain("box-shadow");
   });
 
   it("the highlight mirror matches the textarea's text metrics exactly", () => {


### PR DESCRIPTION
Stacked on #31.

`.page-content` was a 720px measure sitting immediately after a 180px rail and never centred, so in a wide pane everything hugged the left. Connections was the worst of them: at a 1520px pane it had **776px** of dead space on the right.

**All six page panes**, not just the two reported. They share `.page`, and shipping Settings centred while Library sat left-aligned would be a worse inconsistency than either choice applied consistently.

**The head, rail and content centre as one block.** Centring the content alone strands the title at the pane's edge while the form it introduces sits in the middle; centring it in the space *beside* the rail puts the rail outside the thing it belongs to. So each band takes `width: 100%; max-width: var(--page-measure); margin-inline: auto`. The `width: 100%` is load-bearing rather than decoration — an auto cross-axis margin switches a flex item's stretch off, so without it each band shrinks to its longest line.

The cap is what each page shape's own parts add up to, so a page holding more is not squeezed:

```
.page                                  768px   /* 24 gutter + 720 column + 24 */
.page:has(.page-rail, .notif-split)    968px   /* + 180 rail + 20 gap */
.page:has(.page-content[data-wide])   1348px   /* the Tasks lens's own 1100 */
```

**Notifications takes the railed 968 rather than the bare 720.** Its list alone claims 480, so at 720 the detail column would be a ~220px gutter — exactly the failure the existing 760px stacking threshold exists to prevent, reintroduced *above* the threshold where stacking cannot save it. At 968 the detail gets 420px.

Measured live at seven pane widths in both modes. At 1520: Settings went from 24/576 to 300/300, Connections from 24/776 to 400/400. The reading column stays 720 at every width, the rail keeps its 20px gap, and nothing below the caps moved, so the narrow-pane pass is untouched.

One deliberate consequence: switching the space page to Tasks now slides the head and rail 190px left, because that tab genuinely is a wider page. Freezing the whole space page at the widest tab's measure would strand every other tab's column in a 1300px band, which is the bug being fixed.

**The reported scrollbar tracks do not exist.** Verified on composited pixels rather than CSS, in both modes, on scrollers that were actually overflowing — sampling 39 points down each gutter returns exactly two colours, the page's ground and the thumb. Nothing was changed and nothing was added to the guardrail.

Fixed in passing, because centring would have made it glaring: the profile page's space chips started at the pane's very edge, 24px left of every other band.

🤖 Generated with [Claude Code](https://claude.com/claude-code)