### PR TITLE
Let a browser view outlive the pane that was showing it

### DIFF
--- a/apps/desktop/scripts/browser-persistence-live.cjs
+++ b/apps/desktop/scripts/browser-persistence-live.cjs
@@ -1,0 +1,209 @@
+/**
+ * Live check for browser-pane persistence across a space switch
+ * (run with: apps/desktop/node_modules/.bin/electron apps/desktop/scripts/browser-persistence-live.cjs)
+ *
+ * jsdom can prove which methods the pane calls; only the real Electron binary can prove what those
+ * methods do to a renderer process. Against the REAL BrowserPaneHost/electronViewFactory (compiled
+ * from src/main at startup) and a `data:` page this file authors:
+ *   1. retain does not destroy — the WebContentsView and its webContents are still alive after the
+ *      pane that was showing it goes away
+ *   2. the retained view is HIDDEN — persisting is about the process, not about pixels leaking over
+ *      whatever space the user actually switched to
+ *   3. the retained page keeps WORKING — a 50ms interval keeps ticking at full rate, which is only
+ *      true because electronViewFactory turns background throttling off (default: ~1Hz)
+ *   4. the retained view is still DRIVABLE — CDP Input.dispatchMouseEvent, the same call the agent
+ *      executor makes, still lands a click on a view nobody can see
+ *   5. coming back RE-ADOPTS rather than reloads — a runtime-only global, a typed-in form value and
+ *      a scroll position all survive, which a reload would reset
+ *   6. the off-screen budget is real — past RETAINED_VIEW_LIMIT the least-recently-used retained
+ *      view is destroyed for real, not just forgotten
+ *
+ * Opens a small clearly-titled window for ~15s, uses only a scratch userData dir, touches no ports
+ * and no network: the page is a data: URL below.
+ */
+const path = require("node:path");
+const fs = require("node:fs");
+const os = require("node:os");
+
+const repoRoot = path.resolve(__dirname, "../../..");
+const scratch = fs.mkdtempSync(path.join(os.tmpdir(), "realm-persist-live-"));
+
+// Compile the real main-process sources (TS) to CJS with the workspace's own esbuild.
+function esbuild() {
+  const pnpm = path.join(repoRoot, "node_modules/.pnpm");
+  for (const d of fs.readdirSync(pnpm)) {
+    if (!d.startsWith("esbuild@")) continue;
+    try { return require(path.join(pnpm, d, "node_modules/esbuild")); } catch { /* next */ }
+  }
+  throw new Error("esbuild not found in node_modules/.pnpm");
+}
+const outfile = path.join(scratch, "browser-pane.cjs");
+esbuild().buildSync({
+  entryPoints: [path.join(repoRoot, "apps/desktop/src/main/browser-pane.ts")],
+  bundle: true, platform: "node", format: "cjs", external: ["electron"], outfile,
+});
+const hostOut = path.join(scratch, "browser-host.cjs");
+esbuild().buildSync({
+  entryPoints: [path.join(repoRoot, "apps/desktop/src/main/browser-host.ts")],
+  bundle: true, platform: "node", format: "cjs", external: ["electron"], outfile: hostOut,
+});
+
+const { app, BrowserWindow } = require("electron");
+const { createBrowserPane } = require(outfile);
+const { RETAINED_VIEW_LIMIT } = require(hostOut);
+
+app.setPath("userData", path.join(scratch, "userData")); // persist:browser lands here, not in any real profile
+// Cases destroy their windows as they go; without this the app quits on the first one and the rest
+// of the checks silently never run.
+app.on("window-all-closed", () => {});
+
+/** The page under test. Tall enough to scroll, with a click counter and a free-running interval. */
+const PAGE = `data:text/html,${encodeURIComponent(`<!doctype html><html><body style="margin:0;font:14px system-ui">
+<div id="hit" style="width:360px;height:120px;background:#c0392b;color:#fff">click target</div>
+<input id="typed" value="">
+<div style="height:4000px">scroll me</div>
+<script>
+  window.__clicks = 0; window.__ticks = 0;
+  document.getElementById('hit').addEventListener('click', () => { window.__clicks++; });
+  setInterval(() => { window.__ticks++; }, 50);
+</script></body></html>`)}`;
+
+const out = { electron: process.versions.electron, retainedLimit: RETAINED_VIEW_LIMIT, checks: {} };
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+app.whenReady().then(async () => {
+  try {
+    // The REAL window recipe (vibrancy + transparent paint on macOS) at a small size.
+    const win = new BrowserWindow({
+      width: 700, height: 560, x: 60, y: 60, title: "Realm browser-persistence live check (auto-closes)",
+      ...(process.platform === "darwin" ? { vibrancy: "sidebar", backgroundColor: "#00000000" } : { backgroundColor: "#17181a" }),
+    });
+    // A DOM decoy under the view's rect, so check 2 can tell "hidden" from "still painting".
+    await win.webContents.loadURL(`data:text/html,${encodeURIComponent(
+      `<body style="margin:0;background:#111"><div style="position:absolute;left:0;top:0;width:360px;height:240px;background:#1e8e3e"></div></body>`)}`);
+
+    const pane = createBrowserPane(win);
+    const host = pane.host;
+    const destroyed = [];
+    pane.onViewDestroyed((id) => destroyed.push(id));
+
+    // --- the pane mounts: create + a bounds sync carrying the renderer's visibility verdict -------
+    host.create("b1", "about:blank", null);
+    host.setBounds("b1", { x: 0, y: 0, width: 360, height: 240 }, 2, true);
+    const cdp = pane.attachCdp("b1"); // exactly what BrowserAgentHost attaches through
+    const evalIn = async (expr) => {
+      const r = await cdp.send("Runtime.evaluate", { expression: expr, returnByValue: true });
+      return r && r.result ? r.result.value : undefined;
+    };
+    const click = async (x, y) => {
+      for (const type of ["mouseMoved", "mousePressed", "mouseReleased"]) {
+        await cdp.send("Input.dispatchMouseEvent", {
+          type, x, y, button: "left", buttons: type === "mousePressed" ? 1 : 0, clickCount: 1,
+        });
+      }
+    };
+    // normalizeAddress would https-prefix a data: URL, so the page arrives the way a page always
+    // does once a view exists — as a navigation of the live view, not as create's initial load.
+    await cdp.send("Page.navigate", { url: PAGE });
+    await sleep(700);
+
+    // State that only exists at runtime: a reload resets every one of these.
+    await evalIn("window.__survived = 'set-before-the-switch'");
+    await evalIn("document.getElementById('typed').value = 'half-filled form'");
+    // Click BEFORE scrolling: #hit sits at the top of the document, and CDP mouse coordinates are
+    // viewport-relative, so a click at (40,40) after scrolling 1200px lands on nothing.
+    await click(40, 40);
+    await evalIn("window.scrollTo(0, 1200)");
+    const before = {
+      clicks: await evalIn("window.__clicks"),
+      ticks: await evalIn("window.__ticks"),
+      scrollY: await evalIn("window.scrollY"),
+    };
+
+    // --- the space switch: the pane unmounts, so the renderer releases the view ------------------
+    host.retain("b1");
+    await sleep(300);
+
+    out.checks.retainSurvives = { alive: pane.hasView("b1"), destroyedSoFar: [...destroyed] };
+
+    // Hidden, not merely un-synced: sample the screen where the view was and expect the DOM decoy's
+    // green, never the page's red. (getVisible is asserted too — the cheap half of the same claim.)
+    const view = win.contentView.children[win.contentView.children.length - 1];
+    let sampled = null;
+    try {
+      const img = await win.webContents.capturePage({ x: 0, y: 0, width: 60, height: 60 });
+      const bmp = img.toBitmap(); // BGRA
+      sampled = { b: bmp[0], g: bmp[1], r: bmp[2] };
+    } catch (e) { sampled = { error: String(e) }; }
+    out.checks.retainedIsInvisible = {
+      getVisible: typeof view.getVisible === "function" ? view.getVisible() : "unavailable",
+      sampled,
+      // The decoy is #1e8e3e; the page's target is #c0392b. Green wins = the view is not painting.
+      showsDecoyNotPage: !!sampled && sampled.g > sampled.r,
+    };
+
+    // --- requirement 4: it works in the background ----------------------------------------------
+    await sleep(3000);
+    const hiddenTicks = await evalIn("window.__ticks");
+    const ticksPerSec = Math.round(((hiddenTicks - before.ticks) / 3) * 10) / 10;
+    out.checks.keepsRunningWhileHidden = {
+      ticksPerSec, // ~20 unthrottled, ~1 if Chromium is backgrounding it
+      unthrottled: ticksPerSec > 10,
+      visibilityStateSeenByPage: await evalIn("document.visibilityState"),
+    };
+
+    // --- requirement 2: still drivable while off screen ------------------------------------------
+    await evalIn("window.scrollTo(0, 0)"); // bring #hit back under the pointer, then put it back
+    await click(40, 40);
+    await sleep(200);
+    await evalIn(`window.scrollTo(0, ${before.scrollY})`);
+    const hiddenClicks = await evalIn("window.__clicks");
+    await evalIn("document.title = 'driven-while-off-screen'");
+    out.checks.drivableWhileHidden = {
+      clicksBefore: before.clicks, clicksAfter: hiddenClicks,
+      inputLanded: hiddenClicks > before.clicks,
+      pageStateReadsBack: pane.pageState("b1"),
+    };
+
+    // --- switching back: re-adopt, do not reload --------------------------------------------------
+    host.create("b1", "about:blank", null); // the pane remounts and re-adopts
+    host.setBounds("b1", { x: 0, y: 0, width: 360, height: 240 }, 2, true);
+    await sleep(500);
+    out.checks.readoptedWithoutReload = {
+      survivedGlobal: await evalIn("window.__survived"),
+      formValue: await evalIn("document.getElementById('typed').value"),
+      scrollY: await evalIn("window.scrollY"), scrollYBefore: before.scrollY,
+      clicks: await evalIn("window.__clicks"),
+      visibleAgain: typeof view.getVisible === "function" ? view.getVisible() : "unavailable",
+      // All four are runtime-only. A reload would show undefined / "" / 0 / 0.
+      noReload: (await evalIn("window.__survived")) === "set-before-the-switch"
+        && (await evalIn("document.getElementById('typed').value")) === "half-filled form"
+        && (await evalIn("window.scrollY")) === before.scrollY,
+    };
+
+    // --- the off-screen budget, against real renderer processes -----------------------------------
+    const extra = [];
+    for (let i = 0; i < RETAINED_VIEW_LIMIT + 1; i++) {
+      const id = `e${i}`;
+      extra.push(id);
+      host.create(id, "about:blank", null);
+    }
+    for (const id of extra) host.retain(id); // e0 is now the least recently retained
+    await sleep(400);
+    out.checks.budgetEvictsLru = {
+      limit: RETAINED_VIEW_LIMIT,
+      evicted: destroyed.filter((id) => id !== "b1"),
+      stillAlive: extra.filter((id) => pane.hasView(id)),
+      oldestEvicted: !pane.hasView("e0"),
+      newestKept: pane.hasView(`e${RETAINED_VIEW_LIMIT}`),
+      // b1 has a pane on it (re-adopted above), so it is not in the budget at all.
+      readoptedViewNotEvictable: pane.hasView("b1"),
+    };
+
+    win.destroy();
+  } catch (e) {
+    out.error = String((e && e.stack) || e);
+  }
+  console.log(`PERSIST_LIVE ${JSON.stringify(out, null, 2)}`);
+  app.exit(out.error ? 1 : 0);
+});

--- a/apps/desktop/src/main/browser-agent-host.test.ts
+++ b/apps/desktop/src/main/browser-agent-host.test.ts
@@ -21,6 +21,7 @@ function setup(opts: {
   const audit: { ts: number; origin: string; credentialId: string; outcome: string }[] = [];
   const grants: { browserId: string; origin: string; dir: string; expiresAt: number }[] = [];
   const liveViews = new Set(["b1"]);
+  const touched: string[] = [];
   const binding: CdpBinding = {
     send: async (method, params) => {
       calls.push({ method, params });
@@ -36,6 +37,7 @@ function setup(opts: {
   const host = new BrowserAgentHost({
     attach: (id) => (opts.attachFails || !liveViews.has(id) ? null : binding),
     hasView: (id) => liveViews.has(id),
+    touch: (id) => { touched.push(id); },
     navigate: (id, url) => (liveViews.has(id) && url.startsWith("https://allowed.") ? url : null),
     pageState: (id) => (liveViews.has(id) ? { url: "https://example.com/x", title: "Example" } : null),
     secrets: opts.credentials === undefined ? undefined : {
@@ -59,7 +61,7 @@ function setup(opts: {
       },
     } : undefined,
   });
-  return { host, calls, liveViews, audit, grants, emitEvent: (method: string, params: unknown) => emit?.(method, params) };
+  return { host, calls, liveViews, audit, grants, touched, emitEvent: (method: string, params: unknown) => emit?.(method, params) };
 }
 
 describe("BrowserAgentHost", () => {
@@ -431,5 +433,26 @@ describe("BrowserAgentHost — element picking", () => {
     expect(picked.html).toHaveLength(PICK_HTML_MAX);
     expect(picked.text).toHaveLength(PICK_TEXT_MAX);
     expect(picked.html.endsWith("…")).toBe(true);
+  });
+});
+
+/**
+ * A browser whose space is off screen is retained, not closed — so the agent must still reach it,
+ * and reaching it must be what keeps it retained rather than what gets it evicted.
+ */
+describe("driving a browser whose pane is off screen", () => {
+  it("every op marks the view in use, not just the one that attached", async () => {
+    const h = setup();
+    await h.host.handleOp("read", { browserId: "b1", kind: "text" });
+    await h.host.handleOp("read", { browserId: "b1", kind: "text" });
+    await h.host.handleOp("snapshot", { browserId: "b1" });
+    expect(h.touched).toEqual(["b1", "b1", "b1"]);
+  });
+
+  it("a view that is gone for real is still refused, and not marked in use", async () => {
+    const h = setup();
+    h.liveViews.delete("b1");
+    await expect(h.host.handleOp("read", { browserId: "b1", kind: "text" })).rejects.toThrow(/pane is not open/);
+    expect(h.touched).toEqual([]);
   });
 });

--- a/apps/desktop/src/main/browser-agent-host.ts
+++ b/apps/desktop/src/main/browser-agent-host.ts
@@ -20,8 +20,12 @@ export type BrowserAgentHostDeps = {
   /** Attach (or fail with null) to the live view for this browser id. Called once per attachment;
    *  the host caches the binding until an op fails against a dead view. */
   attach(browserId: string): CdpBinding | null;
-  /** Is the pane's view currently alive? Gates the cache — a destroyed view's binding is dropped. */
+  /** Is the pane's view currently alive? Gates the cache — a destroyed view's binding is dropped.
+   *  True for a RETAINED view too: a browser whose space is off screen is still drivable. */
   hasView(browserId: string): boolean;
+  /** This view is in use right now. `BrowserPaneHost.touch` — it keeps the off-screen budget from
+   *  evicting a browser an agent is working in while the user reads something in another space. */
+  touch(browserId: string): void;
   /** BrowserPaneHost.navigate — the SAME normalization + allowlist every other navigation obeys. */
   navigate(browserId: string, url: string): string | null;
   /** Trustworthy page identity (webContents.getURL/getTitle — never page-authored text). */
@@ -293,10 +297,15 @@ export class BrowserAgentHost {
   /** Get-or-create the attachment. A cached binding whose view died is dropped and re-attached —
    *  and if no view exists, the op fails with the one message that tells the agent what to do. */
   private ensure(browserId: string): Attached {
+    if (!this.d.hasView(browserId)) {
+      this.attached.delete(browserId); // a cached binding whose view died
+      throw new Error(`browser ${browserId}'s pane is not open in the app — the user must open (or reopen) the browser pane before tools can drive it`);
+    }
+    // Ahead of the cache hit, so EVERY op refreshes the view's recency and not just the one that
+    // attached — a long agent task in a background browser is exactly what must not be evicted.
+    this.d.touch(browserId);
     const cached = this.attached.get(browserId);
-    if (cached && this.d.hasView(browserId)) return cached;
-    this.attached.delete(browserId);
-    if (!this.d.hasView(browserId)) throw new Error(`browser ${browserId}'s pane is not open in the app — the user must open (or reopen) the browser pane before tools can drive it`);
+    if (cached) return cached;
     const binding = this.d.attach(browserId);
     if (!binding) throw new Error(`could not attach the debugger to browser ${browserId}`);
     const entry: Attached = { binding, consoleLines: [], network: new Map(), networkOrder: [], lastSnapshot: null, pick: null, pickGen: 0 };

--- a/apps/desktop/src/main/browser-host.test.ts
+++ b/apps/desktop/src/main/browser-host.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import {
-  BrowserPaneHost, normalizeAddress, originAllowed, toViewBounds,
+  BrowserPaneHost, RETAINED_VIEW_LIMIT, normalizeAddress, originAllowed, toViewBounds,
   type BrowserViewState, type ViewHandle, type ViewHooks,
 } from "./browser-host";
 
@@ -92,17 +92,23 @@ function fakeView() {
   return { handle, calls, nav, setHooks: (h: ViewHooks) => { hooks = h; }, getHooks: () => hooks! };
 }
 
-function makeHost(scaleFactor = 2, retainedLimit?: number) {
+function makeHost(scaleFactor = 2) {
   const views = new Map<string, ReturnType<typeof fakeView>>();
   const states: BrowserViewState[] = [];
   const factory = vi.fn((id: string, hooks: ViewHooks) => {
     const v = fakeView(); v.setHooks(hooks); views.set(id, v); return v.handle;
   });
-  const host = new BrowserPaneHost({ createView: factory, sendState: (s) => states.push(s), scaleFactor: () => scaleFactor, retainedLimit });
+  const host = new BrowserPaneHost({ createView: factory, sendState: (s) => states.push(s), scaleFactor: () => scaleFactor });
   return { host, views, states, factory };
 }
 
 const alive = (v: ReturnType<typeof fakeView>) => !v.calls.includes("destroy");
+/** One more browser than the budget can retain, named v0 (oldest) upward. */
+const overBudget = (host: BrowserPaneHost) => {
+  const ids = Array.from({ length: RETAINED_VIEW_LIMIT + 1 }, (_, i) => `v${i}`);
+  for (const id of ids) host.create(id, "example.com", null);
+  return ids;
+};
 
 describe("BrowserPaneHost", () => {
   it("create loads the (normalized) url and emits initial state; create is idempotent", () => {
@@ -253,47 +259,39 @@ describe("BrowserPaneHost retention", () => {
   });
 
   it("a re-adopted view leaves the off-screen budget", () => {
-    const { host, views } = makeHost(2, 1);
-    host.create("b1", "", null);
-    host.create("b2", "", null);
-    host.retain("b1");
-    host.create("b1", "", null); // the user came back to b1's space
-    host.retain("b2"); // ...so b2 fits in the budget on its own
-    expect(alive(views.get("b1")!)).toBe(true);
-    expect(alive(views.get("b2")!)).toBe(true);
+    const { host, views } = makeHost();
+    const ids = overBudget(host);
+    host.retain(ids[0]!);
+    host.create(ids[0]!, "example.com", null); // the user came back to its space
+    for (const id of ids.slice(1)) host.retain(id); // exactly the budget, so nothing is evicted
+    for (const id of ids) expect(alive(views.get(id)!)).toBe(true);
   });
 
   it("past the off-screen budget the LEAST recently retained view is destroyed", () => {
-    const { host, views } = makeHost(2, 2);
-    for (const id of ["b1", "b2", "b3"]) host.create(id, "example.com", null);
-    host.retain("b1");
-    host.retain("b2");
-    host.retain("b3");
-    expect(alive(views.get("b1")!)).toBe(false); // oldest off-screen page pays
-    expect(alive(views.get("b2")!)).toBe(true);
-    expect(alive(views.get("b3")!)).toBe(true);
-    expect(host.has("b1")).toBe(false);
+    const { host, views } = makeHost();
+    const ids = overBudget(host);
+    for (const id of ids) host.retain(id);
+    expect(alive(views.get(ids[0]!)!)).toBe(false); // oldest off-screen page pays
+    expect(host.has(ids[0]!)).toBe(false);
+    for (const id of ids.slice(1)) expect(alive(views.get(id)!)).toBe(true);
   });
 
   it("touch spares a background view an agent is still driving", () => {
-    const { host, views } = makeHost(2, 2);
-    for (const id of ["b1", "b2", "b3"]) host.create(id, "example.com", null);
-    host.retain("b1");
-    host.retain("b2");
-    host.touch("b1"); // an agent op reached b1 while its space was off screen
-    host.retain("b3");
-    expect(alive(views.get("b1")!)).toBe(true);
-    expect(alive(views.get("b2")!)).toBe(false);
+    const { host, views } = makeHost();
+    const ids = overBudget(host);
+    for (const id of ids.slice(0, RETAINED_VIEW_LIMIT)) host.retain(id);
+    host.touch(ids[0]!); // an agent op reached it while its space was off screen
+    host.retain(ids[RETAINED_VIEW_LIMIT]!);
+    expect(alive(views.get(ids[0]!)!)).toBe(true);
+    expect(alive(views.get(ids[1]!)!)).toBe(false); // the next-oldest pays instead
   });
 
   it("touch never makes an on-screen view evictable", () => {
-    const { host, views } = makeHost(2, 1);
-    host.create("b1", "", null); // mounted pane, never retained
-    host.create("b2", "", null);
-    host.touch("b1");
-    host.retain("b2");
-    expect(alive(views.get("b1")!)).toBe(true);
-    expect(alive(views.get("b2")!)).toBe(true); // b1 is not in the budget, so b2 fits
+    const { host, views } = makeHost();
+    const ids = overBudget(host);
+    host.touch(ids[0]!); // still mounted, never retained
+    for (const id of ids.slice(1)) host.retain(id); // exactly the budget
+    for (const id of ids) expect(alive(views.get(id)!)).toBe(true);
   });
 
   it("retain on an unknown id is refused, not thrown", () => {

--- a/apps/desktop/src/main/browser-host.test.ts
+++ b/apps/desktop/src/main/browser-host.test.ts
@@ -92,15 +92,17 @@ function fakeView() {
   return { handle, calls, nav, setHooks: (h: ViewHooks) => { hooks = h; }, getHooks: () => hooks! };
 }
 
-function makeHost(scaleFactor = 2) {
+function makeHost(scaleFactor = 2, retainedLimit?: number) {
   const views = new Map<string, ReturnType<typeof fakeView>>();
   const states: BrowserViewState[] = [];
   const factory = vi.fn((id: string, hooks: ViewHooks) => {
     const v = fakeView(); v.setHooks(hooks); views.set(id, v); return v.handle;
   });
-  const host = new BrowserPaneHost({ createView: factory, sendState: (s) => states.push(s), scaleFactor: () => scaleFactor });
+  const host = new BrowserPaneHost({ createView: factory, sendState: (s) => states.push(s), scaleFactor: () => scaleFactor, retainedLimit });
   return { host, views, states, factory };
 }
+
+const alive = (v: ReturnType<typeof fakeView>) => !v.calls.includes("destroy");
 
 describe("BrowserPaneHost", () => {
   it("create loads the (normalized) url and emits initial state; create is idempotent", () => {
@@ -222,5 +224,90 @@ describe("BrowserPaneHost", () => {
     const last = states.at(-1)!;
     expect(last.id).toBe("b1");
     expect(last.title).toBe("Page one");
+  });
+});
+
+/**
+ * Retention: what a pane unmounting means. Switching space or pane group swaps the whole rendered
+ * tree, so unmount is not the user closing anything — the view has to outlive it.
+ */
+describe("BrowserPaneHost retention", () => {
+  it("retain keeps the view alive and hides it — a space switch must not close the browser", () => {
+    const { host, views } = makeHost();
+    host.create("b1", "example.com", null);
+    host.retain("b1");
+    expect(views.get("b1")!.calls).not.toContain("destroy");
+    expect(host.has("b1")).toBe(true);
+    // Main hides it itself: the renderer's per-frame bounds sync, which normally carries the
+    // visibility verdict, stopped with the pane.
+    expect(views.get("b1")!.calls.at(-1)).toBe("visible:false");
+  });
+
+  it("returning to the space re-adopts the SAME view instead of reloading it", () => {
+    const { host, views, factory } = makeHost();
+    host.create("b1", "example.com", null);
+    host.retain("b1");
+    host.create("b1", "example.com", null); // the pane remounts in its space
+    expect(factory).toHaveBeenCalledTimes(1);
+    expect(views.get("b1")!.calls.filter((c) => c.startsWith("load:"))).toHaveLength(1);
+  });
+
+  it("a re-adopted view leaves the off-screen budget", () => {
+    const { host, views } = makeHost(2, 1);
+    host.create("b1", "", null);
+    host.create("b2", "", null);
+    host.retain("b1");
+    host.create("b1", "", null); // the user came back to b1's space
+    host.retain("b2"); // ...so b2 fits in the budget on its own
+    expect(alive(views.get("b1")!)).toBe(true);
+    expect(alive(views.get("b2")!)).toBe(true);
+  });
+
+  it("past the off-screen budget the LEAST recently retained view is destroyed", () => {
+    const { host, views } = makeHost(2, 2);
+    for (const id of ["b1", "b2", "b3"]) host.create(id, "example.com", null);
+    host.retain("b1");
+    host.retain("b2");
+    host.retain("b3");
+    expect(alive(views.get("b1")!)).toBe(false); // oldest off-screen page pays
+    expect(alive(views.get("b2")!)).toBe(true);
+    expect(alive(views.get("b3")!)).toBe(true);
+    expect(host.has("b1")).toBe(false);
+  });
+
+  it("touch spares a background view an agent is still driving", () => {
+    const { host, views } = makeHost(2, 2);
+    for (const id of ["b1", "b2", "b3"]) host.create(id, "example.com", null);
+    host.retain("b1");
+    host.retain("b2");
+    host.touch("b1"); // an agent op reached b1 while its space was off screen
+    host.retain("b3");
+    expect(alive(views.get("b1")!)).toBe(true);
+    expect(alive(views.get("b2")!)).toBe(false);
+  });
+
+  it("touch never makes an on-screen view evictable", () => {
+    const { host, views } = makeHost(2, 1);
+    host.create("b1", "", null); // mounted pane, never retained
+    host.create("b2", "", null);
+    host.touch("b1");
+    host.retain("b2");
+    expect(alive(views.get("b1")!)).toBe(true);
+    expect(alive(views.get("b2")!)).toBe(true); // b1 is not in the budget, so b2 fits
+  });
+
+  it("retain on an unknown id is refused, not thrown", () => {
+    const { host } = makeHost();
+    expect(() => host.retain("nope")).not.toThrow();
+    expect(() => host.touch("nope")).not.toThrow();
+  });
+
+  it("destroyAll still takes retained views — they must never outlive the window", () => {
+    const { host, views } = makeHost();
+    host.create("b1", "", null);
+    host.retain("b1");
+    host.destroyAll();
+    expect(alive(views.get("b1")!)).toBe(false);
+    expect(host.has("b1")).toBe(false);
   });
 });

--- a/apps/desktop/src/main/browser-host.ts
+++ b/apps/desktop/src/main/browser-host.ts
@@ -86,24 +86,51 @@ export type ViewHooks = {
 export type ViewFactory = (id: string, hooks: ViewHooks) => ViewHandle;
 
 /**
+ * How many RETAINED (off-screen) browser views stay alive at once, on top of whatever is on screen.
+ *
+ * This is a process budget, not a cache size: every `WebContentsView` is a full renderer process,
+ * and retained ones run unthrottled (browser-pane.ts sets `backgroundThrottling: false`, without
+ * which a hidden page's timers drop to ~1Hz). Ten spaces holding a browser each must not mean ten
+ * unthrottled renderers, so past this limit the least-recently-used retained view is destroyed and
+ * its page reloads on the user's next visit.
+ */
+export const RETAINED_VIEW_LIMIT = 3;
+
+/**
  * One `WebContentsView` per open browser item, keyed by browser id. Owns lifecycle (create is
  * idempotent; destroy is final; destroyAll on window teardown — a view never outlives its window),
  * the navigation guards, and the state channel back to the renderer.
+ *
+ * A view's lifetime is NOT its pane's. Panes unmount for reasons that have nothing to do with the
+ * user closing anything — switching space or pane group swaps the whole rendered tree — so an
+ * unmounting pane `retain`s its view (hidden, still running, still drivable over CDP) and only an
+ * explicit close or delete `destroy`s it. What bounds the cost is `RETAINED_VIEW_LIMIT`, below.
  */
 export class BrowserPaneHost {
   private views = new Map<string, { handle: ViewHandle; allowlist: string[] | null }>();
+  /** Retained ids in least-recently-used order — `Set` iterates by insertion, so re-adding after a
+   *  delete moves an id to the back. Views with a mounted pane are absent, never evictable. */
+  private retained = new Set<string>();
 
   constructor(private opts: {
     createView: ViewFactory;
     sendState: (s: BrowserViewState) => void;
     /** The window's display scale factor at the time of a bounds sync. */
     scaleFactor: () => number;
+    /** Off-screen view budget; injected so tests can drive eviction without opening four views. */
+    retainedLimit?: number;
   }) {}
 
   has(id: string): boolean { return this.views.has(id); }
 
-  /** Idempotent: React StrictMode double-mounts, and a remount must not reload the page. */
+  /** Is this view alive with no pane showing it? Off-screen and still running. */
+  isRetained(id: string): boolean { return this.retained.has(id); }
+
+  /** Idempotent: React StrictMode double-mounts, and a remount must not reload the page. It is also
+   *  how a retained view is re-adopted — a pane returning to a space calls this and gets the SAME
+   *  view back, mid-scroll and mid-form, rather than a reload. */
   create(id: string, url: string, allowlist: string[] | null): void {
+    this.retained.delete(id); // a pane is showing it again: no longer evictable
     if (this.views.has(id)) { this.emitState(id); return; }
     const handle = this.opts.createView(id, {
       emitState: () => this.emitState(id),
@@ -148,10 +175,43 @@ export class BrowserPaneHost {
     const v = this.views.get(id); if (v) v.allowlist = allowlist;
   }
 
-  /** Final: a browser is not a terminal — closing the pane kills the view, no hidden survival. */
+  /**
+   * The pane showing this view unmounted, but the browser item still exists — the user switched
+   * space or pane group. Hide the view (main does it here because the renderer's per-frame bounds
+   * sync, which is what normally carries the visibility verdict, stops with the pane) and keep the
+   * process running so background work and agent driving continue.
+   *
+   * Hiding is safe for driving: on Electron 37 a hidden `WebContentsView` still accepts CDP
+   * `Input.dispatchMouseEvent`/`dispatchKeyEvent` — measured, both with and without background
+   * throttling. What hiding alone would cost is background WORK, which browser-pane.ts buys back.
+   */
+  retain(id: string): void {
+    const v = this.views.get(id); if (!v) return;
+    v.handle.setVisible(false);
+    this.retained.delete(id);
+    this.retained.add(id); // to the back: most recently retained
+    const limit = this.opts.retainedLimit ?? RETAINED_VIEW_LIMIT;
+    while (this.retained.size > limit) {
+      const oldest = this.retained.values().next().value;
+      if (oldest === undefined) break;
+      this.retained.delete(oldest); // before destroy, so the loop cannot spin on an id destroy skips
+      this.destroy(oldest);
+    }
+  }
+
+  /** Mark a retained view as recently used, so eviction does not take one an agent is driving in the
+   *  background out from under it. A no-op for views with a mounted pane — those cannot be evicted. */
+  touch(id: string): void {
+    if (!this.retained.delete(id)) return;
+    this.retained.add(id);
+  }
+
+  /** Final: the user closed the pane or deleted the item. Only these destroy a view — a pane merely
+   *  unmounting `retain`s instead, or a space switch would throw the page away. */
   destroy(id: string): void {
     const v = this.views.get(id); if (!v) return;
     this.views.delete(id);
+    this.retained.delete(id);
     // Tolerate a view the window already tore down: on BrowserWindow "closed", Electron has destroyed
     // the children before this runs, and a second destroy throws "Object has been destroyed". The row
     // must be forgotten either way (user-hit crash, 2026-08-31).

--- a/apps/desktop/src/main/browser-host.ts
+++ b/apps/desktop/src/main/browser-host.ts
@@ -117,14 +117,9 @@ export class BrowserPaneHost {
     sendState: (s: BrowserViewState) => void;
     /** The window's display scale factor at the time of a bounds sync. */
     scaleFactor: () => number;
-    /** Off-screen view budget; injected so tests can drive eviction without opening four views. */
-    retainedLimit?: number;
   }) {}
 
   has(id: string): boolean { return this.views.has(id); }
-
-  /** Is this view alive with no pane showing it? Off-screen and still running. */
-  isRetained(id: string): boolean { return this.retained.has(id); }
 
   /** Idempotent: React StrictMode double-mounts, and a remount must not reload the page. It is also
    *  how a retained view is re-adopted — a pane returning to a space calls this and gets the SAME
@@ -190,11 +185,12 @@ export class BrowserPaneHost {
     v.handle.setVisible(false);
     this.retained.delete(id);
     this.retained.add(id); // to the back: most recently retained
-    const limit = this.opts.retainedLimit ?? RETAINED_VIEW_LIMIT;
-    while (this.retained.size > limit) {
+    while (this.retained.size > RETAINED_VIEW_LIMIT) {
       const oldest = this.retained.values().next().value;
       if (oldest === undefined) break;
-      this.retained.delete(oldest); // before destroy, so the loop cannot spin on an id destroy skips
+      // Dropped here rather than left to `destroy`, so the loop terminates on its own terms and not
+      // on the invariant that every retained id still has a view behind it.
+      this.retained.delete(oldest);
       this.destroy(oldest);
     }
   }

--- a/apps/desktop/src/main/browser-pane.ts
+++ b/apps/desktop/src/main/browser-pane.ts
@@ -25,6 +25,13 @@ export function electronViewFactory(win: BrowserWindow, onView?: (id: string, wc
         partition: BROWSER_PARTITION,
         // Untrusted web content: full Chromium sandbox, no node, no preload, isolated world.
         sandbox: true, contextIsolation: true, nodeIntegration: false,
+        // A browser pane keeps working while its space is off screen, and Chromium's default
+        // undoes that: measured on Electron 37, a `setVisible(false)` WebContentsView drops a 50ms
+        // interval to ~1Hz and reports `document.visibilityState === "hidden"`, which pages take as
+        // their own cue to stop polling, stall SSE and pause media. With this off, the hidden view
+        // ticks at full rate and still reads as visible to the page. The cost is CPU for pages
+        // nobody is looking at, which is what RETAINED_VIEW_LIMIT exists to bound.
+        backgroundThrottling: false,
       },
     });
     view.setBackgroundColor("#ffffffff"); // opaque — the window behind is transparent on macOS

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -150,6 +150,7 @@ async function createWindow(info: { port: number; home: string }) {
   const host = new BrowserAgentHost({
     attach: (id) => pane.attachCdp(id),
     hasView: (id) => pane.hasView(id),
+    touch: (id) => pane.host.touch(id),
     navigate: (id, url) => pane.host.navigate(id, url),
     pageState: (id) => pane.pageState(id),
     // The fill op's only reach into the store. Passed as an object of bound methods rather than the

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -190,6 +190,9 @@ async function createWindow(info: { port: number; home: string }) {
 // Mutations are invokes; the per-frame bounds sync is a plain send (no reply to wait on).
 ipcMain.handle("browser:create", (_e, id: string, url: string, allowlist: string[] | null) => { browserHost?.create(id, url, allowlist); });
 ipcMain.handle("browser:destroy", (_e, id: string) => { browserHost?.destroy(id); });
+// The pane went away without the browser being closed — a space or pane-group switch. The view
+// keeps running, hidden, until the pane comes back or the off-screen budget evicts it.
+ipcMain.handle("browser:retain", (_e, id: string) => { browserHost?.retain(id); });
 ipcMain.handle("browser:navigate", (_e, id: string, input: string): string | null => browserHost?.navigate(id, input) ?? null);
 ipcMain.handle("browser:nav", (_e, id: string, action: "back" | "forward" | "reload" | "stop") => { browserHost?.navAction(id, action); });
 ipcMain.handle("browser:set-allowlist", (_e, id: string, allowlist: string[] | null) => { browserHost?.setAllowlist(id, allowlist); });

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -116,6 +116,7 @@ contextBridge.exposeInMainWorld("realm", {
   browser: {
     create: (id: string, url: string, allowlist: string[] | null): Promise<void> => ipcRenderer.invoke("browser:create", id, url, allowlist),
     destroy: (id: string): Promise<void> => ipcRenderer.invoke("browser:destroy", id),
+    retain: (id: string): Promise<void> => ipcRenderer.invoke("browser:retain", id),
     /** Resolves the normalized URL actually loaded, or null when refused (allowlist) / empty. */
     navigate: (id: string, input: string): Promise<string | null> => ipcRenderer.invoke("browser:navigate", id, input),
     nav: (id: string, action: "back" | "forward" | "reload" | "stop"): Promise<void> => ipcRenderer.invoke("browser:nav", id, action),

--- a/apps/desktop/src/renderer/src/env.d.ts
+++ b/apps/desktop/src/renderer/src/env.d.ts
@@ -82,6 +82,8 @@ interface Window {
     browser: {
       create(id: string, url: string, allowlist: string[] | null): Promise<void>;
       destroy(id: string): Promise<void>;
+      /** The pane unmounted but the browser did not close: keep the view alive and hidden. */
+      retain(id: string): Promise<void>;
       /** Resolves the normalized URL actually loaded, or null when refused (allowlist) / empty. */
       navigate(id: string, input: string): Promise<string | null>;
       nav(id: string, action: "back" | "forward" | "reload" | "stop"): Promise<void>;

--- a/apps/desktop/src/renderer/src/panes/browser/BrowserPane.tsx
+++ b/apps/desktop/src/renderer/src/panes/browser/BrowserPane.tsx
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useRef, useState, useSyncExternalStore } from "
 import type { StoreApi } from "zustand";
 import type { PaneProps } from "../registry";
 import { useAppStoreMaybe, type AppState, type BrowserActionTick } from "../../state/store";
-import { cancelViewDestroy, getBrowserBridges, scheduleViewDestroy } from "./browser-client";
+import { cancelViewRelease, getBrowserBridges, scheduleViewRelease } from "./browser-client";
 import { sessionForPick } from "./pick-target";
 import { SETTLE_MS, isRealmItemDrag, shouldShowView } from "./view-sync";
 
@@ -235,7 +235,7 @@ export function BrowserPane({ item, visible, focused }: PaneProps) {
     // the view appears once the layout has actually settled, not mid-tween.
     const settleTimer = setTimeout(() => { flags.settled = true; schedule(); }, SETTLE_MS);
 
-    cancelViewDestroy(browserId); // a StrictMode remount adopts the still-live view
+    cancelViewRelease(browserId); // a remount adopts the still-live view
     void (async () => {
       try {
         const [row, allowlist] = await Promise.all([server.get(browserId), server.allowlist(item.spaceId)]);
@@ -267,15 +267,18 @@ export function BrowserPane({ item, visible, focused }: PaneProps) {
       window.removeEventListener("dragend", onDragEnd);
       window.removeEventListener("drop", onDragEnd);
       window.removeEventListener("resize", schedule);
-      // The no-overlay rect lives and dies WITH THE VIEW, so its clear rides the same deferred
-      // destroy: on a layout remount (leaf reparented by a split/unwrap) the adopted view never
+      // The no-overlay rect tracks where the view PAINTS, so its clear rides the same deferred
+      // release: on a layout remount (leaf reparented by a split/unwrap) the adopted view never
       // stops painting, and clearing the rect eagerly would open a window — until the remount's
       // async re-adopt lands — where floating surfaces believe no view exists. A remount cancels
-      // this timer and the rect never blinks; a real close clears rect and view together.
-      // (Deferred one macrotask so a StrictMode double-mount re-adopts instead of reloading.)
-      scheduleViewDestroy(browserId, () => {
+      // this timer and the rect never blinks.
+      //
+      // Release, not destroy: this pane going away says nothing about the browser being closed
+      // (switching space or pane group unmounts every pane in the tree). The view stays alive and
+      // hidden; the store destroys it when the user actually closes or deletes the item.
+      scheduleViewRelease(browserId, () => {
         store?.getState().setBrowserRect(item.id, null); // nothing paints here any more
-        void host.destroy(browserId);
+        void host.retain(browserId);
       });
     };
   }, [browserId, item.id, item.spaceId, store]);

--- a/apps/desktop/src/renderer/src/panes/browser/browser-bridges.test-fakes.ts
+++ b/apps/desktop/src/renderer/src/panes/browser/browser-bridges.test-fakes.ts
@@ -16,6 +16,7 @@ export function fakeBrowserBridges(over: {
   const host: BrowserHostBridge = {
     create: async () => {},
     destroy: async () => {},
+    retain: async () => {},
     navigate: async () => null,
     nav: async () => {},
     setAllowlist: async () => {},

--- a/apps/desktop/src/renderer/src/panes/browser/browser-client.ts
+++ b/apps/desktop/src/renderer/src/panes/browser/browser-client.ts
@@ -50,6 +50,8 @@ export function parseOriginInput(input: string): string | null {
 export type BrowserHostBridge = {
   create(id: string, url: string, allowlist: string[] | null): Promise<void>;
   destroy(id: string): Promise<void>;
+  /** The pane unmounted but the browser is still open somewhere: keep the view alive and hidden. */
+  retain(id: string): Promise<void>;
   navigate(id: string, input: string): Promise<string | null>;
   nav(id: string, action: "back" | "forward" | "reload" | "stop"): Promise<void>;
   setAllowlist(id: string, allowlist: string[] | null): Promise<void>;
@@ -93,17 +95,23 @@ export function getBrowserBridges(): BrowserBridges {
 export function setBrowserBridgesForTests(b: BrowserBridges | null): void { bridges = b; }
 
 /**
- * StrictMode-safe destroy: React double-mounts in dev (mount → cleanup → mount, synchronously), and
- * an immediate destroy would reload the page on every dev mount. Cleanup schedules the destroy a
- * macrotask out; a remount for the same id cancels it and the (idempotent) create simply re-attaches.
- * A real unmount lets the timer fire — the view dies with the pane, never surviving hidden.
+ * Deferred release of the native view on unmount.
+ *
+ * Releasing is not destroying: an unmounting pane means only that nothing is showing this browser
+ * right now — a space or pane-group switch swaps the whole tree — so main hides the view and keeps
+ * it running. Destroying is the user closing the pane or deleting the item, and reaches main from
+ * the store instead.
+ *
+ * Still deferred a macrotask, for the reason it always was: React double-mounts in dev (mount →
+ * cleanup → mount, synchronously) and a layout reshape remounts a leaf, and neither should make the
+ * view blink through a hide. A remount cancels the timer and the (idempotent) create re-attaches.
  */
-const pendingDestroys = new Map<string, ReturnType<typeof setTimeout>>();
-export function scheduleViewDestroy(id: string, destroy: () => void): void {
-  cancelViewDestroy(id);
-  pendingDestroys.set(id, setTimeout(() => { pendingDestroys.delete(id); destroy(); }, 0));
+const pendingReleases = new Map<string, ReturnType<typeof setTimeout>>();
+export function scheduleViewRelease(id: string, release: () => void): void {
+  cancelViewRelease(id);
+  pendingReleases.set(id, setTimeout(() => { pendingReleases.delete(id); release(); }, 0));
 }
-export function cancelViewDestroy(id: string): void {
-  const t = pendingDestroys.get(id);
-  if (t !== undefined) { clearTimeout(t); pendingDestroys.delete(id); }
+export function cancelViewRelease(id: string): void {
+  const t = pendingReleases.get(id);
+  if (t !== undefined) { clearTimeout(t); pendingReleases.delete(id); }
 }

--- a/apps/desktop/src/renderer/src/panes/browser/browser-pane.test.tsx
+++ b/apps/desktop/src/renderer/src/panes/browser/browser-pane.test.tsx
@@ -25,6 +25,7 @@ function fakeBridges(row: Partial<Browser> = {}) {
   const host: BrowserHostBridge = {
     create: async (id, url, list) => { calls.push(`create:${id}:${url}:${JSON.stringify(list)}`); },
     destroy: async (id) => { calls.push(`destroy:${id}`); },
+    retain: async (id) => { calls.push(`retain:${id}`); },
     navigate: async (id, input) => { calls.push(`navigate:${id}:${input}`); return input.trim() === "" ? null : `https://${input}`; },
     nav: async (id, a) => { calls.push(`nav:${id}:${a}`); },
     setAllowlist: async () => {},
@@ -223,35 +224,52 @@ describe("BrowserPane", () => {
       expect(f.bounds.at(-1)!.visible).toBe(false); // native view hidden for the drag...
       expect(store.getState().browserRects).toHaveLength(1); // ...but the no-overlay rect stays
       unmount();
-      // The rect clears WITH the deferred view destroy (one macrotask), not eagerly — a layout
+      // The rect clears WITH the deferred view release (one macrotask), not eagerly — a layout
       // remount cancels that timer and the rect never blinks while the adopted view keeps painting.
       expect(store.getState().browserRects).toHaveLength(1);
       await act(async () => { await vi.advanceTimersByTimeAsync(10); });
       expect(store.getState().browserRects).toEqual([]);
-      expect(f.calls).toContain("destroy:b1");
+      expect(f.calls).toContain("retain:b1");
     });
   });
 
-  it("unmount destroys the native view — no hidden survival", async () => {
+  it("unmount releases the native view and never destroys it — a space switch is not a close", async () => {
     const f = fakeBridges({ url: "https://example.com" });
     setBrowserBridgesForTests(f.bridges);
     const { unmount } = render(<BrowserPane item={browserItem()} visible />);
     await settle();
     unmount();
     await act(async () => { await vi.advanceTimersByTimeAsync(10); });
-    expect(f.calls).toContain("destroy:b1");
+    expect(f.calls).toContain("retain:b1");
+    expect(f.calls).not.toContain("destroy:b1");
   });
 
-  it("a StrictMode-style remount within the same tick re-adopts the view instead of destroying it", async () => {
+  it("remounting after a release re-adopts the view instead of reloading the page", async () => {
     const f = fakeBridges({ url: "https://example.com" });
     setBrowserBridgesForTests(f.bridges);
     const first = render(<BrowserPane item={browserItem()} visible />);
     await settle();
     first.unmount();
-    // Remount BEFORE the deferred destroy's macrotask fires:
+    // Past the deferred release: main is holding the view hidden, exactly as after a space switch.
+    await act(async () => { await vi.advanceTimersByTimeAsync(10); });
+    expect(f.calls).toContain("retain:b1");
     render(<BrowserPane item={browserItem()} visible />);
     await settle();
-    expect(f.calls.filter((c) => c === "destroy:b1")).toHaveLength(0);
+    // Re-adoption is `create` — idempotent on the main side, so the page is not reloaded.
+    expect(f.calls.filter((c) => c.startsWith("create:b1"))).toHaveLength(2);
+    expect(f.calls).not.toContain("destroy:b1");
+  });
+
+  it("a StrictMode-style remount within the same tick cancels the release outright", async () => {
+    const f = fakeBridges({ url: "https://example.com" });
+    setBrowserBridgesForTests(f.bridges);
+    const first = render(<BrowserPane item={browserItem()} visible />);
+    await settle();
+    first.unmount();
+    // Remount BEFORE the deferred release's macrotask fires: the view never even blinks hidden.
+    render(<BrowserPane item={browserItem()} visible />);
+    await settle();
+    expect(f.calls.filter((c) => c === "retain:b1")).toHaveLength(0);
     expect(f.calls.filter((c) => c.startsWith("create:b1"))).toHaveLength(2); // idempotent on the main side
   });
 

--- a/apps/desktop/src/renderer/src/state/live-api.ts
+++ b/apps/desktop/src/renderer/src/state/live-api.ts
@@ -55,6 +55,7 @@ export const liveApi = (): Api => ({
   pathForFile: (file) => window.realm.pathForFile(file),
   saveTempAttachment: (name, mime, bytes) => window.realm.saveTempAttachment(name, mime, bytes),
   disposeTerminal: (terminalId) => getTerminalHub().dispose(terminalId),
+  destroyBrowserView: (browserId) => { void window.realm.browser.destroy(browserId); },
   listSessions: (spaceId) => rpc().call("sessions.list", { spaceId }),
   listAllSessions: () => rpc().call("sessions.listAll", {}),
   getSession: (id) => rpc().call("sessions.get", { id }),

--- a/apps/desktop/src/renderer/src/state/store.test-fakes.ts
+++ b/apps/desktop/src/renderer/src/state/store.test-fakes.ts
@@ -241,6 +241,8 @@ export type FakeApi = Api & {
   /** Method-call log, e.g. `listItems:s1`, `setLayout:s1`, `setSetting:ui.theme=dark`. */
   calls: string[];
   disposed: string[];
+  /** Browser ids whose native view the store asked main to destroy. */
+  destroyedBrowserViews: string[];
   /** Every `sendMessage`, with the attachments that actually went on the wire. `mentions` is present
    *  only when non-empty, so mention-free assertions stay byte-for-byte what they always were. */
   sent: { id: string; text: string; attachments: Attachment[]; mentions?: string[]; elements?: ElementChip[] }[];
@@ -267,6 +269,7 @@ export type FakeApi = Api & {
 export function fakeApi(overrides: FakeData = {}): FakeApi {
   const calls: string[] = [];
   const disposed: string[] = [];
+  const destroyedBrowserViews: string[] = [];
   const sent: { id: string; text: string; attachments: Attachment[]; mentions?: string[] }[] = [];
   const data: Required<FakeData> = {
     profiles: overrides.profiles ?? [profile("p1", "Work"), profile("p2", "School")],
@@ -394,7 +397,7 @@ export function fakeApi(overrides: FakeData = {}): FakeApi {
     };
   };
   const api: FakeApi = {
-    calls, disposed, sent, mcpWrites, importApplied, delays: {}, onCreateTerminal: null, data,
+    calls, disposed, destroyedBrowserViews, sent, mcpWrites, importApplied, delays: {}, onCreateTerminal: null, data,
     // Plan 17 W1. An in-memory filesystem keyed by workspace id: enough for the store's own tests to
     // exercise open/save without touching disk. The DocumentsPane's own behaviour is covered by
     // buffers.test.ts (the transitions) and the server's service.test.ts (the real filesystem).
@@ -618,6 +621,7 @@ export function fakeApi(overrides: FakeData = {}): FakeApi {
       return { path: `/realm-home/tmp/attachments/aa-${name}`, mime: mime || "application/octet-stream", name, size: bytes.byteLength };
     },
     disposeTerminal: (id) => { disposed.push(id); },
+    destroyBrowserView: (id) => { destroyedBrowserViews.push(id); },
     listSessions: async (sid) => { calls.push(`listSessions:${sid}`); return data.sessions.filter((s) => s.spaceId === sid); },
     listAllSessions: async () => { calls.push("listAllSessions"); await wait("listAllSessions"); return [...data.sessions]; },
     getSession: async (id) => { calls.push(`getSession:${id}`); const s = data.sessions.find((x) => x.id === id); if (!s) throw new Error(`no session ${id}`); return s; },

--- a/apps/desktop/src/renderer/src/state/store.test.ts
+++ b/apps/desktop/src/renderer/src/state/store.test.ts
@@ -398,6 +398,16 @@ describe("app store", () => {
       expect(api.destroyedBrowserViews).toEqual(["b9"]);
     });
 
+    it("the driving signal survives the switch too — the dot is there on the way back", async () => {
+      const store = createAppStore(api);
+      await store.getState().boot();
+      await openBrowser(store);
+      store.getState().applyBrowserDriving({ browserId: "b9", driving: true });
+      await store.getState().selectSpace("s2");
+      await store.getState().selectSpace("s1");
+      expect(store.getState().browserDriving["b9"]).toBe(true);
+    });
+
     it("closing a pane that is not a browser destroys no view", async () => {
       const store = createAppStore(api);
       await store.getState().boot();

--- a/apps/desktop/src/renderer/src/state/store.test.ts
+++ b/apps/desktop/src/renderer/src/state/store.test.ts
@@ -362,6 +362,51 @@ describe("app store", () => {
     expect(api.calls.filter((c) => c.startsWith("setGroups:s1")).length).toBe(persists + 1); // the close itself persisted
   });
 
+  /**
+   * Which of the two ways a browser pane can leave the screen ends its native view. Only one does:
+   * the view is a whole renderer process holding a live page, and a space switch is not a close.
+   */
+  describe("a browser's native view outlives the space, not the close", () => {
+    const openBrowser = async (store: ReturnType<typeof createAppStore>) => {
+      api.data.items["s1"]!.push(item("i9", "s1", { kind: "browser", title: "web", refId: "b9" }));
+      await store.getState().refreshItems();
+      await store.getState().openItem("i9");
+    };
+
+    it("switching space leaves the view alone — the page keeps running off screen", async () => {
+      const store = createAppStore(api);
+      await store.getState().boot();
+      await openBrowser(store);
+      await store.getState().selectSpace("s2");
+      expect(store.getState().activeSpaceId).toBe("s2");
+      expect(api.destroyedBrowserViews).toEqual([]);
+    });
+
+    it("closing the pane destroys the view — the one act that means the user is done with it", async () => {
+      const store = createAppStore(api);
+      await store.getState().boot();
+      await openBrowser(store);
+      await store.getState().closeFromLayout("i9");
+      expect(api.destroyedBrowserViews).toEqual(["b9"]);
+    });
+
+    it("deleting the item destroys the view too", async () => {
+      const store = createAppStore(api);
+      await store.getState().boot();
+      await openBrowser(store);
+      await store.getState().deleteItem("i9");
+      expect(api.destroyedBrowserViews).toEqual(["b9"]);
+    });
+
+    it("closing a pane that is not a browser destroys no view", async () => {
+      const store = createAppStore(api);
+      await store.getState().boot();
+      await store.getState().openItem("i1");
+      await store.getState().closeFromLayout("i1");
+      expect(api.destroyedBrowserViews).toEqual([]);
+    });
+  });
+
   describe("agent-opened panes arrive beside, never replacing (live-found deadlock)", () => {
     it("openItemBeside splits right of an occupied focused leaf and opens there", async () => {
       const store = createAppStore(api);

--- a/apps/desktop/src/renderer/src/state/store.ts
+++ b/apps/desktop/src/renderer/src/state/store.ts
@@ -140,6 +140,9 @@ export type Api = {
   saveTempAttachment(name: string, mime: string, bytes: Uint8Array): Promise<PickedAttachment>;
   /** Drop the renderer-side xterm instance/scrollback for a closed terminal. */
   disposeTerminal(terminalId: string): void;
+  /** Destroy the native WebContentsView behind a browser item. The pane unmounting does NOT do this
+   *  — it only releases the view — so closing and deleting have to say so themselves. */
+  destroyBrowserView(browserId: string): void;
   /** The space icon picker's per-profile library (`iconAssets.*`). */
   listIconAssets(profileId: string): Promise<IconAsset[]>;
   /** One-shot Claude call; can take a few seconds. Throws `ICON_INVALID`/`ICON_TOO_LARGE` on a
@@ -2119,6 +2122,12 @@ export function createAppStore(api: Api): StoreApi<AppState> {
         await persist();
       },
       async closeFromLayout(itemId) {
+        // Closing is the one thing that ends a browser's view. An unmounting pane only releases it
+        // (it may just be a space switch), and this runs for every close path there is — the panel
+        // bar's ×, ⌘W, the sidebar row, archive and delete — including the other-group branch below,
+        // where the view is already off screen and alive.
+        const closing = get().items.find((i) => i.id === itemId);
+        if (closing?.kind === "browser") api.destroyBrowserView(closing.refId);
         // The pane may be open in a group other than the one on screen (the sidebar lists every
         // group's rows): close it where it actually is, and leave the active arrangement alone.
         const gs = get().groups;


### PR DESCRIPTION
Stacked on #33.

**What the behaviour actually was**, confirmed rather than assumed: `selectSpace` empties `items` and swaps `layout` in one `set`, so `PaneHost` — which renders only the active space's tree and deliberately unmounts rather than hides — tears down every pane. `BrowserPane`'s cleanup then destroyed the `WebContentsView`, taking the page, its history, its scroll position and any in-flight work with it. The pre-existing test was even named "unmount destroys the native view — no hidden survival". The deferred destroy did not save it: that macrotask fires long before you switch back. Pane-group switches had the identical shape.

**Ownership moved from the pane to the store.** Main already held the views; what changed is who decides destruction. A pane unmounting now *retains* — main hides the view and keeps the process — and only an explicit close destroys, driven from `closeFromLayout`, the single choke point for every real close (panel-bar ×, ⌘W, sidebar row, archive, delete, and the branch closing a pane in a non-active group). The pane is the wrong place to make that call because it cannot see *why* it is going away; the store can.

**Policy: an LRU cap of 3 off-screen views, no idle timeout.** At most (panes on screen) + 3 renderer processes; the fourth least-recently-used background browser is destroyed and reloads on return. A cap beats a timeout because a timeout makes survival depend on wall-clock luck — "I was at lunch" — while a cap depends on how many browsers you are juggling, which is something you can see and control. Agent activity bumps recency ahead of the CDP attachment cache, so *every* op counts and a long background task cannot be evicted out from under itself.

**Throttling was measured, not reasoned about.** A scratch Electron probe on 37.10.3 showed that a `setVisible(false)` view **still accepts CDP `Input.dispatchMouseEvent`** — so driving was never at risk — **but drops a 50ms interval to ~1/sec and reports `document.visibilityState === "hidden"`**, which is a page's own cue to stop polling and stall streams. So the requirement at risk was "works in the background", not "stays drivable". `backgroundThrottling: false` fixes it: 22 ticks/sec while hidden, and the page still reads itself as visible.

**Live proof it survives without reloading.** The check loads a `data:` page, sets a runtime-only global, types into an input, scrolls to 1200px and clicks; retains; re-adopts. The global, the form value, the scroll offset and the click count all survive — a reload would zero every one. Alongside it: the view really is invisible while retained (a screen sample over its rect returns the DOM decoy's green, not the page's red), ticks run at 22/sec, a CDP click lands while hidden, and retaining a fourth view destroys the oldest for real.

`shouldShowView` is unchanged — off-screen still means invisible; persisting is about the process staying alive, not pixels leaking across a space.

**Known bound, stated rather than hidden:** nothing is hooked into `refreshItems`, because it runs on every space switch carrying only the *new* space's items — destroying "items no longer live" there would destroy precisely the views this preserves. So a browser deleted from another window leaves a retained view until the LRU evicts it or the window closes. Bounded, not leaked. There is also no UI when an eviction happens; you just get a reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)