### PR TITLE
Finish computer use: a driving indicator, a per-space app allowlist, and a capture that actually works

### DIFF
--- a/apps/desktop/native/AxHelper.swift
+++ b/apps/desktop/native/AxHelper.swift
@@ -813,6 +813,25 @@ private final class Helper {
       break
     }
 
+    // `type` and `key` may name neither an element nor a point, which the contract defines as
+    // "wherever the app's focus already is" — continuing to type into a field, or pressing a shortcut
+    // at the app rather than at a widget. A keystroke needs no point, only the right app in front, so
+    // it cannot go through `resolveActionPoint`: that demands coordinates the caller was told it
+    // could omit, and answered an indexless key with "an act needs either an element index or x/y".
+    // The hit test is skipped because there is nothing being aimed at; `raise` is what makes the
+    // keystroke land in the intended app rather than in whatever happened to be frontmost.
+    if element == nil, params["x"] == nil, kind == "type" || kind == "key" {
+      try raise(app)
+      if kind == "type" {
+        guard let text = params["text"] as? String, !text.isEmpty else { throw HelperError("type needs text") }
+        input.type(text)
+        return ["ok": true, "detail": "typed into \(snapshot.appName)"]
+      }
+      guard let key = params["key"] as? String else { throw HelperError("key needs a key name") }
+      input.press(keycode: try input.keycode(for: key), modifiers: input.flags(for: (params["modifiers"] as? [String]) ?? []))
+      return ["ok": true, "detail": "pressed \(key) in \(snapshot.appName)"]
+    }
+
     let point = try resolveActionPoint(app: app, element: element, params: params)
     let modifiers = input.flags(for: (params["modifiers"] as? [String]) ?? [])
 

--- a/apps/desktop/native/AxHelper.swift
+++ b/apps/desktop/native/AxHelper.swift
@@ -948,6 +948,12 @@ private final class Helper {
   }
 
   private func resolveApp(_ params: [String: Any]) throws -> NSRunningApplication {
+    // A named app is refused BEFORE anything is looked up. Resolution fails first for an app that is
+    // not running, so with the check only below, asking for a forbidden bundle id answered "not
+    // running" rather than "never driveable" — which made the refusal contingent on the app
+    // happening to be up, and turned the message into a probe for which apps are. `pid` and the
+    // frontmost case cannot be checked this early, and keep the check after resolution.
+    if let bundleId = params["bundleId"] as? String { try refuseForbidden(bundleId: bundleId) }
     let running = NSWorkspace.shared.runningApplications
     var app: NSRunningApplication?
     if let pid = params["pid"] as? Int {

--- a/apps/desktop/native/AxHelper.swift
+++ b/apps/desktop/native/AxHelper.swift
@@ -359,20 +359,35 @@ private func captureApp(pid: pid_t) -> String? {
     content = fetched
     contentSemaphore.signal()
   }
-  guard contentSemaphore.wait(timeout: .now() + CAPTURE_TIMEOUT_S) == .success,
-        let content,
-        let display = content.displays.first else { return nil }
+  guard contentSemaphore.wait(timeout: .now() + CAPTURE_TIMEOUT_S) == .success, let content else { return nil }
 
   let windows = content.windows.filter { $0.owningApplication?.processID == pid }
   guard !windows.isEmpty else { return nil }
+  let bounds = windows.dropFirst().reduce(windows[0].frame) { $0.union($1.frame) }
+
+  // The display the app's windows are actually ON, not `content.displays.first`.
+  //
+  // Observed on a three-display Mac: `displays` came back ordered [external-left, main, laptop], so
+  // `.first` was the monitor at x=-1920 while Calculator's window sat at x=969 on the main display.
+  // A filter whose windows are not on its display does not return a wrong image — it fails the whole
+  // capture with SCStreamErrorDomain -3811, "failed to start stream due to audio/video capture
+  // failure", which reads exactly like a missing permission and is why this path looked ungranted.
+  // On a single-display Mac `.first` is right by luck, which is why it survived this long.
+  let area = { (display: SCDisplay) -> CGFloat in
+    let overlap = display.frame.intersection(bounds)
+    return overlap.isNull ? 0 : overlap.width * overlap.height
+  }
+  guard let display = content.displays.max(by: { area($0) < area($1) }), area(display) > 0 else { return nil }
 
   let filter = SCContentFilter(display: display, including: windows)
   let config = SCStreamConfiguration()
-  // The filter's own bounds, so the image is the app's windows rather than a mostly-empty desktop.
-  // `contentRect` is in points; scaling to 1x keeps a Retina capture from being four times the
-  // bytes for detail no model reads.
-  config.width = Int(filter.contentRect.width)
-  config.height = Int(filter.contentRect.height)
+  // `filter.contentRect` for a display filter is the whole DISPLAY, not the included windows, so the
+  // crop has to be asked for or the image is a mostly-empty desktop at display resolution. Points,
+  // and `.nominal` so a Retina capture is not four times the bytes for detail no model reads.
+  let crop = bounds.intersection(display.frame).offsetBy(dx: -display.frame.minX, dy: -display.frame.minY)
+  config.sourceRect = crop
+  config.width = Int(crop.width)
+  config.height = Int(crop.height)
   config.captureResolution = .nominal
   config.showsCursor = false
 

--- a/apps/desktop/scripts/computer-use-live.cjs
+++ b/apps/desktop/scripts/computer-use-live.cjs
@@ -15,9 +15,11 @@
  * Two tiers, because one of them needs a grant this machine may not have:
  *
  *   ALWAYS — the helper spawns and answers; grants are reported honestly; the app list is real and
- *     excludes Realm itself and System Settings (the refusal that matters most, checked live rather
- *     than assumed); a snapshot without the grant refuses with actionable words; acting on a snapshot
- *     that does not exist is refused; and the client recovers when the helper dies under it.
+ *     excludes the forbidden apps that LaunchServices says are actually up, and the app hosting this
+ *     check, and is checked against a second inventory so an empty list cannot pass for a filtered
+ *     one; a forbidden app is refused by name whether or not it is running; a snapshot without the
+ *     grant refuses with actionable words; acting on a snapshot that does not exist is refused; and
+ *     the client recovers when the helper dies under it.
  *
  *   ONLY WITH ACCESSIBILITY GRANTED — a real end-to-end drive of Calculator: snapshot it, press a
  *     digit by element index, and read the result back out of the accessibility tree. Calculator is
@@ -58,6 +60,39 @@ const ok = (label, cond, detail = "") => {
 const skip = (label, why) => { results.push(`  SKIP  ${label} — ${why}`); skipped += 1; };
 const log = (line) => console.log(`[live] ${line}`);
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+/**
+ * Every bundle id LaunchServices currently has an application registered for.
+ *
+ * A second opinion about what is running, deliberately NOT `NSWorkspace.runningApplications` — that
+ * is the enumeration `listApps` itself filters, so using it to check the filter would be asking the
+ * same source twice. Returns null rather than an empty set when `lsappinfo` cannot be read, so a
+ * missing tool is reported as a skip instead of as "nothing is running".
+ */
+function runningBundleIds() {
+  try {
+    const out = execFileSync("/usr/bin/lsappinfo", ["list"], { encoding: "utf8", maxBuffer: 32 << 20 });
+    const ids = [...out.matchAll(/bundleID="([^"]+)"/g)].map((m) => m[1]);
+    return ids.length > 0 ? new Set(ids) : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The bundle id of the application hosting this check — what the helper's ancestry walk should
+ * resolve to, read here from the bundle around `execPath` so the two are derived independently.
+ * `defaults` rather than a plist parser because Info.plist is usually binary.
+ */
+const selfBundleId = (() => {
+  const bundle = /^(.*?\.app)\//.exec(process.execPath);
+  if (!bundle) return null;
+  try {
+    return execFileSync("/usr/bin/defaults", ["read", path.join(bundle[1], "Contents/Info"), "CFBundleIdentifier"], { encoding: "utf8" }).trim();
+  } catch {
+    return null;
+  }
+})();
 
 // ---- compile the real main-process sources (TS) to CJS with the workspace's own esbuild ----
 function esbuild() {
@@ -120,25 +155,51 @@ async function run() {
   ok("the app list is real, with no Accessibility grant", Array.isArray(apps.apps) && apps.apps.length > 0,
     `${apps.apps?.length ?? 0} app(s) — NSWorkspace rather than the accessibility API, so an ungranted machine can still discover what is running`);
 
-  // The refusals that matter most, observed rather than assumed. Realm is several processes sharing
-  // one bundle id, and the helper is a descendant of one of them.
-  const bundles = (apps.apps ?? []).map((a) => a.bundleId);
-  ok("Realm never lists itself", !bundles.some((b) => b.includes("realm")), bundles.filter((b) => b.includes("realm")).join(", ") || "absent");
-  ok("System Settings is never listed", !bundles.includes("com.apple.systempreferences"));
-  // Named against the whole list rather than two entries: asserting Terminal.app and iTerm are absent
-  // from a machine running neither passes without testing anything, and it did — Ghostty sat in the
-  // app list, driveable, while this line was green.
-  const leaked = bundles.filter((b) => FORBIDDEN.has(b));
-  ok("no forbidden app is ever listed", leaked.length === 0, leaked.length ? `LEAKED: ${leaked.join(", ")}` : "none present");
+  // The refusals that matter most, observed against an INDEPENDENT inventory of what is running.
+  //
+  // `listApps` filters the forbidden set before it returns, so "no forbidden app is in the list"
+  // is empty by construction: it reads the same green whether the filter works, whether the filter
+  // is missing, and whether the list came back empty. LaunchServices is asked separately so each
+  // absence below has a subject that is demonstrably running, and so a machine with no forbidden
+  // app up is reported as SKIP rather than as proof.
+  const listed = new Set((apps.apps ?? []).map((a) => a.bundleId));
+  const running = runningBundleIds();
+  if (!running) {
+    skip("the app list excludes forbidden apps that are running", "lsappinfo did not answer, so nothing independent to compare against");
+  } else {
+    // The positive control. Without it every exclusion below would also pass on an empty list.
+    const alsoRunning = [...listed].filter((b) => running.has(b));
+    ok("the app list agrees with LaunchServices about what is running", alsoRunning.length > 0,
+      `${alsoRunning.length} app(s) in both, e.g. ${alsoRunning.slice(0, 3).join(", ")}`);
 
-  // The absence above cannot prove itself: `listApps` filters the forbidden set, so deriving "which
-  // forbidden apps are running" from its own output is empty by construction whatever the helper
-  // does. The refusal is what can be tested directly, and it does not depend on anything being up —
-  // ask for one by name and require the refusal rather than an empty answer.
+    const forbiddenUp = [...FORBIDDEN].filter((b) => running.has(b));
+    if (forbiddenUp.length === 0) {
+      skip("the app list excludes forbidden apps that are running",
+        "none of the forbidden bundle ids is running, so their absence proves nothing — the by-name refusal below is what covers this case");
+    } else {
+      const leaked = forbiddenUp.filter((b) => listed.has(b));
+      ok("the app list excludes forbidden apps that are running", leaked.length === 0,
+        leaked.length ? `LEAKED: ${leaked.join(", ")}` : `excluded while up: ${forbiddenUp.join(", ")}`);
+    }
+  }
+
+  // Realm's own exclusion is derived from the helper's PROCESS ANCESTRY, not from the forbidden
+  // list, and under a dev run the ancestor is Electron rather than Realm.app — so looking for
+  // "realm" in the list tests the static entry and leaves the ancestry walk unexercised. The host
+  // of this very check is the subject that exercises it.
+  ok("the app hosting this check is excluded by ancestry, not by name",
+    !(apps.apps ?? []).some((a) => a.pid === process.pid)
+      && (selfBundleId === null || !listed.has(selfBundleId)),
+    `host pid ${process.pid}${selfBundleId ? ` (${selfBundleId})` : " (bundle id unreadable)"}`);
+
+  // The exclusions above can only speak for apps that happen to be up. The refusal can be tested
+  // directly and unconditionally — ask for one by name and require a refusal rather than an empty
+  // answer, so the rule is covered on a machine running none of them.
   // A snapshot refusal THROWS, where computerAct returns `{ok:false, refused}` — the two ops do not
   // answer the same way, so a check that only inspected a return value would read a throw as a pass.
+  const byName = ["com.apple.Terminal", "com.mitchellh.ghostty", "com.apple.systempreferences"];
   const refusals = [];
-  for (const bundleId of ["com.apple.Terminal", "com.mitchellh.ghostty", "com.apple.systempreferences"]) {
+  for (const bundleId of byName) {
     try {
       await host.handleOp("computerSnapshot", { bundleId });
       refusals.push(`${bundleId}=ALLOWED`);
@@ -146,8 +207,10 @@ async function run() {
       refusals.push(`${bundleId}=${/never driveable/.test(e.message) ? "refused" : `other(${e.message.slice(0, 40)})`}`);
     }
   }
+  // Length as well as content: `every` holds of an empty array, so a loop that stopped running
+  // would report the same pass as three refusals.
   ok("a forbidden app is refused BY NAME, whether or not it is running",
-    refusals.every((r) => r.endsWith("=refused")), refusals.join(" "));
+    refusals.length === byName.length && refusals.every((r) => r.endsWith("=refused")), refusals.join(" "));
 
   // Acting on a snapshot the helper has never issued must refuse, not act on whatever matches.
   // Without the grant the trust check answers first, and deliberately so: "grant Accessibility" is

--- a/apps/desktop/scripts/computer-use-live.cjs
+++ b/apps/desktop/scripts/computer-use-live.cjs
@@ -69,6 +69,31 @@ const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
  * same source twice. Returns null rather than an empty set when `lsappinfo` cannot be read, so a
  * missing tool is reported as a skip instead of as "nothing is running".
  */
+/**
+ * A JPEG's real pixel dimensions, from its SOF marker.
+ *
+ * Read rather than trusted, because the failure this exists to catch is a capture that succeeds and
+ * returns the wrong thing: since macOS 15 the deprecated `CGWindowListCreateImage` answers an
+ * ungranted caller with a black or desktop-only image instead of failing, and "some base64 came
+ * back" cannot tell that apart from a real window. Comparing against the app's own AX frame can.
+ */
+function jpegSize(buf) {
+  if (buf.length < 4 || buf[0] !== 0xff || buf[1] !== 0xd8) return null;
+  let i = 2;
+  while (i + 9 < buf.length) {
+    if (buf[i] !== 0xff) { i += 1; continue; }
+    const marker = buf[i + 1];
+    // SOF0..SOF15 carry the frame header; C4 (Huffman tables), C8 (JPEG extensions) and CC
+    // (arithmetic coding conditioning) share the range and are not frame headers.
+    if (marker >= 0xc0 && marker <= 0xcf && marker !== 0xc4 && marker !== 0xc8 && marker !== 0xcc) {
+      return { height: buf.readUInt16BE(i + 5), width: buf.readUInt16BE(i + 7) };
+    }
+    if (marker === 0xd8 || (marker >= 0xd0 && marker <= 0xd9)) { i += 2; continue; }
+    i += 2 + buf.readUInt16BE(i + 2);
+  }
+  return null;
+}
+
 function runningBundleIds() {
   try {
     const out = execFileSync("/usr/bin/lsappinfo", ["list"], { encoding: "utf8", maxBuffer: 32 << 20 });
@@ -249,13 +274,20 @@ async function run() {
   ok("Calculator's accessibility tree comes back indexed", snap.elements.length > 0, `${snap.elements.length} element(s)`);
   ok("the rendered listing is addressable", /^\[\d+\] AX/m.test(snap.text), snap.text.split("\n")[0] ?? "");
 
-  // Clear first so the assertion does not depend on whatever the user last computed.
-  const clear = snap.elements.find((e) => /^(AC|C|All Clear|Clear)$/i.test(e.name));
-  if (clear) {
-    await host.handleOp("computerAct", { snapshotId: snap.snapshotId, action: { kind: "click", index: clear.index, button: "left", clickCount: 1, modifiers: [] } });
-    await sleep(400);
-  }
-  ok("Calculator exposes a clear button", Boolean(clear), clear ? `[${clear.index}] ${clear.name}` : "not found");
+  // Clear first, so the digit assertion does not depend on whatever was last computed — including by
+  // a previous run of this check. Escape rather than the clear BUTTON: Calculator relabels that
+  // button from "All Clear" to "Clear" once a digit is entered, and "Clear" drops only the current
+  // entry, so a run that followed another one started with digits still on the display. Escape is
+  // always all-clear, and it exercises the `key` action, which no other tier here does.
+  await host.handleOp("computerAct", { snapshotId: snap.snapshotId, action: { kind: "key", key: "Escape" } });
+  await sleep(400);
+  const cleared = await host.handleOp("computerSnapshot", { bundleId: CALCULATOR });
+  const display = (elements) => {
+    const shown = elements.filter((e) => e.value && /^-?[\d.,]+$/.test(e.value.trim()));
+    return shown.length > 0 ? shown[shown.length - 1].value.trim() : "";
+  };
+  ok("a synthetic key press reaches the app — Escape clears Calculator", display(cleared.elements) === "0",
+    `display reads ${display(cleared.elements) || "(nothing numeric)"}`);
 
   // Re-snapshot: the clear may have changed the tree, and acting on a stale index is exactly what
   // this design refuses to do.
@@ -270,14 +302,43 @@ async function run() {
     await sleep(500);
     // The proof: read the result back out of the tree rather than trusting the click's own report.
     const after = await host.handleOp("computerSnapshot", { bundleId: CALCULATOR });
-    const shows7 = after.elements.some((e) => e.value === "7" || (e.role === "AXStaticText" && e.value.trim() === "7"));
-    ok("the click really landed — Calculator's display now reads 7", shows7,
-      shows7 ? "" : `display values seen: ${after.elements.filter((e) => e.value).map((e) => e.value).slice(0, 8).join(" | ")}`);
+    // Exactly 7, against a display that was just proven to read 0: "contains a 7" would also be true
+    // of the 77 a previous run left behind.
+    ok("the click really landed — Calculator's display now reads 7", display(after.elements) === "7",
+      `display reads ${display(after.elements) || "(nothing numeric)"}`);
   }
 
   // A stale index from the FIRST snapshot must now be refused or re-resolved, never acted on blindly.
   const staleIndex = await host.handleOp("computerAct", { snapshotId: snap.snapshotId, action: { kind: "click", index: 9999, button: "left", clickCount: 1, modifiers: [] } });
   ok("an index that never existed is refused", staleIndex.ok === false, staleIndex.error);
+
+  // ---- tier 3: ScreenCaptureKit, whose grant is separate from Accessibility ------------------
+  //
+  // Both outcomes are supported states and both are asserted. Screen Recording is OPTIONAL: without
+  // it a snapshot must still return the tree and simply omit the image, because the tree is what
+  // acting depends on. Failing the whole op would make an optional grant a required one.
+  const shot = await host.handleOp("computerSnapshot", { bundleId: CALCULATOR, screenshot: true });
+  ok("a snapshot asking for an image still returns the tree", shot.elements.length > 0, `${shot.elements.length} element(s)`);
+
+  // The AX frame of Calculator's window, to measure the capture against.
+  const window = shot.elements.find((e) => e.role === "AXWindow") ?? shot.elements[0];
+
+  if (!grants.screenRecording) {
+    ok("without Screen Recording the image is omitted, not failed", shot.screenshot === undefined,
+      shot.screenshot === undefined ? "tree returned, screenshot absent" : "an image came back with no grant");
+    skip("the capture is of the app's own windows", "macOS has not granted this app Screen Recording — grant it in Realm's Settings → Permissions and re-run");
+  } else {
+    const jpeg = typeof shot.screenshot === "string" ? Buffer.from(shot.screenshot, "base64") : null;
+    ok("with Screen Recording the snapshot carries a real JPEG", jpeg !== null && jpeg.length > 0 && jpeg[0] === 0xff && jpeg[1] === 0xd8,
+      jpeg ? `${jpeg.length} bytes` : "no screenshot field");
+    const size = jpeg ? jpegSize(jpeg) : null;
+    // Measured against the window's own accessibility frame rather than against the display: a
+    // full-screen image would mean the filter captured the desktop, which is the exact wrong answer
+    // ScreenCaptureKit was chosen over CGWindowListCreateImage to avoid.
+    const near = (a, b) => Math.abs(a - b) <= Math.max(24, b * 0.2);
+    ok("the capture is of the app's own windows", Boolean(size && window && near(size.width, window.w) && near(size.height, window.h)),
+      size && window ? `captured ${size.width}×${size.height}, window is ${window.w}×${window.h}` : "no dimensions readable");
+  }
 
   helper.stop();
 }

--- a/apps/desktop/src/main/computer-access.test.ts
+++ b/apps/desktop/src/main/computer-access.test.ts
@@ -45,8 +45,11 @@ describe("computerAccessRows", () => {
   });
 
   it("never claims an unknown state — both grants answer definitively", () => {
+    // The states are named rather than scanned for the absence of "unknown": `every` is true of an
+    // empty array, so a row that stopped being returned would satisfy that scan without existing.
     for (const grants of [{ accessibility: true, screenRecording: false }, { accessibility: false, screenRecording: true }]) {
-      expect(computerAccessRows(grants, { helperAvailable: true }).every((r) => r.state !== "unknown")).toBe(true);
+      expect(computerAccessRows(grants, { helperAvailable: true }).map((r) => r.state))
+        .toEqual([grants.accessibility ? "granted" : "denied", grants.screenRecording ? "granted" : "denied"]);
     }
   });
 

--- a/apps/desktop/src/main/computer-driving.test.ts
+++ b/apps/desktop/src/main/computer-driving.test.ts
@@ -1,0 +1,139 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ComputerDrivingIndicator } from "./computer-driving";
+
+/**
+ * The menu-bar indicator's counting and lingering, over a fake tray. Whether a menu-bar item can be
+ * built from an empty image is Electron's business and is checked live; what must die here is the
+ * indicator claiming the Mac is being driven when it is not, and — the worse direction — failing to
+ * say so when it is.
+ */
+function indicator() {
+  const calls: string[] = [];
+  let live = 0;
+  const inst = new ComputerDrivingIndicator({
+    createTray: () => {
+      live += 1;
+      calls.push("create");
+      return {
+        setTitle: (t) => calls.push(`title:${t}`),
+        setToolTip: (t) => calls.push(`tip:${t}`),
+        destroy: () => { live -= 1; calls.push("destroy"); },
+      };
+    },
+  });
+  return { inst, calls, trays: () => live };
+}
+
+const titles = (calls: string[]): string[] =>
+  calls.filter((c) => c.startsWith("title:")).map((c) => c.slice("title:".length));
+
+beforeEach(() => vi.useFakeTimers());
+afterEach(() => vi.useRealTimers());
+
+describe("ComputerDrivingIndicator", () => {
+  it("puts an item in the menu bar naming the app being driven", () => {
+    const { inst, calls } = indicator();
+    inst.acquire("TextEdit");
+    expect(inst.showing).toBe(true);
+    expect(titles(calls)).toEqual(["Driving TextEdit"]);
+    // The title has no room to say who is driving, so the tooltip must.
+    expect(calls.find((c) => c.startsWith("tip:"))).toMatch(/Realm is driving TextEdit/);
+  });
+
+  it("shows nothing until something is actually driving", () => {
+    const { inst, calls } = indicator();
+    expect(inst.showing).toBe(false);
+    expect(calls).toEqual([]);
+  });
+
+  it("stays up until every act in flight has settled", () => {
+    // Two sessions can be acting at once. Counted rather than flagged: with a boolean the first
+    // settle takes the item down while the second session is still clicking.
+    const { inst } = indicator();
+    inst.acquire("TextEdit");
+    inst.acquire("Calculator");
+    inst.release();
+    vi.advanceTimersByTime(60_000);
+    expect(inst.showing).toBe(true);
+    inst.release();
+    vi.advanceTimersByTime(60_000);
+    expect(inst.showing).toBe(false);
+  });
+
+  it("lingers after the last act rather than vanishing the instant it settles", () => {
+    const { inst } = indicator();
+    inst.acquire("TextEdit");
+    inst.release();
+    expect(inst.showing).toBe(true);
+    vi.advanceTimersByTime(1499);
+    expect(inst.showing).toBe(true);
+    vi.advanceTimersByTime(1);
+    expect(inst.showing).toBe(false);
+  });
+
+  it("keeps one item across a run of acts instead of rebuilding it between them", () => {
+    // Every appearance and disappearance shifts every menu-bar item to the left of it, so a burst
+    // that tore the item down and rebuilt it would move other apps' icons under the cursor.
+    const { inst, calls, trays } = indicator();
+    for (let i = 0; i < 5; i += 1) {
+      inst.acquire("TextEdit");
+      inst.release();
+      vi.advanceTimersByTime(100);
+    }
+    expect(calls.filter((c) => c === "create")).toHaveLength(1);
+    expect(calls.filter((c) => c === "destroy")).toHaveLength(0);
+    vi.advanceTimersByTime(1500);
+    expect(trays()).toBe(0);
+  });
+
+  it("renames the item when the run moves to another app", () => {
+    const { inst, calls } = indicator();
+    inst.acquire("TextEdit");
+    inst.release();
+    inst.acquire("Calculator");
+    expect(titles(calls)).toEqual(["Driving TextEdit", "Driving Calculator"]);
+  });
+
+  it("drops the item on quit, mid-linger, rather than leaving one behind", () => {
+    const { inst, trays } = indicator();
+    inst.acquire("TextEdit");
+    inst.release();
+    inst.dispose();
+    expect(inst.showing).toBe(false);
+    expect(trays()).toBe(0);
+    // The pending linger must not resurrect or re-destroy anything after the app is gone.
+    vi.advanceTimersByTime(60_000);
+    expect(trays()).toBe(0);
+  });
+
+  it("drops the item on quit even with acts still in flight", () => {
+    const { inst } = indicator();
+    inst.acquire("TextEdit");
+    inst.dispose();
+    expect(inst.showing).toBe(false);
+  });
+
+  it("clips a long app name, which shares the menu bar with everything else", () => {
+    const { inst, calls } = indicator();
+    inst.acquire("Microsoft PowerPoint for Mac");
+    expect(titles(calls)).toEqual(["Driving Microsoft PowerPoint…"]);
+  });
+
+  it("still names something when the app arrived unnamed", () => {
+    const { inst, calls } = indicator();
+    inst.acquire("   ");
+    expect(titles(calls)).toEqual(["Driving an app"]);
+  });
+
+  it("survives more releases than acquires without going negative", () => {
+    // A release is emitted from a `finally`, and a future caller pairing them wrongly must not leave
+    // the count below zero, where the next real act would settle to a still-showing item.
+    const { inst } = indicator();
+    inst.release();
+    inst.release();
+    inst.acquire("TextEdit");
+    inst.release();
+    vi.advanceTimersByTime(1500);
+    expect(inst.showing).toBe(false);
+  });
+});

--- a/apps/desktop/src/main/computer-driving.test.ts
+++ b/apps/desktop/src/main/computer-driving.test.ts
@@ -86,6 +86,22 @@ describe("ComputerDrivingIndicator", () => {
     expect(trays()).toBe(0);
   });
 
+  it("does not let a pending linger tear the item down under a new act", () => {
+    // A run of acts spaced further apart than the linger: the second acquire has to cancel the
+    // timer the first release armed, or that timer fires mid-act and takes the menu bar item away
+    // while the Mac is still being driven — the one direction of this indicator that is a lie.
+    const { inst } = indicator();
+    inst.acquire("TextEdit");
+    inst.release();
+    vi.advanceTimersByTime(1000);
+    inst.acquire("TextEdit");
+    vi.advanceTimersByTime(1000);
+    expect(inst.showing).toBe(true);
+    inst.release();
+    vi.advanceTimersByTime(1500);
+    expect(inst.showing).toBe(false);
+  });
+
   it("renames the item when the run moves to another app", () => {
     const { inst, calls } = indicator();
     inst.acquire("TextEdit");

--- a/apps/desktop/src/main/computer-driving.ts
+++ b/apps/desktop/src/main/computer-driving.ts
@@ -1,0 +1,115 @@
+/**
+ * The menu-bar indicator for "an agent is driving this Mac".
+ *
+ * Where this lives is forced by what computer use does. The helper refuses to click unless the
+ * target application actually comes frontmost — that is the `not_frontmost` check in AxHelper.swift
+ * — so at the instant an act lands, Realm is by definition not the active application and its window
+ * may be behind everything or hidden outright. The browser pane's `driving` dot has a window to live
+ * in and computer use has none, so mirroring it in the renderer would put the signal exactly where
+ * it cannot be seen.
+ *
+ * A floating always-on-top window was the other candidate and is actively harmful here: an overlay
+ * above the target is the case `occludingApp` documents its layer filter as unable to see, and one
+ * owned by Realm would sit over the very point about to be clicked. The menu bar is the platform's
+ * own answer for "something is running that you are not looking at" — where macOS puts its screen
+ * recording and location indicators — and it is visible whichever application is frontmost.
+ *
+ * Nothing here animates, so the `prefers-reduced-motion` problem the sidebar's ring solves does not
+ * arise: there is no motion carrying state that stopping would take away.
+ */
+
+/** The part of Electron's `Tray` this needs, so the counting and lingering below can be exercised
+ *  without a menu bar. */
+export type DrivingTray = {
+  setTitle(title: string): void;
+  setToolTip(tip: string): void;
+  destroy(): void;
+};
+
+export type ComputerDrivingDeps = {
+  /** Builds the menu-bar item, called on the first act rather than at startup: this is not a
+   *  permanent resident, and an item that sat there while nothing was driving would say nothing. */
+  createTray: () => DrivingTray;
+};
+
+/**
+ * How long the item stays up after the last act settles.
+ *
+ * An act is often tens of milliseconds and agents issue them in runs, so tearing the item down
+ * between each would flash the menu bar rather than inform it. Worse, every appearance and
+ * disappearance shifts the position of every item to its left, so the flicker would move other
+ * applications' icons under the user's cursor. The linger coalesces a burst into one showing.
+ */
+const LINGER_MS = 1500;
+
+/** Menu bar width is shared with every other item, so a long application name is clipped rather
+ *  than allowed to push the rest off the screen. */
+const MAX_NAME = 22;
+
+export class ComputerDrivingIndicator {
+  private tray: DrivingTray | null = null;
+  private inFlight = 0;
+  private linger: ReturnType<typeof setTimeout> | null = null;
+
+  constructor(private readonly d: ComputerDrivingDeps) {}
+
+  /** True while the menu-bar item exists. */
+  get showing(): boolean {
+    return this.tray !== null;
+  }
+
+  /**
+   * One act is starting against `appName`.
+   *
+   * Counted rather than flagged: two sessions can have acts in flight at once, and the first to
+   * settle must not take the indicator down while the second is still clicking.
+   */
+  acquire(appName: string): void {
+    this.inFlight += 1;
+    this.cancelLinger();
+    if (!this.tray) this.tray = this.d.createTray();
+    const name = drivingName(appName);
+    this.tray.setTitle(`Driving ${name}`);
+    // The tooltip carries the sentence the title has no room for, and names Realm — the title alone
+    // does not say who is doing the driving.
+    this.tray.setToolTip(`Realm is driving ${name}. An agent you are running is controlling this Mac.`);
+  }
+
+  /** The matching settle, whatever the outcome. */
+  release(): void {
+    this.inFlight = Math.max(0, this.inFlight - 1);
+    if (this.inFlight > 0) return;
+    this.cancelLinger();
+    this.linger = setTimeout(() => {
+      this.linger = null;
+      this.teardown();
+    }, LINGER_MS);
+    // Not unref'd: an indicator that says the Mac is being driven must not be the thing keeping the
+    // process alive, but neither should quitting leave it on screen — `dispose` is what quit calls.
+  }
+
+  /** Drop the item now. Quit calls this, where a pending linger would otherwise outlive the app. */
+  dispose(): void {
+    this.cancelLinger();
+    this.inFlight = 0;
+    this.teardown();
+  }
+
+  private cancelLinger(): void {
+    if (!this.linger) return;
+    clearTimeout(this.linger);
+    this.linger = null;
+  }
+
+  private teardown(): void {
+    this.tray?.destroy();
+    this.tray = null;
+  }
+}
+
+function drivingName(appName: string): string {
+  const name = appName.trim();
+  if (!name) return "an app";
+  // trimEnd so a name clipped at a word boundary does not leave a gap before the ellipsis.
+  return name.length > MAX_NAME ? `${name.slice(0, MAX_NAME - 1).trimEnd()}…` : name;
+}

--- a/apps/desktop/src/main/computer-use-host.test.ts
+++ b/apps/desktop/src/main/computer-use-host.test.ts
@@ -129,6 +129,18 @@ describe("ComputerUseHost", () => {
     expect(calls[0]!.params.screenshot).toBe(true);
   });
 
+  it("passes a snapshot through with no image when the helper omitted one", async () => {
+    // Screen Recording is a separate grant from Accessibility and an optional one. Without it the
+    // helper returns the tree and no `screenshot` field, and that has to stay an ordinary result all
+    // the way up — turning it into a failure would make an optional grant a required one.
+    const { instance } = host({
+      snapshot: { snapshotId: "ax_1", pid: 7, bundleId: "com.apple.TextEdit", appName: "TextEdit", frontmost: true, truncated: false, elements: [element({ name: "Save" })] },
+    });
+    const snap = await instance.handleOp("computerSnapshot", { bundleId: "x", screenshot: true }) as { text: string; screenshot?: string };
+    expect(snap.screenshot).toBeUndefined();
+    expect(snap.text).toBe('[0] AXButton "Save" (10,20 30×40)');
+  });
+
   it("turns the helper's tag into a refusal the agent can branch on", async () => {
     const stale = Object.assign(new Error("snapshot ax_1 is no longer current"), { cause: "stale_snapshot" });
     const { instance } = host({ act: () => { throw stale; } });

--- a/apps/desktop/src/main/computer-use-host.test.ts
+++ b/apps/desktop/src/main/computer-use-host.test.ts
@@ -7,20 +7,26 @@ const element = (over: Partial<ComputerElement> = {}): ComputerElement => ({
   x: 10, y: 20, w: 30, h: 40, actions: [], enabled: true, focused: false, depth: 1, ...over,
 });
 
-/** A host over a scripted helper: records the calls, answers from a table. */
+/** A host over a scripted helper: records the calls, answers from a table. `driving` records the
+ *  menu-bar indicator's feed as a transcript, so its ORDER against the helper call is assertable. */
 function host(answers: Record<string, unknown | (() => unknown)>, opts: { available?: boolean } = {}) {
   const calls: { method: string; params: Record<string, unknown> }[] = [];
+  const driving: (string | null)[] = [];
   const instance = new ComputerUseHost({
     available: () => opts.available !== false,
     request: async <T,>(method: string, params: Record<string, unknown> = {}) => {
       calls.push({ method, params });
+      driving.push(`during:${method}` as unknown as string);
       const answer = answers[method];
       if (answer === undefined) throw new Error(`no scripted answer for "${method}"`);
       return (typeof answer === "function" ? (answer as () => unknown)() : answer) as T;
     },
+    driving: (appName) => { driving.push(appName); },
   });
-  return { instance, calls };
+  return { instance, calls, driving };
 }
+
+const click = ComputerActionSchema.parse({ kind: "click", index: 1 });
 
 describe("formatElementLine", () => {
   it("renders index, role, name and frame", () => {
@@ -151,5 +157,45 @@ describe("ComputerUseHost", () => {
   it("rejects an unknown op", async () => {
     const { instance } = host({});
     await expect(instance.handleOp("computerWhatever", {})).rejects.toThrow(/unknown computer host op/);
+  });
+});
+
+describe("the driving indicator's feed", () => {
+  it("is raised around the helper call and lowered once it answers", async () => {
+    const { instance, driving } = host({ act: { ok: true, detail: "clicked" } });
+    await instance.handleOp("computerAct", { snapshotId: "ax_1", action: click, appName: "TextEdit" });
+    expect(driving).toEqual(["TextEdit", "during:act", null]);
+  });
+
+  it("is lowered when the helper throws, so nothing can leave it stuck on", async () => {
+    // The mutant this kills: dropping the `finally`. A helper that dies mid-act, or times out,
+    // would otherwise leave the menu bar saying the Mac is still being driven forever.
+    const { instance, driving } = host({ act: () => { throw Object.assign(new Error("child died"), { cause: "kaboom" }); } });
+    await instance.handleOp("computerAct", { snapshotId: "ax_1", action: click, appName: "TextEdit" });
+    expect(driving).toEqual(["TextEdit", "during:act", null]);
+  });
+
+  it("is not raised for an act refused before the machine is touched", async () => {
+    // No snapshot id and an unparseable chord are both refused here. Claiming the Mac was driven
+    // for either would put the indicator up for input that was never posted.
+    const { instance, driving } = host({});
+    await instance.handleOp("computerAct", { action: click, appName: "TextEdit" });
+    await instance.handleOp("computerAct", {
+      snapshotId: "ax_1", action: ComputerActionSchema.parse({ kind: "key", key: "hello there" }), appName: "TextEdit",
+    });
+    expect(driving).toEqual([]);
+  });
+
+  it("is not raised by reading, which drives nothing", async () => {
+    const { instance, driving } = host({ snapshot: { elements: [] }, listApps: { apps: [] } });
+    await instance.handleOp("computerSnapshot", { bundleId: "x" });
+    await instance.handleOp("computerListApps", {});
+    expect(driving.filter((d) => !String(d).startsWith("during:"))).toEqual([]);
+  });
+
+  it("names the app the server resolved, and stays quiet when it sent none", async () => {
+    const { instance, driving } = host({ act: { ok: true, detail: "ok" } });
+    await instance.handleOp("computerAct", { snapshotId: "ax_1", action: click });
+    expect(driving[0]).toBe("");
   });
 });

--- a/apps/desktop/src/main/computer-use-host.ts
+++ b/apps/desktop/src/main/computer-use-host.ts
@@ -18,6 +18,15 @@ export type ComputerUseHostDeps = {
   request<T>(method: string, params?: Record<string, unknown>): Promise<T>;
   /** False when this build has no compiled helper (non-mac, or no Swift toolchain at build time). */
   available(): boolean;
+  /**
+   * An act against `appName` is starting, and null once it has settled — the menu-bar indicator's
+   * feed. Optional so the unit tests and the live check can build a host with no menu bar.
+   *
+   * Driven from here rather than from the provider because the server's half ends before the input
+   * is posted: the permission card is awaited over there, and lighting the indicator around that
+   * would say the Mac was being driven while the user was still deciding whether it may be.
+   */
+  driving?(appName: string | null): void;
 };
 
 /** The helper's own tags, which are the ones worth reporting to the agent verbatim. Anything else
@@ -49,8 +58,10 @@ export class ComputerUseHost {
         this.requireHelper();
         const snapshotId = String(params.snapshotId ?? "");
         // Schema-validated server-side; this cast is the two processes' contract, exactly as it is
-        // for `browser_act`.
-        return this.act(snapshotId, params.action as ComputerAction);
+        // for `browser_act`. `appName` rides along for the indicator alone — the server already
+        // resolved it to name the permission card, and deriving it a second time here would put two
+        // answers to "which app is this" in two processes.
+        return this.act(snapshotId, params.action as ComputerAction, String(params.appName ?? ""));
       }
       default:
         throw new Error(`unknown computer host op "${op}"`);
@@ -63,7 +74,7 @@ export class ComputerUseHost {
     }
   }
 
-  private async act(snapshotId: string, action: ComputerAction): Promise<ComputerActResult> {
+  private async act(snapshotId: string, action: ComputerAction, appName: string): Promise<ComputerActResult> {
     if (!snapshotId) return { ok: false, error: "no snapshot id — take a computer_snapshot before acting", refused: "stale_snapshot" };
     let params: Record<string, unknown>;
     try {
@@ -71,12 +82,19 @@ export class ComputerUseHost {
     } catch (e) {
       return { ok: false, error: e instanceof Error ? e.message : String(e) };
     }
+    // Raised around the helper call and nothing wider: the refusals above never reach the machine,
+    // and an indicator that lit for them would be claiming input was posted when none was.
+    this.d.driving?.(appName);
     try {
       return await this.d.request<ComputerActResult>("act", params);
     } catch (e) {
       const error = e as Error & { cause?: unknown };
       const tag = typeof error.cause === "string" && REFUSALS.has(error.cause) ? (error.cause as ComputerRefusal) : undefined;
       return { ok: false, error: error.message, ...(tag ? { refused: tag } : {}) };
+    } finally {
+      // In a `finally` so a helper that throws, hangs to its timeout, or dies mid-act cannot leave
+      // the menu bar claiming the Mac is still being driven.
+      this.d.driving?.(null);
     }
   }
 }

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -1,4 +1,4 @@
-import { app, autoUpdater as electronAutoUpdater, BrowserWindow, dialog, ipcMain, Menu, nativeImage, Notification, safeStorage, shell, systemPreferences, type MenuItemConstructorOptions } from "electron";
+import { app, autoUpdater as electronAutoUpdater, BrowserWindow, dialog, ipcMain, Menu, nativeImage, Notification, safeStorage, shell, systemPreferences, Tray, type MenuItemConstructorOptions } from "electron";
 import { BrowserCredentialInputSchema, DEFAULT_MIME, isImageMime, mimeForPath, newId, type BrowserCredential, type MediaFile } from "@realm/contracts";
 import { appendFileSync, closeSync, existsSync, mkdirSync, openSync, readFileSync, writeFileSync } from "node:fs";
 import { spawn } from "node:child_process";
@@ -15,6 +15,7 @@ import { startBrowserAgentBridge } from "./browser-agent-bridge";
 import { TCC_SETTINGS_URLS, isTccPermissionId, probeTcc, type TccRow } from "./tcc";
 import { ComputerUseHelper, axHelperPath } from "./computer-use-helper";
 import { ComputerUseHost } from "./computer-use-host";
+import { ComputerDrivingIndicator } from "./computer-driving";
 import { computerAccessRows, isComputerAccessId, type ComputerAccessStatus } from "./computer-access";
 import {
   MAC_FALLBACK_DIRS, appBundlePath, isMacCapabilityId, macAccessRows, macGrantArgv, macHostName, macSettingsUrl,
@@ -56,9 +57,24 @@ let agentBridge: { stop(): void } | null = null;
  * only while an agent is driving something.
  */
 const computerHelper = new ComputerUseHelper({ helperPath: axHelperPath, onLog: (line) => console.error(line) });
+/**
+ * The menu-bar item that says the Mac is being driven — see `computer-driving.ts` for why the signal
+ * is there rather than in a Realm window.
+ *
+ * Built with an empty image and carried by its title: a menu-bar item that only exists while an act
+ * is in flight has to say what it is in words, where a glyph would be one more unexplained icon
+ * appearing during the exact seconds the user's attention is on another application.
+ */
+const computerDriving = new ComputerDrivingIndicator({
+  createTray: () => {
+    const tray = new Tray(nativeImage.createEmpty());
+    return { setTitle: (t) => tray.setTitle(t), setToolTip: (t) => tray.setToolTip(t), destroy: () => tray.destroy() };
+  },
+});
 const computerHost = new ComputerUseHost({
   available: () => computerHelper.available,
   request: (method, params) => computerHelper.request(method, params),
+  driving: (appName) => { if (appName === null) computerDriving.release(); else computerDriving.acquire(appName); },
 });
 /** The encrypted secret store (safeStorage + the OS Keychain). App-scoped, not per-window: the
  *  bridge asks it for the `oauth` key at registration, and Settings enrolls into it. Built lazily
@@ -632,6 +648,7 @@ app.on("window-all-closed", () => app.quit());
  *  child (SIGTERM — the server's own handler closes ptys and the DB). Idempotent: quitAndInstall
  *  paths can arrive here twice (`before-quit-for-update`, then the ordinary quit machinery). */
 function shutdownForQuit() {
+  computerDriving.dispose();
   computerHelper.stop();
   agentBridge?.stop();
   agentBridge = null;

--- a/apps/desktop/src/renderer/src/components/sidebar/ComputerApps.tsx
+++ b/apps/desktop/src/renderer/src/components/sidebar/ComputerApps.tsx
@@ -1,0 +1,53 @@
+import { useEffect } from "react";
+import { useApp } from "../../state/store";
+
+/**
+ * The per-space computer-use allowed-apps list — the Connections tab's "Mac apps" section, below the
+ * browser origins, since both are lists of things agents in this space may reach out to.
+ *
+ * Read-and-remove rather than an add field: an entry is a bundle id, which nobody knows by heart and
+ * mistyping does not fail loudly — `com.apple.TextEdt` would simply never match and the user would
+ * be left wondering why the card kept appearing. Entries arrive from the permission card instead,
+ * where the app is the one actually in front of them and its identity comes from macOS. This is
+ * where they are reviewed and taken away.
+ */
+export function ComputerApps({ spaceId }: { spaceId: string }) {
+  const apps = useApp((s) => s.computerAllowedApps[spaceId]);
+  const refresh = useApp((s) => s.refreshComputerAllowedApps);
+  const setApps = useApp((s) => s.setComputerAllowedApps);
+  const run = useApp((s) => s.run);
+
+  useEffect(() => { run(() => refresh(spaceId)); }, [spaceId, refresh, run]);
+
+  const listed = apps ?? [];
+  const remove = (bundleId: string) => run(() => setApps(spaceId, listed.filter((a) => a !== bundleId)));
+
+  return (
+    <div className="field">
+      <span>Mac apps</span>
+      <p className="settings-hint">
+        Apps agents in this space may control without asking again. An app lands here when you answer
+        “Always allow” on its permission card.
+      </p>
+      {apps === undefined ? <p className="env-empty">Loading…</p>
+        : listed.length === 0
+          ? <p className="settings-hint">No apps allowed yet — every app is asked about the first time an agent tries to drive it.</p>
+          : (
+            <ul className="env-list">
+              {listed.map((bundleId) => (
+                <li key={bundleId} className="env-row">
+                  <div className="env-main"><span className="env-name">{bundleId}</span></div>
+                  <div className="env-actions">
+                    <button type="button" className="btn-quiet" onClick={() => remove(bundleId)}>Remove</button>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+      <p className="settings-note">
+        Removing an app takes effect at once, including in sessions that are already running. Realm,
+        System Settings, password prompts and terminals can never be driven and can never be added.
+      </p>
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/src/panes/session/PermissionCard.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/PermissionCard.tsx
@@ -16,6 +16,22 @@ const OPTIONS: { decision: PermissionDecision; label: string; kbd: string }[] = 
   { decision: "deny", label: "Deny", kbd: "⌘⌫" },
 ];
 
+/**
+ * What "always" is worth, for the tools where it is not the session.
+ *
+ * `computer_act`'s always is written to the space's allowed-apps list and outlives the session, so
+ * the option has to say so — a user answering "Allow always" about an application on their own Mac
+ * is owed the scope they are granting, and the plain label reads as "for now" next to "Allow". The
+ * option list itself is unchanged: this is the same decision reaching a different store, not a
+ * fourth answer, which would have to be understood by every adapter that can receive one.
+ */
+const ALWAYS_LABEL: Record<string, string> = { computer_act: "Always allow in this space" };
+
+const optionsFor = (toolName: string): typeof OPTIONS => {
+  const label = ALWAYS_LABEL[toolName];
+  return label ? OPTIONS.map((o) => (o.decision === "allow_always" ? { ...o, label } : o)) : OPTIONS;
+};
+
 /** The agent wants to run a tool: Allow (once) / Allow always / Deny.
  *
  *  Keyboard (U-H4): with `autoFocus` (the card sits in the focused pane) the Allow option takes
@@ -77,7 +93,7 @@ export function PermissionCard({ permission, onDecide, autoFocus = false, enter 
       {preview && <div className="permission-preview"><ToolInputBody view={preview} /></div>}
       <details className="permission-details"><summary>{preview ? "Raw input" : "Input"}</summary><pre>{prettyJson(permission.input)}</pre></details>
       <div className="permission-options">
-        {OPTIONS.map((o, i) => (
+        {optionsFor(permission.toolName).map((o, i) => (
           <button key={o.decision} ref={(el) => { rows.current[i] = el; }} className="permission-option"
             aria-label={o.label} data-selected={i === selected || undefined} data-decision={o.decision}
             onFocus={() => setSelected(i)} onClick={() => onDecide(o.decision)}>

--- a/apps/desktop/src/renderer/src/panes/session/permission-card.test.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/permission-card.test.tsx
@@ -1,0 +1,64 @@
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { PermissionCard } from "./PermissionCard";
+import type { PendingPermission } from "./transcript-model";
+
+/**
+ * The card's option list, and the one tool whose "always" is not the session's.
+ *
+ * Everything else about this card — keyboard, ordering, the drawn input — is covered from the pane
+ * in `session-pane.test.tsx`. What must die here is the computer-use card promising a scope it does
+ * not grant, in either direction.
+ */
+function card(over: Partial<PendingPermission> = {}) {
+  const decided: string[] = [];
+  const permission: PendingPermission = {
+    requestId: "r1", toolName: "Bash", input: { command: "ls" }, title: "Run ls?", ...over,
+  };
+  render(<PermissionCard permission={permission} onDecide={(d) => decided.push(d)} />);
+  const root = screen.getByText(permission.title).closest(".permission-card") ?? document.body;
+  const options = within(root as HTMLElement).getAllByRole("button").filter((b) => b.classList.contains("permission-option"));
+  return { decided, options, root: root as HTMLElement };
+}
+
+const labels = (options: HTMLElement[]): (string | null)[] => options.map((o) => o.getAttribute("aria-label"));
+
+describe("PermissionCard options", () => {
+  it("says Allow always for an ordinary tool, whose always is the session", () => {
+    expect(labels(card().options)).toEqual(["Allow", "Allow always", "Deny"]);
+  });
+
+  it("names the scope on a computer-use card, whose always outlives the session", () => {
+    // The grant is written to the space's allowed-apps list. "Allow always" next to "Allow" reads as
+    // "for now", and a user answering about an application on their own Mac is owed the real scope.
+    expect(labels(card({ toolName: "computer_act", title: "Click in TextEdit" }).options))
+      .toEqual(["Allow", "Always allow in this space", "Deny"]);
+  });
+
+  it("relabels only that option, and changes no decision", () => {
+    // The same three answers reach the server. A fourth decision would have to be understood by
+    // every adapter that can receive one, and this is not one.
+    const { options, decided } = card({ toolName: "computer_act", title: "Click in TextEdit" });
+    expect(options.map((o) => o.getAttribute("data-decision"))).toEqual(["allow", "allow_always", "deny"]);
+    for (const option of options) fireEvent.click(option);
+    expect(decided).toEqual(["allow", "allow_always", "deny"]);
+  });
+
+  it("leaves the numbering and shortcuts alone, so the row order is unchanged", () => {
+    const { options } = card({ toolName: "computer_act", title: "Click in TextEdit" });
+    expect(options.map((o) => o.querySelector(".permission-num")!.textContent)).toEqual(["1", "2", "3"]);
+    expect(options.map((o) => o.querySelector(".permission-option-kbd")!.textContent)).toEqual(["⏎", "⇧⏎", "⌘⌫"]);
+  });
+
+  it("does not relabel a tool that merely looks like one", () => {
+    expect(labels(card({ toolName: "computer_snapshot" }).options)).toEqual(["Allow", "Allow always", "Deny"]);
+  });
+});
+
+describe("the computer-use card's own words", () => {
+  it("names the app on the title, which is what the user is deciding about", () => {
+    vi.stubGlobal("scrollTo", () => {});
+    card({ toolName: "computer_act", title: 'Type "hello" into TextEdit' });
+    expect(screen.getByText('Type "hello" into TextEdit')).toBeTruthy();
+  });
+});

--- a/apps/desktop/src/renderer/src/panes/space/SpacePage.tsx
+++ b/apps/desktop/src/renderer/src/panes/space/SpacePage.tsx
@@ -6,6 +6,7 @@ import { relativeTime } from "../../components/CheckpointsSheet";
 import { ORIGIN_META, SESSION_STATUS_LABEL } from "../session-labels";
 import { McpSection } from "../../components/sidebar/McpSection";
 import { BrowserOrigins } from "../../components/sidebar/BrowserOrigins";
+import { ComputerApps } from "../../components/sidebar/ComputerApps";
 import { IconPicker } from "../../components/IconPicker";
 import { SpaceIcon } from "../../components/SpaceIcon";
 import { SkillsPanel } from "../../components/settings/SkillsPanel";
@@ -647,6 +648,9 @@ export function SpacePage({ item }: PaneProps) {
             {/* The per-space browser origin allowlist (Plan 14 W4) — same tab as the other things
                 agents reach out through. Its own settings-panel block, below the servers. */}
             <div className="form settings-panel"><BrowserOrigins spaceId={spaceId} /></div>
+            {/* The computer-use allowlist, in the same tab for the same reason: it is another list of
+                what agents in this space may reach outside it. */}
+            <div className="form settings-panel"><ComputerApps spaceId={spaceId} /></div>
           </>}
           {tab === "sessions" && <SessionsTab spaceId={spaceId} />}
           {tab === "tasks" && <TasksTab spaceId={spaceId} />}

--- a/apps/desktop/src/renderer/src/state/live-api.ts
+++ b/apps/desktop/src/renderer/src/state/live-api.ts
@@ -44,6 +44,8 @@ export const liveApi = (): Api => ({
   deleteItem: async (id) => { await rpc().call("items.delete", { id }); },
   getSetting: async (key) => (await rpc().call("settings.get", { key })).value,
   setSetting: async (key, value) => { await rpc().call("settings.set", { key, value }); },
+  listComputerAllowedApps: async (spaceId) => (await rpc().call("computer.allowedApps.list", { spaceId })).apps,
+  setComputerAllowedApps: async (spaceId, apps) => (await rpc().call("computer.allowedApps.set", { spaceId, apps })).apps,
   systemInfo: async () => { const i = await rpc().call("system.info", {}); return { machineName: i.machineName, userName: i.userName }; },
   pickFolder: () => window.realm.pickFolder(),
   pickFiles: () => window.realm.pickFiles(),

--- a/apps/desktop/src/renderer/src/state/store.test-fakes.ts
+++ b/apps/desktop/src/renderer/src/state/store.test-fakes.ts
@@ -1,5 +1,5 @@
 /** Shared in-memory Api fake for renderer tests (store, sidebar, palette). Not a test file itself. */
-import { activeLayout, setActiveLayout, MCP_SECRET_STORAGE_NOTE, MEMORY_DOC_MAX, type ElementChip } from "@realm/contracts";
+import { activeLayout, setActiveLayout, COMPUTER_FORBIDDEN_BUNDLE_IDS, MCP_SECRET_STORAGE_NOTE, MEMORY_DOC_MAX, type ElementChip } from "@realm/contracts";
 import type { GuideProgress, Lecture, PlynnMeeting, AgentsFileState, Attachment, BrowserCredential, Checkpoint, DiffSummary, Environment, FileDiff, GitInfo, IconAsset, ImportApplyParams, ImportResult, ImportScan, Item, McpCall, McpServer, McpTool, MemorySources, MemoryState, Notification, Profile, Project, RestorePreview, ReviewResult, DelegatedRun, Session, Ship, ShipResult, Skill, Space, StoredSessionEvent, WorktreeStatus, SkillSource, DocumentWorkspace, Run, RunAttempt } from "@realm/contracts";
 import type { AddMcpServerInput, AgentProbe, Api, CredentialStatus, McpTestResult, PickedAttachment, UpdateMcpServerInput } from "./store";
 import type { ModelInfo, SearchResults, UsageBudget, UsageSummary, UsageTotals } from "@realm/contracts";
@@ -120,6 +120,7 @@ export type FakeData = {
   /** By space id. `createWorktree` appends one, as the server's createWorktree does. */
   environments?: Record<string, Environment[]>;
   settings?: Record<string, unknown>;
+  computerAllowedApps?: Record<string, string[]>;
   sessions?: Session[]; sessionEvents?: Record<string, StoredSessionEvent[]>;
   importScan?: ImportScan; importResult?: ImportResult;
   usageSummary?: UsageSummary;
@@ -275,6 +276,7 @@ export function fakeApi(overrides: FakeData = {}): FakeApi {
     projects: overrides.projects ?? {},
     environments: overrides.environments ?? {},
     settings: overrides.settings ?? {},
+    computerAllowedApps: overrides.computerAllowedApps ?? {},
     sessions: overrides.sessions ?? [],
     sessionEvents: overrides.sessionEvents ?? {},
     sessionTerminals: overrides.sessionTerminals ?? {},
@@ -589,6 +591,14 @@ export function fakeApi(overrides: FakeData = {}): FakeApi {
     deleteItem: async (id) => { calls.push(`deleteItem:${id}`); for (const k of Object.keys(data.items)) data.items[k] = data.items[k]!.filter((i) => i.id !== id); },
     getSetting: async (key) => { calls.push(`getSetting:${key}`); return data.settings[key] ?? null; },
     setSetting: async (key, value) => { calls.push(`setSetting:${key}=${String(value)}`); data.settings[key] = value; },
+    listComputerAllowedApps: async (spaceId) => { calls.push(`listComputerAllowedApps:${spaceId}`); return data.computerAllowedApps[spaceId] ?? []; },
+    // Mirrors the server: what comes back is what was stored, sorted and with forbidden ids dropped.
+    setComputerAllowedApps: async (spaceId, apps) => {
+      calls.push(`setComputerAllowedApps:${spaceId}=${apps.join(",")}`);
+      const stored = [...new Set(apps.filter((a) => !COMPUTER_FORBIDDEN_BUNDLE_IDS.includes(a as never)))].sort();
+      data.computerAllowedApps[spaceId] = stored;
+      return stored;
+    },
     systemInfo: async () => { calls.push("systemInfo"); return { machineName: "Carlton's M4 MacBook Pro", userName: "Carlton" }; },
     pickFolder: async () => "/tmp/picked-repo",
     // Whatever a test parks in `data.pickFiles` is what the native picker "returns".

--- a/apps/desktop/src/renderer/src/state/store.test.ts
+++ b/apps/desktop/src/renderer/src/state/store.test.ts
@@ -2774,3 +2774,32 @@ describe("computer access", () => {
     expect(store.getState().computerRequesting).toBeNull();
   });
 });
+
+describe("the computer-use allowed-apps list", () => {
+  let api: FakeApi;
+  beforeEach(() => { api = fakeApi({ computerAllowedApps: { s1: ["com.apple.TextEdit"] } }); });
+
+  it("fetches a space's list, keyed by space", async () => {
+    const store = createAppStore(api);
+    await store.getState().refreshComputerAllowedApps("s1");
+    expect(store.getState().computerAllowedApps.s1).toEqual(["com.apple.TextEdit"]);
+    // Absent, not empty: a space that was never fetched must render as loading rather than as
+    // "nothing is allowed here", which is a different and reassuring-looking claim.
+    expect(store.getState().computerAllowedApps.s2).toBeUndefined();
+  });
+
+  it("keeps what the server stored, not what was sent", async () => {
+    // The server drops an app that can never be driven. Storing the argument would leave the list
+    // showing an entry that is not in effect, and the user believing they had granted something.
+    const store = createAppStore(api);
+    await store.getState().setComputerAllowedApps("s1", ["com.apple.Terminal", "com.apple.TextEdit"]);
+    expect(store.getState().computerAllowedApps.s1).toEqual(["com.apple.TextEdit"]);
+  });
+
+  it("drops an entry the user removed", async () => {
+    const store = createAppStore(api);
+    await store.getState().refreshComputerAllowedApps("s1");
+    await store.getState().setComputerAllowedApps("s1", []);
+    expect(store.getState().computerAllowedApps.s1).toEqual([]);
+  });
+});

--- a/apps/desktop/src/renderer/src/state/store.ts
+++ b/apps/desktop/src/renderer/src/state/store.ts
@@ -124,6 +124,9 @@ export type Api = {
   /** Deleting a terminal item closes its pty server-side. */
   deleteItem(id: string): Promise<void>;
   getSetting(key: string): Promise<unknown>;
+  listComputerAllowedApps(spaceId: string): Promise<string[]>;
+  /** Resolves to the list AS STORED, which may be shorter than the one sent. */
+  setComputerAllowedApps(spaceId: string, apps: string[]): Promise<string[]>;
   setSetting(key: string, value: unknown): Promise<void>;
   /** `system.info` — the under-strip's display-only machine label (Plan 12 W1) and the person's
    *  first name for the hero greeting. One call: boot wants both labels at the same moment. */
@@ -748,6 +751,10 @@ export type AppState = {
    *  as last fetched. null = no list = allow everything (W1's default posture); absent = never
    *  fetched. The Connections tab's Browser origins section reads and writes this. */
   browserAllowlists: Record<string, string[] | null>;
+  /** The per-space computer-use allowed-apps list, by space id — the bundle ids an agent may drive
+   *  in that space without a permission card. Absent = never fetched; `[]` = the list is empty and
+   *  every app is asked about, which is the default. */
+  computerAllowedApps: Record<string, string[]>;
   /** MCP servers for the space whose Connections tab is currently mounted (W6) — `mcp.list`'s
    *  per-space projection. Empty until `refreshMcpServers` runs; McpSection fetches on mount. */
   mcpServers: McpServer[];
@@ -992,6 +999,12 @@ export type AppState = {
   /** Persist a space's browser origin allowlist AND push it into every live browser view of that
    *  space, so the fence moves without a pane reopen (Plan 14 W4). null = back to allow-all. */
   setBrowserAllowlist(spaceId: string, allowlist: string[] | null): Promise<void>;
+  /** Fetch a space's computer-use allowed-apps list (Connections tab mount). */
+  refreshComputerAllowedApps(spaceId: string): Promise<void>;
+  /** Persist a space's computer-use allowed-apps list. The server stores what it will really honour
+   *  — a forbidden bundle id is dropped rather than accepted — so the list it returns is what lands
+   *  in the store, never the one that was sent. */
+  setComputerAllowedApps(spaceId: string, apps: string[]): Promise<void>;
   /** Refresh `agentProbe`. Unforced calls (prompter mount, onboarding) ride the server's TTL cache and
    *  are deduped here too; `force` is the install card's "Check again" and its window-focus refresh. */
   probeAgents(force?: boolean): Promise<void>;
@@ -1802,7 +1815,7 @@ export function createAppStore(api: Api): StoreApi<AppState> {
       worktreeStatuses: {}, worktreeAckStale: null,
       checkpoints: {}, ships: {}, runs: {}, selectedRunId: {}, runAttempts: {}, delegatedRuns: {}, checkpointPreview: null, checkpointAckStale: false, restoreResult: null,
       terminalPanel: {}, sessionTerminals: {},
-      machineName: "", userName: "", connectors: {}, browserAllowlists: {},
+      machineName: "", userName: "", connectors: {}, browserAllowlists: {}, computerAllowedApps: {},
       mcpServers: [], mcpProviders: [], mcpToolsError: {},
       profileMemory: {},
       mcpCalls: [], mcpCallsFilter: {}, mcpCallsHasMore: false,
@@ -2658,6 +2671,17 @@ export function createAppStore(api: Api): StoreApi<AppState> {
         for (const it of get().items) {
           if (it.kind === "browser") void host.setAllowlist(it.refId, allowlist);
         }
+      },
+      async refreshComputerAllowedApps(spaceId) {
+        const apps = await api.listComputerAllowedApps(spaceId);
+        set({ computerAllowedApps: { ...get().computerAllowedApps, [spaceId]: apps } });
+      },
+      async setComputerAllowedApps(spaceId, apps) {
+        // The server's answer, not the argument: removing an entry also revokes it in every live
+        // session, and it refuses to store an app that can never be driven — so what comes back is
+        // the only truthful thing to render.
+        const stored = await api.setComputerAllowedApps(spaceId, apps);
+        set({ computerAllowedApps: { ...get().computerAllowedApps, [spaceId]: stored } });
       },
       usageSummary(p) { return api.usageSummary(p); },
       setUsageBudget(budget) { return api.setUsageBudget(budget); },

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -23,6 +23,7 @@ import { BrowserHostBridge } from "./browsers/host-bridge";
 import { BrowserPermissionBroker } from "./browsers/permissions";
 import { createBrowserAgentProvider } from "./browsers/agent-tools";
 import { createComputerAgentProvider } from "./computer/agent-tools";
+import { ComputerAppAllowlist } from "./computer/allowlist";
 import { BrowserAgentService, createRealmAgentProvider, REALM_AGENT_PROVIDER_NAME } from "./browsers/browser-agent";
 import { DelegationEngine } from "./delegation/engine";
 import { announceDelegation } from "./delegation/announce";
@@ -373,6 +374,7 @@ export async function createApp(opts: { home: string; port: number; adapters?: A
   // The browser agent surface (Plan 11 W3): the main↔server op bridge, the permission broker, and the
   // `realm-browser` provider on the gateway. The broker's callbacks are late-bound to `sessionService`
   // (the checkpoints knot again): nothing in it runs before a session exists to run it for.
+  const computerAllowlist = new ComputerAppAllowlist({ settings });
   const browserBridge = new BrowserHostBridge({ rpc });
   const browserBroker = new BrowserPermissionBroker({
     // A missing row degrades to "plan" — the refuse-mutations mode — never to a prompt on a ghost.
@@ -430,7 +432,7 @@ export async function createApp(opts: { home: string; port: number; adapters?: A
   });
   mcpGateway.registerProvider(createRealmAgentProvider(browserAgents, mcp, agentRuns, reviews, asks));
   // The one provider a space has to switch ON: it reaches every app on the Mac.
-  mcpGateway.registerProvider(createComputerAgentProvider({ mcp, bridge: browserBridge, broker: browserBroker }));
+  mcpGateway.registerProvider(createComputerAgentProvider({ mcp, bridge: browserBridge, broker: browserBroker, allowlist: computerAllowlist }));
   // Plan 22 W2: the `realm-docs` provider — search/list/open/progress over the space's own folder.
   // One extractor for the process: PDF text is memoized across every session's searches.
   const extractor = new TextExtractor();
@@ -482,7 +484,7 @@ export async function createApp(opts: { home: string; port: number; adapters?: A
   const [machine, user] = await Promise.all([machineName(), userFirstName()]);
   registerMethods({
     rpc, home: opts.home, version: SERVER_VERSION, machineName: machine, userName: user,
-    profiles, spaces, projects, environments, envService, items, settings, skills, mcp, hub: mcpHub, gateway: mcpGateway, oauth, calls: mcpCalls, memory, terminals, browsers, browserBridge, documents, sessions, gitInfo: new GitInfoService(), gitDiff: new GitDiffService(), gitWrite, ships, ports, checkpoints, notifications, runs, reviews, search, forks, imports, lectures, plynn, modelCatalog, usage, graphify, delegation: delegationEngine,
+    profiles, spaces, projects, environments, envService, items, settings, skills, mcp, hub: mcpHub, gateway: mcpGateway, oauth, calls: mcpCalls, memory, terminals, browsers, browserBridge, documents, sessions, gitInfo: new GitInfoService(), gitDiff: new GitDiffService(), gitWrite, ships, ports, checkpoints, notifications, runs, reviews, search, forks, imports, lectures, plynn, modelCatalog, usage, graphify, delegation: delegationEngine, computerAllowlist, browserPermissions: browserBroker,
     iconAssets, iconGeneration,
   });
   sessions.markStaleOnBoot();

--- a/apps/server/src/browsers/permissions.test.ts
+++ b/apps/server/src/browsers/permissions.test.ts
@@ -275,3 +275,116 @@ describe("gate({ promptUnderBypass })", () => {
     expect(await again).toEqual({ allowed: true });
   });
 });
+
+/**
+ * `preapproved` and `onAlwaysAllow`: the seam a durable, user-curated grant hangs off. The broker
+ * still owns modes and prompting; where a standing approval is KEPT belongs to the caller, because
+ * the shape of it — bundle ids, per space — is not something this class should know.
+ *
+ * Its mutants: a preapproved gate that still asks; one that is honoured in a read-only session; and
+ * an "always" that is remembered for the session but never written down, which is the whole failure
+ * this option exists to end.
+ */
+describe("gate({ preapproved, onAlwaysAllow })", () => {
+  it("does not ask about something the user has already put on a list", async () => {
+    const { broker, events } = setup("default");
+    expect(await broker.gate("s1", "computer_act:com.apple.TextEdit", "Click", {}, "computer_act", { preapproved: true, promptUnderBypass: true }))
+      .toEqual({ allowed: true });
+    expect(events).toEqual([]);
+  });
+
+  it("still refuses a read-only session, list or no list", async () => {
+    // A standing approval says which apps are eligible. It does not say a Plan session may act, and
+    // the refusal has to outrank it or "always allow TextEdit" would quietly re-arm every mode.
+    for (const mode of ["plan", "ask"]) {
+      const { broker, events } = setup(mode);
+      const gate = await broker.gate("s1", "computer_act:com.apple.TextEdit", "Click", {}, "computer_act", { preapproved: true });
+      expect(gate).toMatchObject({ allowed: false });
+      expect(gate).toMatchObject({ reason: expect.stringMatching(/read-only/) });
+      expect(events).toEqual([]);
+    }
+  });
+
+  it("still asks about an app that is NOT on the list", async () => {
+    const { broker, events } = setup("bypassPermissions");
+    const gate = broker.gate("s1", "computer_act:com.apple.Mail", "Click", {}, "computer_act", { preapproved: false, promptUnderBypass: true });
+    broker.resolve(requestIdOf(events), "allow");
+    expect(await gate).toEqual({ allowed: true });
+  });
+
+  it("hands the answer back to the caller to persist when the user says always", async () => {
+    const { broker, events } = setup("default");
+    const written: string[] = [];
+    const gate = broker.gate("s1", "computer_act:com.apple.TextEdit", "Click", {}, "computer_act",
+      { promptUnderBypass: true, onAlwaysAllow: () => written.push("com.apple.TextEdit") });
+    broker.resolve(requestIdOf(events), "allow_always");
+    expect(await gate).toEqual({ allowed: true });
+    expect(written).toEqual(["com.apple.TextEdit"]);
+  });
+
+  it("persists nothing for a one-off allow or a denial", async () => {
+    for (const decision of ["allow", "deny"] as const) {
+      const { broker, events } = setup("default");
+      const written: string[] = [];
+      const gate = broker.gate("s1", "computer_act:com.apple.TextEdit", "Click", {}, "computer_act", { onAlwaysAllow: () => written.push("x") });
+      broker.resolve(requestIdOf(events), decision);
+      await gate;
+      expect(written, decision).toEqual([]);
+    }
+  });
+
+  it("persists nothing when the card is one that may never be remembered", async () => {
+    // The credential-fill rule: an `alwaysPrompt` gate records nothing in the session set, and must
+    // not find a back door to disk through this callback either.
+    const { broker, events } = setup("default");
+    const written: string[] = [];
+    const gate = broker.gate("s1", "browser_fill_credential", "Fill", {}, "browser_fill_credential",
+      { alwaysPrompt: true, onAlwaysAllow: () => written.push("x") });
+    broker.resolve(requestIdOf(events), "allow_always");
+    await gate;
+    expect(written).toEqual([]);
+  });
+});
+
+describe("BrowserPermissionBroker.revoke", () => {
+  it("makes a session that already answered always ask again", async () => {
+    // Taking an app off the durable list is not a revocation while a live session still holds its
+    // own grant for it — that session would keep driving the app until it ended.
+    const { broker, events } = setup("default");
+    const first = broker.gate("s1", "computer_act:com.apple.TextEdit", "Click", {}, "computer_act", { promptUnderBypass: true });
+    broker.resolve(requestIdOf(events), "allow_always");
+    await first;
+
+    events.length = 0;
+    broker.revoke("computer_act:com.apple.TextEdit");
+    const second = broker.gate("s1", "computer_act:com.apple.TextEdit", "Click again", {}, "computer_act", { promptUnderBypass: true });
+    broker.resolve(requestIdOf(events), "allow");
+    expect(await second).toEqual({ allowed: true });
+  });
+
+  it("leaves other apps' grants alone", async () => {
+    const { broker, events } = setup("default");
+    const first = broker.gate("s1", "computer_act:com.apple.Mail", "Click", {}, "computer_act", { promptUnderBypass: true });
+    broker.resolve(requestIdOf(events), "allow_always");
+    await first;
+
+    events.length = 0;
+    broker.revoke("computer_act:com.apple.TextEdit");
+    expect(await broker.gate("s1", "computer_act:com.apple.Mail", "Click again", {}, "computer_act", { promptUnderBypass: true })).toEqual({ allowed: true });
+    expect(events).toEqual([]);
+  });
+
+  it("reaches every session, since the broker is never told which space one belongs to", async () => {
+    const { broker, events } = setup("default");
+    for (const sessionId of ["s1", "s2"]) {
+      const gate = broker.gate(sessionId, "computer_act:com.apple.TextEdit", "Click", {}, "computer_act", { promptUnderBypass: true });
+      broker.resolve(requestIdOf(events), "allow_always");
+      await gate;
+      events.length = 0;
+    }
+    broker.revoke("computer_act:com.apple.TextEdit");
+    const gate = broker.gate("s2", "computer_act:com.apple.TextEdit", "Click again", {}, "computer_act", { promptUnderBypass: true });
+    broker.resolve(requestIdOf(events), "allow");
+    expect(await gate).toEqual({ allowed: true });
+  });
+});

--- a/apps/server/src/browsers/permissions.ts
+++ b/apps/server/src/browsers/permissions.ts
@@ -13,7 +13,7 @@ const REQUEST_PREFIX = "bperm_";
  *  the agent's own transport gives up at some unhelpful place. */
 const PROMPT_TIMEOUT_MS = 15 * 60 * 1000;
 
-type PendingPrompt = { sessionId: string; toolKey: string; resolve: (d: PermissionDecision) => void; timer: NodeJS.Timeout; alwaysPrompt: boolean };
+type PendingPrompt = { sessionId: string; toolKey: string; resolve: (d: PermissionDecision) => void; timer: NodeJS.Timeout; alwaysPrompt: boolean; onAlwaysAllow?: () => void };
 
 /**
  * Per-call gate behaviour.
@@ -40,7 +40,22 @@ type PendingPrompt = { sessionId: string; toolKey: string; resolve: (d: Permissi
  * and "drive anything on this Mac" is not one a mode set for coding agents can express. Keying the
  * grant per app is what keeps approving one from licensing the rest.
  */
-export type GateOptions = { alwaysPrompt?: boolean; promptUnderBypass?: boolean };
+export type GateOptions = {
+  alwaysPrompt?: boolean;
+  promptUnderBypass?: boolean;
+  /**
+   * A durable grant the CALLER holds already covers this gate, so do not ask.
+   *
+   * The broker owns modes and prompting; where a standing approval is kept, and what it is keyed on,
+   * belongs to whoever made it — the computer tools store bundle ids per space, which is not a shape
+   * this class should know. Consulted in the same place a session `allow_always` is, so it satisfies
+   * a `promptUnderBypass` gate for the same reason one does, and so plan and ask still refuse: a
+   * standing approval says which apps are eligible, never that a read-only session may act.
+   */
+  preapproved?: boolean;
+  /** Answered "always": persist it wherever `preapproved` will be read from next time. */
+  onAlwaysAllow?: () => void;
+};
 
 export type GateResult = { allowed: true } | { allowed: false; reason: string };
 
@@ -89,6 +104,9 @@ export class BrowserPermissionBroker {
       let set = this.always.get(p.sessionId);
       if (!set) { set = new Set(); this.always.set(p.sessionId, set); }
       set.add(p.toolKey);
+      // The session set is kept even for a gate that also persists: it is what answers if the
+      // durable write fails, and it keeps the answer working for the rest of THIS session either way.
+      p.onAlwaysAllow?.();
     }
     this.d.emit(p.sessionId, sessionEvent("permission_response", { requestId, decision }));
     this.d.emit(p.sessionId, sessionEvent("status", { status: "running" }));
@@ -112,6 +130,18 @@ export class BrowserPermissionBroker {
    * browser_act may always act in this session"); `title` is the human-readable line the ApprovalCard
    * shows; `input` is echoed onto the event so the card can show what the agent asked for.
    */
+  /**
+   * Forget one grant in every live session.
+   *
+   * Deliberately broad: a durable list is scoped to a space, this map is scoped to a session, and
+   * the broker is never told which space a session belongs to. Dropping the key everywhere errs
+   * towards asking again, which is the safe direction — the alternative is a session that keeps
+   * driving an application the user has just taken off the list.
+   */
+  revoke(toolKey: string): void {
+    for (const set of this.always.values()) set.delete(toolKey);
+  }
+
   async gate(sessionId: string, toolKey: string, title: string, input: Record<string, unknown>, toolName: string = toolKey, opts: GateOptions = {}): Promise<GateResult> {
     const mode = this.d.permissionMode(sessionId);
     if (isReadOnlyMode(mode)) return { allowed: false, reason: `this session is in ${mode === "plan" ? "Plan" : "Ask"} (read-only) mode — mutating tools are refused; switch modes to act` };
@@ -119,6 +149,7 @@ export class BrowserPermissionBroker {
       // `allow_always` is consulted BEFORE the mode, so a `promptUnderBypass` gate the user has
       // already answered "always" to stops asking. For every other caller the two orders agree:
       // both branches return allowed.
+      if (opts.preapproved) return { allowed: true };
       if (this.always.get(sessionId)?.has(toolKey)) return { allowed: true };
       if (mode === "bypassPermissions" && !opts.promptUnderBypass) return { allowed: true };
     }
@@ -131,7 +162,7 @@ export class BrowserPermissionBroker {
         this.d.emit(sessionId, sessionEvent("status", { status: "running" }));
         resolve("deny");
       }, PROMPT_TIMEOUT_MS);
-      this.pending.set(requestId, { sessionId, toolKey, resolve, timer, alwaysPrompt: opts.alwaysPrompt === true });
+      this.pending.set(requestId, { sessionId, toolKey, resolve, timer, alwaysPrompt: opts.alwaysPrompt === true, onAlwaysAllow: opts.onAlwaysAllow });
       // Emitted AFTER the pending entry exists: a same-tick respondPermission must find it.
       // `toolName` is what the card SHOWS; `toolKey` is what `allow_always` remembers. They differ when
       // the grant must be narrower than the tool — Plan 20's ask keys on `agent_ask:<targetId>` so

--- a/apps/server/src/computer/agent-tools.test.ts
+++ b/apps/server/src/computer/agent-tools.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { COMPUTER_PROVIDER_NAME } from "@realm/contracts";
 import { createComputerAgentProvider } from "./agent-tools";
-import type { GateResult } from "../browsers/permissions";
+import type { GateOptions, GateResult } from "../browsers/permissions";
 
 /**
  * The provider's own decisions, over a scripted bridge and gate. What must die here: the per-app
@@ -22,8 +22,11 @@ function setup(over: {
   ops?: Record<string, unknown | ((params: Record<string, unknown>) => unknown)>;
   gate?: GateResult;
   enabled?: boolean;
+  allowed?: string[];
 } = {}) {
-  const gates: { toolKey: string; title: string; opts: unknown }[] = [];
+  const allowed = new Set(over.allowed ?? []);
+  const added: { spaceId: string; bundleId: string }[] = [];
+  const gates: { toolKey: string; title: string; opts: GateOptions | undefined }[] = [];
   const ops: { op: string; params: Record<string, unknown> }[] = [];
   const table = { computerGrants: { accessibility: true, screenRecording: true }, ...over.ops };
   const provider = createComputerAgentProvider({
@@ -37,13 +40,20 @@ function setup(over: {
       },
     },
     broker: {
-      gate: async (_sessionId: string, toolKey: string, title: string, _input: unknown, _toolName?: string, opts?: unknown) => {
+      gate: async (_sessionId: string, toolKey: string, title: string, _input: unknown, _toolName?: string, opts?: GateOptions) => {
         gates.push({ toolKey, title, opts });
+        // A preapproved gate never reaches a card, so the fake must not run the "always" callback
+        // for one — that is what makes "already on the list" distinguishable from "just added".
+        if (!opts?.preapproved) opts?.onAlwaysAllow?.();
         return over.gate ?? { allowed: true };
       },
     },
+    allowlist: {
+      allows: (spaceId: string, bundleId: string) => allowed.has(`${spaceId} ${bundleId}`),
+      add: (spaceId: string, bundleId: string) => { added.push({ spaceId, bundleId }); },
+    },
   });
-  return { provider, gates, ops };
+  return { provider, gates, ops, added };
 }
 
 const text = (r: CallToolResult): string =>
@@ -195,6 +205,57 @@ describe("computer_act permissions", () => {
     expect(r.isError).toBe(true);
     expect(text(r)).toMatch(/invalid arguments/);
     expect(s.gates).toEqual([]);
+  });
+});
+
+describe("the space's allowed-apps list", () => {
+  const FORBIDDEN_SNAPSHOT = { ...SNAPSHOT, bundleId: "com.apple.Terminal", appName: "Terminal" };
+
+  it("does not ask again about an app the space has already allowed", async () => {
+    const s = setup({ ops: { computerSnapshot: SNAPSHOT, computerAct: { ok: true, detail: "clicked" } }, allowed: ["sp1 com.apple.TextEdit"] });
+    const r = await snapshotThenAct(s, { kind: "click", index: 0 });
+    expect(r.isError).toBe(false);
+    expect(s.gates[0]!.opts).toMatchObject({ preapproved: true });
+    // Still gated, never skipped: the broker is what refuses a read-only session, and an allowlist
+    // says which apps are eligible, not that Plan mode may act.
+    expect(s.gates).toHaveLength(1);
+  });
+
+  it("still asks about an app the space has not allowed", async () => {
+    const s = setup({ ops: { computerSnapshot: SNAPSHOT, computerAct: { ok: true, detail: "clicked" } }, allowed: ["sp1 com.apple.Mail"] });
+    await snapshotThenAct(s, { kind: "click", index: 0 });
+    expect(s.gates[0]!.opts).toMatchObject({ preapproved: false, promptUnderBypass: true });
+  });
+
+  it("does not carry one space's approvals into another", async () => {
+    const s = setup({ ops: { computerSnapshot: SNAPSHOT, computerAct: { ok: true, detail: "clicked" } }, allowed: ["sp1 com.apple.TextEdit"] });
+    await s.provider.call({ sessionId: "s9", spaceId: "sp2" }, "computer_snapshot", {});
+    await s.provider.call({ sessionId: "s9", spaceId: "sp2" }, "computer_act", { snapshotId: SNAPSHOT.snapshotId, action: { kind: "click", index: 0 } });
+    expect(s.gates[0]!.opts).toMatchObject({ preapproved: false });
+  });
+
+  it("writes the app to the space's list when the user answers always", async () => {
+    const s = setup({ ops: { computerSnapshot: SNAPSHOT, computerAct: { ok: true, detail: "clicked" } } });
+    await snapshotThenAct(s, { kind: "click", index: 0 });
+    expect(s.added).toEqual([{ spaceId: "sp1", bundleId: "com.apple.TextEdit" }]);
+  });
+
+  it("refuses a forbidden app even when it is on the list, before any card can be raised", async () => {
+    // The ordering that matters: forbidden beats every grant, including one the user curated. The
+    // refusal lands before the gate, so a forbidden app can never reach a card whose "always" would
+    // write it down as approved.
+    const s = setup({ ops: { computerSnapshot: FORBIDDEN_SNAPSHOT }, allowed: ["sp1 com.apple.Terminal"] });
+    const r = await snapshotThenAct(s, { kind: "click", index: 0 });
+    expect(r.isError).toBe(true);
+    expect(text(r)).toMatch(/no permission lifts this/);
+    expect(s.gates).toEqual([]);
+    expect(s.added).toEqual([]);
+    expect(s.ops.filter((o) => o.op === "computerAct")).toEqual([]);
+  });
+
+  it("refuses a forbidden app that is not on the list the same way", async () => {
+    const s = setup({ ops: { computerSnapshot: FORBIDDEN_SNAPSHOT } });
+    expect(text(await snapshotThenAct(s, { kind: "click", index: 0 }))).toMatch(/no permission lifts this/);
   });
 });
 

--- a/apps/server/src/computer/agent-tools.ts
+++ b/apps/server/src/computer/agent-tools.ts
@@ -43,7 +43,11 @@ import { fenceUntrusted } from "@realm/contracts";
  *     the rest of the session and nothing else.
  *  6. **Two independent checks before any synthetic input lands**, both in the helper: the target app
  *     must actually come to the front, and the point must belong to it at the instant of the click.
- *  7. **App text is untrusted data.** A snapshot is other applications' content — an email body, a
+ *  7. **It is visible while it happens.** Main puts an item in the menu bar for the duration of
+ *     every act (`computer-driving.ts`). Not a gate — nothing is refused by it — but the act itself
+ *     requires the target app to be frontmost, so this is the only layer the user can see at the
+ *     moment it runs, Realm's own window being behind something by then.
+ *  8. **App text is untrusted data.** A snapshot is other applications' content — an email body, a
  *     document, a web page inside someone else's browser — so it is fenced before it enters a tool
  *     result, and where a permission card names an element the label is attributed to the app rather
  *     than spoken in Realm's voice.
@@ -214,7 +218,9 @@ const HANDLERS: Record<string, Handler> = {
     );
     if (!gate.allowed) return err(gate.reason);
 
-    const result = (await d.bridge.call("computerAct", { snapshotId, action })) as ComputerActResult;
+    // `appName` is for main's menu-bar indicator, which has no other way to learn which application
+    // is being driven — the snapshot-to-app map that answers that lives in this process.
+    const result = (await d.bridge.call("computerAct", { snapshotId, action, appName: app.appName })) as ComputerActResult;
     if (result.ok) return ok(result.detail);
     if (result.refused === "secure_field") {
       return err("refused: that is a password field. Realm never types into one, in any mode — tell the user what to enter and let them type it themselves.");

--- a/apps/server/src/computer/agent-tools.ts
+++ b/apps/server/src/computer/agent-tools.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import {
-  COMPUTER_KEY_NAMES, COMPUTER_MODIFIERS, COMPUTER_PROVIDER_NAME, ComputerActionSchema,
+  COMPUTER_FORBIDDEN_BUNDLE_IDS, COMPUTER_KEY_NAMES, COMPUTER_MODIFIERS, COMPUTER_PROVIDER_NAME, ComputerActionSchema,
   type ComputerAction, type ComputerActResult, type ComputerAppsResult, type ComputerSnapshotResult,
 } from "@realm/contracts";
 import type { CallToolResult, Tool } from "@modelcontextprotocol/sdk/types.js";
@@ -9,6 +9,7 @@ import { clip, err, ok, parseArgs } from "../mcp/tool-result";
 import type { McpService } from "../mcp/service";
 import type { BrowserHostBridge } from "../browsers/host-bridge";
 import type { BrowserPermissionBroker } from "../browsers/permissions";
+import type { ComputerAppAllowlist } from "./allowlist";
 import { fenceUntrusted } from "@realm/contracts";
 
 /**
@@ -36,11 +37,13 @@ import { fenceUntrusted } from "@realm/contracts";
  *     field is refused against the element's LIVE role, not the snapshot's.
  *  4. **Read-only mode refuses mutation.** A `plan` session cannot act, exactly as it cannot act on
  *     a page.
- *  5. **A permission card per application, per session** — and `bypassPermissions` does NOT skip it
+ *  5. **A permission card per application** — and `bypassPermissions` does NOT skip it
  *     (`promptUnderBypass`). That mode means "stop asking about ordinary actions", and it earns that
  *     meaning from the blast radius being a page in Realm's own pane. Approving TextEdit must not
- *     license Mail, so the grant is keyed on the bundle id; answering "always" covers that app for
- *     the rest of the session and nothing else.
+ *     license Mail, so the grant is keyed on the bundle id. Answering "always" writes the app to the
+ *     space's allowlist (`allowlist.ts`), which is what the card is asked once per app instead of
+ *     once per app per session forever; the user curates and revokes that list in the space's
+ *     settings. It cannot hold a forbidden app, and layer 3 is checked before it is read.
  *  6. **Two independent checks before any synthetic input lands**, both in the helper: the target app
  *     must actually come to the front, and the point must belong to it at the instant of the click.
  *  7. **It is visible while it happens.** Main puts an item in the menu bar for the duration of
@@ -52,14 +55,15 @@ import { fenceUntrusted } from "@realm/contracts";
  *     result, and where a permission card names an element the label is attributed to the app rather
  *     than spoken in Realm's voice.
  *
- * What this model does NOT have, stated plainly: a durable per-application allowlist the user
- * curates ahead of time. The per-app card is a session-scoped stand-in — it asks before the first
- * action against each app rather than letting the user decide in advance which apps are eligible.
+ * What this model does NOT have, stated plainly: any bound on WHAT may be done to an app once the
+ * app itself is approved. A grant is per application, not per action — an allowlisted TextEdit may
+ * be typed into as well as clicked, and the only per-action refusals are the hard ones in layer 3.
  */
 export type ComputerAgentToolsDeps = {
   mcp: Pick<McpService, "providerEnabled">;
   bridge: Pick<BrowserHostBridge, "call">;
   broker: Pick<BrowserPermissionBroker, "gate">;
+  allowlist: Pick<ComputerAppAllowlist, "allows" | "add">;
 };
 
 export function createComputerAgentProvider(d: ComputerAgentToolsDeps): RealmToolProvider {
@@ -207,6 +211,12 @@ const HANDLERS: Record<string, Handler> = {
       return err(`refused: this session has no snapshot "${snapshotId}". Take a computer_snapshot and act on the id it returns.`);
     }
 
+    // Before the allowlist is read and before a card can be raised: a forbidden app must not reach a
+    // prompt that could be answered "always", which would then be a stored approval for something no
+    // approval covers. The helper refuses again in the last process before an event is posted — this
+    // copy is about what the user is asked, not about what is finally allowed.
+    if ((COMPUTER_FORBIDDEN_BUNDLE_IDS as readonly string[]).includes(app.bundleId)) return err(FORBIDDEN_REFUSAL);
+
     const title = describeAct(action, app.appName);
     // Keyed on the bundle id, not the tool: "the user said this session may drive TextEdit" must not
     // read as "may drive anything". `promptUnderBypass` keeps that true in bypassPermissions too —
@@ -214,7 +224,12 @@ const HANDLERS: Record<string, Handler> = {
     const gate = await d.broker.gate(
       ctx.sessionId, `computer_act:${app.bundleId}`, title,
       { app: app.appName, bundleId: app.bundleId, action },
-      "computer_act", { promptUnderBypass: true },
+      "computer_act",
+      {
+        promptUnderBypass: true,
+        preapproved: d.allowlist.allows(ctx.spaceId, app.bundleId),
+        onAlwaysAllow: () => d.allowlist.add(ctx.spaceId, app.bundleId),
+      },
     );
     if (!gate.allowed) return err(gate.reason);
 
@@ -225,9 +240,7 @@ const HANDLERS: Record<string, Handler> = {
     if (result.refused === "secure_field") {
       return err("refused: that is a password field. Realm never types into one, in any mode — tell the user what to enter and let them type it themselves.");
     }
-    if (result.refused === "forbidden_app") {
-      return err("refused: that application can never be driven. Realm will not drive itself, System Settings, a password prompt, or a terminal — no permission lifts this.");
-    }
+    if (result.refused === "forbidden_app") return err(FORBIDDEN_REFUSAL);
     if (result.refused === "stale_snapshot" || result.refused === "no_element") {
       return err(`${result.error}. Take a fresh computer_snapshot: the app has changed since the one you are holding.`);
     }
@@ -239,6 +252,9 @@ const HANDLERS: Record<string, Handler> = {
 };
 
 /* ---------------------------------- helpers ---------------------------------- */
+
+const FORBIDDEN_REFUSAL =
+  "refused: that application can never be driven. Realm will not drive itself, System Settings, a password prompt, or a terminal — no permission lifts this, including the space's allowed-apps list.";
 
 const NO_ACCESSIBILITY =
   "macOS has not granted Realm the Accessibility permission, so it cannot read or drive other applications. The user grants it in Realm's Settings, under Permissions — it needs a real click from them and cannot be turned on from here.";

--- a/apps/server/src/computer/allowlist.test.ts
+++ b/apps/server/src/computer/allowlist.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+import { COMPUTER_FORBIDDEN_BUNDLE_IDS } from "@realm/contracts";
+import { ComputerAppAllowlist } from "./allowlist";
+
+/**
+ * The durable list, over an in-memory settings table. What must die here: an entry leaking between
+ * spaces, and — the one that matters — a forbidden bundle id being treated as allowed because it is
+ * on the list.
+ */
+function allowlist(seed: Record<string, unknown> = {}) {
+  const rows = new Map<string, unknown>(Object.entries(seed));
+  const settings = {
+    getIds: (key: string) => {
+      const v = rows.get(key);
+      return Array.isArray(v) ? v.filter((x): x is string => typeof x === "string") : [];
+    },
+    set: (key: string, value: unknown) => { rows.set(key, value); },
+  };
+  return { list: new ComputerAppAllowlist({ settings }), rows };
+}
+
+const FORBIDDEN_ID = COMPUTER_FORBIDDEN_BUNDLE_IDS[0];
+
+describe("ComputerAppAllowlist", () => {
+  it("is empty until the user puts something on it", () => {
+    const { list } = allowlist();
+    expect(list.list("sp1")).toEqual([]);
+    expect(list.allows("sp1", "com.apple.TextEdit")).toBe(false);
+  });
+
+  it("remembers an app across calls", () => {
+    const { list } = allowlist();
+    list.add("sp1", "com.apple.TextEdit");
+    expect(list.allows("sp1", "com.apple.TextEdit")).toBe(true);
+    expect(list.list("sp1")).toEqual(["com.apple.TextEdit"]);
+  });
+
+  it("scopes an entry to its space", () => {
+    const { list } = allowlist();
+    list.add("sp1", "com.apple.TextEdit");
+    expect(list.allows("sp2", "com.apple.TextEdit")).toBe(false);
+    expect(list.list("sp2")).toEqual([]);
+  });
+
+  it("does not license a different app in the same space", () => {
+    const { list } = allowlist();
+    list.add("sp1", "com.apple.TextEdit");
+    expect(list.allows("sp1", "com.apple.Mail")).toBe(false);
+  });
+
+  it("stores one sorted, de-duplicated row so the settings value stays diff-stable", () => {
+    const { list, rows } = allowlist();
+    expect(list.replace("sp1", ["com.apple.TextEdit", "com.apple.Mail", "com.apple.TextEdit"]))
+      .toEqual(["com.apple.Mail", "com.apple.TextEdit"]);
+    expect(rows.get("computer.allowedApps:sp1")).toEqual(["com.apple.Mail", "com.apple.TextEdit"]);
+  });
+
+  it("returns the list as stored, so a caller renders what is really in effect", () => {
+    const { list } = allowlist();
+    expect(list.replace("sp1", [FORBIDDEN_ID, "com.apple.TextEdit", "  "])).toEqual(["com.apple.TextEdit"]);
+  });
+
+  it("drops an entry the user removed", () => {
+    const { list } = allowlist();
+    list.replace("sp1", ["com.apple.TextEdit", "com.apple.Mail"]);
+    list.replace("sp1", ["com.apple.Mail"]);
+    expect(list.allows("sp1", "com.apple.TextEdit")).toBe(false);
+  });
+});
+
+describe("the forbidden list beats the allowed list", () => {
+  it("will not store a forbidden app, however it is offered", () => {
+    const { list } = allowlist();
+    list.add("sp1", FORBIDDEN_ID);
+    expect(list.list("sp1")).toEqual([]);
+    list.replace("sp1", [FORBIDDEN_ID]);
+    expect(list.list("sp1")).toEqual([]);
+  });
+
+  it("refuses a forbidden app that is already in the settings row", () => {
+    // The row is user-editable JSON on disk. A value that was never written through this class can
+    // still be read through it, so the READ has to enforce the rule rather than trusting the write.
+    for (const bundleId of COMPUTER_FORBIDDEN_BUNDLE_IDS) {
+      const { list } = allowlist({ "computer.allowedApps:sp1": [bundleId, "com.apple.TextEdit"] });
+      expect(list.allows("sp1", bundleId), bundleId).toBe(false);
+      expect(list.list("sp1"), bundleId).toEqual(["com.apple.TextEdit"]);
+    }
+  });
+
+  it("still allows the ordinary apps alongside a hand-added forbidden one", () => {
+    const { list } = allowlist({ "computer.allowedApps:sp1": [FORBIDDEN_ID, "com.apple.TextEdit"] });
+    expect(list.allows("sp1", "com.apple.TextEdit")).toBe(true);
+  });
+
+  it("treats a corrupt row as an empty list rather than throwing", () => {
+    for (const value of [null, 42, "com.apple.TextEdit", { app: "x" }]) {
+      const { list } = allowlist({ "computer.allowedApps:sp1": value });
+      expect(list.list("sp1")).toEqual([]);
+      expect(list.allows("sp1", "com.apple.TextEdit")).toBe(false);
+    }
+  });
+
+  it("never allows an empty bundle id, which an app with no identifier would send", () => {
+    const { list } = allowlist({ "computer.allowedApps:sp1": [""] });
+    expect(list.allows("sp1", "")).toBe(false);
+  });
+});

--- a/apps/server/src/computer/allowlist.ts
+++ b/apps/server/src/computer/allowlist.ts
@@ -1,0 +1,56 @@
+import { COMPUTER_FORBIDDEN_BUNDLE_IDS } from "@realm/contracts";
+import type { SettingsStore } from "../store/settings";
+
+/**
+ * The applications an agent may drive in a space without being asked again.
+ *
+ * **Per space**, because that is where the feature is switched on: `realm-computer` is the one
+ * provider that stays off until a space enables it, and a list scoped wider than its own switch
+ * would mean a space that was just given computer use silently inheriting approvals made somewhere
+ * else. Global would make approving TextEdit once license every space that will ever exist. Profile
+ * would be a new scope for one feature — nothing else in Realm keeps settings there.
+ *
+ * Entries are bundle ids, so an entry means exactly what the session grant it graduates from means.
+ * The permission card is keyed on the bundle id for the same reason: approving TextEdit must not
+ * read as approving Mail.
+ *
+ * The forbidden list wins over this one at every door. `allows` refuses a forbidden id whatever is
+ * stored; neither `add` nor `replace` will store one; and `list` drops one on the way out. That is
+ * three checks for one rule because a settings row is user-editable JSON on disk — a value that was
+ * never written through this class can still be read through it.
+ */
+const allowedAppsKey = (spaceId: string): string => `computer.allowedApps:${spaceId}`;
+
+const FORBIDDEN: ReadonlySet<string> = new Set(COMPUTER_FORBIDDEN_BUNDLE_IDS);
+
+export class ComputerAppAllowlist {
+  constructor(private readonly d: { settings: Pick<SettingsStore, "getIds" | "set"> }) {}
+
+  /** The space's list, as the user should see it. */
+  list(spaceId: string): string[] {
+    return this.d.settings.getIds(allowedAppsKey(spaceId)).filter((id) => !FORBIDDEN.has(id));
+  }
+
+  /** May this space drive this application without a card? */
+  allows(spaceId: string, bundleId: string): boolean {
+    if (!bundleId || FORBIDDEN.has(bundleId)) return false;
+    return this.d.settings.getIds(allowedAppsKey(spaceId)).includes(bundleId);
+  }
+
+  /** Graduate one app from a session grant to a standing one. */
+  add(spaceId: string, bundleId: string): void {
+    if (!bundleId || FORBIDDEN.has(bundleId)) return;
+    this.replace(spaceId, [...this.list(spaceId), bundleId]);
+  }
+
+  /**
+   * Set the whole list, and return it as stored — so a caller renders what was persisted rather than
+   * what it sent, the way the usage budget re-parses on write. Sorted and de-duplicated to keep the
+   * row diff-stable.
+   */
+  replace(spaceId: string, bundleIds: string[]): string[] {
+    const next = [...new Set(bundleIds.filter((id) => id.trim().length > 0 && !FORBIDDEN.has(id)))].sort();
+    this.d.settings.set(allowedAppsKey(spaceId), next);
+    return next;
+  }
+}

--- a/apps/server/src/rpc/methods.test.ts
+++ b/apps/server/src/rpc/methods.test.ts
@@ -543,3 +543,39 @@ describe("graphify over rpc", () => {
     }
   });
 });
+
+describe("the computer-use allowed-apps list over rpc", () => {
+  it("round-trips a space's list through the settings row", async () => {
+    const { c } = await boot();
+    const prof = (await c.call("profiles.create", { name: "W" })).result;
+    const s1 = (await c.call("spaces.create", { profileId: prof.id, name: "One" })).result;
+    const s2 = (await c.call("spaces.create", { profileId: prof.id, name: "Two" })).result;
+
+    expect((await c.call("computer.allowedApps.list", { spaceId: s1.id })).result.apps).toEqual([]);
+    const set = await c.call("computer.allowedApps.set", { spaceId: s1.id, apps: ["com.apple.TextEdit", "com.apple.Mail"] });
+    expect(set.result.apps).toEqual(["com.apple.Mail", "com.apple.TextEdit"]);
+    expect((await c.call("computer.allowedApps.list", { spaceId: s1.id })).result.apps).toEqual(["com.apple.Mail", "com.apple.TextEdit"]);
+    // The other space is untouched: this is the scope the whole design rests on.
+    expect((await c.call("computer.allowedApps.list", { spaceId: s2.id })).result.apps).toEqual([]);
+    c.close();
+  });
+
+  it("answers with what it will really honour, dropping an app that can never be driven", async () => {
+    const { c } = await boot();
+    const prof = (await c.call("profiles.create", { name: "W" })).result;
+    const s1 = (await c.call("spaces.create", { profileId: prof.id, name: "One" })).result;
+    const r = await c.call("computer.allowedApps.set", { spaceId: s1.id, apps: ["com.apple.Terminal", "com.apple.TextEdit"] });
+    expect(r.result.apps).toEqual(["com.apple.TextEdit"]);
+    c.close();
+  });
+
+  it("returns NOT_FOUND for a space that is not there, rather than reading a settings row for it", async () => {
+    const { c } = await boot();
+    for (const method of ["computer.allowedApps.list", "computer.allowedApps.set"]) {
+      const r = await c.call(method, { spaceId: "01ARZ3NDEKTSV4RRFFQ69G5FAV", apps: [] });
+      expect(r.ok, method).toBe(false);
+      expect(r.error.code, method).toBe("NOT_FOUND");
+    }
+    c.close();
+  });
+});

--- a/apps/server/src/rpc/methods.ts
+++ b/apps/server/src/rpc/methods.ts
@@ -14,6 +14,8 @@ import type { SettingsStore } from "../store/settings";
 import type { ModelCatalogService } from "../models/catalog";
 import type { SkillsService } from "../skills/service";
 import type { McpService } from "../mcp/service";
+import type { ComputerAppAllowlist } from "../computer/allowlist";
+import type { BrowserPermissionBroker } from "../browsers/permissions";
 import type { McpHub } from "../mcp/hub";
 import type { McpGateway } from "../mcp/gateway";
 import { oauthSecretBox, type McpOauth } from "../mcp/oauth";
@@ -49,7 +51,7 @@ type Result<M extends MethodName> = MethodResult<M> | Promise<MethodResult<M>>;
 
 export type Deps = {
   rpc: RpcServer; home: string; version: string; machineName: string; userName: string;
-  profiles: ProfilesStore; spaces: SpacesStore; projects: ProjectsStore; environments: EnvironmentsStore; envService: EnvironmentService; items: ItemsStore; settings: SettingsStore; skills: SkillsService; mcp: McpService; hub: McpHub; gateway: McpGateway; oauth: McpOauth; calls: McpCallLogStore; memory: MemoryService; terminals: TerminalService; browsers: BrowserService; browserBridge: BrowserHostBridge; documents: DocumentService; sessions: SessionService; gitInfo: GitInfoService; gitDiff: GitDiffService; gitWrite: GitWriteService; ships: ShipsStore; ports: PortAllocator; checkpoints: CheckpointService; notifications: NotificationsService; usage: UsageService; graphify: GraphifyService; runs: RunService; reviews: ReviewService; search: SearchService; forks: ForkService; imports: ImportService; lectures: LectureService; plynn: PlynnService; modelCatalog: ModelCatalogService;
+  profiles: ProfilesStore; spaces: SpacesStore; projects: ProjectsStore; environments: EnvironmentsStore; envService: EnvironmentService; items: ItemsStore; settings: SettingsStore; skills: SkillsService; mcp: McpService; hub: McpHub; gateway: McpGateway; oauth: McpOauth; calls: McpCallLogStore; memory: MemoryService; terminals: TerminalService; browsers: BrowserService; browserBridge: BrowserHostBridge; documents: DocumentService; sessions: SessionService; gitInfo: GitInfoService; gitDiff: GitDiffService; gitWrite: GitWriteService; ships: ShipsStore; ports: PortAllocator; checkpoints: CheckpointService; notifications: NotificationsService; usage: UsageService; graphify: GraphifyService; runs: RunService; reviews: ReviewService; search: SearchService; forks: ForkService; imports: ImportService; lectures: LectureService; plynn: PlynnService; modelCatalog: ModelCatalogService; computerAllowlist: ComputerAppAllowlist; browserPermissions: BrowserPermissionBroker;
   iconAssets: IconAssetsStore; iconGeneration: IconGenerationService;
   delegation: DelegationEngine;
 };
@@ -284,6 +286,22 @@ export function registerMethods(d: Deps): void {
     d.gateway.notifyPolicyChanged(p.spaceId);
     rpc.broadcast("mcp.changed", {});
     return { ok: true as const };
+  });
+  reg("computer.allowedApps.list", (p) => {
+    if (!d.spaces.get(p.spaceId)) throw new NotFoundError("space", p.spaceId);
+    return { apps: d.computerAllowlist.list(p.spaceId) };
+  });
+  reg("computer.allowedApps.set", (p) => {
+    if (!d.spaces.get(p.spaceId)) throw new NotFoundError("space", p.spaceId);
+    const before = d.computerAllowlist.list(p.spaceId);
+    const apps = d.computerAllowlist.replace(p.spaceId, p.apps);
+    // Persisting is not the whole of a revocation. A session that answered "always" holds its own
+    // in-memory grant for that app, and would keep driving it until it ended — so every app dropped
+    // from the list is dropped from the live grants too.
+    for (const bundleId of before) {
+      if (!apps.includes(bundleId)) d.browserPermissions.revoke(`computer_act:${bundleId}`);
+    }
+    return { apps };
   });
   reg("mcp.calls.list", (p) => ({ calls: d.calls.list(p) }));
   /** Returns the authorization URL and nothing else — the RENDERER opens it in the system browser, and

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -657,6 +657,11 @@ export const Methods = {
   "mcp.tools.list": { params: z.object({ id: IdSchema }), result: z.object({ tools: z.array(McpToolSchema), error: z.string().nullable() }) },
   /** Narrow this space's tools for one server to exactly `tools`; `null` restores "every cached tool
    *  allowed", the same default a server nobody has touched already has. */
+  /** The space's computer-use allowlist: the applications an agent may drive there without a card.
+   *  `set` returns the list AS STORED — forbidden bundle ids are dropped rather than accepted, so the
+   *  caller renders what is really in effect. */
+  "computer.allowedApps.list": { params: z.object({ spaceId: IdSchema }), result: z.object({ apps: z.array(z.string()) }) },
+  "computer.allowedApps.set": { params: z.object({ spaceId: IdSchema, apps: z.array(z.string()) }), result: z.object({ apps: z.array(z.string()) }) },
   "mcp.setAllowedTools": { params: z.object({ spaceId: IdSchema, id: IdSchema, tools: z.array(z.string()).nullable() }), result: z.object({ ok: z.literal(true) }) },
   /** Realm's own call log (Activity), newest first — see `McpCallSchema`. `before` pages backward by a
    *  composite `{ ts, id }` cursor — a plain `ts` cursor drops same-millisecond siblings at a page


### PR DESCRIPTION
Stacked on #32. Three follow-ups, and three real native bugs found on the way.

**The driving indicator lives in the macOS menu bar, not the renderer.** The helper refuses to click unless the target app comes frontmost, so at the instant an act lands Realm is *by definition* not the active app — mirroring `browserDriving` into a sidebar dot would have produced the one indicator guaranteed to be off screen exactly when it fires, and computer use has no pane or sidebar row to host it anyway. An always-on-top overlay was rejected for a reason the Swift already documents: an overlay above the target is the case `occludingApp`'s layer filter cannot see, and one owned by Realm would sit over the very point about to be clicked. Main raises it rather than the server, because the server's half ends before any input is posted — wrapping the provider handler would light it while the user was still answering the permission card.

**The allowlist is per space**, matching the scope of the provider's own enablement. A list scoped wider would let a space that was just given computer use inherit approvals made elsewhere. The card writes to it through `allow_always` on a gate carrying `onAlwaysAllow` rather than a fourth decision value — that would have touched five enum declaration sites and three adapters that must never receive a value they cannot map. Revocation lives in the space's Connections tab and also calls `broker.revoke()`, because a session that already answered "always" holds its own in-memory grant and would otherwise keep driving after the user took the app back. **Forbidden wins at four doors**, including before the allowlist is read and before any card can be raised, so a forbidden app can never reach a prompt whose "always" would write it down.

**Screen Recording: granted, and it was broken in two ways.** `CGPreflightScreenCaptureAccess()` reported true while every capture returned nil — which is what made the real defect findable rather than declaring victory. Instrumenting the Swift showed `SCShareableContent` succeeding and `SCScreenshotManager.captureImage` failing with `SCStreamErrorDomain -3811`. The cause: `content.displays.first`, which on a three-display Mac was the monitor at x=-1920 while Calculator sat at x=969 on the main display. A filter whose windows are not on its display does not return a wrong image — it fails the whole capture with an error that reads exactly like a missing permission, and on a single-display Mac `.first` is right by luck. Second bug in the same function: `filter.contentRect` for a display filter is the whole display, so the image asked for was display-sized with the app composited into a corner — the opposite of what the comment beside it claimed.

Proved after the fix: a 21965-byte JPEG whose SOF marker measures **230×408**, Calculator's accessibility window frame exactly. Degradation without the grant is proven rather than assumed — the check was run *before* granting and the tree still returned with the image omitted.

A third bug surfaced en route: the contract says `index` is optional on `type`/`key` ("wherever the app's focus already is"), but the helper routed those through point resolution, so an indexless keystroke had never worked.

**Vacuous assertions found and fixed.** "Realm never lists itself" searched for `"realm"` in a run whose host is Electron, leaving the ancestry walk entirely unexercised; it now asserts the host process itself is excluded. The `listApps` exclusion check now takes an independent LaunchServices inventory so each absence has a subject demonstrably running, with a positive control so an empty list cannot pass for a filtered one. The by-name refusal check was genuinely red once Terminal was not running, which is how the fourth bug was found.

15/15 mutants killed. One initially survived — a new act not cancelling the indicator's linger, where a stale timer would take the item away mid-act — and the test that kills it was added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)