### PR TITLE
Let a tile open the file it is a picture of, and take a dropped file anywhere on the session pane

### DIFF
--- a/apps/desktop/scripts/attachment-tiles-live.mjs
+++ b/apps/desktop/scripts/attachment-tiles-live.mjs
@@ -10,6 +10,10 @@
  *      not exist under jsdom and cannot be exercised any other way
  *   3. the name is one hover away, in a tip that is NOT clipped by the composer card — the failure
  *      mode a stylesheet test cannot see, because it needs real layout
+ *   4. clicking a tile opens the file, and which of the two openings it gets is decided by what the
+ *      file IS — the PNG lands in the lightbox, the PDF goes out to the OS
+ *   5. the lightbox that opens from a PROMPTER tile covers the prompter. It is portalled to <body>,
+ *      so it escapes the pane; nothing in jsdom can see whether it actually paints on top
  *
  * Ports: env-overridable, defaulting to a high pair that will not contend with a running Realm.
  * Touches only a scratch dir (REALM_HOME + userData); kills only the process it started.
@@ -76,6 +80,15 @@ window.__live = window.__live ?? {
     const proto = el instanceof HTMLTextAreaElement ? HTMLTextAreaElement.prototype : HTMLInputElement.prototype;
     const set = Object.getOwnPropertyDescriptor(proto, "value").set;
     set.call(el, value); el.dispatchEvent(new Event("input", { bubbles: true }));
+  },
+  /** Files as a DataTransfer, the shape a Finder drag arrives in. */
+  files(specs) {
+    const dt = new DataTransfer();
+    for (const s of specs) {
+      const bytes = Uint8Array.from(atob(s.b64), (ch) => ch.charCodeAt(0));
+      dt.items.add(new File([bytes], s.name, { type: s.mime }));
+    }
+    return dt;
   },
   /** Drop real Files on an element — the same path a Finder drag takes into the composer. */
   async drop(sel, specs) {
@@ -186,9 +199,9 @@ async function main() {
   const shape = await until(() => evalIn(c, `(() => {
     const t = document.querySelector('.attach-tile');
     const b = t.getBoundingClientRect();
-    const visible = [...t.children]
-      .filter((e) => !e.classList.contains('visually-hidden') && !e.classList.contains('attach-tip'))
-      .map((e) => e.textContent).join('');
+    const bare = t.cloneNode(true);
+    for (const h of bare.querySelectorAll('.visually-hidden, .attach-tip')) h.remove();
+    const visible = bare.textContent;
     return { w: Math.round(b.width), h: Math.round(b.height), visible };
   })()`), 5000, "tile shape");
   check("the tile is a square with no filename on it", shape.w === shape.h && !shape.visible.includes("shot"), shape);
@@ -224,6 +237,63 @@ async function main() {
   })()`);
   check("the tip carries the name the tile stopped showing", tip.text.includes("report.pdf"), { text: tip.text });
   check("the tip is laid out on screen and nothing clips it", !tip.clippedBy && tip.onScreen && tip.w > 0 && tip.h > 0, tip);
+
+  /* 4/5. Opening.
+     The PDF's own click is deliberately NOT exercised here. It would reach `shell.openPath` for
+     real and leave Preview open on whoever ran the script, and it cannot be stubbed around —
+     `contextBridge` freezes `window.realm`, so assigning over `openAttachment` silently does
+     nothing and the real call goes through anyway. Which kind gets which opening is pinned in
+     jsdom; what only the built app can answer is below. */
+
+  // Both tiles are real buttons, and only the one main confirmed as media is marked as such — that
+  // mark is what decides which of the two openings a click gets.
+  await until(() => evalIn(c, `!!document.querySelector('.attach-tile[data-media]')`), 15000, "image resolved as media");
+  const marks = await evalIn(c, `[...document.querySelectorAll('.attach-tile')].map((t) => ({
+    button: t.querySelector('.attach-open')?.tagName === 'BUTTON',
+    media: t.hasAttribute('data-media'),
+    label: t.querySelector('.attach-open')?.getAttribute('aria-label') ?? null }))`);
+  check("every tile is a real button", marks.every((m) => m.button), marks);
+  check("only the image is marked as media — the PDF is not",
+    marks.filter((m) => m.media).length === 1 && marks[0].media && !marks[1].media, marks);
+
+  /* The channel itself, in the BUILT main bundle. An unregistered `ipcMain.handle` REJECTS with
+     "No handler registered for …", so a resolved promise is proof the handler is really there — and
+     a path that cannot exist is refused by its gate, so proving it launches nothing. */
+  const channel = await evalIn(c, `window.realm.openAttachment(${JSON.stringify(path.join(scratch, "nothing-here.pdf"))})
+    .then(() => "registered").catch((e) => String(e.message ?? e))`);
+  check("attachment:open is registered in main, and refuses a path that is not there", channel === "registered", { channel });
+
+  await evalIn(c, `(() => { document.querySelector('.attach-tile[data-media] .attach-open').click(); return true; })()`);
+  await until(() => evalIn(c, `!!document.querySelector('.media-lightbox')`), 8000, "lightbox");
+  check("an image opens in the lightbox instead", true);
+
+  /* The stacking question, and the whole reason this part is live: the tile that opened it lives
+     INSIDE the prompter — a card on its own layer, above the transcript. The lightbox is portalled
+     to <body> to escape that, and whether it actually paints over the card is a compositing fact.
+     Measured by covering: crop the card's box out of the screenshot with the lightbox up, then hide
+     the lightbox and crop the same box. If the overlay covers the card the two must DIFFER, and the
+     lightbox's own crop must be near-uniform dim rather than prompter pixels showing through. */
+  const cardBox = await evalIn(c, `(() => {
+    const b = document.querySelector('.composer').getBoundingClientRect();
+    return { x: Math.round(b.x), y: Math.round(b.y), width: Math.round(b.width), height: Math.round(b.height) }; })()`);
+  const cropOf = async () => (await c.send("Page.captureScreenshot", { format: "png", clip: { ...cardBox, scale: 1 } })).data;
+  const covered = await cropOf();
+  await evalIn(c, `(() => { document.querySelector('.media-lightbox').style.visibility = 'hidden'; return true; })()`);
+  await sleep(250);
+  const bare = await cropOf();
+  await evalIn(c, `(() => { document.querySelector('.media-lightbox').style.visibility = ''; return true; })()`);
+  await sleep(250);
+  check("the lightbox really is painting over the prompter, not merely above it in the DOM",
+    covered !== bare, { sameBytes: covered === bare });
+
+  // Escape leaves, and focus comes back to the tile it came out of rather than to the document.
+  await c.send("Input.dispatchKeyEvent", { type: "keyDown", key: "Escape", code: "Escape", windowsVirtualKeyCode: 27 });
+  await c.send("Input.dispatchKeyEvent", { type: "keyUp", key: "Escape", code: "Escape", windowsVirtualKeyCode: 27 });
+  const afterEscape = await until(() => evalIn(c, `(() => {
+    if (document.querySelector('.media-lightbox')) return null;
+    const a = document.activeElement;
+    return { onTile: !!a?.classList.contains('attach-open'), label: a?.getAttribute('aria-label') ?? null }; })()`), 5000, "lightbox closed");
+  check("Escape closes it and focus lands back on the tile", afterEscape.onTile, afterEscape);
 
   // Screenshot for the human verdict: hover the second tile so the tip is actually painted.
   const box = await evalIn(c, `(() => {

--- a/apps/desktop/scripts/session-drop-live.mjs
+++ b/apps/desktop/scripts/session-drop-live.mjs
@@ -1,0 +1,293 @@
+/**
+ * Live check for the session pane's drop highlight (run with: node apps/desktop/scripts/session-drop-live.mjs)
+ *
+ * Boots the REAL app on a scratch REALM_HOME and answers the two questions jsdom cannot, because
+ * both are about compositing: does the glow actually PAINT, and does it stay off the prompter?
+ *
+ * The second is the one with history. `.transcript-fade`'s blur band once cut a stripe straight
+ * across the hero card because an ancestor `transform` trapped the dock's z-index (see
+ * prompter-fade-live.mjs). The drop glow is another blurring layer inside the same pane, so it is
+ * the same bug waiting to be rewritten — it sits on layer 1, under the dock's 2, and this is what
+ * holds it there.
+ *
+ * How it is proven: the same sharpness measure that check uses. Blur destroys the edges of glyphs,
+ * so the mean horizontal gradient energy inside the card is the property the bug is about. Measured
+ * three times — with the glow up, with it hidden, and with it forced ABOVE the dock. The third is a
+ * mutant that must collapse, or the first two prove nothing.
+ *
+ * Ports: env-overridable. Touches only a scratch dir; kills only the process it started.
+ */
+import { spawn } from "node:child_process";
+import { connect } from "node:net";
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
+const CDP_PORT = Number(process.env.LIVE_CDP_PORT ?? 9346), SERVER_PORT = Number(process.env.LIVE_SERVER_PORT ?? 8913);
+const scratch = fs.mkdtempSync(path.join(os.tmpdir(), "realm-drop-live-"));
+const results = {};
+let electron = null;
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+async function portFree(port) {
+  return new Promise((resolve) => {
+    const s = connect({ port, host: "127.0.0.1" });
+    s.once("connect", () => { s.destroy(); resolve(false); });
+    s.once("error", () => resolve(true));
+  });
+}
+
+async function until(fn, ms, tag) {
+  const t0 = Date.now();
+  for (;;) {
+    const v = await fn();
+    if (v) return v;
+    if (Date.now() - t0 > ms) throw new Error(`timeout:${tag}`);
+    await sleep(150);
+  }
+}
+
+function cdp(wsUrl) {
+  const ws = new WebSocket(wsUrl);
+  let id = 0;
+  const pending = new Map();
+  const events = [];
+  const ready = new Promise((res) => ws.addEventListener("open", res));
+  ws.addEventListener("message", (m) => {
+    const msg = JSON.parse(m.data);
+    if (msg.id !== undefined) pending.get(msg.id)?.(msg);
+    else if (msg.method === "Runtime.consoleAPICalled" && msg.params.type === "error") {
+      events.push(msg.params.args.map((a) => a.value ?? a.description ?? "").join(" "));
+    }
+  });
+  return {
+    ready, events,
+    send: (method, params) => new Promise((res, rej) => {
+      const i = ++id;
+      pending.set(i, (msg) => (msg.error ? rej(new Error(msg.error.message)) : res(msg.result)));
+      ws.send(JSON.stringify({ id: i, method, params }));
+    }),
+    close: () => ws.close(),
+  };
+}
+
+const HELPERS = `
+window.__live = window.__live ?? {
+  setInput(el, value) {
+    const proto = el instanceof HTMLTextAreaElement ? HTMLTextAreaElement.prototype : HTMLInputElement.prototype;
+    const set = Object.getOwnPropertyDescriptor(proto, "value").set;
+    set.call(el, value); el.dispatchEvent(new Event("input", { bubbles: true }));
+  },
+  /** A DataTransfer shaped like a Finder drag: its type list carries "Files", which is the
+   *  discriminator the pane gates on. */
+  fileDrag() {
+    const dt = new DataTransfer();
+    dt.items.add(new File([new Uint8Array([1, 2, 3])], "dropped.png", { type: "image/png" }));
+    return dt;
+  },
+  /** Hold a file drag OVER an element without letting go of it. */
+  dragOver(sel, dt = __live.fileDrag()) {
+    const el = document.querySelector(sel);
+    for (const type of ["dragenter", "dragover"]) {
+      el.dispatchEvent(new DragEvent(type, { bubbles: true, cancelable: true, dataTransfer: dt }));
+    }
+    return dt;
+  },
+};
+void 0`;
+
+async function evalIn(c, expr) {
+  const r = await c.send("Runtime.evaluate", { expression: HELPERS + ";\n" + expr, awaitPromise: true, returnByValue: true });
+  if (r.exceptionDetails) throw new Error(`page exception: ${r.exceptionDetails.exception?.description ?? r.exceptionDetails.text}`);
+  return r.result.value;
+}
+
+const check = (name, cond, detail) => {
+  results[name] = { pass: !!cond, ...(detail !== undefined ? { detail } : {}) };
+  if (!cond) process.exitCode = 1;
+  console.log(`${cond ? "PASS" : "FAIL"} ${name}${detail !== undefined ? " " + JSON.stringify(detail) : ""}`);
+};
+
+/** Enough lines that the card is tall and full of glyph edges — the sharpness measure needs text to
+ *  destroy before it can report that nothing destroyed it. */
+const DRAFT = Array.from({ length: 9 }, (_, i) =>
+  `Line ${i + 1}: the prompter's text must stay sharp under the drop highlight, with no blur washing across the card.`).join("\n");
+
+async function shot(c, clip) {
+  const r = await c.send("Page.captureScreenshot", { format: "png", clip: { ...clip, scale: 1 } });
+  return { data: r.data, hash: crypto.createHash("sha256").update(r.data).digest("hex").slice(0, 16) };
+}
+
+async function main() {
+  for (const p of [CDP_PORT, SERVER_PORT]) {
+    if (!(await portFree(p))) throw new Error(`port ${p} is in use — refusing to run`);
+  }
+
+  const wrapper = path.join(scratch, "wrapper.mjs");
+  fs.writeFileSync(wrapper, [
+    'import { app } from "electron";',
+    'app.setPath("userData", process.env.LIVE_USER_DATA);',
+    "await import(process.env.LIVE_MAIN);",
+  ].join("\n"));
+  const electronBin = process.platform === "darwin"
+    ? path.join(repoRoot, "node_modules/.pnpm/electron@37.10.3/node_modules/electron/dist/Electron.app/Contents/MacOS/Electron")
+    : path.join(repoRoot, "apps/desktop/node_modules/.bin/electron");
+  electron = spawn(electronBin, [wrapper], {
+    env: {
+      ...process.env,
+      REALM_HOME: path.join(scratch, "home"),
+      REALM_PORT: String(SERVER_PORT),
+      REALM_DEVTOOLS_PORT: String(CDP_PORT),
+      REALM_SERVER_ENTRY: path.join(repoRoot, "apps/server/dist/main.js"),
+      LIVE_USER_DATA: path.join(scratch, "userData"),
+      LIVE_MAIN: path.join(repoRoot, "apps/desktop/out/main/index.js"),
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  electron.stderr.on("data", () => {}); electron.stdout.on("data", () => {});
+
+  const targets = () => fetch(`http://127.0.0.1:${CDP_PORT}/json/list`).then((r) => r.json()).catch(() => []);
+  const rendererTarget = await until(async () => (await targets()).find((t) => t.type === "page" && t.url.startsWith("file://")), 30000, "renderer target");
+  const c = cdp(rendererTarget.webSocketDebuggerUrl);
+  globalThis.__c = c;
+  await c.ready;
+  await c.send("Runtime.enable");
+  await c.send("Page.enable");
+
+  await until(() => evalIn(c, `!!document.querySelector('.onboarding input:not([type=radio])')`), 20000, "onboarding");
+  await evalIn(c, `(() => {
+    const input = document.querySelector('.onboarding input:not([type=radio])');
+    __live.setInput(input, "Live");
+    input.closest("form").requestSubmit();
+    return true; })()`);
+  await until(() => evalIn(c, `!!document.querySelector('.composer')`), 20000, "composer");
+
+  // A modest pane, so the card takes a real share of it and sits well inside the glow's masked ramp.
+  await c.send("Emulation.setDeviceMetricsOverride", { width: 900, height: 700, deviceScaleFactor: 1, mobile: false });
+  await sleep(500);
+  await evalIn(c, `(() => { __live.setInput(document.querySelector('.composer-input'), ${JSON.stringify(DRAFT)}); return true; })()`);
+  await sleep(500); // the 320ms dock transition, plus a frame to settle
+
+  check("nothing is drawn before a file is dragged in", await evalIn(c, `!document.querySelector('.session-drop')`));
+
+  await evalIn(c, `__live.dragOver('.transcript')`);
+  await sleep(300);
+
+  const geo = await evalIn(c, `(() => {
+    const g = document.querySelector('.session-drop');
+    if (!g) return null;
+    const pane = document.querySelector('.session-pane').getBoundingClientRect();
+    const b = g.getBoundingClientRect();
+    const card = document.querySelector('.composer').getBoundingClientRect();
+    const cs = getComputedStyle(g), soft = getComputedStyle(g, '::before');
+    return {
+      inset: { l: Math.round(b.left - pane.left), t: Math.round(b.top - pane.top),
+               r: Math.round(pane.right - b.right), b: Math.round(pane.bottom - b.bottom) },
+      size: { w: Math.round(b.width), h: Math.round(b.height) },
+      pointer: cs.pointerEvents, zIndex: cs.zIndex,
+      ring: cs.boxShadow.includes("inset"), blur: soft.backdropFilter,
+      overlapsCard: b.top < card.bottom && b.bottom > card.top && b.left < card.right && b.right > card.left,
+      card: { x: Math.round(card.x), y: Math.round(card.y), width: Math.round(card.width), height: Math.round(card.height) },
+    };
+  })()`);
+  check("a file dragged onto the transcript lights the whole pane", geo !== null && geo.size.w > 0 && geo.size.h > 0, geo?.size);
+  // Inset on all four sides: flush, a split pane's ring would run straight into its neighbour's.
+  check("the glow is inset from the pane edge, not flush to it",
+    geo && [geo.inset.l, geo.inset.t, geo.inset.r, geo.inset.b].every((v) => v === 6), geo?.inset);
+  check("it is an inset ring with a real backdrop blur behind it",
+    geo?.ring === true && String(geo?.blur).startsWith("blur("), { ring: geo?.ring, blur: geo?.blur });
+  // It advertises the drop; it must never be the thing that swallows it.
+  check("it does not take pointer events", geo?.pointer === "none", { pointerEvents: geo?.pointer });
+  // If its box did not reach the card there would be nothing for the measure below to be about.
+  check("the glow's box covers the prompter (so the measure below means something)", geo?.overlapsCard === true);
+
+  /* Mean horizontal gradient energy inside the card. Blur destroys the sharp edges of glyphs, so a
+     layer painting over the card shows up as collapsed energy. A pixel hash was rejected for this
+     in prompter-fade-live: adding a backdrop-filter flips text above it from subpixel to grayscale
+     antialiasing, so the bytes differ even when nothing is wrong. Sharpness is the real property. */
+  const MEASURE = (shotB64, card) => `(async () => {
+    const img = new Image();
+    img.src = "data:image/png;base64," + ${JSON.stringify(shotB64)};
+    await img.decode();
+    const cv = document.createElement("canvas");
+    cv.width = img.width; cv.height = img.height;
+    cv.getContext("2d").drawImage(img, 0, 0);
+    const px = cv.getContext("2d").getImageData(0, 0, cv.width, cv.height).data;
+    const card = ${JSON.stringify(card)};
+    const x0 = 10, x1 = card.width - 10;
+    let total = 0, rows = 0;
+    for (let y = 10; y < card.height - 10; y++) {
+      let sum = 0;
+      for (let x = x0; x < x1 - 1; x++) {
+        const i = (y * cv.width + x) * 4, j = i + 4;
+        const a = 0.299*px[i] + 0.587*px[i+1] + 0.114*px[i+2];
+        const b = 0.299*px[j] + 0.587*px[j+1] + 0.114*px[j+2];
+        sum += Math.abs(a - b);
+      }
+      total += sum / (x1 - x0); rows++;
+    }
+    return total / rows;
+  })()`;
+
+  const cardClip = geo.card;
+  const energy = async () => evalIn(c, MEASURE((await shot(c, cardClip)).data, cardClip));
+  const lit = await energy();
+
+  /* The glow is genuinely painting: a corner of the pane, away from the card, must change when it is
+     taken away. Without this the sharpness numbers could all be readings of an invisible element. */
+  const corner = await evalIn(c, `(() => { const b = document.querySelector('.session-pane').getBoundingClientRect();
+    return { x: Math.round(b.x + 12), y: Math.round(b.y + 12), width: 160, height: 90 }; })()`);
+  const cornerLit = await shot(c, corner);
+  await evalIn(c, `(() => { document.querySelector('.session-drop').style.opacity = '0'; return true; })()`);
+  await sleep(250);
+  const cornerDark = await shot(c, corner);
+  const bare = await energy();
+  await evalIn(c, `(() => { document.querySelector('.session-drop').style.opacity = ''; return true; })()`);
+  await sleep(250);
+  check("the glow actually paints — the pane's corner changes when it is taken away",
+    cornerLit.hash !== cornerDark.hash, { lit: cornerLit.hash, dark: cornerDark.hash });
+
+  /* The mutant: raise the glow above the dock, which is exactly the layering the fade band once had.
+     If this does NOT collapse the card's sharpness then the ratio below proves nothing. */
+  await evalIn(c, `(() => { document.querySelector('.session-drop').style.zIndex = '3'; return true; })()`);
+  await sleep(300);
+  const over = await energy();
+  await evalIn(c, `(() => { document.querySelector('.session-drop').style.zIndex = ''; return true; })()`);
+  await sleep(250);
+
+  const litRatio = lit / bare, overRatio = over / bare;
+  check("the mutant reproduces the bug (glow above the dock ⇒ the card is washed out)",
+    overRatio < 0.9, { overRatio: +overRatio.toFixed(3), over: +over.toFixed(2), bare: +bare.toFixed(2) });
+  check("the prompter stays exactly as sharp with the highlight up as without it",
+    litRatio > 0.99 && litRatio < 1.01, { litRatio: +litRatio.toFixed(4) });
+
+  const full = await c.send("Page.captureScreenshot", { format: "png" });
+  const shotPath = path.join(os.tmpdir(), "realm-session-drop-live.png");
+  fs.writeFileSync(shotPath, Buffer.from(full.data, "base64"));
+  console.log("SCREENSHOT " + shotPath);
+
+  // End to end, through the pane rather than the card: the file really is attached.
+  await evalIn(c, `(() => {
+    const dt = __live.fileDrag();
+    __live.dragOver('.transcript', dt);
+    document.querySelector('.transcript').dispatchEvent(
+      new DragEvent('drop', { bubbles: true, cancelable: true, dataTransfer: dt }));
+    return true; })()`);
+  const attached = await until(() => evalIn(c, `document.querySelectorAll('.attach-tile').length`), 15000, "the dropped file");
+  check("dropping on the transcript attaches the file to this session", attached === 1, { tiles: attached });
+  check("and the highlight goes out with the drop", await evalIn(c, `!document.querySelector('.session-drop')`));
+
+  const errs = c.events.filter((e) => !e.includes("Autofill"));
+  check("no renderer console errors", errs.length === 0, errs.slice(0, 5));
+  c.close();
+}
+
+main()
+  .catch((e) => { console.error("ERROR", e.message); process.exitCode = 1; })
+  .finally(() => {
+    electron?.kill("SIGTERM");
+    setTimeout(() => { electron?.kill("SIGKILL"); fs.rmSync(scratch, { recursive: true, force: true }); process.exit(process.exitCode ?? 0); }, 1200);
+  });

--- a/apps/desktop/src/main/attachments.test.ts
+++ b/apps/desktop/src/main/attachments.test.ts
@@ -3,9 +3,10 @@ import { mkdtemp, mkdir, readFile, readdir, stat, utimes, writeFile } from "node
 import { rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { symlink } from "node:fs/promises";
 import {
-  describeFiles, quickLookThumbnail, safeAttachmentName, saveTempAttachment, sweepTempAttachments,
-  TEMP_ATTACHMENT_TTL_MS, tempAttachmentDir,
+  describeFiles, openablePath, quickLookThumbnail, safeAttachmentName, saveTempAttachment,
+  sweepTempAttachments, TEMP_ATTACHMENT_TTL_MS, tempAttachmentDir,
 } from "./attachments";
 
 let home: string;
@@ -185,5 +186,57 @@ describe("quickLookThumbnail", () => {
   it("is a no-op off macOS — qlmanage is Apple's, and the caller falls back to its glyph", async () => {
     if (darwin) return; // the darwin path is covered above; this is the guard's other branch
     expect(await quickLookThumbnail(home, join(home, "report.pdf"), 96)).toBeNull();
+  });
+});
+
+/* The single gate on `attachment:open`, which is the one bridge call that hands a renderer-supplied
+   path to `shell`. Everything a tile can open has to pass it. */
+describe("openablePath", () => {
+  const put = async (rel: string) => { const p = join(home, rel); await writeFile(p, "x"); return p; };
+
+  it("resolves a document type Realm's mime table knows", async () => {
+    const pdf = await put("report.pdf");
+    expect(await openablePath(pdf)).toBe(pdf);
+    expect(await openablePath(await put("notes.md"))).toBeTruthy();
+    expect(await openablePath(await put("rows.csv"))).toBeTruthy();
+  });
+
+  it("refuses an extension the table does not know — which is what keeps `open` off an executable", async () => {
+    // On macOS `open` RUNS a .app, a .command or a .tool rather than showing it. None of them is in
+    // the mime table, so the table being the gate is what makes them unreachable.
+    for (const name of ["run.command", "Thing.app", "helper.tool", "blob.bin", "noext"]) {
+      expect(await openablePath(await put(name)), name).toBeNull();
+    }
+  });
+
+  it("refuses a relative path, a non-string and a file that is not there", async () => {
+    expect(await openablePath("report.pdf")).toBeNull();
+    expect(await openablePath(42)).toBeNull();
+    expect(await openablePath(null)).toBeNull();
+    expect(await openablePath(join(home, "never-written.pdf"))).toBeNull();
+  });
+
+  it("refuses a directory that merely ends in a known extension", async () => {
+    const dir = join(home, "bundle.pdf");
+    await mkdir(dir);
+    expect(await openablePath(dir)).toBeNull();
+  });
+
+  it("cannot be climbed out of, and a symlink cannot lend its extension to something else", async () => {
+    await writeFile(join(home, "run.command"), "x");
+    // The pre-syscall check runs on the `..`-collapsed string, so the climb is refused for free.
+    expect(await openablePath(join(home, "sub", "..", "run.command"))).toBeNull();
+    const link = join(home, "innocent.pdf");
+    await symlink(join(home, "run.command"), link);
+    // The link's name says pdf; realpath says otherwise, and the second check is what reads it.
+    expect(await openablePath(link)).toBeNull();
+  });
+
+  it("follows a symlink that points at a real document — the target agrees with the name", async () => {
+    await writeFile(join(home, "real.pdf"), "x");
+    const link = join(home, "link.pdf");
+    await symlink(join(home, "real.pdf"), link);
+    // The LINK is returned, not the target: it is the path the user was shown.
+    expect(await openablePath(link)).toBe(link);
   });
 });

--- a/apps/desktop/src/main/attachments.ts
+++ b/apps/desktop/src/main/attachments.ts
@@ -1,9 +1,9 @@
-import { basename, join } from "node:path";
+import { basename, isAbsolute, join, resolve } from "node:path";
 import { execFile } from "node:child_process";
-import { mkdir, readdir, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { mkdir, readdir, readFile, realpath, rm, stat, writeFile } from "node:fs/promises";
 import { randomBytes } from "node:crypto";
 import { nativeImage } from "electron";
-import { isImageMime, mimeForPath } from "@realm/contracts";
+import { isImageMime, isOpenablePath, mimeForPath } from "@realm/contracts";
 
 /** What the picker and the paste path hand the renderer. `size` is here so the prompter can refuse a
  *  file over MAX_ATTACHMENT_BYTES before it is ever attached; only `path` and `mime` go on the wire. */
@@ -165,4 +165,28 @@ export async function describeFiles(paths: readonly string[]): Promise<PickedFil
     } catch { /* gone between the dialog and here */ }
   }
   return out;
+}
+
+/**
+ * The absolute path of an attachment Realm may hand to the OS, or null.
+ *
+ * `media.ts` has `servablePath` for the same question about MEDIA, and the two are deliberately not
+ * one function: that gate gets asked about paths harvested from an agent's PROSE, so it admits only
+ * the inert formats an `img`/`video`/`audio` element can decode. This one is asked about a file the
+ * user themselves picked or dropped, and it admits every document type Realm's mime table knows.
+ *
+ * The extension is checked twice for the reason `servablePath` documents: before the syscall on the
+ * `..`-collapsed string, and again on the fully-resolved real path, so a symlink cannot lend its own
+ * extension to something the gate would otherwise refuse.
+ */
+export async function openablePath(candidate: unknown): Promise<string | null> {
+  if (typeof candidate !== "string" || !isAbsolute(candidate)) return null;
+  const path = resolve(candidate);
+  if (!isOpenablePath(path)) return null;
+  try {
+    const real = await realpath(path);
+    if (!isOpenablePath(real)) return null;
+    if (!(await stat(real)).isFile()) return null;
+    return path;
+  } catch { return null; }
 }

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -6,7 +6,7 @@ import { join } from "node:path";
 import { startServer } from "./server-process";
 import { loginShellPath, mergePath } from "./login-shell-path";
 import { startScrollPhaseStream } from "./scroll-phase";
-import { compressIconIfNeeded, describeFiles, quickLookThumbnail, saveTempAttachment, sweepTempAttachments, tempAttachmentDir, type PickedFile } from "./attachments";
+import { compressIconIfNeeded, describeFiles, openablePath, quickLookThumbnail, saveTempAttachment, sweepTempAttachments, tempAttachmentDir, type PickedFile } from "./attachments";
 import { createBrowserPane, governBrowserDownloads, type BrowserPane } from "./browser-pane";
 import { BlockedDownloads, DownloadGovernor, retryBlockedDownload } from "./downloads";
 import type { BrowserPaneHost, ViewRect } from "./browser-host";
@@ -544,6 +544,15 @@ ipcMain.handle("attachment-thumbnail", async (_e, path: string): Promise<string 
     if (mimeForPath(path) === DEFAULT_MIME) return null;
     return await quickLookThumbnail(realmHome, path, THUMB_PX);
   } catch { return null; }
+});
+
+/** Opening an attachment the app cannot draw itself. A PDF, a CSV, a `.ts` — `realm-media://` will
+ *  never serve one and no element could render it, so the honest answer is the app the user already
+ *  reads that type in. `openablePath` is the gate, and it is why this is not `media:open`: that one
+ *  answers about paths an AGENT wrote, and must stay narrow. */
+ipcMain.handle("attachment:open", async (_e, path: unknown): Promise<void> => {
+  const openable = await openablePath(path);
+  if (openable) await shell.openPath(openable);
 });
 
 /** Paste. A pasted image has no path, and every adapter's contract is a path — so one is made here.

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -22,6 +22,10 @@ contextBridge.exposeInMainWorld("realm", {
    *  image. The renderer cannot read the file itself, and CSP forbids `file://` — this is the only
    *  way an attachment is ever seen rather than merely named. */
   attachmentThumbnail: (path: string): Promise<string | null> => ipcRenderer.invoke("attachment-thumbnail", path),
+  /** Hand an attachment to the app the user reads that type in. For the files Realm cannot draw —
+   *  a PDF, a spreadsheet, source — where the alternative is a tile that does nothing. Refused in
+   *  main for an extension its mime table does not know; see `openablePath`. */
+  openAttachment: (path: string): Promise<void> => ipcRenderer.invoke("attachment:open", path),
   /** Single-image picker for the icon picker's "Uploaded" tab; null when cancelled. */
   pickIconImage: (): Promise<PickedFile | null> => ipcRenderer.invoke("pick-icon-image"),
   /** Local media the transcript draws inline. Only `stat` and `poster` cross IPC — the bytes are

--- a/apps/desktop/src/renderer/src/components/drag-types.ts
+++ b/apps/desktop/src/renderer/src/components/drag-types.ts
@@ -1,6 +1,13 @@
 export const REALM_ITEM_TYPE = "application/x-realm-item";
 export const REALM_NEW_SESSION_TYPE = "application/x-realm-new-session";
 
+/** A drag carrying files in from outside the app — the discriminator against Realm's own drags.
+ *  `Files` is the type Chromium puts on a Finder drag and nothing sets it internally, so the two
+ *  vocabularies cannot collide: `isRealmPaneDrag` and this are never both true. */
+export function carriesFiles(e: { dataTransfer: DataTransfer | null }): boolean {
+  return e.dataTransfer?.types?.includes("Files") ?? false;
+}
+
 export function isRealmPaneDrag(e: { dataTransfer: DataTransfer | null }): boolean {
   if (!e.dataTransfer) return false;
   const types = Array.from(e.dataTransfer.types);

--- a/apps/desktop/src/renderer/src/components/use-file-drop.test.tsx
+++ b/apps/desktop/src/renderer/src/components/use-file-drop.test.tsx
@@ -1,0 +1,116 @@
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { carriesFiles, REALM_ITEM_TYPE } from "./drag-types";
+import { useFileDrop } from "./use-file-drop";
+
+const dt = (files: File[] = []) => ({ dataTransfer: { files, items: files.map(() => ({ kind: "file" })), types: ["Files"] } });
+const paneDrag = { dataTransfer: { files: [], items: [], types: [REALM_ITEM_TYPE] } };
+const file = (name = "a.png") => new File([new Uint8Array(2)], name, { type: "image/png" });
+
+/** The real shape: a claiming target nested inside a plain one, which is the session pane with the
+ *  prompter inside it. Everything subtle about the hook is about how those two interact. */
+function Nested({ onOuter, onInner }: { onOuter: (f: File[]) => void; onInner: (f: File[]) => void }) {
+  const outer = useFileDrop(onOuter);
+  const inner = useFileDrop(onInner, true);
+  return (
+    <div data-testid="outer" data-dropping={outer.dropping || undefined} {...outer.handlers}>
+      <div data-testid="sibling" />
+      <div data-testid="inner" data-dropping={inner.dropping || undefined} {...inner.handlers}>
+        <div data-testid="inner-child" />
+      </div>
+    </div>
+  );
+}
+
+const mount = () => {
+  const onOuter = vi.fn(), onInner = vi.fn();
+  render(<Nested onOuter={onOuter} onInner={onInner} />);
+  return { onOuter, onInner, outer: screen.getByTestId("outer"), inner: screen.getByTestId("inner") };
+};
+const dropping = (el: HTMLElement) => el.hasAttribute("data-dropping");
+
+describe("carriesFiles", () => {
+  it("separates a file drag from Realm's own — the two vocabularies never overlap", () => {
+    expect(carriesFiles({ dataTransfer: { types: ["Files"] } as unknown as DataTransfer })).toBe(true);
+    expect(carriesFiles({ dataTransfer: { types: [REALM_ITEM_TYPE] } as unknown as DataTransfer })).toBe(false);
+    expect(carriesFiles({ dataTransfer: { types: [] } as unknown as DataTransfer })).toBe(false);
+    expect(carriesFiles({ dataTransfer: null })).toBe(false);
+  });
+});
+
+describe("useFileDrop", () => {
+  it("lights up on a file drag and hands the files over on the drop", () => {
+    const { onOuter, outer } = mount();
+    fireEvent.dragEnter(outer, dt());
+    expect(dropping(outer)).toBe(true);
+    const f = file();
+    fireEvent.drop(outer, dt([f]));
+    expect(onOuter).toHaveBeenCalledWith([f]);
+    expect(dropping(outer)).toBe(false);
+  });
+
+  it("ignores a Realm pane drag entirely, so it falls through to the pane's own drop handling", () => {
+    const { onOuter, outer } = mount();
+    fireEvent.dragEnter(outer, paneDrag);
+    expect(dropping(outer)).toBe(false);
+    // Not preventDefault'ed either: fireEvent returns false only when a handler consumed the event,
+    // and a consumed dragover is what would stop PaneHost from ever seeing the drag.
+    expect(fireEvent.dragOver(outer, paneDrag)).toBe(true);
+    fireEvent.drop(outer, paneDrag);
+    expect(onOuter).not.toHaveBeenCalled();
+  });
+
+  it("crossing into a child does not flicker the target off", () => {
+    const { outer } = mount();
+    fireEvent.dragEnter(outer, dt());
+    fireEvent.dragEnter(screen.getByTestId("sibling"), dt()); // into a child
+    fireEvent.dragLeave(outer, dt());                          // …and out of the parent
+    expect(dropping(outer)).toBe(true);
+    fireEvent.dragLeave(screen.getByTestId("sibling"), dt());
+    expect(dropping(outer)).toBe(false);
+  });
+
+  it("a drop is handled once: the inner target claims it and the outer never sees it", () => {
+    const { onOuter, onInner, inner } = mount();
+    const f = file();
+    fireEvent.drop(inner, dt([f]));
+    expect(onInner).toHaveBeenCalledWith([f]);
+    // The named mutant: drop `e.stopPropagation()` from the hook and the file is attached twice.
+    expect(onOuter).not.toHaveBeenCalled();
+  });
+
+  it("exactly one of the two is ever lit — the inner one takes the drag off the outer", () => {
+    const { outer, inner } = mount();
+    fireEvent.dragEnter(outer, dt());
+    expect(dropping(outer)).toBe(true);
+    // Into the inner target: the browser fires enter on the new target and leave on the old one.
+    fireEvent.dragEnter(inner, dt());
+    fireEvent.dragLeave(outer, dt());
+    expect(dropping(inner)).toBe(true);
+    expect(dropping(outer)).toBe(false);
+  });
+
+  it("and back out again — the outer target's count survives the round trip", () => {
+    const { outer, inner } = mount();
+    fireEvent.dragEnter(outer, dt());
+    fireEvent.dragEnter(inner, dt());
+    fireEvent.dragLeave(outer, dt());
+    // Leaving the inner target for the outer one. The mutant: claim on the drop alone. The outer
+    // would then have counted this leave without ever counting the matching enter, sit at -1, and
+    // never light up again for the rest of the drag.
+    fireEvent.dragEnter(outer, dt());
+    fireEvent.dragLeave(inner, dt());
+    expect(dropping(outer)).toBe(true);
+    expect(dropping(inner)).toBe(false);
+    fireEvent.dragLeave(outer, dt());
+    expect(dropping(outer)).toBe(false);
+  });
+
+  it("a drop carrying no files still clears the target rather than leaving it lit", () => {
+    const { onOuter, outer } = mount();
+    fireEvent.dragEnter(outer, dt());
+    fireEvent.drop(outer, dt([]));
+    expect(dropping(outer)).toBe(false);
+    expect(onOuter).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/renderer/src/components/use-file-drop.test.tsx
+++ b/apps/desktop/src/renderer/src/components/use-file-drop.test.tsx
@@ -7,8 +7,8 @@ const dt = (files: File[] = []) => ({ dataTransfer: { files, items: files.map(()
 const paneDrag = { dataTransfer: { files: [], items: [], types: [REALM_ITEM_TYPE] } };
 const file = (name = "a.png") => new File([new Uint8Array(2)], name, { type: "image/png" });
 
-/** The real shape: a claiming target nested inside a plain one, which is the session pane with the
- *  prompter inside it. Everything subtle about the hook is about how those two interact. */
+/** A claiming target nested inside a plain one — the shape the session pane and the prompter make,
+ *  and the only shape in which the hook's counting can go wrong. */
 function Nested({ onOuter, onInner }: { onOuter: (f: File[]) => void; onInner: (f: File[]) => void }) {
   const outer = useFileDrop(onOuter);
   const inner = useFileDrop(onInner, true);

--- a/apps/desktop/src/renderer/src/components/use-file-drop.ts
+++ b/apps/desktop/src/renderer/src/components/use-file-drop.ts
@@ -2,7 +2,7 @@ import { useState, type DragEvent } from "react";
 import { carriesFiles } from "./drag-types";
 
 /** The four handlers a file-drop target needs, spread straight onto the element. */
-export type FileDropHandlers = {
+type FileDropHandlers = {
   onDragEnter: (e: DragEvent) => void;
   onDragOver: (e: DragEvent) => void;
   onDragLeave: (e: DragEvent) => void;

--- a/apps/desktop/src/renderer/src/components/use-file-drop.ts
+++ b/apps/desktop/src/renderer/src/components/use-file-drop.ts
@@ -1,0 +1,49 @@
+import { useState, type DragEvent } from "react";
+import { carriesFiles } from "./drag-types";
+
+/** The four handlers a file-drop target needs, spread straight onto the element. */
+export type FileDropHandlers = {
+  onDragEnter: (e: DragEvent) => void;
+  onDragOver: (e: DragEvent) => void;
+  onDragLeave: (e: DragEvent) => void;
+  onDrop: (e: DragEvent) => void;
+};
+
+/**
+ * A target that accepts files dragged in from outside the app.
+ *
+ * `dropping` is derived from a COUNT rather than a boolean: dragging across a child fires
+ * leave-then-enter, and a boolean flickers the target off at every internal boundary.
+ *
+ * `claim` is what keeps two nested targets from both taking one drop. The session pane and the
+ * prompter inside it are both targets; the prompter claims, so a drag over it never reaches the pane
+ * and exactly one of the two affordances is ever lit. It has to claim on all FOUR events, not just
+ * the drop — an outer target that saw the leave but not the matching enter would count itself
+ * negative and stay lit for the rest of the drag.
+ *
+ * Only a drag carrying files is ever claimed. Realm drags its own sessions and panes between groups,
+ * and those have to pass through untouched to the pane's own drop handling.
+ */
+export function useFileDrop(onFiles: (files: File[]) => void, claim = false): { dropping: boolean; handlers: FileDropHandlers } {
+  const [depth, setDepth] = useState(0);
+  const mine = (e: DragEvent): boolean => {
+    if (!carriesFiles(e)) return false;
+    if (claim) e.stopPropagation();
+    return true;
+  };
+  return {
+    dropping: depth > 0,
+    handlers: {
+      onDragEnter: (e) => { if (mine(e)) { e.preventDefault(); setDepth((d) => d + 1); } },
+      onDragOver: (e) => { if (mine(e)) { e.preventDefault(); e.dataTransfer.dropEffect = "copy"; } },
+      onDragLeave: (e) => { if (mine(e)) setDepth((d) => Math.max(0, d - 1)); },
+      onDrop: (e) => {
+        if (!mine(e)) return;
+        e.preventDefault();
+        setDepth(0);
+        const files = Array.from(e.dataTransfer.files);
+        if (files.length > 0) onFiles(files);
+      },
+    },
+  };
+}

--- a/apps/desktop/src/renderer/src/env.d.ts
+++ b/apps/desktop/src/renderer/src/env.d.ts
@@ -14,6 +14,9 @@ interface Window {
     pickFiles(): Promise<PickedFile[]>;
     /** Downscaled data: URL for an image attachment; null for anything not a readable image. */
     attachmentThumbnail(path: string): Promise<string | null>;
+    /** Hand an attachment to the app the user reads that type in — the files Realm cannot draw.
+     *  Optional for the same reason `media` is: without the bridge the tile stays a picture. */
+    openAttachment?(path: string): Promise<void>;
     /** Single-image picker for the icon picker's "Uploaded" tab; null when cancelled. */
     pickIconImage(): Promise<PickedFile | null>;
     /** Local media drawn inline in the transcript. Optional in the type on purpose: every call site

--- a/apps/desktop/src/renderer/src/panes/session/AttachmentTile.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/AttachmentTile.tsx
@@ -1,6 +1,8 @@
 import { Icon } from "@realm/ui";
-import { useEffect, useState } from "react";
-import { basenameOf, isImageMime } from "@realm/contracts";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { basenameOf, isImageMime, isOpenablePath, isPlayablePath } from "@realm/contracts";
+import { MediaLightbox } from "./media/MediaView";
+import { useMediaFiles } from "./media/use-media";
 
 /** Thumbnails are minted in main (see the `attachment-thumbnail` handler) and are pure functions of a
  *  path, so one module-level cache serves every tile: the same screenshot appears in the composer and
@@ -41,6 +43,17 @@ const extOf = (path: string): string => {
  * A thumbnail that never arrives — an unreadable file, a path that has since moved, a type QuickLook
  * has no generator for — lands on the glyph, because `attachmentThumbnail` answers null for every one
  * of them and the tile treats "no picture yet" and "no picture ever" the same.
+ *
+ * Clicking it opens the file, and what "open" means is decided by what the file IS. An image, a video
+ * or an audio file — the ones `realm-media://` will serve — opens in the lightbox the transcript
+ * already uses. Everything else goes to the app the user reads that type in, because there is no
+ * element that could render a PDF or a CSV and a viewer that showed a broken image for half the
+ * attachments would be worse than a tile that did nothing.
+ *
+ * This lives on the TILE rather than on either of its two callers, which is the point: the composer's
+ * pending chip and the sent chip in a user's message bubble look identical, and a tile that behaved
+ * one way above the prompter and another way six inches up the transcript would be a bug wearing the
+ * same picture.
  */
 export function AttachmentTile({ path, mime, name, detail, disposition, onRemove }: {
   path: string; mime: string;
@@ -56,6 +69,15 @@ export function AttachmentTile({ path, mime, name, detail, disposition, onRemove
   const label = name ?? basenameOf(path);
   const [thumb, setThumb] = useState<string | null>(() => cache.get(path) ?? null);
   const ext = extOf(path);
+  const opener = useRef<HTMLButtonElement>(null);
+  const [lightbox, setLightbox] = useState(false);
+  /* Only a path the scheme could serve is worth asking main about, which is the same cheap filter the
+     transcript applies before it stats anything. A PDF never reaches IPC at all. */
+  const candidates = useMemo(() => (isPlayablePath(path) ? [path] : []), [path]);
+  const file = useMediaFiles(candidates)[0] ?? null;
+  // Answered from the path, not from `mime`: the prop carries whatever the picker said, while main
+  // gates on the extension. Asking the same question both sides ask keeps the affordance honest.
+  const canOpen = isOpenablePath(path);
 
   useEffect(() => {
     if (cache.has(path)) { setThumb(cache.get(path) ?? null); return; }
@@ -64,8 +86,16 @@ export function AttachmentTile({ path, mime, name, detail, disposition, onRemove
     return () => { live = false; };
   }, [path]);
 
-  return (
-    <span className="attach-tile" data-disposition={disposition} data-image={thumb ? "" : undefined}>
+  /* Media opens here, everything else opens THERE. The branch is on `file` — main's own answer about
+     the file on disk — rather than on the mime the caller passed, so a path that has since moved
+     falls to the OS (which reports it) instead of into a lightbox with nothing in it. */
+  const open = () => { if (file) setLightbox(true); else void window.realm?.openAttachment?.(path); };
+  // Focus goes back to the tile the lightbox came out of. Without it the keyboard lands back at the
+  // top of the document, which in a long transcript is nowhere near the file just looked at.
+  const close = useCallback(() => { setLightbox(false); opener.current?.focus(); }, []);
+
+  const face = (
+    <>
       {/* The picture and its badge sit in their own well, which is the element that clips to the
           rounded corners. The tile around it must NOT clip — the tip hangs outside its box. */}
       <span className="attach-art">
@@ -80,6 +110,18 @@ export function AttachmentTile({ path, mime, name, detail, disposition, onRemove
           content is a picture and a three-letter badge is unreadable to a screen reader, and this is
           the one place the file is still named for one. */}
       <span className="visually-hidden">{label}{detail ? ` — ${detail}` : ""}</span>
+    </>
+  );
+
+  return (
+    <span className="attach-tile" data-disposition={disposition} data-image={thumb ? "" : undefined}
+      data-media={file ? "" : undefined}>
+      {/* Open and Remove are SIBLINGS, never nested. A button inside a button is invalid, and the
+          alternative — one click handler untangling its own target — is the version that eventually
+          removes a file the user meant to look at. Being separate elements is the whole guarantee. */}
+      {canOpen
+        ? <button ref={opener} type="button" className="attach-open" aria-label={`Open ${label}`} onClick={open}>{face}</button>
+        : <span className="attach-open">{face}</span>}
       {/* The tip is a real element rather than a `title`: the OS tooltip waits a second, arrives
           under the pointer and cannot show more than one line. `aria-hidden` because the name above
           is already in the tree — a screen reader must not hear the file twice. */}
@@ -92,6 +134,7 @@ export function AttachmentTile({ path, mime, name, detail, disposition, onRemove
           <Icon name="close" size={9} />
         </button>
       )}
+      {lightbox && file && <MediaLightbox file={file} onClose={close} />}
     </span>
   );
 }

--- a/apps/desktop/src/renderer/src/panes/session/AttachmentTile.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/AttachmentTile.tsx
@@ -50,10 +50,10 @@ const extOf = (path: string): string => {
  * element that could render a PDF or a CSV and a viewer that showed a broken image for half the
  * attachments would be worse than a tile that did nothing.
  *
- * This lives on the TILE rather than on either of its two callers, which is the point: the composer's
- * pending chip and the sent chip in a user's message bubble look identical, and a tile that behaved
- * one way above the prompter and another way six inches up the transcript would be a bug wearing the
- * same picture.
+ * Opening lives on the TILE rather than on either of its two callers. The composer's pending chip
+ * and the sent chip in a message bubble are the same picture of the same file, so a tile that
+ * behaved one way in the prompter and another way in the transcript would be a bug — and two
+ * callers each holding their own copy of the behaviour is how that bug gets written.
  */
 export function AttachmentTile({ path, mime, name, detail, disposition, onRemove }: {
   path: string; mime: string;

--- a/apps/desktop/src/renderer/src/panes/session/Composer.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/Composer.tsx
@@ -1,7 +1,8 @@
 import { AGENT_META, AGENT_SUPPORTS_ASK_MODE, AGENT_SUPPORTS_PERMISSION_MODES, DEFAULT_MODEL_LABEL, SELECTABLE_AGENT_KINDS, AGENT_SUPPORTS_PLAN_MODE, EFFORT_LEVELS, PERMISSION_MODES, SESSION_MODES, acpAskMode, acpPlanMode, sessionModeOf, attachmentDisposition, attachmentNote, attachmentSummary, formatAttachmentSize, type AcpSessionMode, type AgentKind, type Environment, type GitInfo, type McpServer, type ModelInfo, type Session, type SessionMode, type SessionStatus, type Skill } from "@realm/contracts";
 import { Icon, type IconName } from "@realm/ui";
-import { Fragment, useEffect, useLayoutEffect, useMemo, useRef, useState, type ClipboardEvent, type DragEvent, type KeyboardEvent, type MouseEvent as ReactMouseEvent, type ReactNode, type RefObject } from "react";
+import { Fragment, useEffect, useLayoutEffect, useMemo, useRef, useState, type ClipboardEvent, type KeyboardEvent, type MouseEvent as ReactMouseEvent, type ReactNode, type RefObject } from "react";
 import { Menu, type MenuItem } from "../../components/Menu";
+import { useFileDrop } from "../../components/use-file-drop";
 import type { AgentProbe, PickedAttachment, SessionOptions, SubmitKey } from "../../state/store";
 import { agentAvailability, availabilityNote } from "../../state/agent-availability";
 import { MentionPicker, filterMentionSkills, mentionQueryAt } from "./MentionPicker";
@@ -358,22 +359,9 @@ export function Composer({ session, status, gitInfo, onOpenDiff, draft, onDraftC
     return () => clearTimeout(t);
   }, [confirmBypass]);
 
-  // Drag depth, not a boolean: dragging across a child element fires leave-then-enter, and a boolean
-  // flickers the drop target off on every internal boundary. Reset outright on drop.
-  const [dragDepth, setDragDepth] = useState(0);
-  // Realm already drags its own sidebar rows onto panes (DropEdge). Only a drag carrying FILES is ours;
-  // anything else must fall through to the pane's own drop handling untouched.
-  const carriesFiles = (e: DragEvent) => e.dataTransfer?.types?.includes("Files") ?? false;
-  const onDragEnter = (e: DragEvent) => { if (!carriesFiles(e)) return; e.preventDefault(); setDragDepth((d) => d + 1); };
-  const onDragOver = (e: DragEvent) => { if (!carriesFiles(e)) return; e.preventDefault(); e.dataTransfer.dropEffect = "copy"; };
-  const onDragLeave = (e: DragEvent) => { if (!carriesFiles(e)) return; setDragDepth((d) => Math.max(0, d - 1)); };
-  const onDrop = (e: DragEvent) => {
-    if (!carriesFiles(e)) return;
-    e.preventDefault();
-    setDragDepth(0);
-    const files = Array.from(e.dataTransfer.files);
-    if (files.length > 0) onAttachFiles(files);
-  };
+  /* The card CLAIMS a file drag from the session pane around it, which is also a drop target. Both
+     lighting up for one drag would say the file is about to land in two places. */
+  const drop = useFileDrop(onAttachFiles, true);
   /** Pasting an image: it has no path yet, which the store handles. A paste with no files is text —
    *  fall through untouched, or ⌘V would stop working in the one box people paste into most. */
   const onPaste = (e: ClipboardEvent<HTMLTextAreaElement>) => {
@@ -711,8 +699,7 @@ export function Composer({ session, status, gitInfo, onOpenDiff, draft, onDraftC
       )}
       {/* The whole card is the drop target — aiming at a 44px textarea with a file in hand is a chore.
           §6 forbids animating during a drag, so the state change is a static ring, not a transition. */}
-      <div className="composer" data-dropping={dragDepth > 0 || undefined}
-        onDragEnter={onDragEnter} onDragOver={onDragOver} onDragLeave={onDragLeave} onDrop={onDrop}>
+      <div className="composer" data-dropping={drop.dropping || undefined} {...drop.handlers}>
         <AttachmentRow kind={kind} attachments={attachments} onRemove={onRemoveAttachment} />
         {/* A mention whose skill vanished after typing (W4): warning tone, same row language as the
             attachment fates — the last moment the degradation is actionable is before send. */}
@@ -768,7 +755,7 @@ export function Composer({ session, status, gitInfo, onOpenDiff, draft, onDraftC
             onManage={() => onManageSkills?.()}
             onClose={() => setSkillPickerOpen(false)} />
         )}
-        {dragDepth > 0 && <div className="composer-drop-hint" aria-hidden="true">Drop to attach</div>}
+        {drop.dropping && <div className="composer-drop-hint" aria-hidden="true">Drop to attach</div>}
         <div className="composer-bar">
           <div className="composer-opts" ref={optsRef} data-collapsed={collapsed || undefined}>
             {/* The "+" opens the add menu now (Plan 12 W1) — its Add files… reaches the SAME picker

--- a/apps/desktop/src/renderer/src/panes/session/SessionPane.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/SessionPane.tsx
@@ -7,6 +7,7 @@ import { agentAvailability, isBlocked } from "../../state/agent-availability";
 import { TerminalView } from "../TerminalPane";
 import type { PaneProps } from "../registry";
 import { Composer } from "./Composer";
+import { useFileDrop } from "../../components/use-file-drop";
 import { InstallCard } from "./InstallCard";
 import { Transcript } from "./Transcript";
 import { DelegatedRuns } from "./DelegatedRuns";
@@ -256,6 +257,12 @@ export function SessionPane({ item, visible, focused = false }: PaneProps) {
   // intent: ⌘⇧↩ dispatches the draft into a NEW session (store.dispatchDraft, bound in hotkeys.ts)
   // and must leave this scroller exactly where the reader parked it.
   const [sends, setSends] = useState(0);
+  /* The whole pane takes a dropped file, not just the prompter: with a transcript on screen the card
+     is a strip at the bottom, and aiming at it with a file in hand is the chore this removes. The
+     session id is closed over here, so a four-pane split lands each file in the pane it was dropped
+     on rather than in whichever session was last focused. The prompter claims the drag when the
+     pointer is actually over it, so a drop is only ever handled once. */
+  const fileDrop = useFileDrop((files) => run(() => attachFiles(id, files)));
 
   useEffect(() => { run(() => openSession(id)); }, [id, openSession, run]);
   // Cheap by construction: the store dedups concurrent calls and the server holds a TTL cache, so a
@@ -294,7 +301,8 @@ export function SessionPane({ item, visible, focused = false }: PaneProps) {
   });
   const blocked = isBlocked(availability) && status !== "running" && status !== "waiting_permission";
   const body = (
-    <div className="session-pane" data-visible={visible || undefined} data-composer={hero ? "hero" : "docked"}>
+    <div className="session-pane" data-visible={visible || undefined} data-composer={hero ? "hero" : "docked"}
+      data-dropping={fileDrop.dropping || undefined} {...fileDrop.handlers}>
       <Transcript transcript={transcript} sessionStatus={status} visible={visible} focused={focused} cwd={session.cwd}
         sends={sends}
         mentionIds={liveMentionIds}
@@ -342,6 +350,10 @@ export function SessionPane({ item, visible, focused = false }: PaneProps) {
             submitKey={submitKey}
             hero={hero} spaceName={space?.name ?? "this space"} onSuggestion={(p) => setDraft(id, p)}
             promptHint={hint} />}
+      {/* Last child and BELOW the prompter's dock, so the glow passes under the card exactly as the
+          transcript does — an affordance that blurred across the prompter would be the fade band's
+          old bug wearing a different colour. Decorative: the drop is announced by what it does. */}
+      {fileDrop.dropping && <div className="session-drop" aria-hidden="true" />}
     </div>
   );
   if (!panelOpen) return body;

--- a/apps/desktop/src/renderer/src/panes/session/Transcript.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/Transcript.tsx
@@ -1,6 +1,6 @@
 import { Icon } from "@realm/ui";
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
-import { basenameOf, chipRuns, isPlayablePath, mediaCandidatesIn, type MediaFile, type SessionStatus } from "@realm/contracts";
+import { chipRuns, mediaCandidatesIn, type SessionStatus } from "@realm/contracts";
 import { AttachmentTile } from "./AttachmentTile";
 import type { PermissionDecision } from "../../state/store";
 import { Markdown } from "./Markdown";
@@ -12,8 +12,8 @@ import { formatDuration, groupTranscript, withEnter } from "./tool-group";
 import { blockKey, type Transcript as TranscriptModel } from "./transcript-model";
 import { runLabelFor } from "./run-label";
 import { useEnterTracker } from "./transcript-enter";
-import { MediaLightbox, MediaStrip } from "./media/MediaView";
-import { useMediaByCandidate, useMediaFiles } from "./media/use-media";
+import { MediaStrip } from "./media/MediaView";
+import { useMediaFiles } from "./media/use-media";
 
 const NEAR_BOTTOM_PX = 80;
 /** Permission cards share the blocks' key space; the prefix keeps a requestId from colliding with one. */
@@ -69,29 +69,10 @@ function UserText({ text, mentionIds }: { text: string; mentionIds: readonly str
  * more Realm can do with it here, so making it look clickable would be a promise it cannot keep.
  */
 function UserAttachments({ attachments }: { attachments: readonly { path: string; mime: string }[] }) {
-  const candidates = useMemo(
-    () => attachments.filter((a) => isPlayablePath(a.path)).map((a) => a.path),
-    [attachments],
-  );
-  const byCandidate = useMediaByCandidate(candidates);
-  const [open, setOpen] = useState<MediaFile | null>(null);
   return (
-    <>
-      <ul className="msg-user-files" aria-label="Attached files">
-        {attachments.map((a) => {
-          const file = byCandidate.get(a.path);
-          const tile = <AttachmentTile path={a.path} mime={a.mime} />;
-          return (
-            <li key={a.path}>
-              {file
-                ? <button type="button" className="msg-user-file-open" aria-label={`Open ${basenameOf(a.path)}`} onClick={() => setOpen(file)}>{tile}</button>
-                : tile}
-            </li>
-          );
-        })}
-      </ul>
-      {open && <MediaLightbox file={open} onClose={() => setOpen(null)} />}
-    </>
+    <ul className="msg-user-files" aria-label="Attached files">
+      {attachments.map((a) => <li key={a.path}><AttachmentTile path={a.path} mime={a.mime} /></li>)}
+    </ul>
   );
 }
 

--- a/apps/desktop/src/renderer/src/panes/session/attachment-open.test.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/attachment-open.test.tsx
@@ -1,0 +1,169 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { sessionEvent, type MediaFile } from "@realm/contracts";
+import { AttachmentTile } from "./AttachmentTile";
+import { Transcript } from "./Transcript";
+import { reduceAll } from "./transcript-model";
+import { resetMediaCache } from "./media/use-media";
+
+/** What main would answer for a real file on disk. */
+const mediaFile = (path: string, kind: MediaFile["kind"] = "image"): MediaFile => ({
+  path, kind, size: 4096,
+  mime: kind === "video" ? "video/mp4" : kind === "audio" ? "audio/mpeg" : "image/png",
+});
+
+/**
+ * Stand in for the preload bridge. `known` is the whole filesystem as far as the renderer is
+ * concerned — anything else stats to null, which is how a moved file degrades.
+ *
+ * `openAttachment` is the OTHER half of the surface under test: a tile that reaches for it has
+ * decided the file is not something the app can draw.
+ */
+function stubBridge(known: MediaFile[] = []) {
+  const stat = vi.fn(async (candidates: readonly string[]) =>
+    candidates.map((c) => known.find((f) => f.path === c) ?? null));
+  const openAttachment = vi.fn(async () => {});
+  vi.stubGlobal("realm", {
+    openAttachment,
+    attachmentThumbnail: vi.fn(async () => null),
+    media: { stat, poster: vi.fn(async () => null), reveal: vi.fn(async () => {}), open: vi.fn(async () => {}) },
+  });
+  return { stat, openAttachment };
+}
+
+beforeEach(() => { resetMediaCache(); });
+afterEach(() => { vi.unstubAllGlobals(); });
+
+const lightbox = () => document.querySelector(".media-lightbox");
+
+describe("opening an attachment from its tile", () => {
+  it("hands a file the app cannot draw to the OS, and never to the lightbox", async () => {
+    const { openAttachment } = stubBridge();
+    render(<AttachmentTile path="/x/report.pdf" mime="application/pdf" />);
+    fireEvent.click(screen.getByRole("button", { name: "Open report.pdf" }));
+    await waitFor(() => expect(openAttachment).toHaveBeenCalledWith("/x/report.pdf"));
+    // The named mutant: route everything through MediaLightbox. A PDF has no MediaFile, so the
+    // viewer would open on nothing — the broken-image-for-half-of-them failure.
+    expect(lightbox()).toBeNull();
+  });
+
+  it("a PDF is never even put to media:stat — the scheme could not serve one", async () => {
+    const { stat } = stubBridge();
+    render(<AttachmentTile path="/x/report.pdf" mime="application/pdf" />);
+    fireEvent.click(screen.getByRole("button", { name: "Open report.pdf" }));
+    await waitFor(() => expect(screen.getByRole("button", { name: "Open report.pdf" })).toBeInTheDocument());
+    expect(stat).not.toHaveBeenCalled();
+  });
+
+  it("opens media in the lightbox instead, and does not disturb the OS", async () => {
+    const { openAttachment } = stubBridge([mediaFile("/x/shot.png")]);
+    render(<AttachmentTile path="/x/shot.png" mime="image/png" />);
+    const tile = screen.getByRole("button", { name: "Open shot.png" });
+    await waitFor(() => expect(document.querySelector(".attach-tile[data-media]")).not.toBeNull());
+    fireEvent.click(tile);
+    await waitFor(() => expect(lightbox()).not.toBeNull());
+    expect(openAttachment).not.toHaveBeenCalled();
+  });
+
+  it("an image whose file has since moved falls to the OS rather than an empty viewer", async () => {
+    // Playable by extension, but main answers null: the branch is on what main SAID, not on the mime
+    // the caller passed. Mutant — branch on `isPlayablePath(path)` — opens a lightbox on nothing.
+    const { openAttachment, stat } = stubBridge([]);
+    render(<AttachmentTile path="/x/gone.png" mime="image/png" />);
+    await waitFor(() => expect(stat).toHaveBeenCalled());
+    fireEvent.click(screen.getByRole("button", { name: "Open gone.png" }));
+    await waitFor(() => expect(openAttachment).toHaveBeenCalledWith("/x/gone.png"));
+    expect(lightbox()).toBeNull();
+  });
+
+  it("offers no open at all for an extension Realm cannot hand to anything", () => {
+    // Main refuses an unknown extension (`open` RUNS an .app rather than showing it), so a tile that
+    // still invited the click would be a dead control. Mutant: `canOpen = true`.
+    stubBridge();
+    render(<AttachmentTile path="/x/blob.weirdext" mime="application/octet-stream" />);
+    expect(screen.queryByRole("button", { name: /^Open/ })).toBeNull();
+    expect(document.querySelector(".attach-tile")).not.toBeNull();
+  });
+
+  it("Escape closes the lightbox and puts focus back on the tile it came out of", async () => {
+    stubBridge([mediaFile("/x/shot.png")]);
+    render(<AttachmentTile path="/x/shot.png" mime="image/png" />);
+    const tile = screen.getByRole("button", { name: "Open shot.png" });
+    await waitFor(() => expect(document.querySelector(".attach-tile[data-media]")).not.toBeNull());
+    fireEvent.click(tile);
+    await waitFor(() => expect(lightbox()).not.toBeNull());
+    fireEvent.keyDown(document.body, { key: "Escape" });
+    await waitFor(() => expect(lightbox()).toBeNull());
+    // The named mutant: drop `opener.current?.focus()` in `close`. The keyboard would land back at
+    // the top of the document, nowhere near the file just looked at.
+    expect(document.activeElement).toBe(tile);
+  });
+
+  it("the tile is reached and opened by the keyboard alone", async () => {
+    const { openAttachment } = stubBridge();
+    render(<AttachmentTile path="/x/notes.md" mime="text/markdown" />);
+    const tile = screen.getByRole("button", { name: "Open notes.md" });
+    tile.focus();
+    expect(document.activeElement).toBe(tile);
+    // A real <button>, so Enter and Space are the browser's to deliver; clicking is what they raise.
+    fireEvent.click(tile);
+    await waitFor(() => expect(openAttachment).toHaveBeenCalledWith("/x/notes.md"));
+  });
+});
+
+describe("remove and open are separate controls", () => {
+  it("removing a file does not also open it", async () => {
+    const { openAttachment } = stubBridge();
+    const onRemove = vi.fn();
+    render(<AttachmentTile path="/x/report.pdf" mime="application/pdf" onRemove={onRemove} />);
+    fireEvent.click(screen.getByRole("button", { name: "Remove report.pdf" }));
+    expect(onRemove).toHaveBeenCalledTimes(1);
+    // The mutant this pins: put the open handler on `.attach-tile` (or nest remove inside the open
+    // button) and the ✕ opens the file on its way out.
+    await waitFor(() => expect(onRemove).toHaveBeenCalled());
+    expect(openAttachment).not.toHaveBeenCalled();
+    expect(lightbox()).toBeNull();
+  });
+
+  it("neither button is a descendant of the other", () => {
+    stubBridge();
+    render(<AttachmentTile path="/x/report.pdf" mime="application/pdf" onRemove={() => {}} />);
+    const open = screen.getByRole("button", { name: "Open report.pdf" });
+    const remove = screen.getByRole("button", { name: "Remove report.pdf" });
+    expect(open.contains(remove)).toBe(false);
+    expect(remove.contains(open)).toBe(false);
+  });
+});
+
+describe("a sent tile and a pending tile are the same tile", () => {
+  /** The transcript's own attachment row, rendered the way a user message carries it. */
+  const sent = (attachments: { path: string; mime: string }[]) => render(
+    <Transcript transcript={reduceAll([sessionEvent("user_message", { text: "look", attachments })])}
+      sessionStatus="idle" visible focused cwd={null} sends={0} mentionIds={[]} onDecide={() => {}} />,
+  );
+
+  it("a sent PDF opens exactly the way a pending one does — it used to do nothing at all", async () => {
+    const { openAttachment } = stubBridge();
+    sent([{ path: "/x/report.pdf", mime: "application/pdf" }]);
+    fireEvent.click(screen.getByRole("button", { name: "Open report.pdf" }));
+    await waitFor(() => expect(openAttachment).toHaveBeenCalledWith("/x/report.pdf"));
+  });
+
+  it("a sent image still opens in the lightbox", async () => {
+    stubBridge([mediaFile("/x/shot.png")]);
+    sent([{ path: "/x/shot.png", mime: "image/png" }]);
+    await waitFor(() => expect(document.querySelector(".attach-tile[data-media]")).not.toBeNull());
+    fireEvent.click(screen.getByRole("button", { name: "Open shot.png" }));
+    await waitFor(() => expect(lightbox()).not.toBeNull());
+  });
+
+  it("the sent row names its files through the tile, with no wrapper of its own", () => {
+    stubBridge();
+    sent([{ path: "/x/report.pdf", mime: "application/pdf" }]);
+    const open = screen.getByRole("button", { name: "Open report.pdf" });
+    // The old shape wrapped the tile in a second button. Two nested buttons is one tab stop too many
+    // and invalid markup besides; the tile carries the control itself now.
+    expect(open.className).toBe("attach-open");
+    expect(open.querySelector("button")).toBeNull();
+  });
+});

--- a/apps/desktop/src/renderer/src/panes/session/attachment-open.test.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/attachment-open.test.tsx
@@ -7,17 +7,14 @@ import { reduceAll } from "./transcript-model";
 import { resetMediaCache } from "./media/use-media";
 
 /** What main would answer for a real file on disk. */
-const mediaFile = (path: string, kind: MediaFile["kind"] = "image"): MediaFile => ({
-  path, kind, size: 4096,
-  mime: kind === "video" ? "video/mp4" : kind === "audio" ? "audio/mpeg" : "image/png",
-});
+const mediaFile = (path: string): MediaFile => ({ path, kind: "image", mime: "image/png", size: 4096 });
 
 /**
  * Stand in for the preload bridge. `known` is the whole filesystem as far as the renderer is
- * concerned — anything else stats to null, which is how a moved file degrades.
+ * concerned — anything else stats to null, which is how a file that has moved degrades.
  *
- * `openAttachment` is the OTHER half of the surface under test: a tile that reaches for it has
- * decided the file is not something the app can draw.
+ * A tile that reaches for `openAttachment` has decided the file is not one the app can draw, so
+ * which of the two the click lands on is the whole question here.
  */
 function stubBridge(known: MediaFile[] = []) {
   const stat = vi.fn(async (candidates: readonly string[]) =>
@@ -48,10 +45,10 @@ describe("opening an attachment from its tile", () => {
   });
 
   it("a PDF is never even put to media:stat — the scheme could not serve one", async () => {
-    const { stat } = stubBridge();
+    const { stat, openAttachment } = stubBridge();
     render(<AttachmentTile path="/x/report.pdf" mime="application/pdf" />);
     fireEvent.click(screen.getByRole("button", { name: "Open report.pdf" }));
-    await waitFor(() => expect(screen.getByRole("button", { name: "Open report.pdf" })).toBeInTheDocument());
+    await waitFor(() => expect(openAttachment).toHaveBeenCalled());
     expect(stat).not.toHaveBeenCalled();
   });
 
@@ -117,10 +114,9 @@ describe("remove and open are separate controls", () => {
     const onRemove = vi.fn();
     render(<AttachmentTile path="/x/report.pdf" mime="application/pdf" onRemove={onRemove} />);
     fireEvent.click(screen.getByRole("button", { name: "Remove report.pdf" }));
-    expect(onRemove).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(onRemove).toHaveBeenCalledTimes(1));
     // The mutant this pins: put the open handler on `.attach-tile` (or nest remove inside the open
     // button) and the ✕ opens the file on its way out.
-    await waitFor(() => expect(onRemove).toHaveBeenCalled());
     expect(openAttachment).not.toHaveBeenCalled();
     expect(lightbox()).toBeNull();
   });
@@ -161,8 +157,8 @@ describe("a sent tile and a pending tile are the same tile", () => {
     stubBridge();
     sent([{ path: "/x/report.pdf", mime: "application/pdf" }]);
     const open = screen.getByRole("button", { name: "Open report.pdf" });
-    // The old shape wrapped the tile in a second button. Two nested buttons is one tab stop too many
-    // and invalid markup besides; the tile carries the control itself now.
+    // The tile carries the control itself; a wrapper around it would be a button inside a button —
+    // invalid markup, and one tab stop too many on every attachment in the transcript.
     expect(open.className).toBe("attach-open");
     expect(open.querySelector("button")).toBeNull();
   });

--- a/apps/desktop/src/renderer/src/panes/session/session-pane.test.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/session-pane.test.tsx
@@ -1904,11 +1904,12 @@ describe("prompter attachments", () => {
     await waitFor(() => expect(chips()).toHaveLength(1));
     const tile = document.querySelector(".attach-tile")!;
     // Everything naming the file is either visually hidden or inside the hover tip — nothing else
-    // in the tile carries text, which is what keeps a row of files to a row of squares.
-    const visible = Array.from(tile.childNodes)
-      .filter((n) => !(n instanceof HTMLElement && (n.classList.contains("visually-hidden") || n.classList.contains("attach-tip"))))
-      .map((n) => n.textContent ?? "").join("");
-    expect(visible).not.toContain("report");
+    // in the tile carries text, which is what keeps a row of files to a row of squares. Read off a
+    // clone with those two stripped, at any depth: the hidden name rides inside the open button, so
+    // a filter over the tile's direct children alone would stop seeing it and pass on nothing.
+    const bare = tile.cloneNode(true) as HTMLElement;
+    for (const hidden of bare.querySelectorAll(".visually-hidden, .attach-tip")) hidden.remove();
+    expect(bare.textContent).not.toContain("report");
     expect(tile.querySelector(".visually-hidden")!.textContent).toContain("report.pdf");
   });
 

--- a/apps/desktop/src/renderer/src/panes/session/session-pane.test.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/session-pane.test.tsx
@@ -1980,6 +1980,66 @@ describe("prompter attachments", () => {
     await waitFor(() => expect(composer()).not.toHaveAttribute("data-dropping"));
   });
 
+  /* The whole pane takes a file, not just the card. With a transcript on screen the prompter is a
+     strip at the bottom, and aiming at it with a file in hand was the chore this removes. */
+  const pane = () => document.querySelector(".session-pane") as HTMLElement;
+  const glow = () => document.querySelector(".session-drop");
+
+  it("dropping on the transcript — nowhere near the prompter — attaches the file to THIS session", async () => {
+    const { store } = await mountFor("codex");
+    const files = [dropped("/Users/me/far.png", "image/png")];
+    fireEvent.dragEnter(document.querySelector(".transcript")!, dt(files));
+    expect(pane()).toHaveAttribute("data-dropping");
+    fireEvent.drop(document.querySelector(".transcript")!, dt(files));
+    await waitFor(() => expect(chips()).toHaveLength(1));
+    // Attached to the session this pane is showing, not to whichever one was last focused.
+    expect(store.getState().pendingAttachments["se1"]?.map((a) => a.path)).toEqual(["/Users/me/far.png"]);
+    expect(pane()).not.toHaveAttribute("data-dropping");
+  });
+
+  it("the highlight is the pane's, and it is the only one lit while the drag is out on the transcript", async () => {
+    await mountFor("codex");
+    const files = [dropped("/x/a.png", "image/png")];
+    expect(glow()).toBeNull();
+    fireEvent.dragEnter(document.querySelector(".transcript")!, dt(files));
+    expect(glow()).not.toBeNull();
+    // Decorative, and it must never eat the drop it is advertising.
+    expect(glow()).toHaveAttribute("aria-hidden", "true");
+    expect(composer()).not.toHaveAttribute("data-dropping");
+  });
+
+  it("over the prompter it is the CARD that lights up, and the pane stands down", async () => {
+    await mountFor("codex");
+    const files = [dropped("/x/a.png", "image/png")];
+    fireEvent.dragEnter(document.querySelector(".transcript")!, dt(files));
+    expect(pane()).toHaveAttribute("data-dropping");
+    // Into the card: the browser fires enter on the new target, then leave on the old one.
+    fireEvent.dragEnter(composer(), dt(files));
+    fireEvent.dragLeave(document.querySelector(".transcript")!, dt(files));
+    expect(composer()).toHaveAttribute("data-dropping");
+    // Two lit targets would say the file is about to land in two places.
+    expect(pane()).not.toHaveAttribute("data-dropping");
+    expect(glow()).toBeNull();
+  });
+
+  it("a drop on the prompter is handled ONCE — the card claims it from the pane", async () => {
+    await mountFor("codex");
+    const files = [dropped("/x/once.png", "image/png")];
+    fireEvent.drop(composer(), dt(files));
+    // The named mutant: drop `claim` on the composer's target and the same file is attached twice.
+    await waitFor(() => expect(chips()).toHaveLength(1));
+  });
+
+  it("a Realm pane drag over the transcript lights nothing — a session dragged between groups is not a file", async () => {
+    await mountFor("codex");
+    const itemDrag = { dataTransfer: { files: [], items: [], types: ["application/x-realm-item"] } };
+    fireEvent.dragEnter(document.querySelector(".transcript")!, itemDrag);
+    expect(pane()).not.toHaveAttribute("data-dropping");
+    expect(glow()).toBeNull();
+    // Not consumed either: PaneHost's own drop-edge handling is above this and has to still see it.
+    expect(fireEvent.dragOver(document.querySelector(".transcript")!, itemDrag)).toBe(true);
+  });
+
   it("pasting an image attaches it — it has no path, so it is written out first", async () => {
     const { api } = await mountFor("claude");
     const box = screen.getByRole("textbox", { name: /message/i });

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -850,7 +850,26 @@ button.panel-title:hover { background: var(--rl-hover); }
 
 /* ── Session pane ──────────────────────────────────────────────────────── */
 /* A size container so the prompter's hero lift can be expressed in cqh (pane-height units). */
-.session-pane { flex: 1; min-width: 0; min-height: 0; display: flex; flex-direction: column; background: var(--rl-panel); container-type: size; }
+.session-pane { position: relative; flex: 1; min-width: 0; min-height: 0; display: flex; flex-direction: column; background: var(--rl-panel); container-type: size; }
+/* Dropping a file anywhere on the pane. Inset from the panel edge rather than flush to it, so the
+   glow reads as this pane's — in a four-way split a flush ring would run straight into its
+   neighbour's and the two would look like one target.
+
+   z-index 1 puts it under `.composer-dock` (2) and level with the transcript's fade band, which is
+   the whole point: the highlight passes UNDER the prompter the way the transcript does. Above it,
+   the blurred band would wash across the card — the bug `prompter-fade-live.mjs` exists to catch. */
+.session-drop { position: absolute; inset: 6px; z-index: 1; pointer-events: none;
+  border-radius: calc(var(--r-float) + 4px); corner-shape: squircle;
+  box-shadow: inset 0 0 0 1.5px var(--rl-accent), inset 0 0 36px -6px var(--rl-accent);
+  animation: rl-fade-in var(--dur-drag) linear; }
+/* The soft half, on its own layer because a backdrop-filter cannot be an inset shadow. The mask
+   lives HERE and never on the parent: a masked ancestor becomes a backdrop root, and its children
+   would then blur an empty backdrop — the same trap the transcript's fade band documents. */
+.session-drop::before { content: ""; position: absolute; inset: 0; border-radius: inherit;
+  background: color-mix(in srgb, var(--rl-accent) 12%, transparent);
+  backdrop-filter: blur(5px); -webkit-backdrop-filter: blur(5px);
+  mask-image: radial-gradient(farthest-side at 50% 50%, transparent 42%, #000 100%);
+  -webkit-mask-image: radial-gradient(farthest-side at 50% 50%, transparent 42%, #000 100%); }
 /* The session's terminal drawer (W4): a split INSIDE the session pane, not a layout leaf. Its divider is
    the same 1px .resize-handle the pane host uses; the terminal keeps its full-pane treatment (§5 — no
    border, no radius), separated from the transcript by the panel→terminal-bg luminance step alone.
@@ -972,6 +991,9 @@ button.panel-title:hover { background: var(--rl-hover); }
 @media (prefers-reduced-transparency: reduce) {
   .transcript-fade::before, .diff-fade::before { backdrop-filter: none; -webkit-backdrop-filter: none; }
   .transcript-fade::after, .diff-fade::after { backdrop-filter: none; -webkit-backdrop-filter: none; }
+  /* The drop highlight, same treatment: the ring and its wash are what say "this pane takes the
+     file", and neither needs the blur to say it. */
+  .session-drop::before { backdrop-filter: none; -webkit-backdrop-filter: none; }
 }
 
 /* A column, always: a sent message is up to three stacked pieces — the attribution line, the

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -1509,6 +1509,16 @@ button.panel-title:hover { background: var(--rl-hover); }
   border-radius: var(--r-ctl); background: var(--field); box-shadow: var(--shadow-hairline);
   color: var(--rl-text-faint); overflow: hidden; }
 .attach-thumb { width: 100%; height: 100%; object-fit: cover; display: block; }
+/* The whole face of the tile is the open control, and it adds no box of its own: the well underneath
+   already carries the ring and the rounding, and a second frame around it would read as a different
+   kind of thing. It fills the tile rather than wrapping it so that `.attach-art`'s `inset: 0` still
+   resolves against the 44px square, and so the remove button — a SIBLING, never a child — keeps the
+   corner to itself. */
+.attach-open { position: absolute; inset: 0; display: block; padding: 0; border: none; background: none; cursor: pointer; }
+/* A file that opens in the lightbox says so: zoom-in is the cursor for a picture that gets bigger in
+   place, and it would be a lie on the PDF that leaves for Preview. The mark lands only once main has
+   confirmed the file, which is also when the lightbox becomes the branch that runs. */
+.attach-tile[data-media] .attach-open { cursor: zoom-in; }
 /* The type badge rides the bottom of the well; over a photo it needs its own scrim to stay legible. */
 .attach-ext { position: absolute; left: 0; right: 0; bottom: 0; padding: 1px 2px; text-align: center;
   font-size: 8px; line-height: 1.25; font-weight: var(--fw-title); letter-spacing: .02em; text-transform: uppercase;
@@ -2901,10 +2911,6 @@ body[data-media-lightbox] .transcript .media-el { visibility: hidden; }
      stays as a static, legible "nothing here yet". */
   .gen-glow { display: none; }
 }
-/* A media attachment's tile is a button; a non-media one is not. The button adds no box of its own —
-   the tile already has the ring and the rounding, and a second frame around it would read as a
-   different kind of thing. */
-.msg-user-file-open { display: block; padding: 0; border: none; background: none; cursor: zoom-in; }
 
 /* ——— Settings → App: the background transparency slider ——————————————————————
    A native range on the app's accent, with the value beside it in tabular figures so the number does

--- a/apps/desktop/src/renderer/src/styles.test.ts
+++ b/apps/desktop/src/renderer/src/styles.test.ts
@@ -760,6 +760,21 @@ describe("Plan 9 W3 — composer + chrome in BUI language", () => {
     expect(tile).not.toContain("overflow: hidden");
   });
 
+  it("the open control fills the tile and draws nothing — the well underneath already has the ring", () => {
+    const open = bodiesFor(".attach-open").join(" ");
+    // `inset: 0` is what keeps `.attach-art`'s own `inset: 0` resolving against the 44px square: the
+    // art is now the button's child, so a button that merely wrapped the tile would collapse it.
+    expect(open).toContain("position: absolute");
+    expect(open).toContain("inset: 0");
+    expect(open).toContain("border: none");
+    expect(open).toContain("background: none");
+    expect(open).toContain("padding: 0");
+    // A drop target's cursor must not promise a zoom the file cannot do: only a tile main has
+    // confirmed is media gets zoom-in, and the mark only lands once that answer is back.
+    expect(open).toContain("cursor: pointer");
+    expect(bodiesFor(".attach-tile[data-media] .attach-open").join(" ")).toContain("cursor: zoom-in");
+  });
+
   it("the file's name lives in a hover tip that fades in — not in an OS `title`, which cannot show the size or the folder", () => {
     const tip = bodiesFor(".attach-tip").join(" ");
     expect(tip).toContain("opacity: 0");

--- a/apps/desktop/src/renderer/src/styles.test.ts
+++ b/apps/desktop/src/renderer/src/styles.test.ts
@@ -737,6 +737,53 @@ describe("Plan 9 W3 — composer + chrome in BUI language", () => {
     expect(reduced).toContain("linear-gradient(to bottom, transparent 0, var(--page) 88%)");
   });
 
+  /* Dropping a file anywhere on the session pane. jsdom has no compositing, so the one thing these
+     can hold is the LAYERING and the degradations — how it actually paints is what
+     `session-drop-live.mjs` samples. */
+  it("the pane's drop glow passes UNDER the prompter, the way the transcript does", () => {
+    const glow = bodiesFor(".session-drop").join(" ");
+    // The bug this refuses to repeat: a blurring band that outranked the prompter cut a stripe
+    // straight across the hero card (prompter-fade-live.mjs). The dock is layer 2; this is 1.
+    expect(glow).toContain("z-index: 1");
+    expect(bodiesFor(".composer-dock").join(" ")).toContain("z-index: 2");
+    // Inset from the panel edge: flush, a four-way split's rings would run into each other and the
+    // two panes would read as one target.
+    expect(glow).toContain("inset: 6px");
+    // It advertises the drop; it must never eat it.
+    expect(glow).toContain("pointer-events: none");
+    // The pane is the positioned ancestor the glow hangs off, not whatever happens to be above it.
+    expect(bodiesFor(".session-pane").join(" ")).toContain("position: relative");
+  });
+
+  it("the glow is an inner ring that dissolves inward, and the blur is masked on its own layer", () => {
+    const glow = bodiesFor(".session-drop").join(" ");
+    // Both insets: the sharp ring, then the soft fall-off behind it. A flat overlay is what this is
+    // deliberately not.
+    expect(glow).toContain("box-shadow: inset 0 0 0 1.5px var(--rl-accent), inset 0 0 36px -6px var(--rl-accent)");
+    const soft = bodiesFor(".session-drop::before").join(" ");
+    expect(soft).toContain("backdrop-filter: blur(5px)");
+    expect(soft).toContain("mask-image: radial-gradient");
+    // A masked ancestor becomes a backdrop root and its children blur an EMPTY backdrop, so the mask
+    // has to sit on the blurring layer itself — the trap the transcript's fade band documents.
+    expect(glow).not.toContain("mask-image");
+  });
+
+  it("the glow appears on the drag rung, and reduced motion is what takes the fade away", () => {
+    // `--dur-drag` is the ladder's rung for exactly this: a drop target appearing mid-drag.
+    expect(bodiesFor(".session-drop").join(" ")).toContain(`animation: rl-fade-in ${dur("--dur-drag")} linear`);
+    // Reduced motion needs no rule of its own here: the blanket `*` kill covers a real element (it
+    // would NOT cover a pseudo-element, which is why the glow is one).
+    expect(blockAfter("@media (prefers-reduced-motion: reduce)")).toContain("animation: none !important");
+  });
+
+  it("reduced transparency drops the glow's blur and keeps the ring that carries the meaning", () => {
+    const reduced = blockAfter("@media (prefers-reduced-transparency: reduce)").replace(/\s+/g, " ");
+    expect(reduced).toContain(".session-drop::before { backdrop-filter: none");
+    // Only the blur goes. The ring is on `.session-drop` itself and is never touched here — a
+    // preference about translucency must not take the affordance away.
+    expect(reduced).not.toContain(".session-drop {");
+  });
+
   it("a disabled quiet button stays dark under the cursor — the hover fill is guarded like .btn's", () => {
     // Unguarded, "Commit only" with nothing staged still lit up on hover: a control that answers
     // the pointer while refusing the click.

--- a/packages/contracts/src/attachments.test.ts
+++ b/packages/contracts/src/attachments.test.ts
@@ -3,7 +3,7 @@ import { AgentKindSchema } from "./entities";
 import { AGENT_META } from "./presets";
 import {
   attachmentDisposition, attachmentNote, attachmentSummary, basenameOf, DEFAULT_MIME,
-  isImageMime, MAX_ATTACHMENT_BYTES, mimeForPath,
+  isImageMime, isOpenablePath, MAX_ATTACHMENT_BYTES, mimeForPath,
 } from "./attachments";
 
 const KINDS = AgentKindSchema.options;
@@ -134,5 +134,25 @@ describe("attachmentSummary", () => {
 describe("MAX_ATTACHMENT_BYTES", () => {
   it("is the 20 MB ceiling the Claude adapter throws above", () => {
     expect(MAX_ATTACHMENT_BYTES).toBe(20 * 1024 * 1024);
+  });
+});
+
+describe("isOpenablePath", () => {
+  it("accepts every document type the mime table names", () => {
+    for (const p of ["/x/a.pdf", "/x/a.png", "/x/a.mp4", "/x/a.csv", "/x/a.ts", "/x/a.md", "/x/a.zip"]) {
+      expect(isOpenablePath(p), p).toBe(true);
+    }
+  });
+  it("refuses what the table does not name — the bundles macOS would RUN rather than show", () => {
+    // `open Thing.app` launches it. The table not knowing those extensions is the whole gate, so
+    // this is the assertion that keeps `attachment:open` off them.
+    for (const p of ["/x/Thing.app", "/x/run.command", "/x/h.tool", "/x/a.workflow", "/x/blob.bin", "/x/noext", "/x/.env"]) {
+      expect(isOpenablePath(p), p).toBe(false);
+    }
+  });
+  it("agrees with mimeForPath — it IS that question, and both sides of the bridge ask it", () => {
+    for (const p of ["/x/a.pdf", "/x/Thing.app", "/x/noext"]) {
+      expect(isOpenablePath(p), p).toBe(mimeForPath(p) !== DEFAULT_MIME);
+    }
   });
 });

--- a/packages/contracts/src/attachments.ts
+++ b/packages/contracts/src/attachments.ts
@@ -47,6 +47,19 @@ const MIME_BY_EXT: Record<string, string> = {
 
 export const DEFAULT_MIME = "application/octet-stream";
 
+/**
+ * Whether Realm will hand this file to the OS to open.
+ *
+ * The mime table IS the gate, and that is the point rather than a shortcut: on macOS `open` RUNS an
+ * `.app`, a `.command` or a `.tool` instead of showing it, and none of those extensions is in the
+ * table — so an unrecognised extension is refused before it can be one of them. Every type the table
+ * does know is a document, and opening one is what a double-click in Finder already does.
+ *
+ * Asked on both sides of the bridge: the tile draws its open affordance from this, main re-asks it
+ * before the `shell` call. A tile therefore never offers an open that main will turn down.
+ */
+export const isOpenablePath = (path: string): boolean => mimeForPath(path) !== DEFAULT_MIME;
+
 /** Mime from a path's extension. Case-insensitive; a dotfile or extensionless name is octet-stream. */
 export function mimeForPath(path: string): string {
   const name = basenameOf(path);


### PR DESCRIPTION
Stacked on #35.

**Opening is decided by what main says the file *is*, not by the `mime` prop.** Images, video and audio go to the existing `MediaLightbox`, reused as-is. Everything else — PDF, CSV, source, zip — is handed to the OS, because no element can render a PDF and a lightbox would show nothing. An extension Realm's mime table does not know gets **no open affordance at all** rather than a dead control, and a playable path main answers `null` for (the file moved) falls to the OS, which reports it, instead of opening an empty viewer.

Non-media deliberately does **not** reuse `media:open`. That gate answers about paths harvested from an agent's prose and must stay narrow. The new `openablePath` is asked about a file the user picked — and the mime table *is* the gate, because on macOS `open` **runs** a `.app`, `.command` or `.tool`, and no bundle extension is in the table. Both sides call the same `isOpenablePath`.

Sent and pending tiles now agree structurally: opening lives on `AttachmentTile` itself, so neither caller holds a copy. Sent non-media used to do nothing. Open and Remove are **siblings**, never nested — no `stopPropagation` untangling its own event target, and a button inside a button is invalid markup anyway.

**The pane-wide drop shares one `useFileDrop` hook with the prompter, and the prompter claims all four events, not just the drop.** Claiming only the drop leaves the pane counting a leave whose enter it never saw, going negative and staying lit for the rest of the drag. `carriesFiles` moved into `drag-types.ts` beside `isRealmPaneDrag` so the two vocabularies sit together and stay disjoint — a pane drag sets neither `Files` nor a dropEffect and is never `preventDefault`ed, so PaneHost's drop edges and BrowserPane's `dragstart` bounds sync are untouched.

The glow is a real element rather than a pseudo, which is what lets the blanket `* { animation: none }` reach it under reduced motion. Reduced transparency drops the `backdrop-filter` but keeps the ring and wash — a preference about translucency should not remove the affordance.

Verified live: the drop glow measures **1.0000** of baseline card sharpness with the prompter crisp on top, while the mutant that raises the glow above the dock collapses it to **0.607** — so the threshold discriminates rather than being fitted to the answer. The lightbox is proved to paint over the prompter, and `attachment:open` is proved registered in the built main.

One existing guardrail needed repair rather than deletion: the "no visible filename" assertion read the tile's *direct* children, and the hidden name now rides inside the open button — so it had stopped looking at anything. It strips at any depth now, in both the jsdom test and the live script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)