### PR TITLE
Codex-style Appearance: independent light/dark palettes, overrides through the derivation, contrast, fonts, import

### DIFF
--- a/apps/desktop/scripts/themes-live.mjs
+++ b/apps/desktop/scripts/themes-live.mjs
@@ -43,7 +43,10 @@ const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
  *  drift the assertion is for. */
 const SYNTAX_FLOOR = 2.7;
 /** Every palette, and the modes each one has. Read off THEMES; a theme added there and not here is
- *  simply not screenshotted, which check 5 catches. */
+ *  simply not screenshotted, which check 6 catches.
+ *  Walked MODE-OUTER, because the palette menu now sets the face on screen and offers only the
+ *  palettes that have it — picking the mode second would apply Monokai to whatever face happened to
+ *  be showing, and then ask for a light face it does not have. */
 const PALETTES = [
   ["Realm", "realm", ["light", "dark"]],
   ["One", "one", ["light", "dark"]],
@@ -52,6 +55,9 @@ const PALETTES = [
   ["Nord", "nord", ["dark"]],
   ["Solarized", "solarized", ["light", "dark"]],
   ["Gruvbox", "gruvbox", ["light", "dark"]],
+  ["Catppuccin", "catppuccin", ["light", "dark"]],
+  ["GitHub", "github", ["light", "dark"]],
+  ["Rosé Pine", "rosepine", ["light", "dark"]],
 ];
 const SYNTAX_ROLES = ["keyword", "string", "number", "title", "type", "attr", "comment"];
 
@@ -165,6 +171,83 @@ window.__live = window.__live ?? {
       paneRect: (document.querySelector(".panel") ?? document.querySelector(".main")).getBoundingClientRect().toJSON(),
     };
   },
+  /** Settings → App, which is where every control the space menu cannot reach lives. */
+  async openAppSettings() {
+    document.querySelector('[aria-label="Space menu"]')?.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "k", metaKey: true, bubbles: true }));
+    for (let i = 0; i < 40 && !document.querySelector(".palette-list"); i++) await new Promise((r) => setTimeout(r, 25));
+    const open = [...document.querySelectorAll(".palette-list [role=option], .palette-list button")]
+      .find((b) => /settings/i.test(b.textContent));
+    open?.click();
+    for (let i = 0; i < 80 && !document.querySelector(".settings-page-pane"); i++) await new Promise((r) => setTimeout(r, 25));
+    [...document.querySelectorAll(".page-rail input")].find((r) => r.value === "app")?.click();
+    for (let i = 0; i < 80 && !document.querySelector(".mode-grid"); i++) await new Promise((r) => setTimeout(r, 25));
+    document.querySelector(".mode-grid")?.scrollIntoView();
+    return !!document.querySelector(".mode-grid");
+  },
+  byLabel(role, name) {
+    const all = [...document.querySelectorAll("input, select, textarea, button")];
+    return all.find((el) => el.getAttribute("aria-label") === name && (!role || el.tagName.toLowerCase() === role));
+  },
+  /** A hex field commits on blur, and React listens for focusout rather than blur — so a synthetic
+   *  FocusEvent("blur") sets the value and commits nothing. Focus it, type, blur it for real, and
+   *  let the browser fire the event React is actually subscribed to. */
+  setHex(label, value) {
+    const el = this.byLabel("input", label);
+    if (!el) throw new Error("no field: " + label);
+    el.scrollIntoView({ block: "center" });
+    el.focus();
+    this.setInput(el, value);
+    el.blur();
+    // blur() is a no-op unless the element really is the active one, and it is not while the pane is
+    // mid-scroll or something else holds focus. The commit hangs off focusout, so fire it outright
+    // rather than hoping; committing the same value twice is a no-op, missing it is a silent pass.
+    el.dispatchEvent(new FocusEvent("focusout", { bubbles: true }));
+    return true;
+  },
+  setRange(label, value) { const el = this.byLabel("input", label); this.setInput(el, String(value)); return true; },
+  setSelect(label, value) {
+    const el = this.byLabel("select", label);
+    Object.getOwnPropertyDescriptor(HTMLSelectElement.prototype, "value").set.call(el, value);
+    el.dispatchEvent(new Event("change", { bubbles: true }));
+    return true;
+  },
+  clickButton(re) {
+    const hit = [...document.querySelectorAll("button")].find((b) => re.test(b.textContent.trim()));
+    if (!hit) throw new Error("no button matching " + re);
+    hit.click();
+    return true;
+  },
+  /** What the previews are actually painted with — read off the preview elements, not off :root,
+   *  which is the whole claim. */
+  previews() {
+    const minis = [...document.querySelectorAll(".mode-card-preview .mini-window")];
+    const cp = document.querySelector(".code-preview");
+    const at = (el, prop) => this.srgb(getComputedStyle(el).getPropertyValue(prop).trim()).join(",");
+    return {
+      miniPages: minis.map((m) => this.srgb(getComputedStyle(m).backgroundColor).join(",")),
+      keyword: this.srgb(getComputedStyle(cp.querySelector(".hljs-keyword")).color).join(","),
+      string: this.srgb(getComputedStyle(cp.querySelector(".hljs-string")).color).join(","),
+      body: at(cp, "--syn-fg"),
+    };
+  },
+  inkRamp() {
+    const cs = getComputedStyle(document.documentElement);
+    const t = (n) => this.srgb(cs.getPropertyValue(n).trim());
+    return { ink: t("--ink"), ink2: t("--ink-2"), ink3: t("--ink-3"), surface: t("--surface"), page: t("--page"), accent: t("--accent") };
+  },
+  fonts() {
+    const mono = document.querySelector(".code-preview") ?? document.querySelector("kbd");
+    // The RENDERED weight of each rung, not the token text. The ladder is written as
+    // calc(450 + var(--fw-shift)) and getPropertyValue hands back that string unresolved — only a
+    // real element being laid out resolves it, which is also the number that reaches a glyph.
+    const probe = (this._fw ??= (() => { const el = document.createElement("span"); el.style.position = "fixed"; el.style.visibility = "hidden"; document.body.appendChild(el); return el; })());
+    const rungs = ["--fw-medium", "--fw-label", "--fw-title", "--fw-strong"].map((n) => {
+      probe.style.fontWeight = "var(" + n + ")";
+      return Number(getComputedStyle(probe).fontWeight);
+    });
+    return { body: getComputedStyle(document.body).fontFamily, mono: getComputedStyle(mono).fontFamily, rungs };
+  },
   /** The mean colour of a band of the screenshot, as [r,g,b]. Solid grounds only — glyphs would drag
    *  the mean by however much text happens to be in the band. */
   async band(b64, x0, y0, x1, y1) {
@@ -255,11 +338,18 @@ async function main() {
 
   const grounds = new Map();
   const shots = [];
-  for (const [label, name, modes] of PALETTES) {
-    await evalIn(c, `__live.menu(${JSON.stringify(`Palette: ${label}`)})`);
-    await sleep(250);
-    for (const mode of modes) {
-      await evalIn(c, `__live.menu(${JSON.stringify(`Theme: ${mode[0].toUpperCase()}${mode.slice(1)}`)})`);
+  for (const mode of ["light", "dark"]) {
+    await evalIn(c, `__live.menu(${JSON.stringify(`Theme: ${mode[0].toUpperCase()}${mode.slice(1)}`)})`);
+    await sleep(300);
+    for (const [label, name, modes] of PALETTES) {
+      if (!modes.includes(mode)) {
+        // The other half of the split: a palette with no such face must not be OFFERED for it. The
+        // menu is filtered, so asking throws — which is the assertion.
+        const offered = await evalIn(c, `__live.menu(${JSON.stringify(`Palette: ${label}`)}).then(() => true, () => false)`);
+        check(`${name}: not offered for the ${mode} face it does not have`, offered === false);
+        continue;
+      }
+      await evalIn(c, `__live.menu(${JSON.stringify(`Palette: ${label}`)})`);
       await sleep(300);
       const p = await evalIn(c, `__live.probe()`);
       const tag = `${name}-${mode}`;
@@ -305,7 +395,108 @@ async function main() {
   check("every palette paints a ground of its own", uniq.size === grounds.size,
     { faces: grounds.size, distinct: uniq.size });
 
-  // 7. …and returning to the default lands exactly back on the palette that shipped.
+  // 7. The two slots really are two. Set a different palette on each face and flip between them: a
+  //    shared slot would show the same palette both times, which no per-face check above can see
+  //    because each of them only ever looks at one face.
+  await evalIn(c, `__live.menu("Theme: Light")`); await sleep(250);
+  await evalIn(c, `__live.menu("Palette: Solarized")`); await sleep(300);
+  const lightFace = await evalIn(c, `__live.probe()`);
+  await evalIn(c, `__live.menu("Theme: Dark")`); await sleep(250);
+  await evalIn(c, `__live.menu("Palette: Monokai")`); await sleep(300);
+  const darkFace = await evalIn(c, `__live.probe()`);
+  await evalIn(c, `__live.menu("Theme: Light")`); await sleep(300);
+  const backToLight = await evalIn(c, `__live.probe()`);
+  check("each face keeps its own palette across a mode flip",
+    lightFace.theme === "solarized" && darkFace.theme === "monokai" && backToLight.theme === "solarized",
+    { light: lightFace.theme, dark: darkFace.theme, backToLight: backToLight.theme });
+  check("a dark-only palette does not drag the window dark with it", backToLight.mode === "light", backToLight.mode);
+
+  // 8. Settings → App: the previews, and the three controls the menu cannot reach. Screenshotted
+  //    because everything on this page is a picture of a palette and a picture cannot be asserted.
+  await evalIn(c, `__live.openAppSettings()`);
+  await until(() => evalIn(c, `!!document.querySelector('.mode-grid')`), 10000, "app settings");
+  await sleep(400);
+  const settingsShot = (await c.send("Page.captureScreenshot", { format: "png" })).data;
+  const settingsOut = path.join(os.tmpdir(), "realm-theme-settings.png");
+  fs.writeFileSync(settingsOut, Buffer.from(settingsShot, "base64"));
+  shots.push(settingsOut);
+  console.log(`SCREENSHOT settings ${settingsOut}`);
+
+  const previews = await evalIn(c, `__live.previews()`);
+  // A preview built off :root would show the mode already on screen in every card. Three cards, at
+  // least two distinct grounds, and the code preview coloured by the --syn-* roles rather than by
+  // whatever the page's own text colour is.
+  check("the mode cards preview more than one face at once",
+    new Set(previews.miniPages).size >= 2, previews.miniPages);
+  check("the code preview is painted by the syntax roles, not by the page",
+    previews.keyword !== previews.body && previews.string !== previews.keyword,
+    { keyword: previews.keyword, string: previews.string, body: previews.body });
+
+  // 9. An override reaches the compositor. THE past-the-machinery mutant would still pass a CSSOM
+  //    check; what this asserts is that the whole ladder moved with the ground, so the pane's own
+  //    pixel is the CANVAS derived from the new page rather than the old palette's.
+  const beforeOverride = await evalIn(c, `__live.probe()`);
+  await evalIn(c, `__live.setHex("Background hex", "#1b2a1b")`);
+  await sleep(400);
+  const afterOverride = await evalIn(c, `__live.probe()`);
+  check("an override repaints the whole ladder, not just the one token it names",
+    !near(afterOverride.page, beforeOverride.page, 2) && !near(afterOverride.canvas, beforeOverride.canvas, 2)
+      && !near(afterOverride.surface, beforeOverride.surface, 2),
+    { page: afterOverride.page, canvas: afterOverride.canvas, surface: afterOverride.surface });
+  const ovShot = (await c.send("Page.captureScreenshot", { format: "png" })).data;
+  const ovOut = path.join(os.tmpdir(), "realm-theme-override.png");
+  fs.writeFileSync(ovOut, Buffer.from(ovShot, "base64"));
+  shots.push(ovOut);
+  console.log(`SCREENSHOT override ${ovOut}`);
+  await evalIn(c, `__live.clickButton(/^Reset to /)`);
+  await sleep(400);
+  const afterReset = await evalIn(c, `__live.probe()`);
+  check("resetting an override lands back on the palette's own ground",
+    near(afterReset.page, beforeOverride.page, 1), { was: beforeOverride.page, now: afterReset.page });
+
+  // 10. The contrast control, through the real cascade. It has to move the secondary tier and leave
+  //     the ground and the accent exactly where they were, and never drop below its floor.
+  const inkAt = async (v) => {
+    await evalIn(c, `__live.setRange("Contrast", ${v})`);
+    await sleep(350);
+    return evalIn(c, `__live.inkRamp()`);
+  };
+  const [lo, mid, hi] = [await inkAt(0), await inkAt(60), await inkAt(100)];
+  check("contrast opens and closes the ink ramp on screen",
+    contrast(lo.ink2, lo.surface) < contrast(mid.ink2, mid.surface)
+      && contrast(mid.ink2, mid.surface) < contrast(hi.ink2, hi.surface),
+    { lo: +contrast(lo.ink2, lo.surface).toFixed(2), mid: +contrast(mid.ink2, mid.surface).toFixed(2), hi: +contrast(hi.ink2, hi.surface).toFixed(2) });
+  check("contrast moves nothing but the ramp", near(lo.page, hi.page, 1) && near(lo.accent, hi.accent, 1));
+  for (const [name, s] of [["0", lo], ["60", mid], ["100", hi]]) {
+    check(`contrast ${name}: --ink-2 still clears 3:1 on the surface`, contrast(s.ink2, s.surface) >= 3,
+      { ratio: +contrast(s.ink2, s.surface).toFixed(2) });
+    check(`contrast ${name}: --ink-3 still clears 2.4:1 on the surface`, contrast(s.ink3, s.surface) >= 2.4,
+      { ratio: +contrast(s.ink3, s.surface).toFixed(2) });
+  }
+  await evalIn(c, `__live.setRange("Contrast", 60)`); await sleep(300);
+
+  // 11. The font preference, as the browser resolves it — not as a string comparison on a token.
+  //     `font-family` on a real element is what actually got picked.
+  const fontBefore = await evalIn(c, `__live.fonts()`);
+  await evalIn(c, `__live.setSelect("UI font", "system")`);
+  await evalIn(c, `__live.setSelect("Code font", "system")`);
+  await evalIn(c, `__live.setSelect("UI font weight", "medium")`);
+  await sleep(400);
+  const fontAfter = await evalIn(c, `__live.fonts()`);
+  check("the UI face reaches real elements", fontBefore.body.includes("Inter") && !fontAfter.body.includes("Inter"),
+    { before: fontBefore.body, after: fontAfter.body });
+  check("the code face reaches real elements",
+    fontBefore.mono.includes("JetBrains") && !fontAfter.mono.includes("JetBrains"), { before: fontBefore.mono, after: fontAfter.mono });
+  // THE absolute-weight mutant: the four rungs collapse onto one number. They have to stay four.
+  check("the weight preference shifts the whole ladder and keeps it a ladder",
+    fontAfter.rungs.every((w, i) => i === 0 || w > fontAfter.rungs[i - 1]) && fontAfter.rungs[0] > fontBefore.rungs[0],
+    { before: fontBefore.rungs, after: fontAfter.rungs });
+  await evalIn(c, `__live.setSelect("UI font", "bundled")`);
+  await evalIn(c, `__live.setSelect("Code font", "bundled")`);
+  await evalIn(c, `__live.setSelect("UI font weight", "regular")`);
+  await sleep(300);
+
+  // 12. …and returning to the default lands exactly back on the palette that shipped.
   await evalIn(c, `__live.menu("Palette: Realm")`);
   await sleep(300);
   const back = await evalIn(c, `__live.probe()`);

--- a/apps/desktop/scripts/transparency-live.mjs
+++ b/apps/desktop/scripts/transparency-live.mjs
@@ -108,6 +108,7 @@ window.__live = window.__live ?? {
     return true;
   },
   slider() { return document.querySelector('input[aria-label="Background transparency"]'); },
+  toggle() { return document.querySelector('input[aria-label="Translucent sidebar"]'); },
   /** The settings tabs are radio INPUTS inside labels, so the visible word is on the label. */
   tab(name) {
     const hit = [...document.querySelectorAll("label")].find((l) => l.textContent.trim() === name && l.querySelector('input[type="radio"]'));
@@ -125,7 +126,10 @@ window.__live = window.__live ?? {
       sidebar: this.rgba(getComputedStyle(sidebar).backgroundColor),
       pane: this.rgba(getComputedStyle(pane).backgroundColor),
       sliderValue: this.slider()?.value ?? null,
-      readout: document.querySelector(".ground-alpha-value")?.textContent ?? null,
+      // Scoped to THIS slider's row. The readout class is shared with the contrast control, which sits
+      // above this one in the same form — a bare querySelector reads that one instead and passes or
+      // fails on a number belonging to a different setting.
+      readout: this.slider()?.parentElement?.querySelector(".slider-value")?.textContent ?? null,
     };
   },
 };
@@ -218,6 +222,19 @@ async function main() {
   }
 
   // 3. Reduced transparency wins, and does not eat the value.
+  // 3. The switch and the amount are one number. Fully opaque IS off, so the switch has to read the
+  //    ground rather than a boolean of its own — two stored states could disagree, and the pair of
+  //    them sit on the same row where the disagreement would be visible.
+  await evalIn(c, `__live.setInput(__live.slider(), "${MIN_ALPHA}")`);
+  await sleep(300);
+  let t = await evalIn(c, `({ on: __live.toggle().checked, disabled: __live.slider().disabled, token: getComputedStyle(document.documentElement).getPropertyValue("--ground-alpha").trim() })`);
+  check("dragging the amount to nothing turns the switch off — that IS off", t.on === false && t.token === "100%", t);
+  check("...and the amount goes inert rather than showing a value nothing is using", t.disabled === true, t);
+  await evalIn(c, `__live.toggle().click()`);
+  await sleep(300);
+  t = await evalIn(c, `({ on: __live.toggle().checked, disabled: __live.slider().disabled, token: getComputedStyle(document.documentElement).getPropertyValue("--ground-alpha").trim() })`);
+  check("switching it back on restores a translucent ground", t.on === true && t.token === "82%" && t.disabled === false, t);
+
   await evalIn(c, `__live.setInput(__live.slider(), "${MIN_ALPHA + MAX_ALPHA - MIN_ALPHA}")`);
   await sleep(200);
   await c.send("Emulation.setEmulatedMedia", { features: [{ name: "prefers-reduced-transparency", value: "reduce" }] });

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -10,6 +10,7 @@ import { ActivitySheet } from "./components/ActivitySheet";
 import { CommandPalette, usePaletteHotkey } from "./components/CommandPalette";
 import { SpaceOverview, useSpacesHotkey } from "./components/sidebar/SpaceOverview";
 import { PaneHost } from "./components/PaneHost";
+import { getTerminalHub } from "./panes/terminal-hub";
 import { GroupBar } from "./components/GroupBar";
 import { Onboarding } from "./components/Onboarding";
 import { StoreContext, createAppStore, useApp } from "./state/store";
@@ -56,8 +57,13 @@ function ThemeBridge() {
   const themes = useApp((s) => s.themeNames);
   const overrides = useApp((s) => s.themeOverrides);
   const contrast = useApp((s) => s.contrast);
+  const fonts = useApp((s) => s.fonts);
   const groundAlpha = useApp((s) => s.groundAlpha);
-  useApplyTheme({ color, pref, themes, overrides, contrast, groundAlpha });
+  useApplyTheme({ color, pref, themes, overrides, contrast, fonts, groundAlpha });
+  // xterm reads its font once, at construction, so a terminal already on screen would keep the old
+  // face. A plain effect, not a layout one: it has to run AFTER useApplyTheme has written
+  // --font-mono, because the hub reads the computed value off :root.
+  useEffect(() => { getTerminalHub().refreshFont(); }, [fonts]);
   return null;
 }
 

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -55,8 +55,9 @@ function ThemeBridge() {
   const pref = useApp((s) => s.themePref);
   const themes = useApp((s) => s.themeNames);
   const overrides = useApp((s) => s.themeOverrides);
+  const contrast = useApp((s) => s.contrast);
   const groundAlpha = useApp((s) => s.groundAlpha);
-  useApplyTheme({ color, pref, themes, overrides, groundAlpha });
+  useApplyTheme({ color, pref, themes, overrides, contrast, groundAlpha });
   return null;
 }
 

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -53,9 +53,9 @@ export function AppShell() {
 function ThemeBridge() {
   const color = useApp((s) => s.activeSpace()?.color ?? null);
   const pref = useApp((s) => s.themePref);
-  const theme = useApp((s) => s.themeName);
+  const themes = useApp((s) => s.themeNames);
   const groundAlpha = useApp((s) => s.groundAlpha);
-  useApplyTheme(color, pref, theme, groundAlpha);
+  useApplyTheme(color, pref, themes, groundAlpha);
   return null;
 }
 

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -54,8 +54,9 @@ function ThemeBridge() {
   const color = useApp((s) => s.activeSpace()?.color ?? null);
   const pref = useApp((s) => s.themePref);
   const themes = useApp((s) => s.themeNames);
+  const overrides = useApp((s) => s.themeOverrides);
   const groundAlpha = useApp((s) => s.groundAlpha);
-  useApplyTheme(color, pref, themes, groundAlpha);
+  useApplyTheme({ color, pref, themes, overrides, groundAlpha });
   return null;
 }
 

--- a/apps/desktop/src/renderer/src/components/CommandPalette.tsx
+++ b/apps/desktop/src/renderer/src/components/CommandPalette.tsx
@@ -1,10 +1,10 @@
-import { Icon, THEMES, resolveMode } from "@realm/ui";
+import { Icon, THEMES, themeModes } from "@realm/ui";
 import { AGENT_META, PRESETS, SELECTABLE_AGENT_KINDS, emptyLayout, itemIdOfLeaf, allItems as openItemIds, type DestinationPageKind, type Item, type PresetName, type SearchResults, type SearchSnippet } from "@realm/contracts";
 import { Fragment, useEffect, useMemo, useRef, useState, type KeyboardEvent as ReactKeyboardEvent, type ReactNode } from "react";
 import type { StoreApi } from "zustand";
 import { centerOverComplement } from "../state/no-overlay";
 import { useApp, useBrowserRects, type AppState } from "../state/store";
-import type { ThemePref } from "../theme/useTheme";
+import { useResolvedMode, type ThemePref } from "../theme/useTheme";
 import { ItemGlyph } from "./sidebar/ItemList";
 import { SpaceIcon } from "./SpaceIcon";
 
@@ -106,7 +106,8 @@ function PaletteBody() {
   const sessions = useApp((s) => s.sessions);
   const sessionStatus = useApp((s) => s.sessionStatus);
   const themePref = useApp((s) => s.themePref);
-  const themeName = useApp((s) => s.themeName);
+  const themeNames = useApp((s) => s.themeNames);
+  const mode = useResolvedMode(themePref);
   const setThemeName = useApp((s) => s.setThemeName);
   const selectSpace = useApp((s) => s.selectSpace);
   const openItem = useApp((s) => s.openItem);
@@ -297,16 +298,17 @@ function PaletteBody() {
     }));
 
     // The palette axis, in the same section: light/dark and which colours are the same question to
-    // anyone reaching for ⌘K. A one-faced theme says so in the hint rather than surprising the user
-    // by pinning the mode on select.
-    const palettes = THEMES.map<Entry>((t) => ({
+    // anyone reaching for ⌘K. It sets the palette for the face ON SCREEN and offers only palettes
+    // that have that face — reaching for ⌘K is reaching for what you are looking at, and a picker
+    // here for the face you cannot see would change the window at some unrelated later moment.
+    const palettes = THEMES.filter((t) => themeModes(t.name).includes(mode)).map<Entry>((t) => ({
       id: `palette:${t.name}`, label: `Palette: ${t.label}`, section: "Theme",
-      hint: themeName === t.name ? "current" : t.dark && t.light ? undefined : `${resolveMode(t.name, "light")} only`,
-      icon: <Icon name="paintBucket" size={15} />, run: () => run(() => setThemeName(t.name)),
+      hint: themeNames[mode] === t.name ? `current · ${mode}` : mode,
+      icon: <Icon name="paintBucket" size={15} />, run: () => run(() => setThemeName(mode, t.name)),
     }));
 
     return [...open, ...activeRest, ...others, ...actions, ...themes, ...palettes];
-  }, [spaces, activeSpaceId, items, allItems, layout, focusedLeafId, sessions, sessionStatus, themePref, themeName, drafts, dispatchDraft,
+  }, [spaces, activeSpaceId, items, allItems, layout, focusedLeafId, sessions, sessionStatus, themePref, themeNames, mode, drafts, dispatchDraft,
       selectSpace, openItem, newTerminal, newBrowser, openDocuments, newSession, newSessionInstant, newSessionInWorktree, splitFocused, closeFromLayout, requestRename,
       interruptSession, jumpToPermission, applyPreset, setThemePref, setThemeName, openSheet, openSpacePage, openDestinationPage, destinationPageElsewhere, openProfilePage, openActivity, setSpacesOpen, run,
       groups, zoomedLeaf, activatePaneGroup, newPaneGroup, toggleFocusPane]);

--- a/apps/desktop/src/renderer/src/components/sidebar/SpaceHeader.tsx
+++ b/apps/desktop/src/renderer/src/components/sidebar/SpaceHeader.tsx
@@ -1,10 +1,10 @@
-import { Icon, THEMES } from "@realm/ui";
+import { Icon, THEMES, themeModes } from "@realm/ui";
 import { useCallback, useRef, useState } from "react";
 import type { Space } from "@realm/contracts";
 import { useApp } from "../../state/store";
 import { Menu } from "../Menu";
 import { SpaceIcon } from "../SpaceIcon";
-import type { ThemePref } from "../../theme/useTheme";
+import { useResolvedMode, type ThemePref } from "../../theme/useTheme";
 
 const MODES: { pref: ThemePref; label: string }[] = [{ pref: "system", label: "System" }, { pref: "light", label: "Light" }, { pref: "dark", label: "Dark" }];
 
@@ -12,7 +12,7 @@ export function SpaceHeader({ space }: { space: Space }) {
   const profile = useApp((s) => s.profiles.find((p) => p.id === space.profileId));
   const themePref = useApp((s) => s.themePref);
   const setThemePref = useApp((s) => s.setThemePref);
-  const themeName = useApp((s) => s.themeName);
+  const themeNames = useApp((s) => s.themeNames);
   const setThemeName = useApp((s) => s.setThemeName);
   const swipeInvert = useApp((s) => s.swipeInvert);
   const setSwipeInvert = useApp((s) => s.setSwipeInvert);
@@ -21,6 +21,7 @@ export function SpaceHeader({ space }: { space: Space }) {
   const newTerminal = useApp((s) => s.newTerminal);
   const newSessionInWorktree = useApp((s) => s.newSessionInWorktree);
   const run = useApp((s) => s.run);
+  const mode = useResolvedMode(themePref);
   const [menu, setMenu] = useState(false);
   const btnRef = useRef<HTMLButtonElement>(null);
   const closeMenu = useCallback(() => setMenu(false), []);
@@ -47,7 +48,8 @@ export function SpaceHeader({ space }: { space: Space }) {
               { kind: "separator" },
               ...MODES.map((t) => ({ label: `Theme: ${t.label}`, checked: themePref === t.pref, onSelect: () => run(() => setThemePref(t.pref)) })),
               { kind: "separator" as const },
-              ...THEMES.map((t) => ({ label: `Palette: ${t.label}`, checked: themeName === t.name, onSelect: () => run(() => setThemeName(t.name)) })),
+              // The face on screen, like ⌘K: this menu sits beside the window it repaints.
+              ...THEMES.filter((t) => themeModes(t.name).includes(mode)).map((t) => ({ label: `Palette: ${t.label}`, checked: themeNames[mode] === t.name, onSelect: () => run(() => setThemeName(mode, t.name)) })),
               { kind: "separator" as const },
               { label: "Invert swipe direction", checked: swipeInvert, onSelect: () => run(() => setSwipeInvert(!swipeInvert)) },
           ]} />

--- a/apps/desktop/src/renderer/src/panes/settings/SettingsPage.tsx
+++ b/apps/desktop/src/renderer/src/panes/settings/SettingsPage.tsx
@@ -3,7 +3,7 @@ import {
   CREDENTIAL_2FA_NOTE, CREDENTIAL_PRESENCE_TTLS, CREDENTIAL_STORAGE_NOTE, NOTIFICATION_CATEGORIES,
   PERMISSION_MODES, SELECTABLE_AGENT_KINDS, type AgentKind, type NotificationCategory,
 } from "@realm/contracts";
-import { GROUND_ALPHA_RANGE, Icon, REALM_SEED, THEMES, contrastMisses, isHexColour, isOverridden, overrideKey,
+import { CONTRAST_RANGE, GROUND_ALPHA_RANGE, Icon, REALM_SEED, THEMES, contrastMisses, isHexColour, isOverridden, overrideKey,
   seedFor, themeModes, themeSwatches, type Mode, type ThemeName } from "@realm/ui";
 import { useEffect, useState } from "react";
 import { agentAvailability, isBlocked } from "../../state/agent-availability";
@@ -234,13 +234,17 @@ const OVERRIDE_FIELDS = [
 
 function ThemeOverrideEditor({ name, face }: { name: ThemeName; face: Mode }) {
   const override = useApp((s) => s.themeOverrides[overrideKey(name, face)]);
+  const contrast = useApp((s) => s.contrast);
   const setThemeOverride = useApp((s) => s.setThemeOverride);
   const resetThemeOverride = useApp((s) => s.resetThemeOverride);
   const run = useApp((s) => s.run);
   // The palette AS EDITED. `seedFor` returns null only for an untouched Realm, whose seeds are what
   // the fields have to show anyway — there is no other honest starting value for an edit.
   const seed = seedFor(name, face, override ?? {}) ?? REALM_SEED[face];
-  const misses = contrastMisses(seed, face);
+  // Measured at the contrast the app is actually running at, not at the default — the ramp's spread
+  // is one of the things a tier's ratio depends on, and a warning computed against a setting the
+  // user is not using would name the wrong roles.
+  const misses = contrastMisses(seed, face, contrast);
 
   return (
     <fieldset className="theme-overrides" aria-label={`${face === "light" ? "Light" : "Dark"} theme colours`}>
@@ -286,6 +290,8 @@ function AppTab() {
   const setThemePref = useApp((s) => s.setThemePref);
   const themeNames = useApp((s) => s.themeNames);
   const setThemeName = useApp((s) => s.setThemeName);
+  const contrast = useApp((s) => s.contrast);
+  const setContrast = useApp((s) => s.setContrast);
   const groundAlpha = useApp((s) => s.groundAlpha);
   const setGroundAlpha = useApp((s) => s.setGroundAlpha);
   const submitKey = useApp((s) => s.submitKey);
@@ -344,17 +350,32 @@ function AppTab() {
           onSelect={(name) => run(() => setThemeName(face, name))} />
       ))}
 
+      <div className="field"><span>Contrast</span>
+        {/* The ink ramp's SPREAD — how far the secondary and hint tiers fall below primary text. It
+            is the only thing in the palette that is a matter of eyes rather than of design: the hues
+            are the palette's identity and the surfaces are its structure, and a slider that moved
+            either would be a repaint wearing the word "contrast". It cannot make anything illegible
+            at any setting, because every tier is floored at WCAG before the ramp is walked. */}
+        <div className="slider-row">
+          <input type="range" aria-label="Contrast"
+            min={CONTRAST_RANGE.min} max={CONTRAST_RANGE.max} step={1}
+            value={contrast} onChange={(e) => run(() => setContrast(Number(e.target.value)))} />
+          <span className="slider-value">{contrast}</span>
+        </div>
+        <p className="settings-hint">How far labels, metadata and hints sit below primary text. Every tier stays above the contrast Realm holds its palettes to, whatever this says — turning it down recedes them, it does not make them unreadable.</p>
+      </div>
+
       <div className="field"><span>Background transparency</span>
         {/* The slider runs the way the label reads — right is MORE transparent — while the stored
             value is the ground's OPACITY, because that is what the stylesheet composes. `flip` is
             the one place the two meet.
             step 1, not a coarser grid: the range spans an odd number of points, so any step above 1
             leaves one of its two ends unreachable — including 100%, which is how this is turned off. */}
-        <div className="ground-alpha">
+        <div className="slider-row">
           <input type="range" aria-label="Background transparency" disabled={!material}
             min={GROUND_ALPHA_RANGE.min} max={GROUND_ALPHA_RANGE.max} step={1}
             value={flip(groundAlpha)} onChange={(e) => run(() => setGroundAlpha(flip(Number(e.target.value))))} />
-          <span className="ground-alpha-value">{100 - groundAlpha}%</span>
+          <span className="slider-value">{100 - groundAlpha}%</span>
         </div>
         <p className="settings-hint">{material
           ? "The sidebar is the one surface thin enough to show the desktop behind the window. Panes stay opaque on purpose — at any setting where a pane looked translucent, text on it would fall below the contrast every theme here is held to. Realm also follows the system's Reduce Transparency setting: with it on the sidebar is opaque whatever this says, and your value comes back when you turn it off."

--- a/apps/desktop/src/renderer/src/panes/settings/SettingsPage.tsx
+++ b/apps/desktop/src/renderer/src/panes/settings/SettingsPage.tsx
@@ -5,9 +5,9 @@ import {
 } from "@realm/contracts";
 import { CONTRAST_RANGE, DEFAULT_GROUND_ALPHA, FONT_FACES, FONT_WEIGHTS, GROUND_ALPHA_RANGE, Icon, REALM_SEED,
   THEMES, contrastMisses, isHexColour, isOverridden, overrideKey,
-  exportTheme, importTheme, seedFor, themeModes, themeSwatches,
-  type FontId, type FontWeight, type Mode, type ThemeName } from "@realm/ui";
-import { useEffect, useRef, useState } from "react";
+  deriveVars, exportTheme, importTheme, paletteFor, seedFor, themeModes, themeSwatches,
+  type FontId, type FontWeight, type Mode, type ThemeName, type ThemeOverride } from "@realm/ui";
+import { useEffect, useRef, useState, type CSSProperties } from "react";
 import { agentAvailability, isBlocked } from "../../state/agent-availability";
 import { useApp, type SubmitKey } from "../../state/store";
 import type { PaneProps } from "../registry";
@@ -193,6 +193,43 @@ const CATEGORY_COPY: Record<NotificationCategory, { label: string; desc: string 
   budget: { label: "Spend thresholds", desc: "This month's agent spend passed one of your budget thresholds." },
 };
 
+/** The palette a face would wear, as VALUES. Realm's own face is the static CSS in tokens.css, which
+ *  a preview nested in the page cannot reach — `data-mode` only flips the token blocks at `:root` —
+ *  so the seeds behind it are derived here like any other palette's. */
+function facePalette(name: ThemeName, face: Mode, override: ThemeOverride | undefined, contrast: number): Record<string, string> {
+  return deriveVars(seedFor(name, face, override ?? {}) ?? REALM_SEED[face], face, contrast);
+}
+
+/** The window, small enough to read at a glance: the ground, the sidebar over it, two cards and the
+ *  accent. Built from the derived palette rather than from swatches, so the thing being previewed is
+ *  the arrangement the app actually is and not four dots in a row. */
+function MiniWindow({ vars }: { vars: Record<string, string> }) {
+  return (
+    <span className="mini-window" style={vars as CSSProperties} aria-hidden>
+      <span className="mini-sidebar"><i /><i /><i /></span>
+      <span className="mini-body"><span className="mini-card"><i /><i className="mini-accent" /></span><span className="mini-card"><i /></span></span>
+    </span>
+  );
+}
+
+/** A diff in the palette on the row above it. The spans carry highlight.js's own class names, which
+ *  styles.css already maps onto the ten `--syn-*` roles — so this themes itself off the scope's
+ *  custom properties exactly as a real transcript does, and cannot drift from one. */
+function CodePreview({ vars }: { vars: Record<string, string> }) {
+  return (
+    <pre className="code-preview" style={vars as CSSProperties} aria-label="Preview">
+      <code>
+        <span className="cp-line"><span className="hljs-comment">{"// resolve the palette for this face"}</span></span>
+        <span className="cp-line"><span className="hljs-keyword">export function</span>{" "}<span className="hljs-title">paletteFor</span>(<span className="hljs-params">selection</span>: <span className="hljs-type">ThemeSelection</span>) {"{"}</span>
+        <span className="cp-line" data-diff="del">  <span className="hljs-keyword">return</span> selection.<span className="hljs-attr">dark</span>;</span>
+        <span className="cp-line" data-diff="add">  <span className="hljs-keyword">const</span> name = selection[<span className="hljs-string">&quot;light&quot;</span>];</span>
+        <span className="cp-line" data-diff="add">  <span className="hljs-keyword">return</span> faces(name).length &gt; <span className="hljs-number">0</span> ? name : <span className="hljs-string">&quot;realm&quot;</span>;</span>
+        <span className="cp-line">{"}"}</span>
+      </code>
+    </pre>
+  );
+}
+
 /** One face's palette picker. A card is painted in the palette it names, in the face this row is
  *  for, off the same derivation the app applies — so what is on the card is what the window becomes.
  *  Only palettes with that face are offered: a palette that cannot dress a lit window has no honest
@@ -201,6 +238,10 @@ function PaletteRow({ face, live, selected, onSelect }:
   { face: Mode; live: boolean; selected: ThemeName; onSelect: (name: ThemeName) => void }) {
   const offered = THEMES.filter((t) => themeModes(t.name).includes(face));
   const palette = offered.find((t) => t.name === selected) ?? THEMES[0]!;
+  // The preview is of the palette AS EDITED, at the contrast in force — a preview of something other
+  // than what the window will do is worse than no preview.
+  const override = useApp((s) => s.themeOverrides[overrideKey(palette.name, face)]);
+  const contrast = useApp((s) => s.contrast);
   return (
     <div className="field" data-live={live || undefined}>
       <span>{face === "light" ? "Light theme" : "Dark theme"}</span>
@@ -221,6 +262,7 @@ function PaletteRow({ face, live, selected, onSelect }:
         })}
       </fieldset>
       <p className="settings-hint">{palette.blurb}{palette.credit ? ` ${palette.credit}.` : ""}</p>
+      <CodePreview vars={facePalette(palette.name, face, override, contrast)} />
       <ThemeOverrideEditor name={palette.name} face={face} />
     </div>
   );
@@ -328,6 +370,7 @@ function AppTab() {
   const themePref = useApp((s) => s.themePref);
   const setThemePref = useApp((s) => s.setThemePref);
   const themeNames = useApp((s) => s.themeNames);
+  const themeOverrides = useApp((s) => s.themeOverrides);
   const setThemeName = useApp((s) => s.setThemeName);
   const contrast = useApp((s) => s.contrast);
   const setContrast = useApp((s) => s.setContrast);
@@ -370,12 +413,19 @@ function AppTab() {
   return (
     <div className="form">
       <div className="field"><span>Theme</span>
-        <fieldset className="settings-tabs" aria-label="Theme">
+        {/* A card per choice, each showing the window it produces. "System" shows both faces because
+            that is what choosing it means — the card cannot promise which one you will get. */}
+        <fieldset className="mode-grid" aria-label="Theme">
           {THEME_CHOICES.map((t) => (
-            <label key={t.pref} className="settings-tab" data-selected={themePref === t.pref || undefined}>
+            <label key={t.pref} className="mode-card" data-selected={themePref === t.pref || undefined}>
               <input type="radio" name="settings-theme" value={t.pref} checked={themePref === t.pref}
                 onChange={() => run(() => setThemePref(t.pref))} />
-              {t.label}
+              <span className="mode-card-preview" data-split={t.pref === "system" || undefined}>
+                {(t.pref === "system" ? (["light", "dark"] as const) : [t.pref as Mode]).map((face) => (
+                  <MiniWindow key={face} vars={facePalette(paletteFor(themeNames, face), face, themeOverrides[overrideKey(paletteFor(themeNames, face), face)], contrast)} />
+                ))}
+              </span>
+              <span className="mode-card-name">{t.label}</span>
             </label>
           ))}
         </fieldset>

--- a/apps/desktop/src/renderer/src/panes/settings/SettingsPage.tsx
+++ b/apps/desktop/src/renderer/src/panes/settings/SettingsPage.tsx
@@ -3,12 +3,12 @@ import {
   CREDENTIAL_2FA_NOTE, CREDENTIAL_PRESENCE_TTLS, CREDENTIAL_STORAGE_NOTE, NOTIFICATION_CATEGORIES,
   PERMISSION_MODES, SELECTABLE_AGENT_KINDS, type AgentKind, type NotificationCategory,
 } from "@realm/contracts";
-import { GROUND_ALPHA_RANGE, Icon, THEMES, resolveMode, themeSwatches } from "@realm/ui";
+import { GROUND_ALPHA_RANGE, Icon, THEMES, themeModes, themeSwatches, type Mode, type ThemeName } from "@realm/ui";
 import { useEffect, useState } from "react";
 import { agentAvailability, isBlocked } from "../../state/agent-availability";
 import { useApp, type SubmitKey } from "../../state/store";
 import type { PaneProps } from "../registry";
-import { hasWindowMaterial, useSystemMode, type ThemePref } from "../../theme/useTheme";
+import { hasWindowMaterial, useResolvedMode, type ThemePref } from "../../theme/useTheme";
 import { ImportPanel } from "../../components/settings/ImportPanel";
 import { UsagePanel } from "./usage/UsagePanel";
 
@@ -190,10 +190,42 @@ const CATEGORY_COPY: Record<NotificationCategory, { label: string; desc: string 
   budget: { label: "Spend thresholds", desc: "This month's agent spend passed one of your budget thresholds." },
 };
 
+/** One face's palette picker. A card is painted in the palette it names, in the face this row is
+ *  for, off the same derivation the app applies — so what is on the card is what the window becomes.
+ *  Only palettes with that face are offered: a palette that cannot dress a lit window has no honest
+ *  card to show in the light row. */
+function PaletteRow({ face, live, selected, onSelect }:
+  { face: Mode; live: boolean; selected: ThemeName; onSelect: (name: ThemeName) => void }) {
+  const offered = THEMES.filter((t) => themeModes(t.name).includes(face));
+  const palette = offered.find((t) => t.name === selected) ?? THEMES[0]!;
+  return (
+    <div className="field" data-live={live || undefined}>
+      <span>{face === "light" ? "Light theme" : "Dark theme"}</span>
+      <fieldset className="theme-grid" aria-label={face === "light" ? "Light theme" : "Dark theme"}>
+        {offered.map((t) => {
+          const [page, surface, accent, string] = themeSwatches(t.name, face);
+          return (
+            <label key={t.name} className="theme-card" data-selected={selected === t.name || undefined}
+              style={{ background: page, borderColor: surface }}>
+              <input type="radio" name={`settings-palette-${face}`} value={t.name} checked={selected === t.name}
+                onChange={() => onSelect(t.name)} />
+              <span className="theme-card-swatches" aria-hidden>
+                {[surface, accent, string].map((c, i) => <span key={i} style={{ background: c }} />)}
+              </span>
+              <span className="theme-card-name" style={{ color: accent }}>{t.label}</span>
+            </label>
+          );
+        })}
+      </fieldset>
+      <p className="settings-hint">{palette.blurb}{palette.credit ? ` ${palette.credit}.` : ""}</p>
+    </div>
+  );
+}
+
 function AppTab() {
   const themePref = useApp((s) => s.themePref);
   const setThemePref = useApp((s) => s.setThemePref);
-  const themeName = useApp((s) => s.themeName);
+  const themeNames = useApp((s) => s.themeNames);
   const setThemeName = useApp((s) => s.setThemeName);
   const groundAlpha = useApp((s) => s.groundAlpha);
   const setGroundAlpha = useApp((s) => s.setGroundAlpha);
@@ -208,7 +240,6 @@ function AppTab() {
   const setDesktopNotifications = useApp((s) => s.setDesktopNotifications);
   const setDefaultPermissionMode = useApp((s) => s.setDefaultPermissionMode);
   const run = useApp((s) => s.run);
-  const sys = useSystemMode();
   useEffect(() => { void run(() => refreshSettingsPrefs()); }, [run, refreshSettingsPrefs]);
   // bypassPermissions must never be a one-click slip, HERE least of all — this is every future
   // session at once. Same two-step as the composer chip (U-M7): arm for 5s, apply only on the
@@ -220,12 +251,9 @@ function AppTab() {
     return () => clearTimeout(t);
   }, [confirmBypass]);
 
-  // The mode the preference resolves to before the palette has its say, and what it becomes after.
-  // Both are needed: the cards preview against what the user ASKED for, the hint explains the gap.
-  const wanted = themePref === "system" ? sys : themePref;
-  const effective = resolveMode(themeName, wanted);
-  const pinned = effective !== wanted;
-  const palette = THEMES.find((t) => t.name === themeName) ?? THEMES[0]!;
+  // The face on screen. Both slots are always editable — the point of two is that you set the one
+  // you are not looking at — so this only decides which row is marked as the live one.
+  const mode = useResolvedMode(themePref);
   const material = hasWindowMaterial();
 
   const supported = SELECTABLE_AGENT_KINDS.filter((k) => AGENT_SUPPORTS_PERMISSION_MODES[k]);
@@ -235,11 +263,7 @@ function AppTab() {
   return (
     <div className="form">
       <div className="field"><span>Theme</span>
-        {/* `data-pinned` when the chosen palette has only one face. The radios stay LIVE — the
-            preference is still recorded and still applies the moment a two-faced palette is chosen —
-            but a control that cannot change what is on screen right now has to say so rather than
-            look broken. */}
-        <fieldset className="settings-tabs" aria-label="Theme" data-pinned={pinned || undefined}>
+        <fieldset className="settings-tabs" aria-label="Theme">
           {THEME_CHOICES.map((t) => (
             <label key={t.pref} className="settings-tab" data-selected={themePref === t.pref || undefined}>
               <input type="radio" name="settings-theme" value={t.pref} checked={themePref === t.pref}
@@ -248,34 +272,18 @@ function AppTab() {
             </label>
           ))}
         </fieldset>
-        {pinned && <p className="settings-hint">{`${palette.label} has no ${wanted} variant, so the window stays ${effective} while it is chosen. Your preference is kept.`}</p>}
         {/* One line, not a switch (Plan 14 W5): the OS setting is the control, and styles.css's global
             prefers-reduced-motion kill is what makes this sentence true. */}
         <p className="settings-hint">Realm follows the system's Reduce Motion setting everywhere — with it on, animations and transitions are disabled app-wide.</p>
       </div>
 
-      <div className="field"><span>Palette</span>
-        {/* Each card is painted in the palette it names, in the mode that palette would actually
-            resolve to — the swatches are the same derivation the app runs, so what is on the card is
-            what the window becomes. */}
-        <fieldset className="theme-grid" aria-label="Palette">
-          {THEMES.map((t) => {
-            const [page, surface, accent, string] = themeSwatches(t.name, wanted);
-            return (
-              <label key={t.name} className="theme-card" data-selected={themeName === t.name || undefined}
-                style={{ background: page, borderColor: surface }}>
-                <input type="radio" name="settings-palette" value={t.name} checked={themeName === t.name}
-                  onChange={() => run(() => setThemeName(t.name))} />
-                <span className="theme-card-swatches" aria-hidden>
-                  {[surface, accent, string].map((c, i) => <span key={i} style={{ background: c }} />)}
-                </span>
-                <span className="theme-card-name" style={{ color: accent }}>{t.label}</span>
-              </label>
-            );
-          })}
-        </fieldset>
-        <p className="settings-hint">{palette.blurb}{palette.credit ? ` ${palette.credit}.` : ""}</p>
-      </div>
+      {/* A row per face, both always editable: setting the one you are NOT looking at is the whole
+          reason there are two. `data-live` marks the one on screen so the window and the page agree
+          about which row explains what is in front of you. */}
+      {(["light", "dark"] as const).map((face) => (
+        <PaletteRow key={face} face={face} live={face === mode} selected={themeNames[face]}
+          onSelect={(name) => run(() => setThemeName(face, name))} />
+      ))}
 
       <div className="field"><span>Background transparency</span>
         {/* The slider runs the way the label reads — right is MORE transparent — while the stored

--- a/apps/desktop/src/renderer/src/panes/settings/SettingsPage.tsx
+++ b/apps/desktop/src/renderer/src/panes/settings/SettingsPage.tsx
@@ -3,7 +3,8 @@ import {
   CREDENTIAL_2FA_NOTE, CREDENTIAL_PRESENCE_TTLS, CREDENTIAL_STORAGE_NOTE, NOTIFICATION_CATEGORIES,
   PERMISSION_MODES, SELECTABLE_AGENT_KINDS, type AgentKind, type NotificationCategory,
 } from "@realm/contracts";
-import { CONTRAST_RANGE, FONT_FACES, FONT_WEIGHTS, GROUND_ALPHA_RANGE, Icon, REALM_SEED, THEMES, contrastMisses, isHexColour, isOverridden, overrideKey,
+import { CONTRAST_RANGE, DEFAULT_GROUND_ALPHA, FONT_FACES, FONT_WEIGHTS, GROUND_ALPHA_RANGE, Icon, REALM_SEED,
+  THEMES, contrastMisses, isHexColour, isOverridden, overrideKey,
   seedFor, themeModes, themeSwatches, type FontId, type FontWeight, type Mode, type ThemeName } from "@realm/ui";
 import { useEffect, useState } from "react";
 import { agentAvailability, isBlocked } from "../../state/agent-availability";
@@ -322,6 +323,7 @@ function AppTab() {
   // you are not looking at — so this only decides which row is marked as the live one.
   const mode = useResolvedMode(themePref);
   const material = hasWindowMaterial();
+  const translucent = groundAlpha < GROUND_ALPHA_RANGE.max;
 
   const supported = SELECTABLE_AGENT_KINDS.filter((k) => AGENT_SUPPORTS_PERMISSION_MODES[k]);
   const unsupported = SELECTABLE_AGENT_KINDS.filter((k) => !AGENT_SUPPORTS_PERMISSION_MODES[k]);
@@ -396,14 +398,21 @@ function AppTab() {
         <p className="settings-hint">How far labels, metadata and hints sit below primary text. Every tier stays above the contrast Realm holds its palettes to, whatever this says — turning it down recedes them, it does not make them unreadable.</p>
       </div>
 
-      <div className="field"><span>Background transparency</span>
-        {/* The slider runs the way the label reads — right is MORE transparent — while the stored
-            value is the ground's OPACITY, because that is what the stylesheet composes. `flip` is
-            the one place the two meet.
-            step 1, not a coarser grid: the range spans an odd number of points, so any step above 1
-            leaves one of its two ends unreachable — including 100%, which is how this is turned off. */}
+      <div className="field"><span>Translucent sidebar</span>
+        {/* A switch and an amount over ONE stored number, not two controls that can disagree: fully
+            opaque IS off, because covering the material completely is the same as not having asked
+            for it. So the switch reads `groundAlpha < max` and writes either the maximum or the
+            default, and the slider is inert while it is off — nothing here can put the app in a
+            state where the switch says one thing and the amount another.
+            The slider runs the way its label reads — right is MORE transparent — while the stored
+            value is the ground's OPACITY, because that is what the stylesheet composes. `flip` is the
+            one place the two meet. step 1, not a coarser grid: the range spans an odd number of
+            points, so any step above 1 leaves one of its two ends unreachable. */}
         <div className="slider-row">
-          <input type="range" aria-label="Background transparency" disabled={!material}
+          <input type="checkbox" role="switch" className="switch" aria-label="Translucent sidebar"
+            disabled={!material} checked={translucent}
+            onChange={(e) => run(() => setGroundAlpha(e.target.checked ? DEFAULT_GROUND_ALPHA : GROUND_ALPHA_RANGE.max))} />
+          <input type="range" aria-label="Background transparency" disabled={!material || !translucent}
             min={GROUND_ALPHA_RANGE.min} max={GROUND_ALPHA_RANGE.max} step={1}
             value={flip(groundAlpha)} onChange={(e) => run(() => setGroundAlpha(flip(Number(e.target.value))))} />
           <span className="slider-value">{100 - groundAlpha}%</span>

--- a/apps/desktop/src/renderer/src/panes/settings/SettingsPage.tsx
+++ b/apps/desktop/src/renderer/src/panes/settings/SettingsPage.tsx
@@ -3,7 +3,8 @@ import {
   CREDENTIAL_2FA_NOTE, CREDENTIAL_PRESENCE_TTLS, CREDENTIAL_STORAGE_NOTE, NOTIFICATION_CATEGORIES,
   PERMISSION_MODES, SELECTABLE_AGENT_KINDS, type AgentKind, type NotificationCategory,
 } from "@realm/contracts";
-import { GROUND_ALPHA_RANGE, Icon, THEMES, themeModes, themeSwatches, type Mode, type ThemeName } from "@realm/ui";
+import { GROUND_ALPHA_RANGE, Icon, REALM_SEED, THEMES, contrastMisses, isHexColour, isOverridden, overrideKey,
+  seedFor, themeModes, themeSwatches, type Mode, type ThemeName } from "@realm/ui";
 import { useEffect, useState } from "react";
 import { agentAvailability, isBlocked } from "../../state/agent-availability";
 import { useApp, type SubmitKey } from "../../state/store";
@@ -218,7 +219,65 @@ function PaletteRow({ face, live, selected, onSelect }:
         })}
       </fieldset>
       <p className="settings-hint">{palette.blurb}{palette.credit ? ` ${palette.credit}.` : ""}</p>
+      <ThemeOverrideEditor name={palette.name} face={face} />
     </div>
+  );
+}
+
+/** The three seeds that decide what a palette feels like — its paper, its text and its one hue.
+ *  Edits go into the SEED and back through the same derivation a vendored palette goes through, so a
+ *  moved background gets the surface ladder, the ink ramp and the contrast correction rather than a
+ *  raw value written past all three. */
+const OVERRIDE_FIELDS = [
+  { role: "accent", label: "Accent" }, { role: "bg", label: "Background" }, { role: "ink", label: "Foreground" },
+] as const;
+
+function ThemeOverrideEditor({ name, face }: { name: ThemeName; face: Mode }) {
+  const override = useApp((s) => s.themeOverrides[overrideKey(name, face)]);
+  const setThemeOverride = useApp((s) => s.setThemeOverride);
+  const resetThemeOverride = useApp((s) => s.resetThemeOverride);
+  const run = useApp((s) => s.run);
+  // The palette AS EDITED. `seedFor` returns null only for an untouched Realm, whose seeds are what
+  // the fields have to show anyway — there is no other honest starting value for an edit.
+  const seed = seedFor(name, face, override ?? {}) ?? REALM_SEED[face];
+  const misses = contrastMisses(seed, face);
+
+  return (
+    <fieldset className="theme-overrides" aria-label={`${face === "light" ? "Light" : "Dark"} theme colours`}>
+      {OVERRIDE_FIELDS.map(({ role, label }) => (
+        <label key={role} className="theme-override">
+          <span>{label}</span>
+          <input type="color" aria-label={`${label} colour`} value={seed[role]}
+            onChange={(e) => run(() => setThemeOverride(name, face, { [role]: e.target.value }))} />
+          {/* Text as well as a swatch: a hex is a value you paste from somewhere else, and the OS
+              colour picker cannot be typed into. Committed on blur/Enter rather than per keystroke —
+              every prefix of a hex is a different colour, and "#f" would repaint the window red on
+              the way to "#f92672". */}
+          <input type="text" className="hex" aria-label={`${label} hex`} defaultValue={seed[role]} key={seed[role]}
+            spellCheck={false} maxLength={7}
+            onKeyDown={(e) => { if (e.key === "Enter") e.currentTarget.blur(); }}
+            onBlur={(e) => {
+              const hex = e.target.value.trim();
+              if (isHexColour(hex)) run(() => setThemeOverride(name, face, { [role]: hex }));
+              else e.target.value = seed[role];
+            }} />
+        </label>
+      ))}
+      {isOverridden(override) && (
+        <button type="button" className="btn-quiet" onClick={() => run(() => resetThemeOverride(name, face))}>
+          Reset to {THEMES.find((t) => t.name === name)?.label}
+        </button>
+      )}
+      {/* Named, not corrected. The ground and the ink are the two seeds nothing lifts — moving them
+          silently to clear a floor hands back a theme the user did not pick — and a hue that misses
+          after its whole lift budget is one this ramp cannot carry. Either way the useful thing to
+          show is which colour, and by how much. */}
+      {misses.length > 0 && (
+        <p className="settings-hint" data-tone="warn">
+          {`Below the contrast Realm holds every palette to: ${misses.map((m) => `${m.role} ${m.ratio.toFixed(1)}:1 (needs ${m.floor}:1)`).join(", ")}.`}
+        </p>
+      )}
+    </fieldset>
   );
 }
 

--- a/apps/desktop/src/renderer/src/panes/settings/SettingsPage.tsx
+++ b/apps/desktop/src/renderer/src/panes/settings/SettingsPage.tsx
@@ -4,9 +4,9 @@ import {
   PERMISSION_MODES, SELECTABLE_AGENT_KINDS, type AgentKind, type NotificationCategory,
 } from "@realm/contracts";
 import { CONTRAST_RANGE, DEFAULT_GROUND_ALPHA, FONT_FACES, FONT_WEIGHTS, GROUND_ALPHA_RANGE, Icon, REALM_SEED,
-  THEMES, contrastMisses, isHexColour, isOverridden, overrideKey,
-  deriveVars, exportTheme, importTheme, paletteFor, seedFor, themeModes, themeSwatches,
-  type FontId, type FontWeight, type Mode, type ThemeName, type ThemeOverride } from "@realm/ui";
+  THEMES, contrastMisses, deriveVars, exportTheme, importTheme, isHexColour, isOverridden, overrideKey,
+  paletteFor, seedFor, themeModes, themeSwatches,
+  type FontId, type FontWeight, type Mode, type ThemeName, type ThemeOverride, type ThemeSeed } from "@realm/ui";
 import { useEffect, useRef, useState, type CSSProperties } from "react";
 import { agentAvailability, isBlocked } from "../../state/agent-availability";
 import { useApp, type SubmitKey } from "../../state/store";
@@ -193,11 +193,18 @@ const CATEGORY_COPY: Record<NotificationCategory, { label: string; desc: string 
   budget: { label: "Spend thresholds", desc: "This month's agent spend passed one of your budget thresholds." },
 };
 
-/** The palette a face would wear, as VALUES. Realm's own face is the static CSS in tokens.css, which
- *  a preview nested in the page cannot reach — `data-mode` only flips the token blocks at `:root` —
- *  so the seeds behind it are derived here like any other palette's. */
+/** The seed a face is really wearing. `seedFor` answers null for an untouched Realm, whose whole
+ *  point is to write nothing — but a field showing the current colour and a preview painting it both
+ *  need values, and Realm's own seeds are the only honest ones to show. */
+function faceSeed(name: ThemeName, face: Mode, override: ThemeOverride | undefined): ThemeSeed {
+  return seedFor(name, face, override ?? {}) ?? REALM_SEED[face];
+}
+
+/** ...and as the palette it derives to. Realm's face is the static CSS in tokens.css, which a preview
+ *  nested in the page cannot reach — `data-mode` only flips the token blocks at `:root` — so it is
+ *  derived here like any other palette's. */
 function facePalette(name: ThemeName, face: Mode, override: ThemeOverride | undefined, contrast: number): Record<string, string> {
-  return deriveVars(seedFor(name, face, override ?? {}) ?? REALM_SEED[face], face, contrast);
+  return deriveVars(faceSeed(name, face, override), face, contrast);
 }
 
 /** The window, small enough to read at a glance: the ground, the sidebar over it, two cards and the
@@ -291,9 +298,7 @@ function ThemeOverrideEditor({ name, face }: { name: ThemeName; face: Mode }) {
     const t = setTimeout(() => setCopied(false), 1600);
     return () => clearTimeout(t);
   }, [copied]);
-  // The palette AS EDITED. `seedFor` returns null only for an untouched Realm, whose seeds are what
-  // the fields have to show anyway — there is no other honest starting value for an edit.
-  const seed = seedFor(name, face, override ?? {}) ?? REALM_SEED[face];
+  const seed = faceSeed(name, face, override);
   // Measured at the contrast the app is actually running at, not at the default — the ramp's spread
   // is one of the things a tier's ratio depends on, and a warning computed against a setting the
   // user is not using would name the wrong roles.

--- a/apps/desktop/src/renderer/src/panes/settings/SettingsPage.tsx
+++ b/apps/desktop/src/renderer/src/panes/settings/SettingsPage.tsx
@@ -3,8 +3,8 @@ import {
   CREDENTIAL_2FA_NOTE, CREDENTIAL_PRESENCE_TTLS, CREDENTIAL_STORAGE_NOTE, NOTIFICATION_CATEGORIES,
   PERMISSION_MODES, SELECTABLE_AGENT_KINDS, type AgentKind, type NotificationCategory,
 } from "@realm/contracts";
-import { CONTRAST_RANGE, GROUND_ALPHA_RANGE, Icon, REALM_SEED, THEMES, contrastMisses, isHexColour, isOverridden, overrideKey,
-  seedFor, themeModes, themeSwatches, type Mode, type ThemeName } from "@realm/ui";
+import { CONTRAST_RANGE, FONT_FACES, FONT_WEIGHTS, GROUND_ALPHA_RANGE, Icon, REALM_SEED, THEMES, contrastMisses, isHexColour, isOverridden, overrideKey,
+  seedFor, themeModes, themeSwatches, type FontId, type FontWeight, type Mode, type ThemeName } from "@realm/ui";
 import { useEffect, useState } from "react";
 import { agentAvailability, isBlocked } from "../../state/agent-availability";
 import { useApp, type SubmitKey } from "../../state/store";
@@ -292,6 +292,8 @@ function AppTab() {
   const setThemeName = useApp((s) => s.setThemeName);
   const contrast = useApp((s) => s.contrast);
   const setContrast = useApp((s) => s.setContrast);
+  const fonts = useApp((s) => s.fonts);
+  const setFonts = useApp((s) => s.setFonts);
   const groundAlpha = useApp((s) => s.groundAlpha);
   const setGroundAlpha = useApp((s) => s.setGroundAlpha);
   const submitKey = useApp((s) => s.submitKey);
@@ -349,6 +351,35 @@ function AppTab() {
         <PaletteRow key={face} face={face} live={face === mode} selected={themeNames[face]}
           onSelect={(name) => run(() => setThemeName(face, name))} />
       ))}
+
+      <div className="field"><span>UI font</span>
+        {/* Two families, not four hundred. Enumerating installed fonts needs a main-process hop and
+            returns mostly faces this layout cannot use — the chrome is set against a four-step weight
+            ladder and tabular figures, and a display face picked out of a long list loses both
+            silently. The bundled faces are guaranteed to be present and to have those axes; the
+            system stack is for someone who would rather Realm looked like the rest of their machine. */}
+        <div className="font-row">
+          <select aria-label="UI font" value={fonts.ui} onChange={(e) => run(() => setFonts({ ui: e.target.value as FontId }))}>
+            {FONT_FACES.ui.map((f) => <option key={f.id} value={f.id}>{f.label}</option>)}
+          </select>
+          <select aria-label="UI font weight" value={fonts.uiWeight}
+            onChange={(e) => run(() => setFonts({ uiWeight: e.target.value as FontWeight }))}>
+            {FONT_WEIGHTS.map((w) => <option key={w.id} value={w.id}>{w.label}</option>)}
+          </select>
+        </div>
+      </div>
+
+      <div className="field"><span>Code font</span>
+        <div className="font-row">
+          <select aria-label="Code font" value={fonts.code} onChange={(e) => run(() => setFonts({ code: e.target.value as FontId }))}>
+            {FONT_FACES.code.map((f) => <option key={f.id} value={f.id}>{f.label}</option>)}
+          </select>
+        </div>
+        {/* The asymmetry is a fact about the stylesheet, not a judgement: every mono surface sets its
+            font with the `font:` shorthand, which resets weight by definition, so a code weight would
+            mean editing fifty-odd rules or hiding a weight inside a family name. */}
+        <p className="settings-hint">Code, diffs, terminals and keyboard hints. Weight follows the app's own scale here — the UI weight above is the one control over it. Open terminals change face with the setting; their font size does not follow it.</p>
+      </div>
 
       <div className="field"><span>Contrast</span>
         {/* The ink ramp's SPREAD — how far the secondary and hint tiers fall below primary text. It

--- a/apps/desktop/src/renderer/src/panes/settings/SettingsPage.tsx
+++ b/apps/desktop/src/renderer/src/panes/settings/SettingsPage.tsx
@@ -247,14 +247,14 @@ function PaletteRow({ face, live, selected, onSelect }:
       <span>{face === "light" ? "Light theme" : "Dark theme"}</span>
       <fieldset className="theme-grid" aria-label={face === "light" ? "Light theme" : "Dark theme"}>
         {offered.map((t) => {
-          const [page, surface, accent, string] = themeSwatches(t.name, face);
+          const [page, surface, accent, string, line] = themeSwatches(t.name, face);
           return (
             <label key={t.name} className="theme-card" data-selected={selected === t.name || undefined}
               style={{ background: page, borderColor: surface }}>
               <input type="radio" name={`settings-palette-${face}`} value={t.name} checked={selected === t.name}
                 onChange={() => onSelect(t.name)} />
               <span className="theme-card-swatches" aria-hidden>
-                {[surface, accent, string].map((c, i) => <span key={i} style={{ background: c }} />)}
+                {[surface, accent, string].map((c, i) => <span key={i} style={{ background: c, boxShadow: `0 0 0 1px ${line}` }} />)}
               </span>
               <span className="theme-card-name" style={{ color: accent }}>{t.label}</span>
             </label>

--- a/apps/desktop/src/renderer/src/panes/settings/SettingsPage.tsx
+++ b/apps/desktop/src/renderer/src/panes/settings/SettingsPage.tsx
@@ -5,8 +5,9 @@ import {
 } from "@realm/contracts";
 import { CONTRAST_RANGE, DEFAULT_GROUND_ALPHA, FONT_FACES, FONT_WEIGHTS, GROUND_ALPHA_RANGE, Icon, REALM_SEED,
   THEMES, contrastMisses, isHexColour, isOverridden, overrideKey,
-  seedFor, themeModes, themeSwatches, type FontId, type FontWeight, type Mode, type ThemeName } from "@realm/ui";
-import { useEffect, useState } from "react";
+  exportTheme, importTheme, seedFor, themeModes, themeSwatches,
+  type FontId, type FontWeight, type Mode, type ThemeName } from "@realm/ui";
+import { useEffect, useRef, useState } from "react";
 import { agentAvailability, isBlocked } from "../../state/agent-availability";
 import { useApp, type SubmitKey } from "../../state/store";
 import type { PaneProps } from "../registry";
@@ -239,6 +240,15 @@ function ThemeOverrideEditor({ name, face }: { name: ThemeName; face: Mode }) {
   const setThemeOverride = useApp((s) => s.setThemeOverride);
   const resetThemeOverride = useApp((s) => s.resetThemeOverride);
   const run = useApp((s) => s.run);
+  const [copied, setCopied] = useState(false);
+  const [importing, setImporting] = useState(false);
+  const [rejected, setRejected] = useState<string | null>(null);
+  const paste = useRef<HTMLTextAreaElement>(null);
+  useEffect(() => {
+    if (!copied) return;
+    const t = setTimeout(() => setCopied(false), 1600);
+    return () => clearTimeout(t);
+  }, [copied]);
   // The palette AS EDITED. `seedFor` returns null only for an untouched Realm, whose seeds are what
   // the fields have to show anyway — there is no other honest starting value for an edit.
   const seed = seedFor(name, face, override ?? {}) ?? REALM_SEED[face];
@@ -246,6 +256,7 @@ function ThemeOverrideEditor({ name, face }: { name: ThemeName; face: Mode }) {
   // is one of the things a tier's ratio depends on, and a warning computed against a setting the
   // user is not using would name the wrong roles.
   const misses = contrastMisses(seed, face, contrast);
+  const label = THEMES.find((t) => t.name === name)?.label ?? name;
 
   return (
     <fieldset className="theme-overrides" aria-label={`${face === "light" ? "Light" : "Dark"} theme colours`}>
@@ -270,8 +281,35 @@ function ThemeOverrideEditor({ name, face }: { name: ThemeName; face: Mode }) {
       ))}
       {isOverridden(override) && (
         <button type="button" className="btn-quiet" onClick={() => run(() => resetThemeOverride(name, face))}>
-          Reset to {THEMES.find((t) => t.name === name)?.label}
+          Reset to {label}
         </button>
+      )}
+      {/* Copy emits the face AS EDITED, so what lands on the clipboard is what is on screen — the
+          palette's own seeds under a set of overrides would be a theme the user was not looking at. */}
+      <button type="button" className="btn-quiet"
+        onClick={() => { void navigator.clipboard?.writeText(exportTheme(label, face, seed)); setCopied(true); }}>
+        {copied ? "Copied" : "Copy theme"}
+      </button>
+      <button type="button" className="btn-quiet" aria-expanded={importing}
+        onClick={() => { setImporting((o) => !o); setRejected(null); }}>Import</button>
+      {importing && (
+        // A paste box rather than a button that reads the clipboard: a rejection has to be shown
+        // beside the thing that was rejected, and reaching for the clipboard on a click is a
+        // permission prompt in exchange for one saved keystroke.
+        <div className="theme-import">
+          <textarea aria-label="Theme to import" spellCheck={false} rows={4}
+            placeholder={`{ "realmTheme": 1, "name": …, "mode": "${face}", "seed": { … } }`}
+            onChange={() => setRejected(null)} ref={paste} />
+          <div className="theme-import-actions">
+            <button type="button" className="btn" onClick={() => {
+              const result = importTheme(paste.current?.value ?? "", face);
+              if (!result.ok) { setRejected(result.reason); return; }
+              setRejected(null); setImporting(false);
+              run(() => setThemeOverride(name, face, { ...result.doc.seed }));
+            }}>Apply</button>
+            {rejected && <p className="settings-hint" data-tone="danger">{rejected}</p>}
+          </div>
+        </div>
       )}
       {/* Named, not corrected. The ground and the ink are the two seeds nothing lifts — moving them
           silently to clear a floor hands back a theme the user did not pick — and a hue that misses

--- a/apps/desktop/src/renderer/src/panes/settings/settings-page.test.tsx
+++ b/apps/desktop/src/renderer/src/panes/settings/settings-page.test.tsx
@@ -268,6 +268,28 @@ describe("App tab", () => {
     await vi.waitFor(() => expect(api.calls).toContain("setSetting:ui.contrast=10"));
   });
 
+  it("the switch and the amount are one number, so they cannot disagree", async () => {
+    // THE two-controls mutant: give the switch its own stored boolean. It can then say "on" over a
+    // ground the slider has at 100% — a control claiming a state the window is not in, with the
+    // other control on the same row contradicting it.
+    vi.stubGlobal("realm", { platform: "darwin" });
+    const { store } = await openApp();
+    const sw = screen.getByRole("switch", { name: "Translucent sidebar" });
+    const slider = screen.getByRole("slider", { name: "Background transparency" });
+    expect(sw).toBeChecked();               // 82 by default, which is translucent
+    fireEvent.click(sw);
+    await waitFor(() => expect(store.getState().groundAlpha).toBe(100));
+    expect(screen.getByRole("switch", { name: "Translucent sidebar" })).not.toBeChecked();
+    // Off means opaque, and the amount is inert rather than showing a value nothing is using.
+    expect(screen.getByRole("slider", { name: "Background transparency" })).toBeDisabled();
+    fireEvent.click(screen.getByRole("switch", { name: "Translucent sidebar" }));
+    await waitFor(() => expect(store.getState().groundAlpha).toBe(82));
+    // Dragging the amount to fully opaque turns the switch off, because that IS off.
+    fireEvent.change(slider, { target: { value: "55" } });
+    await waitFor(() => expect(store.getState().groundAlpha).toBe(100));
+    expect(screen.getByRole("switch", { name: "Translucent sidebar" })).not.toBeChecked();
+  });
+
   it("background transparency runs the way its label reads and persists the ground's opacity", async () => {
     // The bridge is what says this platform has a material; jsdom has none, so the mac case is
     // stubbed rather than assumed. An unstubbed renderer must not guess macOS.

--- a/apps/desktop/src/renderer/src/panes/settings/settings-page.test.tsx
+++ b/apps/desktop/src/renderer/src/panes/settings/settings-page.test.tsx
@@ -147,25 +147,36 @@ describe("App tab", () => {
     expect(api.calls).toContain("setSetting:ui.theme=dark");
   });
 
-  it("the palette is a card per theme; choosing one writes ui.themeName and not ui.theme", async () => {
+  const row = (face: "Light" | "Dark") => within(screen.getByRole("group", { name: `${face} theme` }));
+
+  it("there is a palette row per face, and each writes only its own key", async () => {
     const { store, api } = await openApp();
-    expect(screen.getByRole("radio", { name: "Realm" })).toBeChecked();
-    fireEvent.click(screen.getByRole("radio", { name: "One" }));
-    await waitFor(() => expect(store.getState().themeName).toBe("one"));
-    expect(api.calls).toContain("setSetting:ui.themeName=one");
+    expect(row("Light").getByRole("radio", { name: "Realm" })).toBeChecked();
+    fireEvent.click(row("Dark").getByRole("radio", { name: "One" }));
+    await waitFor(() => expect(store.getState().themeNames.dark).toBe("one"));
+    expect(api.calls).toContain("setSetting:ui.themeName.dark=one");
+    // THE shared-row mutant: render one picker and point both faces at it. The two rows would move
+    // together and the whole feature would be a relabelled single selection.
+    expect(store.getState().themeNames.light).toBe("realm");
+    expect(row("Light").getByRole("radio", { name: "Realm" })).toBeChecked();
     // THE conflated-axis mutant: have the picker set the mode too. The light/dark preference is the
     // user's and a palette choice is not permission to overwrite it.
     expect(api.calls.filter((c) => c.startsWith("setSetting:ui.theme="))).toEqual([]);
     expect(store.getState().themePref).toBe("system");
   });
 
-  it("a one-faced palette says so rather than leaving the mode control looking broken", async () => {
-    const { store } = await openApp();
-    fireEvent.click(screen.getByRole("radio", { name: "Monokai" }));
-    await waitFor(() => expect(store.getState().themeName).toBe("monokai"));
-    expect(screen.getByText(/Monokai has no light variant/)).toBeInTheDocument();
-    // Still operable: the preference it records applies again under a two-faced palette.
-    expect(screen.getByRole("radio", { name: "Light" })).not.toBeDisabled();
+  it("a face is offered only palettes that have it", async () => {
+    // THE every-palette mutant: list all of THEMES in both rows. Choosing Monokai for the light face
+    // stores a slot the light window cannot read, and the row's own card would have to preview a
+    // light face Monokai does not have — which is a card that lies about what clicking it does.
+    await openApp();
+    expect(row("Dark").getByRole("radio", { name: "Monokai" })).toBeInTheDocument();
+    expect(row("Light").queryByRole("radio", { name: "Monokai" })).toBeNull();
+    for (const face of ["Light", "Dark"] as const) {
+      for (const name of ["Realm", "One", "Solarized", "Gruvbox"]) {
+        expect(row(face).getByRole("radio", { name }), `${face}/${name}`).toBeInTheDocument();
+      }
+    }
   });
 
   it("background transparency runs the way its label reads and persists the ground's opacity", async () => {

--- a/apps/desktop/src/renderer/src/panes/settings/settings-page.test.tsx
+++ b/apps/desktop/src/renderer/src/panes/settings/settings-page.test.tsx
@@ -233,6 +233,19 @@ describe("App tab", () => {
     expect(await colours("Light").findByText(/Below the contrast Realm holds every palette to.*Foreground/)).toBeInTheDocument();
   });
 
+  it("contrast is a slider over the ink ramp, defaulting to the shipped spread", async () => {
+    // What the store does with it. That it reaches the WINDOW is use-theme.test.ts's assertion — the
+    // bridge that writes :root is mounted there, not here.
+    const { store, api } = await openApp();
+    const slider = screen.getByRole("slider", { name: "Contrast" }) as HTMLInputElement;
+    expect(slider.value).toBe("60");
+    expect(slider.min).toBe("0");
+    expect(slider.max).toBe("100");
+    fireEvent.change(slider, { target: { value: "10" } });
+    await waitFor(() => expect(store.getState().contrast).toBe(10));
+    await vi.waitFor(() => expect(api.calls).toContain("setSetting:ui.contrast=10"));
+  });
+
   it("background transparency runs the way its label reads and persists the ground's opacity", async () => {
     // The bridge is what says this platform has a material; jsdom has none, so the mac case is
     // stubbed rather than assumed. An unstubbed renderer must not guess macOS.

--- a/apps/desktop/src/renderer/src/panes/settings/settings-page.test.tsx
+++ b/apps/desktop/src/renderer/src/panes/settings/settings-page.test.tsx
@@ -148,6 +148,7 @@ describe("App tab", () => {
   });
 
   const row = (face: "Light" | "Dark") => within(screen.getByRole("group", { name: `${face} theme` }));
+  const colours = (face: "Light" | "Dark") => within(screen.getByRole("group", { name: `${face} theme colours` }));
 
   it("there is a palette row per face, and each writes only its own key", async () => {
     const { store, api } = await openApp();
@@ -177,6 +178,59 @@ describe("App tab", () => {
         expect(row(face).getByRole("radio", { name }), `${face}/${name}`).toBeInTheDocument();
       }
     }
+  });
+
+  it("the override fields show the palette as edited, and a hex commits on blur", async () => {
+    const { store, api } = await openApp();
+    const hex = colours("Dark").getByRole("textbox", { name: "Accent hex" }) as HTMLInputElement;
+    // One Dark's own accent, before anything is edited — the field is a view of the seed, not a blank.
+    expect(hex.value).toBe("#3d9aff"); // Realm dark, the default selection
+    fireEvent.click(row("Dark").getByRole("radio", { name: "One" }));
+    await waitFor(() => expect((colours("Dark").getByRole("textbox", { name: "Accent hex" }) as HTMLInputElement).value).toBe("#61afef"));
+
+    const field = colours("Dark").getByRole("textbox", { name: "Accent hex" });
+    fireEvent.change(field, { target: { value: "#f92672" } });
+    fireEvent.blur(field);
+    await waitFor(() => expect(store.getState().themeOverrides["one:dark"]).toEqual({ accent: "#f92672" }));
+    expect(api.calls.some((c) => c.startsWith("setSetting:ui.themeOverrides"))).toBe(true);
+  });
+
+  it("a hex that is not a colour is refused and the field goes back to what is on screen", async () => {
+    // THE trusting-field mutant: commit whatever was typed. "#f" is a valid prefix of a hex and an
+    // invalid colour, and the derivation throws on it — from inside the paint of the next frame.
+    const { store } = await openApp();
+    const field = colours("Light").getByRole("textbox", { name: "Background hex" }) as HTMLInputElement;
+    fireEvent.change(field, { target: { value: "not a colour" } });
+    fireEvent.blur(field);
+    expect(store.getState().themeOverrides).toEqual({});
+    expect(field.value).toBe("#fafafb");
+  });
+
+  it("an edited palette offers a way back to the palette itself", async () => {
+    // THE no-reset mutant: leave the button out. An override is per palette and per face, so a user
+    // who dislikes what they did has no path back short of matching the original hex by hand.
+    const { store } = await openApp();
+    expect(colours("Light").queryByRole("button", { name: /Reset to/ })).toBeNull();
+    const field = colours("Light").getByRole("textbox", { name: "Accent hex" });
+    fireEvent.change(field, { target: { value: "#ff0000" } });
+    fireEvent.blur(field);
+    await waitFor(() => expect(colours("Light").getByRole("button", { name: "Reset to Realm" })).toBeInTheDocument());
+    fireEvent.click(colours("Light").getByRole("button", { name: "Reset to Realm" }));
+    await waitFor(() => expect(store.getState().themeOverrides).toEqual({}));
+  });
+
+  it("a colour that cannot reach the floor is named rather than quietly corrected", async () => {
+    // The decision: the ground and the ink are never moved for the user, so the app has to SAY what
+    // it did with them. THE silent-warning mutant: drop the line. The window is illegible and the
+    // page that caused it shows the hex the user typed with nothing beside it.
+    const { store } = await openApp();
+    for (const [label, hex] of [["Background", "#282828"], ["Foreground", "#2b2b2b"]] as const) {
+      const field = colours("Light").getByRole("textbox", { name: `${label} hex` });
+      fireEvent.change(field, { target: { value: hex } });
+      fireEvent.blur(field);
+    }
+    await waitFor(() => expect(store.getState().themeOverrides["realm:light"]).toMatchObject({ bg: "#282828", ink: "#2b2b2b" }));
+    expect(await colours("Light").findByText(/Below the contrast Realm holds every palette to.*Foreground/)).toBeInTheDocument();
   });
 
   it("background transparency runs the way its label reads and persists the ground's opacity", async () => {

--- a/apps/desktop/src/renderer/src/panes/settings/settings-page.test.tsx
+++ b/apps/desktop/src/renderer/src/panes/settings/settings-page.test.tsx
@@ -255,6 +255,43 @@ describe("App tab", () => {
     expect(screen.getByText(/Weight follows the app's own scale here/)).toBeInTheDocument();
   });
 
+  it("a pasted theme becomes the face's colours; a blob that is not one is refused in place", async () => {
+    const { store } = await openApp();
+    fireEvent.click(colours("Dark").getByRole("button", { name: "Import" }));
+    const box = colours("Dark").getByRole("textbox", { name: "Theme to import" });
+
+    // THE optimistic-apply mutant: apply first and report afterwards. The window repaints off a
+    // half-read document and the message explaining why arrives against colours it caused.
+    fireEvent.change(box, { target: { value: "{ not json" } });
+    fireEvent.click(colours("Dark").getByRole("button", { name: "Apply" }));
+    expect(store.getState().themeOverrides).toEqual({});
+    expect(colours("Dark").getByText(/not JSON/)).toBeInTheDocument();
+    // The box stays open over the thing that was rejected, so the message has something to point at.
+    expect(colours("Dark").getByRole("textbox", { name: "Theme to import" })).toBeInTheDocument();
+
+    const seed = { bg: "#101014", ink: "#e6e6ea", accent: "#7c6cff", green: "#3cbb72", orange: "#f68f3c", red: "#ee5c61",
+      syntax: { comment: "#6c6f75", keyword: "#7c6cff", string: "#3cbb72", number: "#f68f3c", title: "#e6e6ea", type: "#e6e6ea", attr: "#a5a8ad" } };
+    fireEvent.change(box, { target: { value: JSON.stringify({ realmTheme: 1, name: "Night", mode: "dark", seed }) } });
+    fireEvent.click(colours("Dark").getByRole("button", { name: "Apply" }));
+    await waitFor(() => expect(store.getState().themeOverrides["realm:dark"]).toEqual(seed));
+    // It lands on the face it was imported into, not the other one.
+    expect(store.getState().themeOverrides["realm:light"]).toBeUndefined();
+  });
+
+  it("copies the face AS EDITED, so what is on the clipboard is what is on screen", async () => {
+    // THE unedited-copy mutant: export the palette's own seeds. Someone who spent a while moving
+    // three colours would hand a colleague the theme they started from.
+    const written: string[] = [];
+    vi.stubGlobal("navigator", { ...navigator, clipboard: { writeText: (t: string) => { written.push(t); return Promise.resolve(); } } });
+    const { store } = await openApp();
+    const field = colours("Dark").getByRole("textbox", { name: "Accent hex" });
+    fireEvent.change(field, { target: { value: "#f92672" } });
+    fireEvent.blur(field);
+    await waitFor(() => expect(store.getState().themeOverrides["realm:dark"]).toEqual({ accent: "#f92672" }));
+    fireEvent.click(colours("Dark").getByRole("button", { name: "Copy theme" }));
+    expect(JSON.parse(written[0]!)).toMatchObject({ realmTheme: 1, mode: "dark", seed: { accent: "#f92672" } });
+  });
+
   it("contrast is a slider over the ink ramp, defaulting to the shipped spread", async () => {
     // What the store does with it. That it reaches the WINDOW is use-theme.test.ts's assertion — the
     // bridge that writes :root is mounted there, not here.

--- a/apps/desktop/src/renderer/src/panes/settings/settings-page.test.tsx
+++ b/apps/desktop/src/renderer/src/panes/settings/settings-page.test.tsx
@@ -233,6 +233,28 @@ describe("App tab", () => {
     expect(await colours("Light").findByText(/Below the contrast Realm holds every palette to.*Foreground/)).toBeInTheDocument();
   });
 
+  it("the two faces are chosen independently, and the weight rides the UI face", async () => {
+    // THE one-font mutant: a single family for both. Someone who wants the system UI face is not
+    // thereby asking for the system mono face, and the two live in different parts of the app.
+    const { store, api } = await openApp();
+    expect((screen.getByRole("combobox", { name: "UI font" }) as HTMLSelectElement).value).toBe("bundled");
+    fireEvent.change(screen.getByRole("combobox", { name: "UI font" }), { target: { value: "system" } });
+    await waitFor(() => expect(store.getState().fonts).toEqual({ ui: "system", uiWeight: "regular", code: "bundled" }));
+    fireEvent.change(screen.getByRole("combobox", { name: "UI font weight" }), { target: { value: "medium" } });
+    await waitFor(() => expect(store.getState().fonts.uiWeight).toBe("medium"));
+    expect(store.getState().fonts.code).toBe("bundled");
+    fireEvent.change(screen.getByRole("combobox", { name: "Code font" }), { target: { value: "system" } });
+    await waitFor(() => expect(store.getState().fonts.code).toBe("system"));
+    expect(store.getState().fonts.ui).toBe("system");
+    expect(api.calls.some((c) => c.startsWith("setSetting:ui.fonts"))).toBe(true);
+  });
+
+  it("offers no weight for code, and says why rather than leaving a gap", async () => {
+    await openApp();
+    expect(screen.queryByRole("combobox", { name: "Code font weight" })).toBeNull();
+    expect(screen.getByText(/Weight follows the app's own scale here/)).toBeInTheDocument();
+  });
+
   it("contrast is a slider over the ink ramp, defaulting to the shipped spread", async () => {
     // What the store does with it. That it reaches the WINDOW is use-theme.test.ts's assertion — the
     // bridge that writes :root is mounted there, not here.

--- a/apps/desktop/src/renderer/src/panes/settings/settings-page.test.tsx
+++ b/apps/desktop/src/renderer/src/panes/settings/settings-page.test.tsx
@@ -233,6 +233,50 @@ describe("App tab", () => {
     expect(await colours("Light").findByText(/Below the contrast Realm holds every palette to.*Foreground/)).toBeInTheDocument();
   });
 
+  it("each mode card shows the window it produces, and System shows both", async () => {
+    // THE decorative-preview mutant: paint the cards from :root's live values. Every card on the page
+    // would then be the mode already on screen, in the palette already on — three identical pictures
+    // claiming to be a choice between three things.
+    await openApp();
+    const frames = (name: string) =>
+      [...screen.getByRole("radio", { name }).closest(".mode-card")!.querySelectorAll(".mini-window")];
+    expect(frames("Light")).toHaveLength(1);
+    expect(frames("Dark")).toHaveLength(1);
+    // "System" cannot promise which face you will get, so its card does not pretend to either.
+    expect(frames("System")).toHaveLength(2);
+    const page = (el: Element) => (el as HTMLElement).style.getPropertyValue("--page");
+    expect(page(frames("Light")[0]!)).not.toBe(page(frames("Dark")[0]!));
+    expect([page(frames("System")[0]!), page(frames("System")[1]!)])
+      .toEqual([page(frames("Light")[0]!), page(frames("Dark")[0]!)]);
+  });
+
+  it("the code preview is the palette on the row, as edited, in the app's own syntax roles", async () => {
+    const { store } = await openApp();
+    const preview = (face: "Light" | "Dark") =>
+      screen.getByRole("group", { name: `${face} theme` }).parentElement!.querySelector(".code-preview") as HTMLElement;
+    // THE private-table mutant: give the preview its own colours instead of the --syn-* roles the
+    // stylesheet maps highlight.js onto. It would look plausible and would stop being a preview of
+    // anything the transcript does.
+    expect(preview("Dark").querySelector(".hljs-keyword")).toBeTruthy();
+    expect(preview("Dark").querySelector(".hljs-string")).toBeTruthy();
+    expect(preview("Dark").style.getPropertyValue("--syn-keyword")).toMatch(/^oklch\(/);
+    expect(preview("Dark").style.getPropertyValue("--page")).not.toBe(preview("Light").style.getPropertyValue("--page"));
+
+    // THE static-preview mutant: derive it once, off the palette's own seeds. Editing a colour would
+    // leave the picture underneath showing the theme before the edit.
+    const before = preview("Dark").style.getPropertyValue("--accent");
+    const field = colours("Dark").getByRole("textbox", { name: "Accent hex" });
+    fireEvent.change(field, { target: { value: "#f92672" } });
+    fireEvent.blur(field);
+    await waitFor(() => expect(store.getState().themeOverrides["realm:dark"]).toEqual({ accent: "#f92672" }));
+    expect(preview("Dark").style.getPropertyValue("--accent")).not.toBe(before);
+
+    // ...and it follows the contrast control, which moves the secondary tier the code body is drawn in.
+    const fg = preview("Dark").style.getPropertyValue("--syn-fg");
+    fireEvent.change(screen.getByRole("slider", { name: "Contrast" }), { target: { value: "10" } });
+    await waitFor(() => expect(preview("Dark").style.getPropertyValue("--syn-fg")).not.toBe(fg));
+  });
+
   it("the two faces are chosen independently, and the weight rides the UI face", async () => {
     // THE one-font mutant: a single family for both. Someone who wants the system UI face is not
     // thereby asking for the system mono face, and the two live in different parts of the app.

--- a/apps/desktop/src/renderer/src/panes/terminal-hub.test.ts
+++ b/apps/desktop/src/renderer/src/panes/terminal-hub.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { terminalBackground, TerminalHub, type HubTransport, type TerminalLike } from "./terminal-hub";
+import { terminalBackground, terminalFont, TerminalHub, type HubTransport, type TerminalLike } from "./terminal-hub";
 
 type Listener = (payload: unknown) => void;
 function fakeTransport() {
@@ -17,7 +17,7 @@ function fakeTransport() {
 function fakeTerm() {
   const writes: string[] = []; let dataFn: ((d: string) => void) | null = null; let disposed = false; let opened: HTMLElement | null = null;
   const term: TerminalLike & { writes: string[]; typed(d: string): void; disposed(): boolean; openedIn(): HTMLElement | null } = {
-    cols: 80, rows: 24, writes,
+    cols: 80, rows: 24, writes, options: { fontFamily: "start" },
     open: (el) => { opened = el; }, write: (d) => { writes.push(d); }, dispose: () => { disposed = true; }, focus: () => {},
     onData: (fn) => { dataFn = fn; return { dispose() { dataFn = null; } }; },
     onResize: () => ({ dispose() {} }),
@@ -29,8 +29,9 @@ function fakeTerm() {
 function setup() {
   const t = fakeTransport();
   const terms: ReturnType<typeof fakeTerm>[] = [];
-  const hub = new TerminalHub(t.transport, () => { const term = fakeTerm(); terms.push(term); return { term, fit: { fit() {} } }; });
-  return { ...t, hub, terms };
+  const fits: number[] = [];
+  const hub = new TerminalHub(t.transport, () => { const term = fakeTerm(); terms.push(term); return { term, fit: { fit() { fits.push(terms.indexOf(term)); } } }; });
+  return { ...t, hub, terms, fits };
 }
 
 describe("TerminalHub", () => {
@@ -165,5 +166,44 @@ describe("terminalBackground", () => {
     document.documentElement.style.setProperty("--rl-terminal-bg", "#101010");
     expect(terminalBackground()).toBe("#101010");
     document.documentElement.style.removeProperty("--rl-terminal-bg");
+  });
+});
+
+describe("the code face reaches a terminal that is already open", () => {
+  it("reads --font-mono rather than a stack of its own", () => {
+    // THE hardcoded-stack mutant: keep the literal '"JetBrains Mono", ui-monospace, …' the factory
+    // used to carry. It is the same value as the default preference, so every terminal looks right
+    // until someone picks the system face — and then the one surface that is nothing but code is the
+    // one surface that ignores the code font.
+    expect(terminalFont()).toContain("JetBrains Mono");
+    document.documentElement.style.setProperty("--font-mono", "ui-monospace, Menlo, monospace");
+    expect(terminalFont()).toBe("ui-monospace, Menlo, monospace");
+    document.documentElement.style.removeProperty("--font-mono");
+  });
+
+  it("pushes a changed face into every live terminal and re-fits the opened ones", () => {
+    // xterm reads its font once, at construction. THE next-terminal-only mutant: leave it there. The
+    // setting appears to do nothing to the terminal in front of you, which is the terminal you were
+    // looking at when you changed it.
+    const { hub, terms, fits } = setup();
+    const container = document.createElement("div"); document.body.appendChild(container);
+    hub.acquire("open").attach(container);
+    hub.acquire("detached");
+    fits.length = 0;
+
+    document.documentElement.style.setProperty("--font-mono", "ui-monospace, Menlo, monospace");
+    hub.refreshFont();
+    expect(terms.map((t) => t.options!.fontFamily)).toEqual(["ui-monospace, Menlo, monospace", "ui-monospace, Menlo, monospace"]);
+    // The cell size is measured off the face, so an opened terminal has to re-measure or the grid is
+    // the wrong shape and the pty was resized to a lie. A detached one has nothing to measure yet.
+    expect(fits).toEqual([0]);
+
+    // THE unconditional-refit mutant: re-fit on every call. This runs on every theme apply, and a
+    // re-fit that changes nothing still costs a reflow per terminal per repaint.
+    fits.length = 0;
+    hub.refreshFont();
+    expect(fits).toEqual([]);
+    document.documentElement.style.removeProperty("--font-mono");
+    container.remove();
   });
 });

--- a/apps/desktop/src/renderer/src/panes/terminal-hub.ts
+++ b/apps/desktop/src/renderer/src/panes/terminal-hub.ts
@@ -13,6 +13,9 @@ export type TerminalLike = {
   onData(fn: (data: string) => void): { dispose(): void };
   onResize(fn: (size: { cols: number; rows: number }) => void): { dispose(): void };
   readonly cols: number; readonly rows: number;
+  /** xterm's live options bag. Optional because the only thing the hub writes back into it is the
+   *  code face, and a fake that does not care about fonts should not have to carry one. */
+  options?: { fontFamily?: string };
 };
 export type FitLike = { fit(): void };
 export type TerminalFactory = () => { term: TerminalLike; fit: FitLike };
@@ -34,15 +37,24 @@ export type HubEntry = {
   detach(): void;
 };
 
-/** Terminal background from the `--rl-terminal-bg` token (read once, at hub creation). */
+/** A `:root` custom property, or the fallback for a renderer whose stylesheet has not loaded. */
+const rootVar = (name: string, fallback: string, doc: Document): string =>
+  doc.defaultView?.getComputedStyle(doc.documentElement).getPropertyValue(name).trim() || fallback;
+
+/** Terminal background from the `--rl-terminal-bg` token. */
 export function terminalBackground(doc: Document = document): string {
-  const v = doc.defaultView?.getComputedStyle(doc.documentElement).getPropertyValue("--rl-terminal-bg").trim();
-  return v || "#17181b";
+  return rootVar("--rl-terminal-bg", "#17181b", doc);
+}
+
+/** The code face, from the same `--font-mono` the rest of the app's code surfaces read — so the
+ *  Settings preference reaches a terminal instead of leaving it on a hardcoded stack that happens to
+ *  match the default. */
+export function terminalFont(doc: Document = document): string {
+  return rootVar("--font-mono", '"JetBrains Mono", ui-monospace, Menlo, monospace', doc);
 }
 
 const defaultFactory: TerminalFactory = () => {
-  // Bundled JetBrains Mono (V-X4) first — same face as the tool cards/wells; system mono as fallback.
-  const term = new Terminal({ cursorBlink: true, fontSize: 13, fontFamily: '"JetBrains Mono", ui-monospace, Menlo, monospace', theme: { background: terminalBackground() }, allowProposedApi: true });
+  const term = new Terminal({ cursorBlink: true, fontSize: 13, fontFamily: terminalFont(), theme: { background: terminalBackground() }, allowProposedApi: true });
   const fit = new FitAddon(); term.loadAddon(fit);
   return { term, fit };
 };
@@ -159,6 +171,22 @@ export class TerminalHub {
     this.buffers.delete(terminalId);
     this.hasDataIds.delete(terminalId);
     this.firstDataListeners.delete(terminalId);
+  }
+
+  /** Re-reads the code face from `--font-mono` and pushes it into every live terminal.
+   *
+   *  Without this the preference would only reach terminals opened AFTER it changed — xterm reads
+   *  its font once, at construction, exactly as it reads its background. A setting that takes effect
+   *  on the next terminal is a setting the user tries, sees nothing from, and moves on from. Each
+   *  one is re-fit afterwards because the cell size is measured off the face: changing it without
+   *  re-measuring leaves the grid the wrong shape and the pty resized to a lie. */
+  refreshFont() {
+    const font = terminalFont(this.doc);
+    for (const e of this.entries.values()) {
+      if (!e.term.options || e.term.options.fontFamily === font) continue;
+      e.term.options.fontFamily = font;
+      if (e.opened) try { e.fit.fit(); } catch { /* not measurable while detached */ }
+    }
   }
 
   disposeAll() {

--- a/apps/desktop/src/renderer/src/state/store.test.ts
+++ b/apps/desktop/src/renderer/src/state/store.test.ts
@@ -285,6 +285,30 @@ describe("app store", () => {
     expect(s.getState().themeOverrides).toEqual({ "one:dark": { bg: "#101014" } });
   });
 
+  it("contrast persists once per gesture and is clamped on the way in and out", async () => {
+    const set: string[] = []; const store = createAppStore({ ...api, setSetting: async (k, v) => { set.push(`${k}=${v}`); } });
+    await store.getState().boot();
+    expect(store.getState().contrast).toBe(60);
+    for (const v of [55, 48, 40]) await store.getState().setContrast(v);
+    expect(store.getState().contrast).toBe(40);
+    await vi.waitFor(() => expect(set).toContain("ui.contrast=40"));
+    expect(set.filter((k) => k.startsWith("ui.contrast="))).toEqual(["ui.contrast=40"]);
+
+    // THE unclamped mutant: store what the caller passed. The slider's min/max is not the guard —
+    // this is the store's API, and the derivation's own floors would silently absorb the excess so
+    // nothing on screen would ever show that the stored number had stopped meaning anything.
+    await store.getState().setContrast(400);
+    expect(store.getState().contrast).toBe(100);
+
+    const read = async (v: unknown) => {
+      const s = createAppStore({ ...api, getSetting: async (k) => (k === "ui.contrast" ? v : null) });
+      await s.getState().boot(); return s.getState().contrast;
+    };
+    expect(await read(20)).toBe(20);
+    expect(await read(-5)).toBe(0);
+    expect(await read("high")).toBe(60);
+  });
+
   it("groundAlpha persists once per gesture, and boot clamps whatever it reads back", async () => {
     const set: string[] = []; const store = createAppStore({ ...api, setSetting: async (k, v) => { set.push(`${k}=${v}`); } });
     await store.getState().boot();

--- a/apps/desktop/src/renderer/src/state/store.test.ts
+++ b/apps/desktop/src/renderer/src/state/store.test.ts
@@ -235,15 +235,20 @@ describe("app store", () => {
     expect(store.getState().themePref).toBe("dark"); expect(set).toContain("ui.theme=dark");
   });
 
-  it("themeName persists under its own key, leaving the mode preference untouched", async () => {
+  it("each face's palette persists under its own key, leaving the other face and the mode alone", async () => {
     // THE compound-key mutant: fold the palette into ui.theme as "dark:monokai". It reads back fine
     // here and an older build finds a mode it cannot parse where it used to find "dark".
+    // THE shared-slot mutant: write both faces on every set. Choosing Monokai for the night would
+    // silently replace whatever the user had picked for the day, which is the one thing splitting
+    // the selection exists to stop.
     const set: string[] = []; const store = createAppStore({ ...api, setSetting: async (k, v) => { set.push(`${k}=${v}`); } });
-    await store.getState().boot(); await store.getState().setThemeName("one");
-    expect(store.getState().themeName).toBe("one");
+    await store.getState().boot();
+    await store.getState().setThemeName("dark", "monokai");
+    expect(store.getState().themeNames).toEqual({ light: "realm", dark: "monokai" });
+    await store.getState().setThemeName("light", "solarized");
+    expect(store.getState().themeNames).toEqual({ light: "solarized", dark: "monokai" });
     expect(store.getState().themePref).toBe("system");
-    expect(set).toContain("ui.themeName=one");
-    expect(set.filter((k) => k.startsWith("ui.theme="))).toEqual([]);
+    expect(set.filter((k) => k.startsWith("ui.theme"))).toEqual(["ui.themeName.dark=monokai", "ui.themeName.light=solarized"]);
   });
 
   it("groundAlpha persists once per gesture, and boot clamps whatever it reads back", async () => {
@@ -272,16 +277,42 @@ describe("app store", () => {
     expect(await read("very")).toBe(82);
   });
 
-  it("boot reads the palette; garbage and an unknown name both fall back to realm", async () => {
-    const named = async (v: unknown) => {
-      const s = createAppStore({ ...api, getSetting: async (k) => (k === "ui.themeName" ? v : null) });
-      await s.getState().boot(); return s.getState().themeName;
+  it("boot reads a palette per face; garbage and an unknown name both fall back to realm", async () => {
+    const stored = async (rows: Record<string, unknown>) => {
+      const s = createAppStore({ ...api, getSetting: async (k) => rows[k] ?? null });
+      await s.getState().boot(); return s.getState().themeNames;
     };
-    expect(await named("one")).toBe("one");
+    expect(await stored({ "ui.themeName.light": "solarized", "ui.themeName.dark": "one" }))
+      .toEqual({ light: "solarized", dark: "one" });
     // A home written by a build that shipped a theme this one does not have must not leave the app
     // with a palette it cannot derive.
-    expect(await named("cobalt")).toBe("realm");
-    expect(await named({ mode: "x" })).toBe("realm");
+    expect(await stored({ "ui.themeName.dark": "cobalt" })).toEqual({ light: "realm", dark: "realm" });
+    expect(await stored({ "ui.themeName.light": { mode: "x" } })).toEqual({ light: "realm", dark: "realm" });
+  });
+
+  it("a home last opened by the single-selection build keeps its palette on the faces that have one", async () => {
+    // THE dropped-migration mutant: read only the two new keys. Every user who had chosen a palette
+    // is silently returned to Realm on the first launch of this build, with nothing to tell them why.
+    const stored = async (legacy: unknown) => {
+      const s = createAppStore({ ...api, getSetting: async (k) => (k === "ui.themeName" ? legacy : null) });
+      await s.getState().boot(); return s.getState().themeNames;
+    };
+    expect(await stored("one")).toEqual({ light: "one", dark: "one" });
+    // ...and only those faces. Monokai in the light slot is a slot the light window cannot read;
+    // it has to become the palette that always has a light face, not a dark window at noon.
+    expect(await stored("monokai")).toEqual({ light: "realm", dark: "monokai" });
+    expect(await stored("cobalt")).toEqual({ light: "realm", dark: "realm" });
+  });
+
+  it("the per-face key wins over the legacy one, and the legacy key is never written again", async () => {
+    const set: string[] = [];
+    const s = createAppStore({ ...api,
+      getSetting: async (k) => ({ "ui.themeName": "gruvbox", "ui.themeName.dark": "nord" })[k] ?? null,
+      setSetting: async (k, v) => { set.push(`${k}=${v}`); } });
+    await s.getState().boot();
+    expect(s.getState().themeNames).toEqual({ light: "gruvbox", dark: "nord" });
+    await s.getState().setThemeName("light", "one");
+    expect(set.filter((k) => k.startsWith("ui.theme"))).toEqual(["ui.themeName.light=one"]);
   });
 
   it("updateItem merges the returned item (pin/rename)", async () => {

--- a/apps/desktop/src/renderer/src/state/store.test.ts
+++ b/apps/desktop/src/renderer/src/state/store.test.ts
@@ -251,6 +251,40 @@ describe("app store", () => {
     expect(set.filter((k) => k.startsWith("ui.theme"))).toEqual(["ui.themeName.dark=monokai", "ui.themeName.light=solarized"]);
   });
 
+  it("an override is stored per palette and per face, and clearing a role removes it", async () => {
+    const set: string[] = []; const store = createAppStore({ ...api, setSetting: async (k, v) => { set.push(`${k}=${JSON.stringify(v)}`); } });
+    await store.getState().boot();
+    await store.getState().setThemeOverride("one", "dark", { accent: "#f92672" });
+    await store.getState().setThemeOverride("one", "dark", { bg: "#101014" });
+    // THE clobbering-setter mutant: replace rather than merge. Setting the Background would silently
+    // discard the Accent the user set a moment earlier, in a control with no undo.
+    expect(store.getState().themeOverrides).toEqual({ "one:dark": { accent: "#f92672", bg: "#101014" } });
+    // A different face of the same palette is a different edit.
+    await store.getState().setThemeOverride("one", "light", { accent: "#4078f2" });
+    expect(Object.keys(store.getState().themeOverrides).sort()).toEqual(["one:dark", "one:light"]);
+
+    // THE undefined-as-a-value mutant: spread the clear in instead of deleting the key. It survives
+    // JSON as a missing key on the way out and reads back as unedited — but until the next boot the
+    // in-memory record still has the key, so "Reset" shows for an edit that is no longer there.
+    await store.getState().setThemeOverride("one", "dark", { accent: undefined });
+    expect(store.getState().themeOverrides["one:dark"]).toEqual({ bg: "#101014" });
+    await store.getState().setThemeOverride("one", "dark", { bg: undefined });
+    expect(store.getState().themeOverrides["one:dark"]).toBeUndefined();
+
+    await store.getState().resetThemeOverride("one", "light");
+    expect(store.getState().themeOverrides).toEqual({});
+    expect(set.filter((k) => k.startsWith("ui.themeOverrides")).at(-1)).toBe("ui.themeOverrides={}");
+  });
+
+  it("boot drops an override that is not a colour rather than letting it reach the derivation", async () => {
+    // THE trusted-row mutant: pass the stored object through. `hexToOklch` throws on "blue", inside
+    // the layout effect that paints the first frame — a white window with no Settings left to fix it.
+    const s = createAppStore({ ...api,
+      getSetting: async (k) => (k === "ui.themeOverrides" ? { "one:dark": { accent: "blue", bg: "#101014" }, "cobalt:dark": { bg: "#000000" } } : null) });
+    await s.getState().boot();
+    expect(s.getState().themeOverrides).toEqual({ "one:dark": { bg: "#101014" } });
+  });
+
   it("groundAlpha persists once per gesture, and boot clamps whatever it reads back", async () => {
     const set: string[] = []; const store = createAppStore({ ...api, setSetting: async (k, v) => { set.push(`${k}=${v}`); } });
     await store.getState().boot();

--- a/apps/desktop/src/renderer/src/state/store.ts
+++ b/apps/desktop/src/renderer/src/state/store.ts
@@ -11,7 +11,8 @@ import {
 } from "@realm/contracts";
 import { createContext, useCallback, useContext, useMemo, useSyncExternalStore } from "react";
 import { SHEET_MIN_WIDTH, complementOf, snapBrowserLeaves } from "./no-overlay";
-import { DEFAULT_GROUND_ALPHA, clampGroundAlpha, isThemeName, type ThemeName } from "@realm/ui";
+import { DEFAULT_GROUND_ALPHA, DEFAULT_SELECTION, clampGroundAlpha, isThemeName, themeModes,
+  type Mode, type ThemeName, type ThemeSelection } from "@realm/ui";
 import type { ThemePref } from "../theme/useTheme";
 import { emptyTranscript, reduceTranscript, type Transcript } from "../panes/session/transcript-model";
 import { allowlistKey, getBrowserBridges, parseAllowlist } from "../panes/browser/browser-client";
@@ -418,10 +419,15 @@ export type SubmitKey = "enter" | "cmdEnter";
 export const PERSIST_DEBOUNCE_MS = 300;
 export const SETTING_ACTIVE_SPACE = "ui.activeSpaceId";
 export const SETTING_THEME = "ui.theme";
-/** The palette, which is a second axis from `ui.theme`'s light/dark: one says which mode, the other
- *  says what the colours are in it. Its own key rather than a compound value in `ui.theme`, so an
- *  older build reading `ui.theme` still finds a mode it understands. */
-export const SETTING_THEME_NAME = "ui.themeName";
+/** The palette, one key per face — a second axis from `ui.theme`'s light/dark: that says which mode,
+ *  these say what the colours are in it. A key each rather than one compound value so the two faces
+ *  are written independently, which is what choosing them independently means.
+ *
+ *  `ui.themeName` is what a single selection used to be stored under; it is READ as the fallback for
+ *  both faces and never written again. A home last opened by an older build keeps the palette it had
+ *  wherever that palette has a face, which for a dark-only one is the dark slot alone. */
+export const SETTING_THEME_NAME: Record<Mode, string> = { light: "ui.themeName.light", dark: "ui.themeName.dark" };
+const SETTING_THEME_NAME_LEGACY = "ui.themeName";
 /** How opaque the sidebar's ground is over the macOS window material, in percent. */
 export const SETTING_GROUND_ALPHA = "ui.groundAlpha";
 /** Agent of the most recent session the user created or switched to — what "+"/⌘N reach for next. */
@@ -497,9 +503,10 @@ export type AppState = {
   /** All spaces across profiles, in user sort order. Exactly one is active at a time. */
   spaces: Space[]; activeSpaceId: string | null;
   themePref: ThemePref;
-  /** The palette. Orthogonal to `themePref`: a theme with only one face pins the effective mode
-   *  while it is selected, and leaves the preference alone (see `useApplyTheme`). */
-  themeName: ThemeName;
+  /** The palette each face wears. Orthogonal to `themePref`, which says only WHEN to switch faces —
+   *  a palette can no longer move the mode, because each slot is offered only palettes that have
+   *  its face (see `paletteFor`). */
+  themeNames: ThemeSelection;
   /** The sidebar's opacity over the macOS vibrancy material, 40–100. Persisted on every platform —
    *  a preference set on a Mac should survive opening the same home somewhere without a material,
    *  and come back unchanged. */
@@ -808,7 +815,7 @@ export type AppState = {
   deleteSpace(id: string): Promise<void>;
   reorderSpaces(ids: string[]): Promise<void>;
   setThemePref(pref: ThemePref): Promise<void>;
-  setThemeName(name: ThemeName): Promise<void>;
+  setThemeName(mode: Mode, name: ThemeName): Promise<void>;
   setGroundAlpha(pct: number): Promise<void>;
   setSwipeInvert(v: boolean): Promise<void>;
   /** Flip the sidebar between full column and top rail, and persist it. */
@@ -1476,6 +1483,14 @@ const sameSizes = (a: number[], b: number[]) => a.length === b.length && a.every
 const isThemePref = (x: unknown): x is ThemePref => x === "system" || x === "light" || x === "dark";
 const isSubmitKey = (x: unknown): x is SubmitKey => x === "enter" || x === "cmdEnter";
 
+/** One face's palette, from its own key or from the single selection an older build stored. A
+ *  palette is only accepted for a face it HAS: the legacy key can name a dark-only palette, and
+ *  putting that in the light slot would leave the window with no light palette to fall back from. */
+const storedPalette = (stored: unknown, legacy: unknown, mode: Mode): ThemeName => {
+  const name = isThemeName(stored) ? stored : isThemeName(legacy) ? legacy : "realm";
+  return themeModes(name).includes(mode) ? name : "realm";
+};
+
 /** Forget both sides of every named path in one checkout — what staging or unstaging invalidates. */
 function dropPatches(patches: Record<string, FileDiff>, cwd: string, paths: string[]): Record<string, FileDiff> {
   const doomed = new Set(paths.flatMap((p) => [patchKey(cwd, p, true), patchKey(cwd, p, false)]));
@@ -1792,7 +1807,7 @@ export function createAppStore(api: Api): StoreApi<AppState> {
 
     return {
       booted: false,
-      profiles: [], spaces: [], activeSpaceId: null, themePref: "system", themeName: "realm", groundAlpha: DEFAULT_GROUND_ALPHA, swipeInvert: false, submitKey: "enter", sidebarCollapsed: false, items: [], groups: null, layout: null, focusedLeafId: null, projects: [], environments: {}, error: null,
+      profiles: [], spaces: [], activeSpaceId: null, themePref: "system", themeNames: DEFAULT_SELECTION, groundAlpha: DEFAULT_GROUND_ALPHA, swipeInvert: false, submitKey: "enter", sidebarCollapsed: false, items: [], groups: null, layout: null, focusedLeafId: null, projects: [], environments: {}, error: null,
       allItems: [], lastAgentKind: null, renamingItemId: null, renamingGroupId: null,
       connectionState: "connected",
       paletteOpen: false, spacesOpen: false, lastSpaceByProfile: {}, sheet: null, browserRects: [], sheetSnap: null, browserActions: {}, browserDriving: {},
@@ -1814,15 +1829,16 @@ export function createAppStore(api: Api): StoreApi<AppState> {
       activeIndex() { const id = get().activeSpaceId; return id ? get().spaces.findIndex((s) => s.id === id) : -1; },
 
       async boot() {
-        const [profiles, spaces, saved, theme, themeName, groundAlpha, swipeInvert, submitKey, sidebarCollapsed, lastAgent, panels, system] = await Promise.all([
-          api.listProfiles(), api.listSpaces(), api.getSetting(SETTING_ACTIVE_SPACE), api.getSetting(SETTING_THEME), api.getSetting(SETTING_THEME_NAME), api.getSetting(SETTING_GROUND_ALPHA), api.getSetting(SETTING_SWIPE_INVERT), api.getSetting(SETTING_SUBMIT_KEY), api.getSetting(SETTING_SIDEBAR_COLLAPSED), api.getSetting(SETTING_LAST_AGENT),
+        const [profiles, spaces, saved, theme, light, dark, legacyName, groundAlpha, swipeInvert, submitKey, sidebarCollapsed, lastAgent, panels, system] = await Promise.all([
+          api.listProfiles(), api.listSpaces(), api.getSetting(SETTING_ACTIVE_SPACE), api.getSetting(SETTING_THEME),
+          api.getSetting(SETTING_THEME_NAME.light), api.getSetting(SETTING_THEME_NAME.dark), api.getSetting(SETTING_THEME_NAME_LEGACY), api.getSetting(SETTING_GROUND_ALPHA), api.getSetting(SETTING_SWIPE_INVERT), api.getSetting(SETTING_SUBMIT_KEY), api.getSetting(SETTING_SIDEBAR_COLLAPSED), api.getSetting(SETTING_LAST_AGENT),
           api.getSetting(SETTING_TERMINAL_PANEL),
           // Labels, not dependencies: a failure here must not take boot down with it — the strip
           // simply shows no machine name, and the greeting no name.
           api.systemInfo().catch(() => ({ machineName: "", userName: "" })),
         ]);
         const agent = AgentKindSchema.safeParse(lastAgent);
-        set({ profiles, themePref: isThemePref(theme) ? theme : "system", themeName: isThemeName(themeName) ? themeName : "realm",
+        set({ profiles, themePref: isThemePref(theme) ? theme : "system", themeNames: { light: storedPalette(light, legacyName, "light"), dark: storedPalette(dark, legacyName, "dark") },
           groundAlpha: typeof groundAlpha === "number" ? clampGroundAlpha(groundAlpha) : DEFAULT_GROUND_ALPHA, swipeInvert: swipeInvert === true,
           submitKey: isSubmitKey(submitKey) ? submitKey : "enter", sidebarCollapsed: sidebarCollapsed === true, lastAgentKind: agent.success ? agent.data : null,
           terminalPanel: parseTerminalPanels(panels), machineName: system.machineName, userName: system.userName });
@@ -1981,9 +1997,9 @@ export function createAppStore(api: Api): StoreApi<AppState> {
         set({ themePref: pref });
         await api.setSetting(SETTING_THEME, pref);
       },
-      async setThemeName(name) {
-        set({ themeName: name });
-        await api.setSetting(SETTING_THEME_NAME, name);
+      async setThemeName(mode, name) {
+        set({ themeNames: { ...get().themeNames, [mode]: name } });
+        await api.setSetting(SETTING_THEME_NAME[mode], name);
       },
       async setGroundAlpha(pct) {
         // Clamped before it is stored, not just before it is painted: an out-of-range value written

--- a/apps/desktop/src/renderer/src/state/store.ts
+++ b/apps/desktop/src/renderer/src/state/store.ts
@@ -11,7 +11,8 @@ import {
 } from "@realm/contracts";
 import { createContext, useCallback, useContext, useMemo, useSyncExternalStore } from "react";
 import { SHEET_MIN_WIDTH, complementOf, snapBrowserLeaves } from "./no-overlay";
-import { CONTRAST_RANGE, DEFAULT_GROUND_ALPHA, DEFAULT_SELECTION, clampContrast, clampGroundAlpha, isOverridden,
+import { CONTRAST_RANGE, DEFAULT_FONTS, DEFAULT_GROUND_ALPHA, DEFAULT_SELECTION, clampContrast, clampGroundAlpha,
+  isOverridden, parseFontPref, type FontPref,
   isThemeName, overrideKey, parseThemeOverrides, themeModes,
   type Mode, type ThemeName, type ThemeOverride, type ThemeOverrides, type ThemeSelection } from "@realm/ui";
 import type { ThemePref } from "../theme/useTheme";
@@ -436,6 +437,8 @@ export const SETTING_THEME_OVERRIDES = "ui.themeOverrides";
 /** How far the ink ramp spreads below primary text, 0–100. Not per palette: it is a statement about
  *  the eyes reading the screen, not about One Dark. */
 export const SETTING_CONTRAST = "ui.contrast";
+/** The UI and code faces, and the UI weight. One row: they are read together and set together. */
+export const SETTING_FONTS = "ui.fonts";
 /** How opaque the sidebar's ground is over the macOS window material, in percent. */
 export const SETTING_GROUND_ALPHA = "ui.groundAlpha";
 /** Agent of the most recent session the user created or switched to — what "+"/⌘N reach for next. */
@@ -522,6 +525,9 @@ export type AppState = {
   /** The ink ramp's spread. Floored by the derivation at every setting, so this is a preference and
    *  never a legibility risk. */
   contrast: number;
+  /** Which type faces the app wears. Not per palette — a face is a fact about reading, not about
+   *  One Dark. */
+  fonts: FontPref;
   /** The sidebar's opacity over the macOS vibrancy material, 40–100. Persisted on every platform —
    *  a preference set on a Mac should survive opening the same home somewhere without a material,
    *  and come back unchanged. */
@@ -835,6 +841,7 @@ export type AppState = {
   setThemeOverride(name: ThemeName, mode: Mode, patch: ThemeOverride & { syntax?: Partial<Record<string, string>> }): Promise<void>;
   resetThemeOverride(name: ThemeName, mode: Mode): Promise<void>;
   setContrast(level: number): Promise<void>;
+  setFonts(patch: Partial<FontPref>): Promise<void>;
   setGroundAlpha(pct: number): Promise<void>;
   setSwipeInvert(v: boolean): Promise<void>;
   /** Flip the sidebar between full column and top rail, and persist it. */
@@ -1827,7 +1834,7 @@ export function createAppStore(api: Api): StoreApi<AppState> {
 
     return {
       booted: false,
-      profiles: [], spaces: [], activeSpaceId: null, themePref: "system", themeNames: DEFAULT_SELECTION, themeOverrides: {}, contrast: CONTRAST_RANGE.default, groundAlpha: DEFAULT_GROUND_ALPHA, swipeInvert: false, submitKey: "enter", sidebarCollapsed: false, items: [], groups: null, layout: null, focusedLeafId: null, projects: [], environments: {}, error: null,
+      profiles: [], spaces: [], activeSpaceId: null, themePref: "system", themeNames: DEFAULT_SELECTION, themeOverrides: {}, contrast: CONTRAST_RANGE.default, fonts: DEFAULT_FONTS, groundAlpha: DEFAULT_GROUND_ALPHA, swipeInvert: false, submitKey: "enter", sidebarCollapsed: false, items: [], groups: null, layout: null, focusedLeafId: null, projects: [], environments: {}, error: null,
       allItems: [], lastAgentKind: null, renamingItemId: null, renamingGroupId: null,
       connectionState: "connected",
       paletteOpen: false, spacesOpen: false, lastSpaceByProfile: {}, sheet: null, browserRects: [], sheetSnap: null, browserActions: {}, browserDriving: {},
@@ -1849,9 +1856,9 @@ export function createAppStore(api: Api): StoreApi<AppState> {
       activeIndex() { const id = get().activeSpaceId; return id ? get().spaces.findIndex((s) => s.id === id) : -1; },
 
       async boot() {
-        const [profiles, spaces, saved, theme, light, dark, legacyName, overrides, contrast, groundAlpha, swipeInvert, submitKey, sidebarCollapsed, lastAgent, panels, system] = await Promise.all([
+        const [profiles, spaces, saved, theme, light, dark, legacyName, overrides, contrast, fonts, groundAlpha, swipeInvert, submitKey, sidebarCollapsed, lastAgent, panels, system] = await Promise.all([
           api.listProfiles(), api.listSpaces(), api.getSetting(SETTING_ACTIVE_SPACE), api.getSetting(SETTING_THEME),
-          api.getSetting(SETTING_THEME_NAME.light), api.getSetting(SETTING_THEME_NAME.dark), api.getSetting(SETTING_THEME_NAME_LEGACY), api.getSetting(SETTING_THEME_OVERRIDES), api.getSetting(SETTING_CONTRAST), api.getSetting(SETTING_GROUND_ALPHA), api.getSetting(SETTING_SWIPE_INVERT), api.getSetting(SETTING_SUBMIT_KEY), api.getSetting(SETTING_SIDEBAR_COLLAPSED), api.getSetting(SETTING_LAST_AGENT),
+          api.getSetting(SETTING_THEME_NAME.light), api.getSetting(SETTING_THEME_NAME.dark), api.getSetting(SETTING_THEME_NAME_LEGACY), api.getSetting(SETTING_THEME_OVERRIDES), api.getSetting(SETTING_CONTRAST), api.getSetting(SETTING_FONTS), api.getSetting(SETTING_GROUND_ALPHA), api.getSetting(SETTING_SWIPE_INVERT), api.getSetting(SETTING_SUBMIT_KEY), api.getSetting(SETTING_SIDEBAR_COLLAPSED), api.getSetting(SETTING_LAST_AGENT),
           api.getSetting(SETTING_TERMINAL_PANEL),
           // Labels, not dependencies: a failure here must not take boot down with it — the strip
           // simply shows no machine name, and the greeting no name.
@@ -1859,7 +1866,7 @@ export function createAppStore(api: Api): StoreApi<AppState> {
         ]);
         const agent = AgentKindSchema.safeParse(lastAgent);
         set({ profiles, themePref: isThemePref(theme) ? theme : "system", themeNames: { light: storedPalette(light, legacyName, "light"), dark: storedPalette(dark, legacyName, "dark") },
-          themeOverrides: parseThemeOverrides(overrides), contrast: typeof contrast === "number" ? clampContrast(contrast) : CONTRAST_RANGE.default,
+          themeOverrides: parseThemeOverrides(overrides), contrast: typeof contrast === "number" ? clampContrast(contrast) : CONTRAST_RANGE.default, fonts: parseFontPref(fonts),
           groundAlpha: typeof groundAlpha === "number" ? clampGroundAlpha(groundAlpha) : DEFAULT_GROUND_ALPHA, swipeInvert: swipeInvert === true,
           submitKey: isSubmitKey(submitKey) ? submitKey : "enter", sidebarCollapsed: sidebarCollapsed === true, lastAgentKind: agent.success ? agent.data : null,
           terminalPanel: parseTerminalPanels(panels), machineName: system.machineName, userName: system.userName });
@@ -2039,6 +2046,11 @@ export function createAppStore(api: Api): StoreApi<AppState> {
         if (isOverridden(merged)) next[key] = merged; else delete next[key];
         set({ themeOverrides: next });
         await api.setSetting(SETTING_THEME_OVERRIDES, next);
+      },
+      async setFonts(patch) {
+        const next = { ...get().fonts, ...patch };
+        set({ fonts: next });
+        await api.setSetting(SETTING_FONTS, next);
       },
       async setContrast(level) {
         // Clamped before it is stored, like the ground's alpha: an out-of-range value written by an

--- a/apps/desktop/src/renderer/src/state/store.ts
+++ b/apps/desktop/src/renderer/src/state/store.ts
@@ -11,8 +11,8 @@ import {
 } from "@realm/contracts";
 import { createContext, useCallback, useContext, useMemo, useSyncExternalStore } from "react";
 import { SHEET_MIN_WIDTH, complementOf, snapBrowserLeaves } from "./no-overlay";
-import { DEFAULT_GROUND_ALPHA, DEFAULT_SELECTION, clampGroundAlpha, isOverridden, isThemeName, overrideKey,
-  parseThemeOverrides, themeModes,
+import { CONTRAST_RANGE, DEFAULT_GROUND_ALPHA, DEFAULT_SELECTION, clampContrast, clampGroundAlpha, isOverridden,
+  isThemeName, overrideKey, parseThemeOverrides, themeModes,
   type Mode, type ThemeName, type ThemeOverride, type ThemeOverrides, type ThemeSelection } from "@realm/ui";
 import type { ThemePref } from "../theme/useTheme";
 import { emptyTranscript, reduceTranscript, type Transcript } from "../panes/session/transcript-model";
@@ -433,6 +433,9 @@ const SETTING_THEME_NAME_LEGACY = "ui.themeName";
  *  than a key per palette: they are read together on every boot and there is no palette whose
  *  override is interesting on its own. */
 export const SETTING_THEME_OVERRIDES = "ui.themeOverrides";
+/** How far the ink ramp spreads below primary text, 0–100. Not per palette: it is a statement about
+ *  the eyes reading the screen, not about One Dark. */
+export const SETTING_CONTRAST = "ui.contrast";
 /** How opaque the sidebar's ground is over the macOS window material, in percent. */
 export const SETTING_GROUND_ALPHA = "ui.groundAlpha";
 /** Agent of the most recent session the user created or switched to — what "+"/⌘N reach for next. */
@@ -516,6 +519,9 @@ export type AppState = {
    *  moved background gets the same surface ladder and the same contrast correction a vendored one
    *  does, rather than a raw value written past the machinery. */
   themeOverrides: ThemeOverrides;
+  /** The ink ramp's spread. Floored by the derivation at every setting, so this is a preference and
+   *  never a legibility risk. */
+  contrast: number;
   /** The sidebar's opacity over the macOS vibrancy material, 40–100. Persisted on every platform —
    *  a preference set on a Mac should survive opening the same home somewhere without a material,
    *  and come back unchanged. */
@@ -828,6 +834,7 @@ export type AppState = {
   /** Merges into the palette's existing edits; an undefined role clears that one. */
   setThemeOverride(name: ThemeName, mode: Mode, patch: ThemeOverride & { syntax?: Partial<Record<string, string>> }): Promise<void>;
   resetThemeOverride(name: ThemeName, mode: Mode): Promise<void>;
+  setContrast(level: number): Promise<void>;
   setGroundAlpha(pct: number): Promise<void>;
   setSwipeInvert(v: boolean): Promise<void>;
   /** Flip the sidebar between full column and top rail, and persist it. */
@@ -1816,10 +1823,11 @@ export function createAppStore(api: Api): StoreApi<AppState> {
     };
 
     let groundAlphaTimer: ReturnType<typeof setTimeout> | null = null;
+    let contrastTimer: ReturnType<typeof setTimeout> | null = null;
 
     return {
       booted: false,
-      profiles: [], spaces: [], activeSpaceId: null, themePref: "system", themeNames: DEFAULT_SELECTION, themeOverrides: {}, groundAlpha: DEFAULT_GROUND_ALPHA, swipeInvert: false, submitKey: "enter", sidebarCollapsed: false, items: [], groups: null, layout: null, focusedLeafId: null, projects: [], environments: {}, error: null,
+      profiles: [], spaces: [], activeSpaceId: null, themePref: "system", themeNames: DEFAULT_SELECTION, themeOverrides: {}, contrast: CONTRAST_RANGE.default, groundAlpha: DEFAULT_GROUND_ALPHA, swipeInvert: false, submitKey: "enter", sidebarCollapsed: false, items: [], groups: null, layout: null, focusedLeafId: null, projects: [], environments: {}, error: null,
       allItems: [], lastAgentKind: null, renamingItemId: null, renamingGroupId: null,
       connectionState: "connected",
       paletteOpen: false, spacesOpen: false, lastSpaceByProfile: {}, sheet: null, browserRects: [], sheetSnap: null, browserActions: {}, browserDriving: {},
@@ -1841,9 +1849,9 @@ export function createAppStore(api: Api): StoreApi<AppState> {
       activeIndex() { const id = get().activeSpaceId; return id ? get().spaces.findIndex((s) => s.id === id) : -1; },
 
       async boot() {
-        const [profiles, spaces, saved, theme, light, dark, legacyName, overrides, groundAlpha, swipeInvert, submitKey, sidebarCollapsed, lastAgent, panels, system] = await Promise.all([
+        const [profiles, spaces, saved, theme, light, dark, legacyName, overrides, contrast, groundAlpha, swipeInvert, submitKey, sidebarCollapsed, lastAgent, panels, system] = await Promise.all([
           api.listProfiles(), api.listSpaces(), api.getSetting(SETTING_ACTIVE_SPACE), api.getSetting(SETTING_THEME),
-          api.getSetting(SETTING_THEME_NAME.light), api.getSetting(SETTING_THEME_NAME.dark), api.getSetting(SETTING_THEME_NAME_LEGACY), api.getSetting(SETTING_THEME_OVERRIDES), api.getSetting(SETTING_GROUND_ALPHA), api.getSetting(SETTING_SWIPE_INVERT), api.getSetting(SETTING_SUBMIT_KEY), api.getSetting(SETTING_SIDEBAR_COLLAPSED), api.getSetting(SETTING_LAST_AGENT),
+          api.getSetting(SETTING_THEME_NAME.light), api.getSetting(SETTING_THEME_NAME.dark), api.getSetting(SETTING_THEME_NAME_LEGACY), api.getSetting(SETTING_THEME_OVERRIDES), api.getSetting(SETTING_CONTRAST), api.getSetting(SETTING_GROUND_ALPHA), api.getSetting(SETTING_SWIPE_INVERT), api.getSetting(SETTING_SUBMIT_KEY), api.getSetting(SETTING_SIDEBAR_COLLAPSED), api.getSetting(SETTING_LAST_AGENT),
           api.getSetting(SETTING_TERMINAL_PANEL),
           // Labels, not dependencies: a failure here must not take boot down with it — the strip
           // simply shows no machine name, and the greeting no name.
@@ -1851,7 +1859,7 @@ export function createAppStore(api: Api): StoreApi<AppState> {
         ]);
         const agent = AgentKindSchema.safeParse(lastAgent);
         set({ profiles, themePref: isThemePref(theme) ? theme : "system", themeNames: { light: storedPalette(light, legacyName, "light"), dark: storedPalette(dark, legacyName, "dark") },
-          themeOverrides: parseThemeOverrides(overrides),
+          themeOverrides: parseThemeOverrides(overrides), contrast: typeof contrast === "number" ? clampContrast(contrast) : CONTRAST_RANGE.default,
           groundAlpha: typeof groundAlpha === "number" ? clampGroundAlpha(groundAlpha) : DEFAULT_GROUND_ALPHA, swipeInvert: swipeInvert === true,
           submitKey: isSubmitKey(submitKey) ? submitKey : "enter", sidebarCollapsed: sidebarCollapsed === true, lastAgentKind: agent.success ? agent.data : null,
           terminalPanel: parseTerminalPanels(panels), machineName: system.machineName, userName: system.userName });
@@ -2031,6 +2039,15 @@ export function createAppStore(api: Api): StoreApi<AppState> {
         if (isOverridden(merged)) next[key] = merged; else delete next[key];
         set({ themeOverrides: next });
         await api.setSetting(SETTING_THEME_OVERRIDES, next);
+      },
+      async setContrast(level) {
+        // Clamped before it is stored, like the ground's alpha: an out-of-range value written by an
+        // older build or by hand must not be what the next boot reads back.
+        const next = clampContrast(level);
+        set({ contrast: next });
+        // The window follows the thumb, and a drag fires on every step. Same debounce, same reason.
+        if (contrastTimer) clearTimeout(contrastTimer);
+        contrastTimer = setTimeout(() => { contrastTimer = null; get().run(() => api.setSetting(SETTING_CONTRAST, next)); }, PERSIST_DEBOUNCE_MS);
       },
       async resetThemeOverride(name, mode) {
         const next = { ...get().themeOverrides };

--- a/apps/desktop/src/renderer/src/state/store.ts
+++ b/apps/desktop/src/renderer/src/state/store.ts
@@ -514,9 +514,9 @@ export type AppState = {
   /** All spaces across profiles, in user sort order. Exactly one is active at a time. */
   spaces: Space[]; activeSpaceId: string | null;
   themePref: ThemePref;
-  /** The palette each face wears. Orthogonal to `themePref`, which says only WHEN to switch faces —
-   *  a palette can no longer move the mode, because each slot is offered only palettes that have
-   *  its face (see `paletteFor`). */
+  /** The palette each face wears. Orthogonal to `themePref`, which says only WHEN to switch faces:
+   *  a palette cannot move the mode, because each slot is offered only palettes that have its face
+   *  (see `paletteFor`). */
   themeNames: ThemeSelection;
   /** Per-palette, per-face colour edits, merged into the palette's seeds before derivation — so a
    *  moved background gets the same surface ladder and the same contrast correction a vendored one

--- a/apps/desktop/src/renderer/src/state/store.ts
+++ b/apps/desktop/src/renderer/src/state/store.ts
@@ -11,8 +11,9 @@ import {
 } from "@realm/contracts";
 import { createContext, useCallback, useContext, useMemo, useSyncExternalStore } from "react";
 import { SHEET_MIN_WIDTH, complementOf, snapBrowserLeaves } from "./no-overlay";
-import { DEFAULT_GROUND_ALPHA, DEFAULT_SELECTION, clampGroundAlpha, isThemeName, themeModes,
-  type Mode, type ThemeName, type ThemeSelection } from "@realm/ui";
+import { DEFAULT_GROUND_ALPHA, DEFAULT_SELECTION, clampGroundAlpha, isOverridden, isThemeName, overrideKey,
+  parseThemeOverrides, themeModes,
+  type Mode, type ThemeName, type ThemeOverride, type ThemeOverrides, type ThemeSelection } from "@realm/ui";
 import type { ThemePref } from "../theme/useTheme";
 import { emptyTranscript, reduceTranscript, type Transcript } from "../panes/session/transcript-model";
 import { allowlistKey, getBrowserBridges, parseAllowlist } from "../panes/browser/browser-client";
@@ -428,6 +429,10 @@ export const SETTING_THEME = "ui.theme";
  *  wherever that palette has a face, which for a dark-only one is the dark slot alone. */
 export const SETTING_THEME_NAME: Record<Mode, string> = { light: "ui.themeName.light", dark: "ui.themeName.dark" };
 const SETTING_THEME_NAME_LEGACY = "ui.themeName";
+/** Colours the user has moved off a palette's own seeds, keyed by palette and face. One row rather
+ *  than a key per palette: they are read together on every boot and there is no palette whose
+ *  override is interesting on its own. */
+export const SETTING_THEME_OVERRIDES = "ui.themeOverrides";
 /** How opaque the sidebar's ground is over the macOS window material, in percent. */
 export const SETTING_GROUND_ALPHA = "ui.groundAlpha";
 /** Agent of the most recent session the user created or switched to — what "+"/⌘N reach for next. */
@@ -507,6 +512,10 @@ export type AppState = {
    *  a palette can no longer move the mode, because each slot is offered only palettes that have
    *  its face (see `paletteFor`). */
   themeNames: ThemeSelection;
+  /** Per-palette, per-face colour edits, merged into the palette's seeds before derivation — so a
+   *  moved background gets the same surface ladder and the same contrast correction a vendored one
+   *  does, rather than a raw value written past the machinery. */
+  themeOverrides: ThemeOverrides;
   /** The sidebar's opacity over the macOS vibrancy material, 40–100. Persisted on every platform —
    *  a preference set on a Mac should survive opening the same home somewhere without a material,
    *  and come back unchanged. */
@@ -816,6 +825,9 @@ export type AppState = {
   reorderSpaces(ids: string[]): Promise<void>;
   setThemePref(pref: ThemePref): Promise<void>;
   setThemeName(mode: Mode, name: ThemeName): Promise<void>;
+  /** Merges into the palette's existing edits; an undefined role clears that one. */
+  setThemeOverride(name: ThemeName, mode: Mode, patch: ThemeOverride & { syntax?: Partial<Record<string, string>> }): Promise<void>;
+  resetThemeOverride(name: ThemeName, mode: Mode): Promise<void>;
   setGroundAlpha(pct: number): Promise<void>;
   setSwipeInvert(v: boolean): Promise<void>;
   /** Flip the sidebar between full column and top rail, and persist it. */
@@ -1807,7 +1819,7 @@ export function createAppStore(api: Api): StoreApi<AppState> {
 
     return {
       booted: false,
-      profiles: [], spaces: [], activeSpaceId: null, themePref: "system", themeNames: DEFAULT_SELECTION, groundAlpha: DEFAULT_GROUND_ALPHA, swipeInvert: false, submitKey: "enter", sidebarCollapsed: false, items: [], groups: null, layout: null, focusedLeafId: null, projects: [], environments: {}, error: null,
+      profiles: [], spaces: [], activeSpaceId: null, themePref: "system", themeNames: DEFAULT_SELECTION, themeOverrides: {}, groundAlpha: DEFAULT_GROUND_ALPHA, swipeInvert: false, submitKey: "enter", sidebarCollapsed: false, items: [], groups: null, layout: null, focusedLeafId: null, projects: [], environments: {}, error: null,
       allItems: [], lastAgentKind: null, renamingItemId: null, renamingGroupId: null,
       connectionState: "connected",
       paletteOpen: false, spacesOpen: false, lastSpaceByProfile: {}, sheet: null, browserRects: [], sheetSnap: null, browserActions: {}, browserDriving: {},
@@ -1829,9 +1841,9 @@ export function createAppStore(api: Api): StoreApi<AppState> {
       activeIndex() { const id = get().activeSpaceId; return id ? get().spaces.findIndex((s) => s.id === id) : -1; },
 
       async boot() {
-        const [profiles, spaces, saved, theme, light, dark, legacyName, groundAlpha, swipeInvert, submitKey, sidebarCollapsed, lastAgent, panels, system] = await Promise.all([
+        const [profiles, spaces, saved, theme, light, dark, legacyName, overrides, groundAlpha, swipeInvert, submitKey, sidebarCollapsed, lastAgent, panels, system] = await Promise.all([
           api.listProfiles(), api.listSpaces(), api.getSetting(SETTING_ACTIVE_SPACE), api.getSetting(SETTING_THEME),
-          api.getSetting(SETTING_THEME_NAME.light), api.getSetting(SETTING_THEME_NAME.dark), api.getSetting(SETTING_THEME_NAME_LEGACY), api.getSetting(SETTING_GROUND_ALPHA), api.getSetting(SETTING_SWIPE_INVERT), api.getSetting(SETTING_SUBMIT_KEY), api.getSetting(SETTING_SIDEBAR_COLLAPSED), api.getSetting(SETTING_LAST_AGENT),
+          api.getSetting(SETTING_THEME_NAME.light), api.getSetting(SETTING_THEME_NAME.dark), api.getSetting(SETTING_THEME_NAME_LEGACY), api.getSetting(SETTING_THEME_OVERRIDES), api.getSetting(SETTING_GROUND_ALPHA), api.getSetting(SETTING_SWIPE_INVERT), api.getSetting(SETTING_SUBMIT_KEY), api.getSetting(SETTING_SIDEBAR_COLLAPSED), api.getSetting(SETTING_LAST_AGENT),
           api.getSetting(SETTING_TERMINAL_PANEL),
           // Labels, not dependencies: a failure here must not take boot down with it — the strip
           // simply shows no machine name, and the greeting no name.
@@ -1839,6 +1851,7 @@ export function createAppStore(api: Api): StoreApi<AppState> {
         ]);
         const agent = AgentKindSchema.safeParse(lastAgent);
         set({ profiles, themePref: isThemePref(theme) ? theme : "system", themeNames: { light: storedPalette(light, legacyName, "light"), dark: storedPalette(dark, legacyName, "dark") },
+          themeOverrides: parseThemeOverrides(overrides),
           groundAlpha: typeof groundAlpha === "number" ? clampGroundAlpha(groundAlpha) : DEFAULT_GROUND_ALPHA, swipeInvert: swipeInvert === true,
           submitKey: isSubmitKey(submitKey) ? submitKey : "enter", sidebarCollapsed: sidebarCollapsed === true, lastAgentKind: agent.success ? agent.data : null,
           terminalPanel: parseTerminalPanels(panels), machineName: system.machineName, userName: system.userName });
@@ -2000,6 +2013,30 @@ export function createAppStore(api: Api): StoreApi<AppState> {
       async setThemeName(mode, name) {
         set({ themeNames: { ...get().themeNames, [mode]: name } });
         await api.setSetting(SETTING_THEME_NAME[mode], name);
+      },
+      async setThemeOverride(name, mode, patch) {
+        const key = overrideKey(name, mode);
+        const prev = get().themeOverrides[key] ?? {};
+        // An undefined role means "back to the palette's own", so it is DELETED rather than spread
+        // in: a stored `{ accent: undefined }` survives JSON as a missing key on the way out and as
+        // a present one on the way in, and the two disagree about whether the palette is edited.
+        const merged: ThemeOverride = { ...prev, ...patch, syntax: { ...prev.syntax, ...patch.syntax } };
+        for (const [role, hex] of Object.entries({ ...patch, ...patch.syntax })) {
+          if (hex !== undefined) continue;
+          delete (merged as Record<string, unknown>)[role];
+          delete (merged.syntax as Record<string, unknown> | undefined)?.[role];
+        }
+        if (!Object.keys(merged.syntax ?? {}).length) delete merged.syntax;
+        const next = { ...get().themeOverrides };
+        if (isOverridden(merged)) next[key] = merged; else delete next[key];
+        set({ themeOverrides: next });
+        await api.setSetting(SETTING_THEME_OVERRIDES, next);
+      },
+      async resetThemeOverride(name, mode) {
+        const next = { ...get().themeOverrides };
+        delete next[overrideKey(name, mode)];
+        set({ themeOverrides: next });
+        await api.setSetting(SETTING_THEME_OVERRIDES, next);
       },
       async setGroundAlpha(pct) {
         // Clamped before it is stored, not just before it is painted: an out-of-range value written

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -2940,10 +2940,11 @@ body[data-media-lightbox] .transcript .media-el { visibility: hidden; }
 /* ——— Settings → App: the background transparency slider ——————————————————————
    A native range on the app's accent, with the value beside it in tabular figures so the number does
    not jitter as the thumb moves. Disabled off macOS, where the window has no material behind it. */
-.ground-alpha { display: flex; align-items: center; gap: 10px; }
-.ground-alpha input { flex: 1; min-width: 0; max-width: 260px; accent-color: var(--rl-accent); }
-.ground-alpha input:disabled { cursor: default; opacity: .45; }
-.ground-alpha-value { font-size: 12px; color: var(--rl-text-dim); font-variant-numeric: tabular-nums; }
+.slider-row { display: flex; align-items: center; gap: 10px; }
+.slider-row input[type="range"] { flex: 1; min-width: 0; max-width: 260px; accent-color: var(--rl-accent); }
+.slider-row input:disabled { cursor: default; opacity: .45; }
+/* Tabular so the readout does not shuffle the thumb sideways while it is being dragged. */
+.slider-value { font-size: 12px; color: var(--rl-text-dim); font-variant-numeric: tabular-nums; }
 
 /* ——— Settings → App: the palette picker ——————————————————————————————————————
    Each card is painted in the theme it names, so the row is a set of previews rather than a list of

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -2237,6 +2237,9 @@ button.panel-title:hover { background: var(--rl-hover); }
 .settings-input-label { display: flex; flex-direction: column; gap: 4px; font-size: 12px; color: var(--rl-text-dim); }
 .settings-hint { margin: 0; font-size: 11px; line-height: 1.5; color: var(--rl-text-faint); }
 .settings-hint[data-tone="danger"] { color: var(--rl-danger); }
+/* A choice the app has carried out and is reporting on, not one it refused — the contrast a moved
+   colour actually landed at. Orange rather than red: the window still works. */
+.settings-hint[data-tone="warn"] { color: var(--orange); }
 
 .settings-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; }
 .settings-row { display: flex; align-items: flex-start; gap: 10px; padding: 10px 0; }
@@ -2960,6 +2963,19 @@ body[data-media-lightbox] .transcript .media-el { visibility: hidden; }
 .theme-card-swatches { display: flex; gap: 4px; }
 .theme-card-swatches span { width: 14px; height: 14px; border-radius: 999px; }
 .theme-card-name { font-size: 12px; font-weight: var(--fw-label); }
+
+/* The three seeds a palette can be edited on. A swatch and a hex per row: the OS colour picker
+   cannot be typed into and a hex cannot be dragged, and both are how people actually arrive at a
+   colour. Wraps rather than scrolls — this sits in a pane whose width is wherever the split is. */
+.theme-overrides { display: flex; flex-wrap: wrap; align-items: center; gap: 8px 14px; margin: 2px 0 0; padding: 0; border: 0; }
+.theme-override { display: flex; align-items: center; gap: 6px; }
+.theme-override > span { font-size: 12px; color: var(--rl-text-dim); }
+.theme-override input[type="color"] {
+  width: 26px; height: 26px; padding: 2px; flex: none; cursor: pointer;
+  border-radius: var(--r-chip); border: 1px solid var(--rl-line); background: var(--rl-panel);
+}
+.theme-override .hex { width: 82px; text-transform: lowercase; }
+.theme-overrides .settings-hint { flex-basis: 100%; }
 /* The face on screen, of the two palette rows. A dot rather than a highlight: both rows are equally
    live controls, and the only thing that distinguishes them is which one the window is wearing while
    you read the page. */

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -2245,7 +2245,12 @@ button.panel-title:hover { background: var(--rl-hover); }
 .settings-hint { margin: 0; font-size: 11px; line-height: 1.5; color: var(--rl-text-faint); }
 .settings-hint[data-tone="danger"] { color: var(--rl-danger); }
 /* A choice the app has carried out and is reporting on, not one it refused — the contrast a moved
-   colour actually landed at. Orange rather than red: the window still works. */
+   colour actually landed at. Orange rather than red: the window still works.
+   --orange is load-bearing here rather than decorative. This line's whole job is to be readable on a
+   palette whose ground and ink have just been set to something illegible, and it is: the ground and
+   the ink are the two seeds nothing corrects, while every HUE is lifted to clear the floor against
+   the surface it lands on. So the sentence explaining the unreadable window is the one thing on it
+   that stays readable. */
 .settings-hint[data-tone="warn"] { color: var(--orange); }
 
 .settings-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; }
@@ -3016,6 +3021,9 @@ body[data-media-lightbox] .transcript .media-el { visibility: hidden; }
 .theme-card[data-selected] { box-shadow: 0 0 0 2px var(--rl-accent), var(--shadow-card-lift); }
 .theme-card:has(input:focus-visible) { outline: 2px solid var(--rl-accent); outline-offset: 2px; }
 .theme-card-swatches { display: flex; gap: 4px; }
+/* The ring is drawn in the THEME's own hint ink, inline: the card is painted in the palette it
+   names, so every light palette's --surface dot sits on a --page within a step of it and would
+   otherwise vanish into the card. A fixed hairline would be the invisible one on half the set. */
 .theme-card-swatches span { width: 14px; height: 14px; border-radius: 999px; }
 .theme-card-name { font-size: 12px; font-weight: var(--fw-label); }
 

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -109,8 +109,15 @@
   --ease: var(--ease-out-strong);
   /* The weight ladder, from tembo: 450 is "medium", 560 is the one title weight.
      Named rather than written per rule, so the ladder stays a ladder — the old
-     500/550/600/650 spread had two rungs a reader could not tell apart. */
-  --fw-medium: 450; --fw-label: 500; --fw-title: 560; --fw-strong: 600;
+     500/550/600/650 spread had two rungs a reader could not tell apart.
+     Every rung carries the same --fw-shift, which is how the UI font-weight preference reaches the
+     whole app from one place: an OFFSET, so the four rungs stay four rungs. Absolute weights from a
+     dropdown would flatten a label and a title into the same number on the way to making both
+     heavier. applyTheme() writes the shift; 0 here is what a renderer that never ran it gets. */
+  --fw-shift: 0;
+  --fw-body: calc(400 + var(--fw-shift));
+  --fw-medium: calc(450 + var(--fw-shift)); --fw-label: calc(500 + var(--fw-shift));
+  --fw-title: calc(560 + var(--fw-shift)); --fw-strong: calc(600 + var(--fw-shift));
 }
 /* The per-mode residue: the three tokens whose dark/light values do not flow from a BUI var. */
 :root[data-mode="light"] {
@@ -122,7 +129,7 @@
 /* 14/20 rather than 14/1.5: tembo pairs every type step with an explicit line
    height, and 21px line boxes are what left Realm's chrome sitting a hair
    looser than the references it gets measured against. */
-html, body, #root { height: 100%; margin: 0; color: var(--rl-text-bright); font: 14px/20px var(--font-ui); -webkit-font-smoothing: antialiased; }
+html, body, #root { height: 100%; margin: 0; color: var(--rl-text-bright); font: var(--fw-body) 14px/20px var(--font-ui); -webkit-font-smoothing: antialiased; }
 /* §5 vibrancy: html/body/#root/.app stay transparent so the macOS material shows through the
    sidebar column; .main (and every pane) paints opaque --rl-panel, so text there renders on a solid
    ground. On non-mac the BrowserWindow keeps its opaque backgroundColor and this composes to the
@@ -2940,6 +2947,8 @@ body[data-media-lightbox] .transcript .media-el { visibility: hidden; }
 /* ——— Settings → App: the background transparency slider ——————————————————————
    A native range on the app's accent, with the value beside it in tabular figures so the number does
    not jitter as the thumb moves. Disabled off macOS, where the window has no material behind it. */
+.font-row { display: flex; align-items: center; gap: 8px; }
+.font-row select { flex: 1; min-width: 0; max-width: 220px; }
 .slider-row { display: flex; align-items: center; gap: 10px; }
 .slider-row input[type="range"] { flex: 1; min-width: 0; max-width: 260px; accent-color: var(--rl-accent); }
 .slider-row input:disabled { cursor: default; opacity: .45; }

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -1898,7 +1898,7 @@ button.panel-title:hover { background: var(--rl-hover); }
   .diff-list, .diff-hunks, .diff-review-body, .commit-message,
   /* page panes */
   .cp-list, .activity-list, .task-detail-result, .notif-list, .notif-detail, .notif-split, .delegation-list,
-  .lecture-list, .install-cmd code,
+  .lecture-list, .install-cmd code, .code-preview,
   /* documents */
   .documents-tabs, .documents-picker, .documents-rich-surface, .documents-rich .tiptap, .documents-raw
 ) { scrollbar-width: thin; }
@@ -2954,6 +2954,51 @@ body[data-media-lightbox] .transcript .media-el { visibility: hidden; }
 .slider-row input:disabled { cursor: default; opacity: .45; }
 /* Tabular so the readout does not shuffle the thumb sideways while it is being dragged. */
 .slider-value { font-size: 12px; color: var(--rl-text-dim); font-variant-numeric: tabular-nums; }
+
+/* ——— Settings → App: the previews ————————————————————————————————————————————
+   Every preview below paints from CUSTOM PROPERTIES set inline on its own element, not from :root.
+   That is what lets one page show a light window and a dark one at once: the token blocks in
+   tokens.css hang off `data-mode` at the root and cannot be flipped per subtree, so a preview built
+   on them could only ever show the mode already on screen. */
+.mode-grid { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 8px; margin: 0; padding: 0; border: 0; max-width: 420px; }
+.mode-card {
+  display: flex; flex-direction: column; gap: 7px; padding: 7px; cursor: pointer;
+  border: 1px solid var(--rl-line); border-radius: var(--r-panel); background: var(--rl-panel);
+  transition: box-shadow var(--dur-hover) ease;
+}
+.mode-card input { position: absolute; opacity: 0; pointer-events: none; }
+.mode-card[data-selected] { box-shadow: 0 0 0 2px var(--rl-accent); }
+.mode-card:has(input:focus-visible) { outline: 2px solid var(--rl-accent); outline-offset: 2px; }
+.mode-card-name { font-size: 11.5px; font-weight: var(--fw-label); text-align: center; }
+/* The System card shows both faces side by side, each clipped to half the frame — the choice cannot
+   promise which one you will get, so the card does not pretend to either. */
+.mode-card-preview { display: flex; gap: 0; border-radius: var(--r-chip); overflow: hidden; }
+.mode-card-preview > * { flex: 1; min-width: 0; }
+.mode-card-preview[data-split] .mini-window:first-child { border-right: 1px solid var(--rl-line); }
+
+.mini-window { display: flex; height: 48px; background: var(--page); }
+.mini-sidebar { flex: none; width: 26%; display: flex; flex-direction: column; justify-content: center; gap: 4px; padding: 0 4px; background: var(--canvas); }
+.mini-sidebar i { height: 3px; border-radius: 999px; background: var(--ink-3); }
+.mini-sidebar i:first-child { background: var(--accent); width: 70%; }
+.mini-body { flex: 1; min-width: 0; display: flex; flex-direction: column; justify-content: center; gap: 4px; padding: 0 5px; }
+.mini-card { display: flex; align-items: center; gap: 3px; padding: 4px; border-radius: 3px; background: var(--surface); }
+.mini-card i { height: 3px; flex: 1; border-radius: 999px; background: var(--ink-2); }
+.mini-card i.mini-accent { flex: none; width: 22%; background: var(--accent); }
+
+/* A diff in the palette the row above it names. The spans carry highlight.js's own class names, so
+   this is coloured by the same `--syn-*` mapping a real transcript is — a preview with a private
+   colour table would be a preview of nothing. */
+.code-preview {
+  margin: 2px 0 0; padding: 8px 0; border-radius: var(--r-ctl); border: 1px solid var(--rl-line);
+  background: var(--surface); color: var(--syn-fg); overflow-x: auto;
+  font: 11.5px/1.7 var(--font-mono); white-space: pre;
+}
+.code-preview code { display: block; }
+.cp-line { display: block; padding: 0 10px; }
+/* The tint, not the hue: a diff band is a ground, and painting the line in --green would make the
+   added code itself unreadable in every palette whose green is near its surface. */
+.cp-line[data-diff="add"] { background: var(--green-tint); box-shadow: inset 2px 0 0 var(--green); }
+.cp-line[data-diff="del"] { background: var(--red-tint); box-shadow: inset 2px 0 0 var(--red); }
 
 /* ——— Settings → App: the palette picker ——————————————————————————————————————
    Each card is painted in the theme it names, so the row is a set of previews rather than a list of

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -2986,6 +2986,14 @@ body[data-media-lightbox] .transcript .media-el { visibility: hidden; }
 }
 .theme-override .hex { width: 82px; text-transform: lowercase; }
 .theme-overrides .settings-hint { flex-basis: 100%; }
+.theme-import { flex-basis: 100%; display: flex; flex-direction: column; gap: 6px; }
+.theme-import textarea {
+  width: 100%; box-sizing: border-box; resize: vertical; padding: 8px 10px;
+  border-radius: var(--r-ctl); border: 1px solid var(--rl-line); background: var(--field);
+  color: var(--rl-text-bright); font: 11.5px/1.6 var(--font-mono); outline: none;
+}
+.theme-import textarea:focus { border-color: var(--rl-accent); }
+.theme-import-actions { display: flex; align-items: center; gap: 10px; }
 /* The face on screen, of the two palette rows. A dot rather than a highlight: both rows are equally
    live controls, and the only thing that distinguishes them is which one the window is wearing while
    you read the page. */

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -2960,9 +2960,13 @@ body[data-media-lightbox] .transcript .media-el { visibility: hidden; }
 .theme-card-swatches { display: flex; gap: 4px; }
 .theme-card-swatches span { width: 14px; height: 14px; border-radius: 999px; }
 .theme-card-name { font-size: 12px; font-weight: var(--fw-label); }
-/* A mode control the palette has overruled. Dimmed, never disabled — it still records a preference
-   that applies again the moment a two-faced palette is chosen. */
-.settings-tabs[data-pinned] { opacity: .5; }
+/* The face on screen, of the two palette rows. A dot rather than a highlight: both rows are equally
+   live controls, and the only thing that distinguishes them is which one the window is wearing while
+   you read the page. */
+.field[data-live] > span::after {
+  content: ""; display: inline-block; width: 5px; height: 5px; margin-left: 6px; vertical-align: middle;
+  border-radius: 999px; background: var(--rl-accent);
+}
 
 /* ——— Settings → Usage ————————————————————————————————————————————————————————
    Spend, tokens and activity. The palette itself lives in tokens.css (`--series-1..8`, validated as

--- a/apps/desktop/src/renderer/src/styles.test.ts
+++ b/apps/desktop/src/renderer/src/styles.test.ts
@@ -1,7 +1,7 @@
 import { existsSync, readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { describe, expect, it } from "vitest";
-import { deriveVars, oklchToHex, themeSwatches } from "@realm/ui";
+import { REALM_SEED, deriveVars, oklchToHex } from "@realm/ui";
 
 /** §6's motion table and its "do NOT animate" list are enforceable only against the stylesheet
  *  itself — jsdom has no layout, no compositor and no CSSOM for a raw file, so nothing else in the
@@ -1416,6 +1416,19 @@ const SYNTAX_ROLES = [
 describe("custom themes", () => {
   const tokens = readFileSync(repoFile("apps/desktop/src/renderer/src/theme/tokens.css"), "utf8");
 
+  /** One mode's declaration block, so a token is read from the ramp that actually states it. */
+  const modeBlock = (mode: "dark" | "light"): string => {
+    const at = tokens.indexOf(mode === "dark" ? ":root {\n  color-scheme: dark" : ':root[data-mode="light"] {');
+    expect(at, `no ${mode} token block in tokens.css`).toBeGreaterThan(-1);
+    return tokens.slice(at, tokens.indexOf("\n}", at));
+  };
+  const oklchIn = (name: string, block: string): { l: number; c: number; h: number } => {
+    const m = new RegExp(`${name}: oklch\\(([\\d.]+) ([\\d.]+) ([\\d.]+)`).exec(block);
+    expect(m, `${name} is not a plain oklch value in tokens.css`).not.toBeNull();
+    return { l: Number(m![1]), c: Number(m![2]), h: Number(m![3]) };
+  };
+  const hexIn = (name: string, block: string): string => oklchToHex(oklchIn(name, block));
+
   it("the default palette defines every syntax role in terms of the ramps the old block wrote inline", () => {
     // Byte-for-byte the mapping styles.css used to carry, so introducing the roles cannot have
     // changed how the shipped theme highlights code. A drift here is a silent restyle of every
@@ -1456,29 +1469,19 @@ describe("custom themes", () => {
     // exponent, the tooltip's inversion. Every theme still clears every contrast floor, because the
     // floors are about legibility and this is about SHAPE; only this notices that the derived
     // palettes have stopped being the same system as the one they sit beside.
-    const L = (name: string, block: string): number => {
-      const m = new RegExp(`${name}: oklch\\(([\\d.]+) ([\\d.]+) ([\\d.]+)`).exec(block);
-      expect(m, `${name} is not a plain oklch value in tokens.css`).not.toBeNull();
-      return Number(m![1]);
-    };
-    const hex = (name: string, block: string): string => {
-      const m = new RegExp(`${name}: oklch\\(([\\d.]+) ([\\d.]+) ([\\d.]+)`).exec(block)!;
-      return oklchToHex({ l: Number(m[1]), c: Number(m[2]), h: Number(m[3]) });
-    };
+    const L = (name: string, block: string): number => oklchIn(name, block).l;
     const derivedL = (v: string): number => Number(/^oklch\(([\d.]+)/.exec(v)![1]);
 
     for (const mode of ["dark", "light"] as const) {
-      const at = tokens.indexOf(mode === "dark" ? ":root {\n  color-scheme: dark" : ':root[data-mode="light"] {');
-      expect(at, `no ${mode} token block in tokens.css`).toBeGreaterThan(-1);
-      const block = tokens.slice(at, tokens.indexOf("\n}", at));
+      const block = modeBlock(mode);
       // The seeds are read back out of the palette rather than written here, so this cannot drift
       // by someone updating tokens.css and the copy in the test to match each other.
       const derived = deriveVars({
-        bg: hex("--page", block), ink: hex("--ink", block), accent: hex("--accent", block),
-        green: hex("--green", block), orange: hex("--orange", block), red: hex("--red", block),
+        bg: hexIn("--page", block), ink: hexIn("--ink", block), accent: hexIn("--accent", block),
+        green: hexIn("--green", block), orange: hexIn("--orange", block), red: hexIn("--red", block),
         // The same role mapping the base --syn-* block states, so the seeds are Realm's own.
-        syntax: { comment: hex("--ink-3", block), keyword: hex("--accent", block), string: hex("--green", block),
-          number: hex("--orange", block), title: hex("--ink", block), type: hex("--ink", block), attr: hex("--ink-2", block) },
+        syntax: { comment: hexIn("--ink-3", block), keyword: hexIn("--accent", block), string: hexIn("--green", block),
+          number: hexIn("--orange", block), title: hexIn("--ink", block), type: hexIn("--ink", block), attr: hexIn("--ink-2", block) },
       }, mode);
 
       // The surface ladder and the tooltip chip are pure geometry off the seed: they have to land on
@@ -1496,10 +1499,23 @@ describe("custom themes", () => {
   });
 
   it("the picker's copy of Realm's own colours has not drifted from tokens.css", () => {
-    // themeSwatches cannot read the live values — under any other theme they are that theme's — so
-    // it carries four literals. This is the pin that keeps the copy honest.
+    // themeSwatches cannot read the live values — under any other theme they are that theme's — and
+    // an override needs a seed to move, so REALM_SEED carries Realm's twelve as hex. This is the pin
+    // that keeps the copy honest: the same read-back the ramp test does above, compared value for
+    // value. THE drifted-seed mutant: repaint --accent in tokens.css and leave REALM_SEED alone —
+    // the picker's Realm card, and every override derived off Realm, keep the old blue.
     for (const mode of ["dark", "light"] as const) {
-      for (const value of themeSwatches("realm", mode)) expect(tokens, `${mode} ${value}`).toContain(value);
+      const block = modeBlock(mode);
+      const want = REALM_SEED[mode];
+      for (const [role, token] of [["bg", "--page"], ["ink", "--ink"], ["accent", "--accent"],
+        ["green", "--green"], ["orange", "--orange"], ["red", "--red"]] as const) {
+        expect(want[role], `${mode} ${role}`).toBe(hexIn(token, block));
+      }
+      // The syntax seeds are the role mapping the base --syn-* block states, resolved through it.
+      for (const [role, token] of [["comment", "--ink-3"], ["keyword", "--accent"], ["string", "--green"],
+        ["number", "--orange"], ["title", "--ink"], ["type", "--ink"], ["attr", "--ink-2"]] as const) {
+        expect(want.syntax[role], `${mode} syntax.${role}`).toBe(hexIn(token, block));
+      }
     }
   });
 });

--- a/apps/desktop/src/renderer/src/styles.test.ts
+++ b/apps/desktop/src/renderer/src/styles.test.ts
@@ -472,13 +472,20 @@ describe("Plan 9 W1 — the BUI bridge", () => {
   it("the weight ladder is four named rungs on tembo's values — no bare weight survives in a component rule", () => {
     const root = css.match(/:root \{([^}]*)\}/)?.[1] ?? "";
     // 450/500/560/600. The old 500/550/600/650 spread had two rungs nobody could tell apart.
-    expect(root).toContain("--fw-medium: 450");
-    expect(root).toContain("--fw-label: 500");
-    expect(root).toContain("--fw-title: 560");
-    expect(root).toContain("--fw-strong: 600");
+    // Each rung carries --fw-shift, which is the whole of how the font-weight preference reaches the
+    // app. THE absolute-weight mutant: have the preference write --fw-medium..--fw-strong directly.
+    // Two rungs a user picked "Medium" for would land on the same number and the ladder would stop
+    // being a ladder for exactly the people who asked for heavier text.
+    for (const [rung, base] of [["medium", 450], ["label", 500], ["title", 560], ["strong", 600]] as const) {
+      expect(root, rung).toContain(`--fw-${rung}: calc(${base} + var(--fw-shift))`);
+    }
+    expect(root).toContain("--fw-shift: 0");
     // Everything but the @font-face ranges and the two deliberate 400s goes through the ladder.
     const bare = [...css.matchAll(/font-weight:\s*(\d+)\s*;/g)].map((m) => m[1]);
     expect(bare.filter((w) => w !== "400")).toEqual([]);
+    // ...and body copy is on it too, or the preference would move every label in the app and leave
+    // the prose it sits beside behind. The `font:` shorthand resets weight, so it has to be IN it.
+    expect(bodiesFor("html, body, #root".split(", ")[0]!).join(" ")).toContain("var(--fw-body) 14px/20px");
   });
 
   it("hairlines are half-pixel alpha overlays — one device pixel on retina, and no ground they are painted for", () => {
@@ -495,7 +502,7 @@ describe("Plan 9 W1 — the BUI bridge", () => {
     for (const decl of ["--text-xs--letter-spacing: -0.2px", "--text-sm--letter-spacing: -0.2px", "--text-base--line-height: 20px"])
       expect(tokens, decl).toContain(decl);
     // The body line box is the 20px the scale asks for, not 1.5×.
-    expect(bodiesFor("html, body, #root".split(", ")[0]!).join(" ")).toContain("font: 14px/20px var(--font-ui)");
+    expect(bodiesFor("html, body, #root".split(", ")[0]!).join(" ")).toContain("font: var(--fw-body) 14px/20px var(--font-ui)");
   });
 
   it("every custom property the stylesheet reads is one it (or tokens.css) actually defines", () => {

--- a/apps/desktop/src/renderer/src/theme/use-theme.test.ts
+++ b/apps/desktop/src/renderer/src/theme/use-theme.test.ts
@@ -108,6 +108,28 @@ describe("theme and mode compose", () => {
   });
 });
 
+describe("the contrast preference reaches :root", () => {
+  it("repaints the ink ramp when it changes, and touches nothing else", () => {
+    // THE decorative-slider mutant: render the control, persist the number, never pass it to
+    // applyTheme. It moves, it survives a restart, and the window never changes — the failure a
+    // settings control is most likely to ship with and least likely to be noticed in.
+    // THE missing-dependency mutant: leave `contrast` out of the layout effect's deps. Same symptom,
+    // until something unrelated forces a re-apply.
+    const root = document.documentElement;
+    const { rerender } = renderHook(
+      ({ contrast }) => useApplyTheme({ color: "#7c6cff", pref: "dark", themes: { light: "one", dark: "one" }, contrast }),
+      { initialProps: { contrast: 60 } },
+    );
+    const at60 = { ink2: root.style.getPropertyValue("--ink-2"), page: root.style.getPropertyValue("--page"), accent: root.style.getPropertyValue("--accent") };
+    expect(at60.ink2).toMatch(/^oklch\(/);
+    rerender({ contrast: 10 });
+    expect(root.style.getPropertyValue("--ink-2")).not.toBe(at60.ink2);
+    // ...and the ground and the hues are untouched, or it is not a contrast control.
+    expect(root.style.getPropertyValue("--page")).toBe(at60.page);
+    expect(root.style.getPropertyValue("--accent")).toBe(at60.accent);
+  });
+});
+
 describe("the adjustable ground reaches :root", () => {
   afterEach(() => { vi.unstubAllGlobals(); });
 

--- a/apps/desktop/src/renderer/src/theme/use-theme.test.ts
+++ b/apps/desktop/src/renderer/src/theme/use-theme.test.ts
@@ -32,7 +32,7 @@ describe("theme switching is not animated (§6)", () => {
 
   it("applying a theme fences the write, and switching mode fences it again", () => {
     vi.useFakeTimers();
-    const { rerender } = renderHook(({ pref }) => useApplyTheme("#7c6cff", pref), { initialProps: { pref: "dark" as ThemePref } });
+    const { rerender } = renderHook(({ pref }) => useApplyTheme({ color: "#7c6cff", pref }), { initialProps: { pref: "dark" as ThemePref } });
     expect(marked()).toBe(true); // set by the same layout effect that writes the palette
     act(() => { vi.advanceTimersByTime(100); });
     expect(marked()).toBe(false);
@@ -42,7 +42,7 @@ describe("theme switching is not animated (§6)", () => {
 
   it("leaves no mark behind when the app unmounts mid-swap", () => {
     vi.useFakeTimers();
-    const { unmount } = renderHook(() => useApplyTheme("#7c6cff", "dark"));
+    const { unmount } = renderHook(() => useApplyTheme({ color: "#7c6cff", pref: "dark" }));
     expect(marked()).toBe(true);
     unmount();
     expect(marked()).toBe(false);
@@ -60,7 +60,7 @@ describe("theme and mode compose", () => {
     // THE one-slot mutant: read a single palette for both faces (`themes.dark` whatever the mode).
     // Everything below still paints, and the light window silently wears the dark palette.
     const { result, rerender } = renderHook(
-      ({ pref }) => useApplyTheme("#7c6cff", pref, sel("solarized", "one")),
+      ({ pref }) => useApplyTheme({ color: "#7c6cff", pref, themes: sel("solarized", "one") }),
       { initialProps: { pref: "light" as ThemePref } },
     );
     expect(result.current).toBe("light");
@@ -75,7 +75,7 @@ describe("theme and mode compose", () => {
     // face. With a slot per face that is a control changing the OTHER axis behind the user's back:
     // asking for light and being handed a dark window because of something stored in a slot the
     // light window does not read.
-    const { result } = renderHook(() => useApplyTheme("#7c6cff", "light" as ThemePref, sel("monokai", "monokai")));
+    const { result } = renderHook(() => useApplyTheme({ color: "#7c6cff", pref: "light", themes: sel("monokai", "monokai") }));
     expect(result.current).toBe("light");
     expect(root().dataset.mode).toBe("light");
     expect(root().dataset.theme).toBe("realm");
@@ -84,7 +84,7 @@ describe("theme and mode compose", () => {
 
   it("a custom palette paints inline and the default palette scrubs it off again", () => {
     const { rerender } = renderHook(
-      ({ theme }) => useApplyTheme("#7c6cff", "dark" as ThemePref, sel("realm", theme)),
+      ({ theme }) => useApplyTheme({ color: "#7c6cff", pref: "dark", themes: sel("realm", theme) }),
       { initialProps: { theme: "one" } },
     );
     expect(root().style.getPropertyValue("--page")).toMatch(/^oklch\(/);
@@ -96,7 +96,7 @@ describe("theme and mode compose", () => {
   it("switching palette is fenced by the no-transition mark, exactly like switching mode", () => {
     vi.useFakeTimers();
     const { rerender } = renderHook(
-      ({ theme }) => useApplyTheme("#7c6cff", "dark" as ThemePref, sel("realm", theme)),
+      ({ theme }) => useApplyTheme({ color: "#7c6cff", pref: "dark", themes: sel("realm", theme) }),
       { initialProps: { theme: "realm" } },
     );
     act(() => { vi.advanceTimersByTime(100); });
@@ -113,7 +113,7 @@ describe("the adjustable ground reaches :root", () => {
 
   it("carries the user's value, and a change to it repaints without a mode or theme change", () => {
     const { rerender } = renderHook(
-      ({ alpha }) => useApplyTheme("#7c6cff", "dark" as ThemePref, { light: "realm", dark: "realm" }, alpha),
+      ({ alpha }) => useApplyTheme({ color: "#7c6cff", pref: "dark", groundAlpha: alpha }),
       { initialProps: { alpha: 82 } },
     );
     expect(document.documentElement.style.getPropertyValue("--ground-alpha")).toBe("82%");

--- a/apps/desktop/src/renderer/src/theme/use-theme.test.ts
+++ b/apps/desktop/src/renderer/src/theme/use-theme.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { act, cleanup, renderHook } from "@testing-library/react";
-import type { ThemeName } from "@realm/ui";
+import type { ThemeSelection } from "@realm/ui";
 import { hasWindowMaterial, suppressTransitions, useApplyTheme, type ThemePref } from "./useTheme";
 
 afterEach(() => { cleanup(); vi.useRealTimers(); document.documentElement.removeAttribute("data-theme-switching"); document.documentElement.removeAttribute("style"); });
@@ -49,30 +49,43 @@ describe("theme switching is not animated (§6)", () => {
   });
 });
 
-/** The palette is a second axis over light/dark, so the interesting cases are the ones where the two
- *  disagree: a theme with no light face, and the trip back out of it. */
+/** The palette is a second axis over light/dark, with a slot per face. The interesting cases are the
+ *  ones where the two axes could disagree: which slot a face reads, and a slot naming a palette that
+ *  has no such face. */
 describe("theme and mode compose", () => {
   const root = () => document.documentElement;
+  const sel = (light: string, dark: string) => ({ light, dark }) as ThemeSelection;
 
-  it("a one-faced palette pins the effective mode, and the preference survives it", () => {
+  it("each face wears its OWN slot, and the mode is the preference and nothing else", () => {
+    // THE one-slot mutant: read a single palette for both faces (`themes.dark` whatever the mode).
+    // Everything below still paints, and the light window silently wears the dark palette.
     const { result, rerender } = renderHook(
-      ({ theme }) => useApplyTheme("#7c6cff", "light" as ThemePref, theme),
-      { initialProps: { theme: "monokai" as ThemeName } },
+      ({ pref }) => useApplyTheme("#7c6cff", pref, sel("solarized", "one")),
+      { initialProps: { pref: "light" as ThemePref } },
     );
+    expect(result.current).toBe("light");
+    expect(root().dataset.theme).toBe("solarized");
+    rerender({ pref: "dark" });
     expect(result.current).toBe("dark");
-    expect(root().dataset.mode).toBe("dark");
-    expect(root().dataset.theme).toBe("monokai");
-    // THE pinning-by-preference mutant: implement this by writing "dark" into themePref. The window
-    // looks identical and the user's "light" is gone — this rerender would then still say dark.
-    rerender({ theme: "one" });
+    expect(root().dataset.theme).toBe("one");
+  });
+
+  it("a palette can no longer move the mode — a slot it has no face for falls back instead", () => {
+    // THE pinning mutant: keep the old rule that a one-faced palette resolves the mode to its own
+    // face. With a slot per face that is a control changing the OTHER axis behind the user's back:
+    // asking for light and being handed a dark window because of something stored in a slot the
+    // light window does not read.
+    const { result } = renderHook(() => useApplyTheme("#7c6cff", "light" as ThemePref, sel("monokai", "monokai")));
     expect(result.current).toBe("light");
     expect(root().dataset.mode).toBe("light");
+    expect(root().dataset.theme).toBe("realm");
+    expect(root().style.getPropertyValue("--page")).toBe("");
   });
 
   it("a custom palette paints inline and the default palette scrubs it off again", () => {
     const { rerender } = renderHook(
-      ({ theme }) => useApplyTheme("#7c6cff", "dark" as ThemePref, theme),
-      { initialProps: { theme: "one" as ThemeName } },
+      ({ theme }) => useApplyTheme("#7c6cff", "dark" as ThemePref, sel("realm", theme)),
+      { initialProps: { theme: "one" } },
     );
     expect(root().style.getPropertyValue("--page")).toMatch(/^oklch\(/);
     rerender({ theme: "realm" });
@@ -83,8 +96,8 @@ describe("theme and mode compose", () => {
   it("switching palette is fenced by the no-transition mark, exactly like switching mode", () => {
     vi.useFakeTimers();
     const { rerender } = renderHook(
-      ({ theme }) => useApplyTheme("#7c6cff", "dark" as ThemePref, theme),
-      { initialProps: { theme: "realm" as ThemeName } },
+      ({ theme }) => useApplyTheme("#7c6cff", "dark" as ThemePref, sel("realm", theme)),
+      { initialProps: { theme: "realm" } },
     );
     act(() => { vi.advanceTimersByTime(100); });
     expect(root().hasAttribute("data-theme-switching")).toBe(false);
@@ -100,7 +113,7 @@ describe("the adjustable ground reaches :root", () => {
 
   it("carries the user's value, and a change to it repaints without a mode or theme change", () => {
     const { rerender } = renderHook(
-      ({ alpha }) => useApplyTheme("#7c6cff", "dark" as ThemePref, "realm", alpha),
+      ({ alpha }) => useApplyTheme("#7c6cff", "dark" as ThemePref, { light: "realm", dark: "realm" }, alpha),
       { initialProps: { alpha: 82 } },
     );
     expect(document.documentElement.style.getPropertyValue("--ground-alpha")).toBe("82%");

--- a/apps/desktop/src/renderer/src/theme/useTheme.ts
+++ b/apps/desktop/src/renderer/src/theme/useTheme.ts
@@ -44,9 +44,9 @@ export function suppressTransitions(root: HTMLElement, ms = SETTLE_MS): () => vo
  *  static CSS (BUI tokens in theme/tokens.css keyed on `data-mode`) and the only runtime writes are
  *  `--rl-space` and the two attributes.
  *
- *  The mode is now the preference and nothing else. A palette used to be able to pin it — the only
- *  way a single selection could honour "Monokai, which has no light face" — and with a slot per face
- *  there is no such conflict to resolve: each slot is offered only palettes that have its face. */
+ *  The mode is the preference and nothing else. A palette cannot move it: each slot is offered only
+ *  palettes that have its face, so "Monokai, which has no light face" is settled by what the dark
+ *  slot may hold rather than by overruling the other axis at paint time. */
 export type AppliedTheme = {
   color: string | null;
   pref: ThemePref;

--- a/apps/desktop/src/renderer/src/theme/useTheme.ts
+++ b/apps/desktop/src/renderer/src/theme/useTheme.ts
@@ -1,5 +1,6 @@
 import { useEffect, useLayoutEffect, useState } from "react";
-import { DEFAULT_GROUND_ALPHA, DEFAULT_SELECTION, applyTheme, paletteFor, type Mode, type ThemeSelection } from "@realm/ui";
+import { DEFAULT_GROUND_ALPHA, DEFAULT_SELECTION, applyTheme, overrideKey, paletteFor,
+  type Mode, type ThemeOverrides, type ThemeSelection } from "@realm/ui";
 
 export type ThemePref = "system" | "light" | "dark";
 
@@ -46,16 +47,27 @@ export function suppressTransitions(root: HTMLElement, ms = SETTLE_MS): () => vo
  *  The mode is now the preference and nothing else. A palette used to be able to pin it — the only
  *  way a single selection could honour "Monokai, which has no light face" — and with a slot per face
  *  there is no such conflict to resolve: each slot is offered only palettes that have its face. */
-export function useApplyTheme(color: string | null, pref: ThemePref,
-  themes: ThemeSelection = DEFAULT_SELECTION, groundAlpha: number = DEFAULT_GROUND_ALPHA): Mode {
+export type AppliedTheme = {
+  color: string | null;
+  pref: ThemePref;
+  themes?: ThemeSelection;
+  /** Keyed by palette AND face, so the effect's dependency is the ONE override on screen rather than
+   *  every override the user has ever set — editing Gruvbox's accent must not repaint One Dark. */
+  overrides?: ThemeOverrides;
+  groundAlpha?: number;
+};
+
+export function useApplyTheme({ color, pref, themes = DEFAULT_SELECTION, overrides = {},
+  groundAlpha = DEFAULT_GROUND_ALPHA }: AppliedTheme): Mode {
   const mode = useResolvedMode(pref);
   const theme = paletteFor(themes, mode);
+  const override = overrides[overrideKey(theme, mode)];
   // Layout effect so the first paint already carries the mode (no flash of default vars).
   useLayoutEffect(() => {
     const done = suppressTransitions(document.documentElement);
-    applyTheme({ space: color ?? "#7c6cff", mode, theme, groundAlpha });
+    applyTheme({ space: color ?? "#7c6cff", mode, theme, override, groundAlpha });
     return done;
-  }, [color, mode, theme, groundAlpha]);
+  }, [color, mode, theme, override, groundAlpha]);
   return mode;
 }
 

--- a/apps/desktop/src/renderer/src/theme/useTheme.ts
+++ b/apps/desktop/src/renderer/src/theme/useTheme.ts
@@ -1,5 +1,5 @@
 import { useEffect, useLayoutEffect, useState } from "react";
-import { DEFAULT_GROUND_ALPHA, applyTheme, resolveMode, type Mode, type ThemeName } from "@realm/ui";
+import { DEFAULT_GROUND_ALPHA, DEFAULT_SELECTION, applyTheme, paletteFor, type Mode, type ThemeSelection } from "@realm/ui";
 
 export type ThemePref = "system" | "light" | "dark";
 
@@ -16,6 +16,14 @@ export function useSystemMode(): Mode {
   return mode;
 }
 
+/** The face on screen: the preference, resolved against the OS only where it defers to it. Every
+ *  control that offers "the palette for the mode you are looking at" needs this same answer, and one
+ *  of them computing it differently would set the slot the user is not seeing. */
+export function useResolvedMode(pref: ThemePref): Mode {
+  const sys = useSystemMode();
+  return pref === "system" ? sys : pref;
+}
+
 /** How long the no-transition guard holds. Long enough for the new palette to paint, short enough
  *  that a hover started right after a theme switch still animates. */
 const SETTLE_MS = 60;
@@ -30,17 +38,18 @@ export function suppressTransitions(root: HTMLElement, ms = SETTLE_MS): () => vo
   return () => { clearTimeout(id); root.removeAttribute("data-theme-switching"); };
 }
 
-/** Resolves the effective mode from the two axes — the user's light/dark preference and the theme,
- *  which may only have one face — and stamps it (plus the space colour and the theme's palette) on
- *  `:root`. On the default theme the palette is still static CSS (BUI tokens in theme/tokens.css
- *  keyed on `data-mode`) and the only runtime writes are `--rl-space` and the two attributes.
+/** Resolves the two axes — the user's light/dark preference, and the palette that face wears — and
+ *  stamps the result (plus the space colour) on `:root`. On the default theme the palette is still
+ *  static CSS (BUI tokens in theme/tokens.css keyed on `data-mode`) and the only runtime writes are
+ *  `--rl-space` and the two attributes.
  *
- *  The PREFERENCE is deliberately not clamped here, only the resolved mode: choosing Monokai pins
- *  the window dark, and choosing a two-faced theme afterwards must find "system" where it left it. */
-export function useApplyTheme(color: string | null, pref: ThemePref, theme: ThemeName = "realm",
-  groundAlpha: number = DEFAULT_GROUND_ALPHA): Mode {
-  const sys = useSystemMode();
-  const mode = resolveMode(theme, pref === "system" ? sys : pref);
+ *  The mode is now the preference and nothing else. A palette used to be able to pin it — the only
+ *  way a single selection could honour "Monokai, which has no light face" — and with a slot per face
+ *  there is no such conflict to resolve: each slot is offered only palettes that have its face. */
+export function useApplyTheme(color: string | null, pref: ThemePref,
+  themes: ThemeSelection = DEFAULT_SELECTION, groundAlpha: number = DEFAULT_GROUND_ALPHA): Mode {
+  const mode = useResolvedMode(pref);
+  const theme = paletteFor(themes, mode);
   // Layout effect so the first paint already carries the mode (no flash of default vars).
   useLayoutEffect(() => {
     const done = suppressTransitions(document.documentElement);

--- a/apps/desktop/src/renderer/src/theme/useTheme.ts
+++ b/apps/desktop/src/renderer/src/theme/useTheme.ts
@@ -1,6 +1,6 @@
 import { useEffect, useLayoutEffect, useState } from "react";
-import { CONTRAST_RANGE, DEFAULT_GROUND_ALPHA, DEFAULT_SELECTION, applyTheme, overrideKey, paletteFor,
-  type Mode, type ThemeOverrides, type ThemeSelection } from "@realm/ui";
+import { CONTRAST_RANGE, DEFAULT_FONTS, DEFAULT_GROUND_ALPHA, DEFAULT_SELECTION, applyTheme, overrideKey,
+  paletteFor, type FontPref, type Mode, type ThemeOverrides, type ThemeSelection } from "@realm/ui";
 
 export type ThemePref = "system" | "light" | "dark";
 
@@ -55,20 +55,21 @@ export type AppliedTheme = {
    *  every override the user has ever set — editing Gruvbox's accent must not repaint One Dark. */
   overrides?: ThemeOverrides;
   contrast?: number;
+  fonts?: FontPref;
   groundAlpha?: number;
 };
 
 export function useApplyTheme({ color, pref, themes = DEFAULT_SELECTION, overrides = {},
-  contrast = CONTRAST_RANGE.default, groundAlpha = DEFAULT_GROUND_ALPHA }: AppliedTheme): Mode {
+  contrast = CONTRAST_RANGE.default, fonts = DEFAULT_FONTS, groundAlpha = DEFAULT_GROUND_ALPHA }: AppliedTheme): Mode {
   const mode = useResolvedMode(pref);
   const theme = paletteFor(themes, mode);
   const override = overrides[overrideKey(theme, mode)];
   // Layout effect so the first paint already carries the mode (no flash of default vars).
   useLayoutEffect(() => {
     const done = suppressTransitions(document.documentElement);
-    applyTheme({ space: color ?? "#7c6cff", mode, theme, override, contrast, groundAlpha });
+    applyTheme({ space: color ?? "#7c6cff", mode, theme, override, contrast, fonts, groundAlpha });
     return done;
-  }, [color, mode, theme, override, contrast, groundAlpha]);
+  }, [color, mode, theme, override, contrast, fonts, groundAlpha]);
   return mode;
 }
 

--- a/apps/desktop/src/renderer/src/theme/useTheme.ts
+++ b/apps/desktop/src/renderer/src/theme/useTheme.ts
@@ -1,5 +1,5 @@
 import { useEffect, useLayoutEffect, useState } from "react";
-import { DEFAULT_GROUND_ALPHA, DEFAULT_SELECTION, applyTheme, overrideKey, paletteFor,
+import { CONTRAST_RANGE, DEFAULT_GROUND_ALPHA, DEFAULT_SELECTION, applyTheme, overrideKey, paletteFor,
   type Mode, type ThemeOverrides, type ThemeSelection } from "@realm/ui";
 
 export type ThemePref = "system" | "light" | "dark";
@@ -54,20 +54,21 @@ export type AppliedTheme = {
   /** Keyed by palette AND face, so the effect's dependency is the ONE override on screen rather than
    *  every override the user has ever set — editing Gruvbox's accent must not repaint One Dark. */
   overrides?: ThemeOverrides;
+  contrast?: number;
   groundAlpha?: number;
 };
 
 export function useApplyTheme({ color, pref, themes = DEFAULT_SELECTION, overrides = {},
-  groundAlpha = DEFAULT_GROUND_ALPHA }: AppliedTheme): Mode {
+  contrast = CONTRAST_RANGE.default, groundAlpha = DEFAULT_GROUND_ALPHA }: AppliedTheme): Mode {
   const mode = useResolvedMode(pref);
   const theme = paletteFor(themes, mode);
   const override = overrides[overrideKey(theme, mode)];
   // Layout effect so the first paint already carries the mode (no flash of default vars).
   useLayoutEffect(() => {
     const done = suppressTransitions(document.documentElement);
-    applyTheme({ space: color ?? "#7c6cff", mode, theme, override, groundAlpha });
+    applyTheme({ space: color ?? "#7c6cff", mode, theme, override, contrast, groundAlpha });
     return done;
-  }, [color, mode, theme, override, groundAlpha]);
+  }, [color, mode, theme, override, contrast, groundAlpha]);
   return mode;
 }
 

--- a/packages/ui/src/fonts.test.ts
+++ b/packages/ui/src/fonts.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { DEFAULT_FONTS, FONT_FACES, FONT_VARS, FONT_WEIGHT_SHIFT, fontVars, parseFontPref } from "./fonts";
+
+describe("the faces on offer", () => {
+  it("are ones the app can actually deliver: a bundled family, or a real system stack", () => {
+    // THE bare-family mutant: offer "Inter" and "system-ui" with nothing behind them. A bundled face
+    // that failed to load, or a system stack on a platform without that generic, leaves the app with
+    // no family at all and the browser's default serif — which is not a font this layout was drawn
+    // against and is not what the user picked either.
+    for (const role of ["ui", "code"] as const) {
+      expect(FONT_FACES[role].map((f) => f.id)).toEqual(["bundled", "system"]);
+      for (const face of FONT_FACES[role]) {
+        expect(face.stack.split(",").length, `${role}/${face.id}`).toBeGreaterThan(2);
+        expect(face.stack, `${role}/${face.id}`).toMatch(role === "ui" ? /sans-serif$/ : /monospace$/);
+      }
+    }
+    // The bundled options lead with the self-hosted family and keep the system stack behind them.
+    expect(FONT_FACES.ui[0]!.stack).toMatch(/^"Inter", /);
+    expect(FONT_FACES.code[0]!.stack).toMatch(/^"JetBrains Mono", /);
+    expect(FONT_FACES.ui[0]!.stack.endsWith(FONT_FACES.ui[1]!.stack)).toBe(true);
+    expect(FONT_FACES.code[0]!.stack.endsWith(FONT_FACES.code[1]!.stack)).toBe(true);
+  });
+});
+
+describe("what a font preference writes", () => {
+  it("fills exactly FONT_VARS, on every preference including the default", () => {
+    // Unlike a palette these are never cleared: the stylesheet's own values ARE the bundled stacks,
+    // so there is no static-CSS behaviour that writing nothing would preserve — and a preference
+    // that wrote only some of the three would leave the app half on the previous one.
+    for (const ui of ["bundled", "system"] as const) {
+      for (const code of ["bundled", "system"] as const) {
+        for (const uiWeight of ["regular", "medium"] as const) {
+          expect(Object.keys(fontVars({ ui, code, uiWeight })).sort()).toEqual([...FONT_VARS].sort());
+        }
+      }
+    }
+  });
+
+  it("the weight is a SHIFT, so the four rungs of the ladder stay four rungs", () => {
+    // THE absolute-weight mutant: write a font-weight instead of an offset. `--fw-medium` (450) and
+    // `--fw-label` (500) would land on the same number, and a user who asked for heavier text would
+    // lose the distinction between a label and the value beside it to get it.
+    expect(fontVars(DEFAULT_FONTS)["--fw-shift"]).toBe("0");
+    expect(fontVars({ ...DEFAULT_FONTS, uiWeight: "medium" })["--fw-shift"]).toBe(String(FONT_WEIGHT_SHIFT.medium));
+    expect(FONT_WEIGHT_SHIFT.medium).toBeGreaterThan(0);
+    // ...and small enough that the heaviest rung stays inside the weight axis Inter is bundled for.
+    expect(600 + FONT_WEIGHT_SHIFT.medium).toBeLessThanOrEqual(900);
+  });
+
+  it("the two roles are independent — a code face cannot move the chrome", () => {
+    const a = fontVars({ ui: "bundled", code: "system", uiWeight: "regular" });
+    const b = fontVars({ ui: "bundled", code: "bundled", uiWeight: "regular" });
+    expect(a["--font-ui"]).toBe(b["--font-ui"]);
+    expect(a["--font-mono"]).not.toBe(b["--font-mono"]);
+  });
+});
+
+describe("read back off a user-editable settings row", () => {
+  it("keeps what it recognises and defaults the rest, field by field", () => {
+    // THE trusted-row mutant: cast it. An unknown family resolves to undefined in `fontVars` and
+    // writes the literal string "undefined" into --font-ui — a window with no text in it.
+    expect(parseFontPref({ ui: "system", uiWeight: "medium", code: "system" }))
+      .toEqual({ ui: "system", uiWeight: "medium", code: "system" });
+    expect(parseFontPref({ ui: "Comic Sans", uiWeight: 700, code: "system" }))
+      .toEqual({ ui: "bundled", uiWeight: "regular", code: "system" });
+    for (const junk of [null, undefined, "bundled", 3, []]) expect(parseFontPref(junk)).toEqual(DEFAULT_FONTS);
+    // Whatever comes back is a family the app has a stack for.
+    expect(fontVars(parseFontPref({ ui: "nope" }))["--font-ui"]).toContain("sans-serif");
+  });
+});

--- a/packages/ui/src/fonts.ts
+++ b/packages/ui/src/fonts.ts
@@ -1,0 +1,88 @@
+/** The type faces, as a preference.
+ *
+ *  What is NOT here: every font installed on the machine. Enumerating those needs a main-process hop
+ *  (or `queryLocalFonts`, which is permission-gated and Chromium-only), and the list it returns is
+ *  mostly faces this UI cannot use — Realm's chrome is laid out against a four-step weight scale and
+ *  tabular figures, and a display face picked out of a list of four hundred silently loses both. The
+ *  honest offer is the faces the app ships, which are guaranteed to be there and to have the axes the
+ *  layout leans on, plus a genuine system stack for someone who would rather the app looked like the
+ *  rest of their machine.
+ *
+ *  Weight is offered for the UI face and not for code, and that asymmetry is a fact about the
+ *  stylesheet rather than a judgement: every mono surface in styles.css sets its font with the `font:`
+ *  shorthand, which resets font-weight to normal by definition. Reaching them would mean editing
+ *  fifty-odd rules in a shared stylesheet, or encoding a weight into a family name. The UI face has
+ *  no such problem — its weights come from a four-token scale the whole app already reads — so the
+ *  control shifts that scale and the hierarchy it draws survives intact. */
+
+export type FontRole = "ui" | "code";
+export type FontId = "bundled" | "system";
+export type FontWeight = "regular" | "medium";
+
+export type FontFace = {
+  id: FontId;
+  label: string;
+  /** The CSS font stack. Bundled families lead with the self-hosted name and keep the system stack
+   *  behind them, so a face that somehow fails to load degrades to the same thing "System" picks. */
+  stack: string;
+};
+
+/** Inter and JetBrains Mono are @font-face'd at the top of styles.css; the fallbacks after them are
+ *  the stacks that block was written against. */
+export const FONT_FACES: Record<FontRole, readonly FontFace[]> = {
+  ui: [
+    { id: "bundled", label: "Inter", stack: '"Inter", ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif' },
+    { id: "system", label: "System default", stack: 'ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif' },
+  ],
+  code: [
+    { id: "bundled", label: "JetBrains Mono", stack: '"JetBrains Mono", ui-monospace, "SF Mono", Menlo, monospace' },
+    { id: "system", label: "System default", stack: 'ui-monospace, "SF Mono", Menlo, monospace' },
+  ],
+};
+
+/** How much the whole UI weight scale moves. Applied as an offset rather than as absolute weights so
+ *  the four steps stay four steps: `--fw-medium` through `--fw-strong` are 450/500/560/600, and a
+ *  control that flattened them to one number would erase the difference between a label and a title
+ *  in the course of making both a little heavier. 45 is one step of that scale. */
+export const FONT_WEIGHT_SHIFT: Record<FontWeight, number> = { regular: 0, medium: 45 };
+
+export const FONT_WEIGHTS: { id: FontWeight; label: string }[] = [
+  { id: "regular", label: "Regular" }, { id: "medium", label: "Medium" },
+];
+
+export type FontPref = { ui: FontId; uiWeight: FontWeight; code: FontId };
+
+export const DEFAULT_FONTS: FontPref = { ui: "bundled", uiWeight: "regular", code: "bundled" };
+
+const isFontId = (x: unknown): x is FontId => x === "bundled" || x === "system";
+const isFontWeight = (x: unknown): x is FontWeight => x === "regular" || x === "medium";
+
+/** Read back off a user-editable settings row, field by field. An unknown family would resolve to
+ *  `undefined` in `fontVars` and write the literal string "undefined" into `--font-ui`, which is a
+ *  window with no text in it. */
+export function parseFontPref(raw: unknown): FontPref {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return DEFAULT_FONTS;
+  const { ui, uiWeight, code } = raw as Record<string, unknown>;
+  return {
+    ui: isFontId(ui) ? ui : DEFAULT_FONTS.ui,
+    uiWeight: isFontWeight(uiWeight) ? uiWeight : DEFAULT_FONTS.uiWeight,
+    code: isFontId(code) ? code : DEFAULT_FONTS.code,
+  };
+}
+
+export const FONT_VARS = ["--font-ui", "--font-mono", "--fw-shift"] as const;
+
+const stack = (role: FontRole, id: FontId): string =>
+  (FONT_FACES[role].find((f) => f.id === id) ?? FONT_FACES[role][0]!).stack;
+
+/** The three properties a font preference writes. The default writes them too rather than clearing
+ *  them: unlike a palette, these are not a second skin over a hand-tuned one — the stylesheet's own
+ *  values ARE the bundled stacks, so writing them back is a no-op and there is no static-CSS
+ *  behaviour to preserve by staying silent. */
+export function fontVars(pref: FontPref): Record<string, string> {
+  return {
+    "--font-ui": stack("ui", pref.ui),
+    "--font-mono": stack("code", pref.code),
+    "--fw-shift": String(FONT_WEIGHT_SHIFT[pref.uiWeight]),
+  };
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -7,7 +7,7 @@ export { applyTheme, clampGroundAlpha, DEFAULT_GROUND_ALPHA, GROUND_ALPHA_RANGE,
    types) stay exported from their own modules, where applyTheme and the package's own suites import
    them directly — a barrel entry for each would advertise a public API nothing consumes. */
 export { oklchToHex } from "./oklch";
-export { contrastMisses, DEFAULT_SELECTION, deriveVars, isHexColour, isOverridden, isThemeName, overrideKey,
+export { clampContrast, CONTRAST_RANGE, contrastMisses, DEFAULT_SELECTION, deriveVars, isHexColour, isOverridden, isThemeName, overrideKey,
   paletteFor, parseThemeOverride, parseThemeOverrides, REALM_SEED, resolveMode, seedFor, SEED_ROLES, SYNTAX_ROLES,
   THEMES, themeModes, themeSwatches, type ContrastMiss, type ThemeName, type ThemeOverride, type ThemeOverrides,
   type ThemeSeed, type ThemeSelection } from "./themes";

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -7,6 +7,7 @@ export { applyTheme, clampGroundAlpha, DEFAULT_GROUND_ALPHA, GROUND_ALPHA_RANGE,
    types) stay exported from their own modules, where applyTheme and the package's own suites import
    them directly — a barrel entry for each would advertise a public API nothing consumes. */
 export { oklchToHex } from "./oklch";
+export { exportTheme, importTheme, THEME_DOC_VERSION, type ThemeDocument, type ThemeImport } from "./theme-io";
 export { DEFAULT_FONTS, FONT_FACES, FONT_VARS, FONT_WEIGHTS, FONT_WEIGHT_SHIFT, fontVars, parseFontPref,
   type FontId, type FontPref, type FontRole, type FontWeight } from "./fonts";
 export { clampContrast, CONTRAST_RANGE, contrastMisses, DEFAULT_SELECTION, deriveVars, isHexColour, isOverridden, isThemeName, overrideKey,

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -3,14 +3,14 @@ export { brandMarks, isBrandName, type BrandMark, type BrandName } from "./brand
 export { applyTheme, clampGroundAlpha, DEFAULT_GROUND_ALPHA, GROUND_ALPHA_RANGE, hexToHsl, hslToHex, spaceColor,
   type Hsl, type Mode } from "./theme";
 /* Only what is consumed OUTSIDE this package. The colour maths and the derivation internals
-   (hexToOklch, contrast, luminance, CONTRAST_FLOOR, THEME_VARS, themeVars, themeModes and the seed
-   types) stay exported from their own modules, where applyTheme and the package's own suites import
-   them directly — a barrel entry for each would advertise a public API nothing consumes. */
+   (hexToOklch, contrast, luminance, CONTRAST_FLOOR, THEME_VARS, themeVars, resolveMode, the document
+   and seed types, and the role lists the parsers walk) stay exported from their own modules, where
+   applyTheme and the package's own suites import them directly — a barrel entry for each would
+   advertise a public API nothing consumes. */
 export { oklchToHex } from "./oklch";
-export { exportTheme, importTheme, THEME_DOC_VERSION, type ThemeDocument, type ThemeImport } from "./theme-io";
-export { DEFAULT_FONTS, FONT_FACES, FONT_VARS, FONT_WEIGHTS, FONT_WEIGHT_SHIFT, fontVars, parseFontPref,
-  type FontId, type FontPref, type FontRole, type FontWeight } from "./fonts";
-export { clampContrast, CONTRAST_RANGE, contrastMisses, DEFAULT_SELECTION, deriveVars, isHexColour, isOverridden, isThemeName, overrideKey,
-  paletteFor, parseThemeOverride, parseThemeOverrides, REALM_SEED, resolveMode, seedFor, SEED_ROLES, SYNTAX_ROLES,
-  THEMES, themeModes, themeSwatches, type ContrastMiss, type ThemeName, type ThemeOverride, type ThemeOverrides,
-  type ThemeSeed, type ThemeSelection } from "./themes";
+export { exportTheme, importTheme } from "./theme-io";
+export { DEFAULT_FONTS, FONT_FACES, FONT_WEIGHTS, parseFontPref,
+  type FontId, type FontPref, type FontWeight } from "./fonts";
+export { clampContrast, CONTRAST_RANGE, contrastMisses, DEFAULT_SELECTION, deriveVars, isHexColour, isOverridden,
+  isThemeName, overrideKey, paletteFor, parseThemeOverrides, REALM_SEED, seedFor, THEMES, themeModes, themeSwatches,
+  type ThemeName, type ThemeOverride, type ThemeOverrides, type ThemeSeed, type ThemeSelection } from "./themes";

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -7,5 +7,7 @@ export { applyTheme, clampGroundAlpha, DEFAULT_GROUND_ALPHA, GROUND_ALPHA_RANGE,
    types) stay exported from their own modules, where applyTheme and the package's own suites import
    them directly — a barrel entry for each would advertise a public API nothing consumes. */
 export { oklchToHex } from "./oklch";
-export { DEFAULT_SELECTION, deriveVars, isThemeName, paletteFor, REALM_SEED, resolveMode, THEMES, themeModes,
-  themeSwatches, type ThemeName, type ThemeSelection } from "./themes";
+export { contrastMisses, DEFAULT_SELECTION, deriveVars, isHexColour, isOverridden, isThemeName, overrideKey,
+  paletteFor, parseThemeOverride, parseThemeOverrides, REALM_SEED, resolveMode, seedFor, SEED_ROLES, SYNTAX_ROLES,
+  THEMES, themeModes, themeSwatches, type ContrastMiss, type ThemeName, type ThemeOverride, type ThemeOverrides,
+  type ThemeSeed, type ThemeSelection } from "./themes";

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -7,4 +7,5 @@ export { applyTheme, clampGroundAlpha, DEFAULT_GROUND_ALPHA, GROUND_ALPHA_RANGE,
    types) stay exported from their own modules, where applyTheme and the package's own suites import
    them directly — a barrel entry for each would advertise a public API nothing consumes. */
 export { oklchToHex } from "./oklch";
-export { deriveVars, isThemeName, REALM_SEED, resolveMode, THEMES, themeSwatches, type ThemeName } from "./themes";
+export { DEFAULT_SELECTION, deriveVars, isThemeName, paletteFor, REALM_SEED, resolveMode, THEMES, themeModes,
+  themeSwatches, type ThemeName, type ThemeSelection } from "./themes";

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -7,6 +7,8 @@ export { applyTheme, clampGroundAlpha, DEFAULT_GROUND_ALPHA, GROUND_ALPHA_RANGE,
    types) stay exported from their own modules, where applyTheme and the package's own suites import
    them directly — a barrel entry for each would advertise a public API nothing consumes. */
 export { oklchToHex } from "./oklch";
+export { DEFAULT_FONTS, FONT_FACES, FONT_VARS, FONT_WEIGHTS, FONT_WEIGHT_SHIFT, fontVars, parseFontPref,
+  type FontId, type FontPref, type FontRole, type FontWeight } from "./fonts";
 export { clampContrast, CONTRAST_RANGE, contrastMisses, DEFAULT_SELECTION, deriveVars, isHexColour, isOverridden, isThemeName, overrideKey,
   paletteFor, parseThemeOverride, parseThemeOverrides, REALM_SEED, resolveMode, seedFor, SEED_ROLES, SYNTAX_ROLES,
   THEMES, themeModes, themeSwatches, type ContrastMiss, type ThemeName, type ThemeOverride, type ThemeOverrides,

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -7,4 +7,4 @@ export { applyTheme, clampGroundAlpha, DEFAULT_GROUND_ALPHA, GROUND_ALPHA_RANGE,
    types) stay exported from their own modules, where applyTheme and the package's own suites import
    them directly — a barrel entry for each would advertise a public API nothing consumes. */
 export { oklchToHex } from "./oklch";
-export { deriveVars, isThemeName, resolveMode, THEMES, themeSwatches, type ThemeName } from "./themes";
+export { deriveVars, isThemeName, REALM_SEED, resolveMode, THEMES, themeSwatches, type ThemeName } from "./themes";

--- a/packages/ui/src/oklch.test.ts
+++ b/packages/ui/src/oklch.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { contrast, css, hexToOklch, luminance, oklchToHex } from "./oklch";
+import { contrast, css, emitted, hexToOklch, luminance, oklchToHex } from "./oklch";
 
 /** These numbers are checkable against something outside this repo, which is the point of testing a
  *  colour space at all: an arithmetic slip in one matrix row produces colours that still look like
@@ -59,5 +59,17 @@ describe("css()", () => {
   it("writes the form tokens.css writes, and carries alpha when asked", () => {
     expect(css({ l: 0.209, c: 0.004, h: 264.477 })).toBe("oklch(0.209 0.004 264.48)");
     expect(css({ l: 0.68, c: 0.173, h: 253.301 }, 0.16)).toBe("oklch(0.68 0.173 253.3 / 0.16)");
+  });
+});
+
+describe("emitted", () => {
+  it("is what css() writes, so a walk that stops at a floor stops at the shipped value", () => {
+    // THE unrounded-floor mutant: measure a contrast walk on the working value instead. `css` keeps
+    // three decimals of lightness — finer than a display resolves, coarser than a WCAG floor — so a
+    // tier walked to exactly 3.00:1 can be written at 2.9987 and break the assertion the whole
+    // palette is held to. Gruvbox dark's --ink-2 at the bottom of the contrast range is that case.
+    const o = { l: 0.6184937, c: 0.0173456, h: 92.4567 };
+    expect(emitted(o)).toEqual({ l: 0.618, c: 0.0173, h: 92.46 });
+    expect(css(emitted(o))).toBe(css(o));
   });
 });

--- a/packages/ui/src/oklch.ts
+++ b/packages/ui/src/oklch.ts
@@ -80,6 +80,12 @@ export function parseOklch(value: string): Oklch {
   return { l: Number(m[1]), c: Number(m[2]), h: Number(m[3]) };
 }
 
+/** The colour as it will actually be WRITTEN. `css` rounds lightness to three decimals, which is
+ *  finer than a display can resolve but NOT finer than a contrast floor: a walk that stops the
+ *  instant it reaches 3.00:1 can round to 2.9987 on the way out, and ship a ratio the palette is
+ *  asserted never to have. Any walk whose stopping condition is a floor measures this instead. */
+export const emitted = (o: Oklch): Oklch => parseOklch(css(o));
+
 /** WCAG 2.x relative luminance. */
 export function luminance(o: Oklch): number {
   const [r, g, b] = toLinearRgb(o);

--- a/packages/ui/src/oklch.ts
+++ b/packages/ui/src/oklch.ts
@@ -72,6 +72,14 @@ export function css(o: Oklch, alpha?: number): string {
   return alpha === undefined ? `oklch(${base})` : `oklch(${base} / ${n(alpha, 3)})`;
 }
 
+/** Back from the CSS form. The derivation's own output is the only thing this parses — a full
+ *  colour parser is a different job, and every caller here is reading a value `css` wrote. */
+export function parseOklch(value: string): Oklch {
+  const m = /^oklch\(([\d.]+) ([\d.]+) ([\d.]+)/.exec(value.trim());
+  if (!m) throw new Error(`not an oklch value: ${value}`);
+  return { l: Number(m[1]), c: Number(m[2]), h: Number(m[3]) };
+}
+
 /** WCAG 2.x relative luminance. */
 export function luminance(o: Oklch): number {
   const [r, g, b] = toLinearRgb(o);

--- a/packages/ui/src/theme-io.test.ts
+++ b/packages/ui/src/theme-io.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import { THEME_DOC_VERSION, exportTheme, importTheme } from "./theme-io";
+import { REALM_SEED, THEMES, deriveVars, seedFor } from "./themes";
+
+const one = seedFor("one", "dark")!;
+const doc = (over: Record<string, unknown> = {}) =>
+  JSON.stringify({ realmTheme: 1, name: "One", mode: "dark", seed: one, ...over });
+
+describe("what a theme travels as", () => {
+  it("round-trips every palette in the app, in every face it has", () => {
+    // THE derived-document mutant: export the ninety derived properties instead of the twelve seeds.
+    // It reads back into the same window today and goes stale the moment a ramp constant moves — and
+    // it arrives as raw colours the contrast floors never got to look at.
+    for (const theme of THEMES) {
+      for (const mode of ["dark", "light"] as const) {
+        const seed = seedFor(theme.name, mode) ?? (theme.name === "realm" ? REALM_SEED[mode] : null);
+        if (!seed) continue;
+        const back = importTheme(exportTheme(theme.label, mode, seed), mode);
+        expect(back.ok, `${theme.name}/${mode}`).toBe(true);
+        if (!back.ok) return;
+        expect(back.doc.seed).toEqual(seed);
+        // ...and through the machinery, which is the claim that matters: the same twelve values give
+        // the same palette wherever they land.
+        expect(deriveVars(back.doc.seed, mode)).toEqual(deriveVars(seed, mode));
+      }
+    }
+  });
+
+  it("is JSON a person can read and edit, not an opaque blob", () => {
+    const text = exportTheme("One", "dark", one);
+    expect(text).toContain('"realmTheme": 1');
+    expect(text).toContain('"mode": "dark"');
+    expect(text.endsWith("\n")).toBe(true);
+    expect(JSON.parse(text).seed.accent).toBe(one.accent);
+  });
+});
+
+describe("a blob that is not a theme is refused, and told why", () => {
+  const reason = (text: string, face: "dark" | "light" = "dark") => {
+    const r = importTheme(text, face);
+    expect(r.ok).toBe(false);
+    return r.ok ? "" : r.reason;
+  };
+
+  it("names what is wrong with the thing that was pasted", () => {
+    // THE catch-all mutant: one "invalid theme" for every failure. It sends someone back to a JSON
+    // blob with no idea which of ninety characters to look at, which is the same as no message.
+    expect(reason("not json at all")).toMatch(/not JSON/);
+    expect(reason("[1,2,3]")).toMatch(/JSON object/);
+    expect(reason('{"hello":"world"}')).toMatch(/realmTheme/);
+    expect(reason(doc({ mode: "sepia" }))).toMatch(/light or a dark/);
+    expect(reason(doc({ seed: undefined }))).toMatch(/carry a seed/);
+    // Every one is different, or the messages are decoration.
+    const all = ["not json", "[1]", "{}", doc({ mode: 3 }), doc({ seed: 7 })].map((t) => reason(t));
+    expect(new Set(all).size).toBe(all.length);
+  });
+
+  it("refuses a seed that is short a colour, and says which ones", () => {
+    // THE partial-import mutant: accept whatever roles are present and merge them over the current
+    // palette. A document missing its syntax block would silently become an edit to three colours of
+    // whatever happened to be selected, presented as having imported a theme.
+    const { syntax, ...noSyntax } = one;
+    expect(reason(doc({ seed: { ...noSyntax, bg: undefined } }))).toMatch(/bg, syntax\.comment/);
+    expect(reason(doc({ seed: { ...one, accent: "cornflowerblue" } }))).toMatch(/not hex colours: accent/);
+    expect(reason(doc({ seed: { ...one, syntax: { ...syntax, keyword: "#12345" } } }))).toMatch(/syntax\.keyword/);
+  });
+
+  it("refuses a face it was not written for rather than producing a broken one", () => {
+    // A dark seed in the light slot is not a dark light theme — the light ramp SINKS its surfaces
+    // below the page, so the ladder inverts, and `color-scheme: light` puts light scrollbars on it.
+    // THE any-face mutant: drop the check. It imports, it looks catastrophic, and nothing said so.
+    expect(reason(doc(), "light")).toMatch(/dark theme.*Dark theme row/s);
+    expect(importTheme(doc({ mode: "light" }), "light").ok).toBe(true);
+  });
+
+  it("refuses a format from a newer build rather than reading the fields it happens to share", () => {
+    // A version bump is how a later format says the old reading of it is wrong.
+    expect(reason(doc({ realmTheme: THEME_DOC_VERSION + 1 }))).toMatch(/newer version/);
+    expect(importTheme(doc({ realmTheme: THEME_DOC_VERSION }), "dark").ok).toBe(true);
+  });
+
+  it("keeps only the twelve, so nothing else in the document reaches the derivation", () => {
+    // THE cast mutant: take `d.seed` as a ThemeSeed. A document carrying `bg: "#101014", __proto__:
+    // …` or an extra hundred keys would be stored and re-exported forever.
+    const r = importTheme(doc({ seed: { ...one, extra: "#ffffff", nested: { a: 1 } } }), "dark");
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(Object.keys(r.doc.seed).sort()).toEqual(["accent", "bg", "green", "ink", "orange", "red", "syntax"]);
+    expect(Object.keys(r.doc.seed.syntax).sort()).toEqual(["attr", "comment", "keyword", "number", "string", "title", "type"]);
+  });
+
+  it("survives a document with no usable name", () => {
+    for (const name of [undefined, "", "   ", 7]) {
+      const r = importTheme(doc({ name }), "dark");
+      expect(r.ok, String(name)).toBe(true);
+      if (r.ok) expect(r.doc.name.length).toBeGreaterThan(0);
+    }
+    expect(importTheme(doc({ name: "x".repeat(500) }), "dark")).toMatchObject({ doc: { name: "x".repeat(60) } });
+  });
+});

--- a/packages/ui/src/theme-io.ts
+++ b/packages/ui/src/theme-io.ts
@@ -1,0 +1,88 @@
+import { SEED_ROLES, SYNTAX_ROLES, isHexColour, type ThemeSeed } from "./themes";
+import type { Mode } from "./theme";
+
+/** Carrying a theme between two Realms, or out of one and into a gist.
+ *
+ *  The document IS a `ThemeSeed` and a face, because that is the only thing in this system that is
+ *  stated rather than derived. Everything a theme looks like — the surface ladder, the ink ramp, the
+ *  tints, the tooltip chip, the corrected hues — comes back out of `deriveVars` from these twelve
+ *  values, so a document that carried the derived palette instead would be ninety numbers that go
+ *  stale the moment a ramp constant changes, and would arrive as a set of raw colours the contrast
+ *  floors never got to look at. Twelve values through the same machinery a vendored palette goes
+ *  through is the whole point.
+ *
+ *  A FULL seed, not a partial one. An override is an edit to a palette that is already there; an
+ *  import is a theme. Requiring all twelve means a document is either a theme or it is refused, and
+ *  never half of one silently merged over whatever the user happened to have selected. */
+export const THEME_DOC_VERSION = 1;
+
+export type ThemeDocument = {
+  realmTheme: number;
+  /** What it was called where it came from. Kept for the message the import shows, never applied —
+   *  an imported theme edits the palette it lands on rather than becoming a new entry in the picker. */
+  name: string;
+  mode: Mode;
+  seed: ThemeSeed;
+};
+
+export type ThemeImport = { ok: true; doc: ThemeDocument } | { ok: false; reason: string };
+
+/** What Copy puts on the clipboard: the face AS EDITED, so what is copied is what is on screen —
+ *  copying the palette's own seeds under a set of overrides would hand someone a theme that is not
+ *  the one they were looking at. Two-space JSON because this is read and edited by people. */
+export function exportTheme(name: string, mode: Mode, seed: ThemeSeed): string {
+  const doc: ThemeDocument = { realmTheme: THEME_DOC_VERSION, name, mode, seed };
+  return `${JSON.stringify(doc, null, 2)}\n`;
+}
+
+/** Every reason a blob is refused, as the sentence the user sees. A rejection has to say what is
+ *  wrong with the thing they pasted: "invalid theme" sends someone back to a JSON blob with no idea
+ *  which of ninety characters to look at. */
+export function importTheme(text: string, face: Mode): ThemeImport {
+  let raw: unknown;
+  try { raw = JSON.parse(text); }
+  catch { return { ok: false, reason: "That is not JSON. Paste the whole block, braces included." }; }
+
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    return { ok: false, reason: "A theme is a JSON object; this is not one." };
+  }
+  const d = raw as Record<string, unknown>;
+  if (typeof d["realmTheme"] !== "number") {
+    return { ok: false, reason: "This is not a Realm theme — it has no realmTheme version." };
+  }
+  // Newer than this build understands. Refused rather than read for the fields it happens to share:
+  // a version bump is how a later format says the old reading of it is wrong.
+  if (d["realmTheme"] > THEME_DOC_VERSION) {
+    return { ok: false, reason: `This theme was written for a newer version of Realm (format ${d["realmTheme"]}, this build reads ${THEME_DOC_VERSION}).` };
+  }
+  if (d["mode"] !== "dark" && d["mode"] !== "light") {
+    return { ok: false, reason: "A theme has to say whether it is a light or a dark theme." };
+  }
+  if (d["mode"] !== face) {
+    return { ok: false, reason: `This is a ${d["mode"]} theme. Import it in the ${d["mode"] === "dark" ? "Dark" : "Light"} theme row.` };
+  }
+
+  const seed = d["seed"];
+  if (!seed || typeof seed !== "object" || Array.isArray(seed)) {
+    return { ok: false, reason: "A theme has to carry a seed: the colours it is built from." };
+  }
+  const s = seed as Record<string, unknown>;
+  const syntax = (s["syntax"] && typeof s["syntax"] === "object" && !Array.isArray(s["syntax"])
+    ? s["syntax"] : {}) as Record<string, unknown>;
+  const missing = [
+    ...SEED_ROLES.filter((r) => !isHexColour(s[r])),
+    ...SYNTAX_ROLES.filter((r) => !isHexColour(syntax[r])).map((r) => `syntax.${r}`),
+  ];
+  if (missing.length) {
+    return { ok: false, reason: `These are missing or are not hex colours: ${missing.join(", ")}.` };
+  }
+
+  // Rebuilt field by field rather than cast, so nothing the document happens to carry beyond the
+  // twelve reaches the derivation — and so the object stored is the shape this build states.
+  const built = {
+    ...Object.fromEntries(SEED_ROLES.map((r) => [r, s[r] as string])),
+    syntax: Object.fromEntries(SYNTAX_ROLES.map((r) => [r, syntax[r] as string])),
+  } as ThemeSeed;
+  const name = typeof d["name"] === "string" && d["name"].trim() ? d["name"].trim().slice(0, 60) : "an imported theme";
+  return { ok: true, doc: { realmTheme: THEME_DOC_VERSION, name, mode: face, seed: built } };
+}

--- a/packages/ui/src/theme.test.ts
+++ b/packages/ui/src/theme.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { applyTheme, hexToHsl, hslToHex, spaceColor } from "./theme";
 import { THEME_VARS } from "./themes";
+import { DEFAULT_FONTS, FONT_VARS, fontVars } from "./fonts";
 import { DEFAULT_GROUND_ALPHA, GROUND_ALPHA_RANGE, clampGroundAlpha } from "./theme";
 
 /** Plan 9 W1 re-scope: the ink-grayscale palette generator is gone — surfaces, text tiers, accent,
@@ -40,7 +41,14 @@ describe("spaceColor (the one identity pixel, clamp rules unchanged from spec 20
   });
 });
 
-describe("applyTheme (runtime writes: --rl-space, the two attributes, and a custom theme's palette)", () => {
+/** What `applyTheme` writes on EVERY apply, whatever the palette. The font stacks are here and the
+ *  palette is not, and the difference is the point: a palette is a second skin over 85 properties of
+ *  hand-tuned static CSS, so the default has to write none of it; the font tokens' static values ARE
+ *  the bundled stacks, so writing them back is a no-op and there is nothing to preserve by staying
+ *  silent. */
+const BASE_PROPS = ["--ground-alpha", "--rl-space", ...FONT_VARS].sort();
+
+describe("applyTheme (runtime writes: --rl-space, the fonts, the two attributes, and a custom theme's palette)", () => {
   const fakeRoot = () => {
     const props: Record<string, string> = {};
     const root = {
@@ -69,7 +77,7 @@ describe("applyTheme (runtime writes: --rl-space, the two attributes, and a cust
     // for every user who never asked for a theme.
     const { root, props } = fakeRoot();
     applyTheme({ space: "#7c6cff", mode: "dark", theme: "realm" }, root);
-    expect(Object.keys(props).sort()).toEqual(["--ground-alpha", "--rl-space"]);
+    expect(Object.keys(props).sort()).toEqual(BASE_PROPS);
   });
 
   it("a custom theme writes its whole palette inline, and returning to the default clears every one", () => {
@@ -80,7 +88,20 @@ describe("applyTheme (runtime writes: --rl-space, the two attributes, and a cust
     // THE stale-palette mutant: drop the removeProperty branch and this keeps One Dark's inline
     // values, which beat both token blocks in tokens.css — the app would be stuck on the last theme
     // chosen with no way back short of a reload.
-    expect(Object.keys(props).sort()).toEqual(["--ground-alpha", "--rl-space"]);
+    expect(Object.keys(props).sort()).toEqual(BASE_PROPS);
+  });
+
+  it("writes the type faces on every apply, default included", () => {
+    // THE clear-on-default mutant: treat fonts like the palette and remove them when they are the
+    // default. Every property here would fall back to the stylesheet's value, which is the same
+    // value — so it would look correct, until someone changed --font-ui in styles.css and the
+    // "default" preference stopped meaning "the bundled face".
+    const { root, props } = fakeRoot();
+    applyTheme({ space: "#7c6cff", mode: "dark" }, root);
+    for (const [name, value] of Object.entries(fontVars(DEFAULT_FONTS))) expect(props[name], name).toBe(value);
+    applyTheme({ space: "#7c6cff", mode: "dark", fonts: { ui: "system", uiWeight: "medium", code: "system" } }, root);
+    expect(props["--font-ui"]).not.toContain("Inter");
+    expect(props["--fw-shift"]).not.toBe("0");
   });
 
   it("stamps the theme on the root so the stylesheet and the live checks can name it", () => {

--- a/packages/ui/src/theme.ts
+++ b/packages/ui/src/theme.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_FONTS, fontVars, type FontPref } from "./fonts";
 import { CONTRAST_RANGE, THEME_VARS, themeVars, type ThemeName, type ThemeOverride } from "./themes";
 
 export type Mode = "light" | "dark";
@@ -90,11 +91,17 @@ export const clampGroundAlpha = (pct: number): number =>
  *  property would beat any media query, and the app already honours that preference in its fade
  *  bands. */
 export function applyTheme(
-  { space, mode, theme = "realm", override = {}, contrast = CONTRAST_RANGE.default, groundAlpha = DEFAULT_GROUND_ALPHA }:
-    { space: string; mode: Mode; theme?: ThemeName; override?: ThemeOverride; contrast?: number; groundAlpha?: number },
+  { space, mode, theme = "realm", override = {}, contrast = CONTRAST_RANGE.default,
+    fonts = DEFAULT_FONTS, groundAlpha = DEFAULT_GROUND_ALPHA }:
+    { space: string; mode: Mode; theme?: ThemeName; override?: ThemeOverride; contrast?: number;
+      fonts?: FontPref; groundAlpha?: number },
   root: HTMLElement = document.documentElement,
 ): void {
   root.style.setProperty("--rl-space", spaceColor(space, mode));
+  /* Written on every apply, default included, and never cleared. Unlike a palette these are not a
+     second skin over a hand-tuned one — the stylesheet's own values ARE the bundled stacks — so
+     there is no static-CSS behaviour that staying silent would preserve. */
+  for (const [name, value] of Object.entries(fontVars(fonts))) root.style.setProperty(name, value);
   root.style.setProperty("--ground-alpha", `${clampGroundAlpha(groundAlpha)}%`);
   root.dataset.mode = mode;
   root.dataset.theme = theme;

--- a/packages/ui/src/theme.ts
+++ b/packages/ui/src/theme.ts
@@ -1,4 +1,4 @@
-import { THEME_VARS, themeVars, type ThemeName } from "./themes";
+import { THEME_VARS, themeVars, type ThemeName, type ThemeOverride } from "./themes";
 
 export type Mode = "light" | "dark";
 export type Hsl = { h: number; s: number; l: number };
@@ -90,15 +90,15 @@ export const clampGroundAlpha = (pct: number): number =>
  *  property would beat any media query, and the app already honours that preference in its fade
  *  bands. */
 export function applyTheme(
-  { space, mode, theme = "realm", groundAlpha = DEFAULT_GROUND_ALPHA }:
-    { space: string; mode: Mode; theme?: ThemeName; groundAlpha?: number },
+  { space, mode, theme = "realm", override = {}, groundAlpha = DEFAULT_GROUND_ALPHA }:
+    { space: string; mode: Mode; theme?: ThemeName; override?: ThemeOverride; groundAlpha?: number },
   root: HTMLElement = document.documentElement,
 ): void {
   root.style.setProperty("--rl-space", spaceColor(space, mode));
   root.style.setProperty("--ground-alpha", `${clampGroundAlpha(groundAlpha)}%`);
   root.dataset.mode = mode;
   root.dataset.theme = theme;
-  const vars = themeVars(theme, mode);
+  const vars = themeVars(theme, mode, override);
   for (const name of THEME_VARS) {
     const value = vars[name];
     if (value === undefined) root.style.removeProperty(name);

--- a/packages/ui/src/theme.ts
+++ b/packages/ui/src/theme.ts
@@ -1,4 +1,4 @@
-import { THEME_VARS, themeVars, type ThemeName, type ThemeOverride } from "./themes";
+import { CONTRAST_RANGE, THEME_VARS, themeVars, type ThemeName, type ThemeOverride } from "./themes";
 
 export type Mode = "light" | "dark";
 export type Hsl = { h: number; s: number; l: number };
@@ -90,15 +90,15 @@ export const clampGroundAlpha = (pct: number): number =>
  *  property would beat any media query, and the app already honours that preference in its fade
  *  bands. */
 export function applyTheme(
-  { space, mode, theme = "realm", override = {}, groundAlpha = DEFAULT_GROUND_ALPHA }:
-    { space: string; mode: Mode; theme?: ThemeName; override?: ThemeOverride; groundAlpha?: number },
+  { space, mode, theme = "realm", override = {}, contrast = CONTRAST_RANGE.default, groundAlpha = DEFAULT_GROUND_ALPHA }:
+    { space: string; mode: Mode; theme?: ThemeName; override?: ThemeOverride; contrast?: number; groundAlpha?: number },
   root: HTMLElement = document.documentElement,
 ): void {
   root.style.setProperty("--rl-space", spaceColor(space, mode));
   root.style.setProperty("--ground-alpha", `${clampGroundAlpha(groundAlpha)}%`);
   root.dataset.mode = mode;
   root.dataset.theme = theme;
-  const vars = themeVars(theme, mode, override);
+  const vars = themeVars(theme, mode, { override, contrast });
   for (const name of THEME_VARS) {
     const value = vars[name];
     if (value === undefined) root.style.removeProperty(name);

--- a/packages/ui/src/themes.test.ts
+++ b/packages/ui/src/themes.test.ts
@@ -1,24 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { contrast, hexToOklch, type Oklch } from "./oklch";
-import { CONTRAST_FLOOR, THEMES, THEME_VARS, deriveVars, paletteFor, resolveMode, themeModes, themeSwatches, themeVars } from "./themes";
+import { contrast, hexToOklch, parseOklch as parse } from "./oklch";
+import { CONTRAST_FLOOR, INK_GROUNDS, REALM_SEED, THEMES, THEME_VARS, contrastMisses, deriveVars, paletteFor,
+  parseThemeOverride, parseThemeOverrides, resolveMode, seedFor, themeModes, themeSwatches, themeVars,
+  type ThemeOverride } from "./themes";
 import type { Mode } from "./theme";
-
-const parse = (value: string): Oklch => {
-  const m = /^oklch\(([\d.]+) ([\d.]+) ([\d.]+)/.exec(value);
-  if (!m) throw new Error(`not an oklch value: ${value}`);
-  return { l: Number(m[1]), c: Number(m[2]), h: Number(m[3]) };
-};
-
-/** The grounds each ink tier actually lands on, read off styles.css rather than taken as the whole
- *  ladder: `--ink-2` never appears on `--hover-2` or `--field` (both are written with `--ink` in
- *  every rule that uses them), and `--ink-3` never leaves the resting surfaces. Widening these to the
- *  full cross-product would fail themes over pairings the stylesheet never produces; narrowing them
- *  past what it does produce is how an unreadable pairing ships. */
-const GROUNDS = {
-  ink: ["--page", "--canvas", "--surface", "--inset", "--hover", "--hover-2", "--field"],
-  ink2: ["--page", "--canvas", "--surface", "--inset", "--hover"],
-  ink3: ["--page", "--canvas", "--surface", "--inset"],
-} as const;
 
 /** The eight validated chart series, copied from tokens.css. A theme does not repaint them; what it
  *  moves is the ground under them, so this is the set the clamp has to keep working for. */
@@ -133,9 +118,9 @@ describe(`every theme clears the floor (ink ${CONTRAST_FLOOR.ink}:1, ink-2 ${CON
       // The one assertion here that no derivation can rescue: `--ink` is a seed, held to AA on every
       // ground the stylesheet puts it on. A theme whose foreground is too close to its background is
       // a bug in the theme, and this is the line that says so.
-      expect(worst("--ink", GROUNDS.ink), "--ink").toBeGreaterThanOrEqual(CONTRAST_FLOOR.ink);
-      expect(worst("--ink-2", GROUNDS.ink2), "--ink-2").toBeGreaterThanOrEqual(CONTRAST_FLOOR.ink2);
-      expect(worst("--ink-3", GROUNDS.ink3), "--ink-3").toBeGreaterThanOrEqual(CONTRAST_FLOOR.ink3);
+      expect(worst("--ink", INK_GROUNDS.ink), "--ink").toBeGreaterThanOrEqual(CONTRAST_FLOOR.ink);
+      expect(worst("--ink-2", INK_GROUNDS.ink2), "--ink-2").toBeGreaterThanOrEqual(CONTRAST_FLOOR.ink2);
+      expect(worst("--ink-3", INK_GROUNDS.ink3), "--ink-3").toBeGreaterThanOrEqual(CONTRAST_FLOOR.ink3);
 
       for (const token of ["--accent", "--green", "--orange", "--red"]) {
         expect(onSurface(token), token).toBeGreaterThanOrEqual(CONTRAST_FLOOR.chrome);
@@ -244,5 +229,97 @@ describe("provenance", () => {
       if (theme.name === "realm") { expect(theme.credit).toBeNull(); continue; }
       expect(theme.credit, theme.name).toMatch(/MIT ©/);
     }
+  });
+});
+
+describe("a user's own colours go through the same machinery", () => {
+  const derived = (name: Parameters<typeof themeVars>[0], mode: Mode, o: ThemeOverride) => themeVars(name, mode, o);
+
+  it("an override is merged into the SEED, so the whole palette follows it", () => {
+    // THE raw-write mutant: write the three overridden values straight onto :root and leave the rest
+    // of the derivation on the palette's own seeds. Every floor still passes — they are measured
+    // against the surface the OLD ground derived — and the app is a One Dark card ladder floating on
+    // a black page, with a tooltip and a chart ground that never heard about the change.
+    const v = derived("one", "dark", { bg: "#101014" });
+    const base = themeVars("one", "dark");
+    for (const token of ["--page", "--canvas", "--surface", "--inset", "--hover", "--hover-2",
+      "--field", "--stripe-bg", "--tooltip-bg", "--tooltip-border", "--chart-surface"]) {
+      expect(v[token], token).not.toBe(base[token]);
+    }
+    expect(parse(v["--page"]!).l).toBeCloseTo(hexToOklch("#101014").l, 3);
+    // ...and the ladder still climbs off the NEW ground by the ramp's own step.
+    expect(parse(v["--surface"]!).l - parse(v["--page"]!).l)
+      .toBeCloseTo(parse(base["--surface"]!).l - parse(base["--page"]!).l, 3);
+  });
+
+  it("an overridden hue is corrected exactly as a vendored one is — lightness only, inside the budget", () => {
+    // THE unchecked-override mutant: skip `lift` for user colours because "the user asked for it".
+    // A #333 accent on One Dark's card is 1.3:1, which is a focus ring nobody can find.
+    const v = derived("one", "dark", { accent: "#333333" });
+    const want = hexToOklch("#333333"), got = parse(v["--accent"]!);
+    expect(got.c).toBeCloseTo(want.c, 3);
+    expect(Math.abs(got.h - want.h)).toBeLessThan(0.5);
+    expect(Math.abs(got.l - want.l)).toBeLessThanOrEqual(0.121);
+    expect(contrast(got, parse(v["--surface"]!))).toBeGreaterThan(contrast(want, parse(v["--surface"]!)));
+  });
+
+  it("the ground and the ink are handed back exactly as asked, and the miss is REPORTED", () => {
+    // The decision this pins: correcting these two silently would hand back a theme the user did not
+    // pick — a palette's identity is its paper and its text. So they are derived verbatim and named.
+    // THE silent-fix mutant: lift `ink` off `bg` like any other hue. `contrastMisses` returns empty,
+    // the warning never renders, and the foreground in the field stops being the one on screen.
+    const seed = seedFor("one", "dark", { bg: "#282828", ink: "#2b2b2b" })!;
+    const v = deriveVars(seed, "dark");
+    expect(parse(v["--ink"]!).l).toBeCloseTo(hexToOklch("#2b2b2b").l, 3);
+    expect(contrastMisses(seed, "dark").map((m) => m.role)).toContain("Foreground");
+  });
+
+  it("a palette that clears every floor reports nothing — the warning cannot be always-on", () => {
+    // Without this, `contrastMisses` returning every role unconditionally would pass the test above.
+    for (const { theme, mode } of faces()) {
+      if (theme.name === "realm") continue;
+      expect(contrastMisses(seedFor(theme.name, mode)!, mode), `${theme.name}/${mode}`).toEqual([]);
+    }
+    expect(contrastMisses(REALM_SEED.dark, "dark")).toEqual([]);
+    expect(contrastMisses(REALM_SEED.light, "light")).toEqual([]);
+  });
+
+  it("Realm untouched still writes nothing, and Realm edited derives off its own seeds", () => {
+    // THE eager-seed mutant: give `realm` seeds in THEMES. Every user who never chose a theme gets
+    // 34 inline properties over the hand-tuned static CSS — near-identical, and no longer it.
+    expect(seedFor("realm", "dark")).toBeNull();
+    expect(themeVars("realm", "dark", {})).toEqual({});
+    const edited = seedFor("realm", "dark", { accent: "#f92672" })!;
+    expect(edited.bg).toBe(REALM_SEED.dark.bg);
+    expect(edited.accent).toBe("#f92672");
+    expect(Object.keys(themeVars("realm", "dark", { accent: "#f92672" })).sort()).toEqual([...THEME_VARS].sort());
+  });
+
+  it("a face with no seeds cannot be conjured out of an override", () => {
+    // Monokai has no light palette. An override is an edit to something, not a way to invent the
+    // thing — otherwise a stray stored key would produce a "Monokai Light" nobody designed.
+    expect(seedFor("monokai", "light", { accent: "#f92672" })).toBeNull();
+  });
+});
+
+describe("overrides read back off a user-editable settings row", () => {
+  it("keeps hex and drops everything else, per field", () => {
+    // THE trusted-blob mutant: cast the stored row to ThemeOverride. `hexToOklch` THROWS on
+    // "cornflowerblue", inside a layout effect, at boot — a white window with no settings page left
+    // to undo it from.
+    expect(parseThemeOverride({ bg: "#101014", ink: "cornflowerblue", accent: 42, nope: "#fff" }))
+      .toEqual({ bg: "#101014" });
+    expect(parseThemeOverride({ syntax: { keyword: "#abc", string: "rgb(1,2,3)" } }))
+      .toEqual({ syntax: { keyword: "#abc" } });
+    for (const junk of [null, undefined, "one", 7, [], { bg: "#12345" }]) expect(parseThemeOverride(junk)).toEqual({});
+  });
+
+  it("drops a key naming a palette or a face this build does not have", () => {
+    expect(parseThemeOverrides({ "one:dark": { accent: "#ff0000" } })).toEqual({ "one:dark": { accent: "#ff0000" } });
+    expect(parseThemeOverrides({ "cobalt:dark": { accent: "#ff0000" } })).toEqual({});
+    expect(parseThemeOverrides({ "one:sepia": { accent: "#ff0000" } })).toEqual({});
+    // An entry whose every field was dropped is not an override — it would make `isOverridden` true
+    // and show a "Reset" button for an edit that no longer exists.
+    expect(parseThemeOverrides({ "one:dark": { accent: "nope" } })).toEqual({});
   });
 });

--- a/packages/ui/src/themes.test.ts
+++ b/packages/ui/src/themes.test.ts
@@ -343,10 +343,14 @@ describe("the contrast control moves the ink ramp and nothing else", () => {
     { seed: REALM_SEED.dark, mode: "dark" as Mode, label: "realm/dark" },
     { seed: REALM_SEED.light, mode: "light" as Mode, label: "realm/light" }];
 
-  it("the default IS the shipped ramp — moving the slider and back returns the palette it started from", () => {
-    // THE off-by-a-default mutant: centre the scale on 50. Every palette in the app shifts the first
-    // time this ships, for everyone, and the ramp constants measured off tokens.css stop being what
-    // the app draws.
+  it("passing the default is the same as passing nothing — moving the slider and back returns the palette it started from", () => {
+    // THE drifted-default mutant: hardcode some other level as deriveVars' default argument. Every
+    // caller that does not thread the preference — the picker swatches, the guardrail in
+    // styles.test.ts — would derive a palette the window never shows.
+    // What this canNOT catch is the scale itself being centred somewhere other than the default:
+    // both sides of this comparison would move together. The check with teeth for that is
+    // styles.test.ts's "the ramp reproduces the palette it was measured from", where the default
+    // derivation is held against tokens.css and a shifted centre stops reproducing it.
     for (const { seed, mode, label } of seeds()) {
       expect(deriveVars(seed, mode, CONTRAST_RANGE.default), label).toEqual(deriveVars(seed, mode));
     }

--- a/packages/ui/src/themes.test.ts
+++ b/packages/ui/src/themes.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { contrast, hexToOklch, type Oklch } from "./oklch";
-import { CONTRAST_FLOOR, THEMES, THEME_VARS, deriveVars, resolveMode, themeModes, themeSwatches, themeVars } from "./themes";
+import { CONTRAST_FLOOR, THEMES, THEME_VARS, deriveVars, paletteFor, resolveMode, themeModes, themeSwatches, themeVars } from "./themes";
 import type { Mode } from "./theme";
 
 const parse = (value: string): Oklch => {
@@ -28,28 +28,39 @@ const faces = (): { theme: (typeof THEMES)[number]; mode: Mode }[] =>
   THEMES.flatMap((theme) => themeModes(theme.name).map((mode) => ({ theme, mode })));
 
 describe("the two axes compose", () => {
-  it("a theme with both faces takes whichever mode the preference resolved to", () => {
-    for (const mode of ["dark", "light"] as const) {
-      expect(resolveMode("realm", mode)).toBe(mode);
-      expect(resolveMode("one", mode)).toBe(mode);
-    }
-  });
-
-  it("a theme with one face pins the mode, and every theme still resolves to something", () => {
-    for (const { theme } of THEMES.map((theme) => ({ theme }))) {
+  it("every theme previews as a face it actually has", () => {
+    // `resolveMode` is what a picker card and a ⌘K hint use to say which face they are showing, so
+    // it must never name a face the theme has no seeds for.
+    for (const theme of THEMES) {
       const modes = themeModes(theme.name);
       expect(modes.length, theme.name).toBeGreaterThan(0);
       for (const mode of ["dark", "light"] as const) expect(modes).toContain(resolveMode(theme.name, mode));
     }
-  });
-
-  it("pinning is a fact about the theme, not a write to the preference", () => {
-    // THE clobber mutant: have the picker call setThemePref("dark") when a dark-only palette is
-    // chosen. Nothing here would notice — which is why `resolveMode` is a pure function of the two
-    // inputs and the preference is never an output. A user who prefers "system" and tries Monokai
-    // for an afternoon must find "system" again afterwards.
     expect(resolveMode("monokai", "light")).toBe("dark");
     expect(resolveMode("one", "light")).toBe("light");
+  });
+
+  it("a face reads its OWN slot — the two are chosen independently or they are one control", () => {
+    // THE shared-slot mutant: return `selection.dark` whatever the mode. Every palette still paints,
+    // every floor still clears, and the light window silently wears the night's palette.
+    const sel = { light: "solarized", dark: "monokai" } as const;
+    expect(paletteFor(sel, "light")).toBe("solarized");
+    expect(paletteFor(sel, "dark")).toBe("monokai");
+  });
+
+  it("a slot naming a palette with no such face falls back rather than moving the mode", () => {
+    // THE pinning mutant: keep the old rule that a one-faced palette resolves the mode to its face.
+    // The mode is the user's other axis; a value sitting in a slot the light window does not read is
+    // not permission to hand them a dark window. `realm` is the fallback because its face is the
+    // static CSS, which is the one face that cannot be missing.
+    expect(paletteFor({ light: "monokai", dark: "monokai" }, "light")).toBe("realm");
+    expect(paletteFor({ light: "monokai", dark: "monokai" }, "dark")).toBe("monokai");
+    // And the fallback is reachable for every face of every theme, so no selection can be unpaintable.
+    for (const theme of THEMES) {
+      for (const mode of ["dark", "light"] as const) {
+        expect(themeModes(paletteFor({ light: theme.name, dark: theme.name }, mode)), `${theme.name}/${mode}`).toContain(mode);
+      }
+    }
   });
 });
 

--- a/packages/ui/src/themes.test.ts
+++ b/packages/ui/src/themes.test.ts
@@ -219,7 +219,20 @@ describe("the picker's swatches", () => {
 
   it("come from the same derivation the app applies, so a card cannot lie about its theme", () => {
     const v = themeVars("one", "dark");
-    expect(themeSwatches("one", "dark")).toEqual([v["--page"], v["--surface"], v["--accent"], v["--syn-string"]]);
+    expect(themeSwatches("one", "dark")).toEqual([v["--page"], v["--surface"], v["--accent"], v["--syn-string"], v["--ink-3"]]);
+  });
+
+  it("carry a hairline the swatches stay visible against, on every face", () => {
+    // THE fixed-hairline mutant: ring the swatches in a constant black or white. The card is painted
+    // in the theme it names, so a constant ring is invisible on half of them — and the dot it was
+    // added for is the one that matches the card ground, which on every light palette is --surface.
+    // 1.5:1 is the floor for "this is a shape" rather than for text.
+    for (const { theme, mode } of faces()) {
+      const [page, surface, , , line] = themeSwatches(theme.name, mode);
+      for (const [what, ground] of [["page", page], ["surface", surface]] as const) {
+        expect(contrast(parse(line), parse(ground)), `${theme.name}/${mode} hairline on ${what}`).toBeGreaterThan(1.5);
+      }
+    }
   });
 });
 

--- a/packages/ui/src/themes.test.ts
+++ b/packages/ui/src/themes.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { contrast, hexToOklch, parseOklch as parse } from "./oklch";
-import { CONTRAST_FLOOR, INK_GROUNDS, REALM_SEED, THEMES, THEME_VARS, contrastMisses, deriveVars, paletteFor,
+import { clampContrast, CONTRAST_FLOOR, CONTRAST_RANGE, INK_GROUNDS, REALM_SEED, THEMES, THEME_VARS, contrastMisses, deriveVars, paletteFor,
   parseThemeOverride, parseThemeOverrides, resolveMode, seedFor, themeModes, themeSwatches, themeVars,
   type ThemeOverride } from "./themes";
 import type { Mode } from "./theme";
@@ -233,7 +233,7 @@ describe("provenance", () => {
 });
 
 describe("a user's own colours go through the same machinery", () => {
-  const derived = (name: Parameters<typeof themeVars>[0], mode: Mode, o: ThemeOverride) => themeVars(name, mode, o);
+  const derived = (name: Parameters<typeof themeVars>[0], mode: Mode, override: ThemeOverride) => themeVars(name, mode, { override });
 
   it("an override is merged into the SEED, so the whole palette follows it", () => {
     // THE raw-write mutant: write the three overridden values straight onto :root and leave the rest
@@ -288,11 +288,11 @@ describe("a user's own colours go through the same machinery", () => {
     // THE eager-seed mutant: give `realm` seeds in THEMES. Every user who never chose a theme gets
     // 34 inline properties over the hand-tuned static CSS — near-identical, and no longer it.
     expect(seedFor("realm", "dark")).toBeNull();
-    expect(themeVars("realm", "dark", {})).toEqual({});
+    expect(themeVars("realm", "dark", { override: {} })).toEqual({});
     const edited = seedFor("realm", "dark", { accent: "#f92672" })!;
     expect(edited.bg).toBe(REALM_SEED.dark.bg);
     expect(edited.accent).toBe("#f92672");
-    expect(Object.keys(themeVars("realm", "dark", { accent: "#f92672" })).sort()).toEqual([...THEME_VARS].sort());
+    expect(Object.keys(themeVars("realm", "dark", { override: { accent: "#f92672" } })).sort()).toEqual([...THEME_VARS].sort());
   });
 
   it("a face with no seeds cannot be conjured out of an override", () => {
@@ -321,5 +321,84 @@ describe("overrides read back off a user-editable settings row", () => {
     // An entry whose every field was dropped is not an override — it would make `isOverridden` true
     // and show a "Reset" button for an edit that no longer exists.
     expect(parseThemeOverrides({ "one:dark": { accent: "nope" } })).toEqual({});
+  });
+});
+
+describe("the contrast control moves the ink ramp and nothing else", () => {
+  const levels = [CONTRAST_RANGE.min, 20, 40, CONTRAST_RANGE.default, 80, CONTRAST_RANGE.max];
+  const seeds = () => [...faces().filter((f) => f.theme.name !== "realm").map(({ theme, mode }) => ({ seed: seedFor(theme.name, mode)!, mode, label: `${theme.name}/${mode}` })),
+    { seed: REALM_SEED.dark, mode: "dark" as Mode, label: "realm/dark" },
+    { seed: REALM_SEED.light, mode: "light" as Mode, label: "realm/light" }];
+
+  it("the default IS the shipped ramp — moving the slider and back returns the palette it started from", () => {
+    // THE off-by-a-default mutant: centre the scale on 50. Every palette in the app shifts the first
+    // time this ships, for everyone, and the ramp constants measured off tokens.css stop being what
+    // the app draws.
+    for (const { seed, mode, label } of seeds()) {
+      expect(deriveVars(seed, mode, CONTRAST_RANGE.default), label).toEqual(deriveVars(seed, mode));
+    }
+  });
+
+  it("raising it closes the ramp up and lowering it opens it out, monotonically", () => {
+    // THE inverted-scale mutant: multiply where it should divide. The label says Contrast and the
+    // control does the opposite, which no floor and no ratio would ever catch.
+    for (const { seed, mode, label } of seeds()) {
+      const gap = (level: number) => {
+        const v = deriveVars(seed, mode, level);
+        const ground = parse(v["--surface"]!);
+        return contrast(parse(v["--ink"]!), ground) - contrast(parse(v["--ink-2"]!), ground);
+      };
+      for (let i = 1; i < levels.length; i++) {
+        expect(gap(levels[i]!), `${label} @${levels[i]}`).toBeLessThanOrEqual(gap(levels[i - 1]!) + 1e-9);
+      }
+      expect(gap(CONTRAST_RANGE.min), label).toBeGreaterThan(gap(CONTRAST_RANGE.max));
+    }
+  });
+
+  it("cannot push any tier below the floor, at any setting, on any palette", () => {
+    // This is the whole safety claim, and it is structural rather than arithmetic: `inkStep` floors
+    // every tier before it walks. THE unfloored mutant: pass 0 as inkStep's floor and let the
+    // exponent decide. Nothing about the slider looks different until it is near the bottom, where
+    // the hint tier quietly stops being text.
+    for (const { seed, mode, label } of seeds()) {
+      for (const level of levels) {
+        const v = deriveVars(seed, mode, level);
+        const worst = (token: string, grounds: readonly string[]) =>
+          Math.min(...grounds.map((g) => contrast(parse(v[token]!), parse(v[g]!))));
+        expect(worst("--ink", INK_GROUNDS.ink), `${label} @${level} --ink`).toBeGreaterThanOrEqual(CONTRAST_FLOOR.ink);
+        expect(worst("--ink-2", INK_GROUNDS.ink2), `${label} @${level} --ink-2`).toBeGreaterThanOrEqual(CONTRAST_FLOOR.ink2);
+        expect(worst("--ink-3", INK_GROUNDS.ink3), `${label} @${level} --ink-3`).toBeGreaterThanOrEqual(CONTRAST_FLOOR.ink3);
+      }
+    }
+  });
+
+  it("cannot collapse the three tiers into one, at the top of the range", () => {
+    // THE unbounded-top mutant: let the exponent reach 1. --ink-2 and --ink-3 become --ink, and
+    // every distinction the ramp draws — a label from its value, a timestamp from a title — is gone.
+    // Raising contrast must not be a way to destroy the hierarchy contrast is for.
+    for (const { seed, mode, label } of seeds()) {
+      const v = deriveVars(seed, mode, CONTRAST_RANGE.max);
+      const g = parse(v["--surface"]!);
+      const [ink, ink2, ink3] = ["--ink", "--ink-2", "--ink-3"].map((k) => contrast(parse(v[k]!), g));
+      expect(ink!, label).toBeGreaterThan(ink2! * 1.15);
+      expect(ink2!, label).toBeGreaterThan(ink3! * 1.15);
+    }
+  });
+
+  it("moves no hue and no surface — a contrast control that repainted a palette would be a repaint", () => {
+    // THE overreaching mutant: apply the spread to the accent, or to the surface ladder. It would
+    // look like it was working, and Monokai at 20 would no longer be Monokai.
+    const seed = seedFor("one", "dark")!;
+    const [lo, hi] = [deriveVars(seed, "dark", CONTRAST_RANGE.min), deriveVars(seed, "dark", CONTRAST_RANGE.max)];
+    for (const token of THEME_VARS.filter((t) => t !== "--ink-2" && t !== "--ink-3" && t !== "--syn-fg" && t !== "--tooltip-muted")) {
+      expect(hi[token], token).toBe(lo[token]);
+    }
+  });
+
+  it("clamps whatever it is handed, so a stored or hand-edited value cannot leave the range", () => {
+    expect(clampContrast(-40)).toBe(CONTRAST_RANGE.min);
+    expect(clampContrast(1000)).toBe(CONTRAST_RANGE.max);
+    expect(clampContrast(61.6)).toBe(62);
+    expect(deriveVars(REALM_SEED.dark, "dark", -40)).toEqual(deriveVars(REALM_SEED.dark, "dark", CONTRAST_RANGE.min));
   });
 });

--- a/packages/ui/src/themes.ts
+++ b/packages/ui/src/themes.ts
@@ -376,22 +376,37 @@ export function resolveMode(name: ThemeName, mode: Mode): Mode {
   return modes.includes(mode) ? mode : (modes[0] ?? mode);
 }
 
-/** Realm's own window, card, accent and string colours, copied from theme/tokens.css.
- *  The picker cannot read them off the document: by the time it renders under any other theme the
- *  live `var(--page)` is THAT theme's page, so a preview built from computed styles would draw every
- *  card in the colours of whichever palette is already on. Copied, therefore, and pinned by a test
- *  against the stylesheet so the copy cannot drift. */
-const REALM_SWATCHES: Record<Mode, [string, string, string, string]> = {
-  dark: ["oklch(0.209 0.004 264.477)", "oklch(0.26 0.006 271.191)", "oklch(0.68 0.173 253.301)", "oklch(0.705 0.154 153.814)"],
-  light: ["oklch(0.985 0.001 286.376)", "oklch(1 0 0)", "oklch(0.626 0.205 254.947)", "oklch(0.603 0.155 150.883)"],
+/** Realm's own twelve, read out of theme/tokens.css and written here as hex — the same seeds the
+ *  stylesheet's own ramp guardrail recovers from that file, so styles.test.ts pins this copy against
+ *  it rather than letting two sets of Realm's colours drift apart.
+ *
+ *  It exists for the two jobs that need Realm's palette as VALUES rather than as a stylesheet. The
+ *  picker cannot read them off the document — by the time it renders under any other theme the live
+ *  `var(--page)` is THAT theme's page, so a preview built from computed styles would draw every card
+ *  in the colours of whichever palette is already on. And an override needs a ground to derive from:
+ *  a user who moves Realm's accent has asked for a palette, and there has to be a seed under it.
+ *
+ *  Realm's `ThemeDef` still states no seeds, which is what keeps the untouched default byte-for-byte
+ *  the static CSS: an unoverridden `realm` writes nothing, and this is never consulted. */
+export const REALM_SEED: Record<Mode, ThemeSeed> = {
+  dark: {
+    bg: "#17181a", ink: "#f2f3f4", accent: "#3d9aff",
+    green: "#3cbb72", orange: "#f68f3c", red: "#ee5c61",
+    syntax: { comment: "#6c6f75", keyword: "#3d9aff", string: "#3cbb72", number: "#f68f3c", title: "#f2f3f4", type: "#f2f3f4", attr: "#a5a8ad" },
+  },
+  light: {
+    bg: "#fafafb", ink: "#1f2124", accent: "#0285ff",
+    green: "#199a4d", orange: "#ef720d", red: "#e3474c",
+    syntax: { comment: "#9a9da3", keyword: "#0285ff", string: "#199a4d", number: "#ef720d", title: "#1f2124", type: "#1f2124", attr: "#62656b" },
+  },
 };
 
 /** The four colours a picker shows for a theme: the window, the card that floats on it, the accent,
  *  and the one syntax hue that says most about a code palette. */
 export function themeSwatches(name: ThemeName, mode: Mode): [string, string, string, string] {
   const v = themeVars(name, resolveMode(name, mode));
-  if (!v["--page"]) return REALM_SWATCHES[mode];
-  return [v["--page"]!, v["--surface"]!, v["--accent"]!, v["--syn-string"]!];
+  const s = v["--page"] ? v : deriveVars(REALM_SEED[mode], mode);
+  return [s["--page"]!, s["--surface"]!, s["--accent"]!, s["--syn-string"]!];
 }
 
 export function isThemeName(x: unknown): x is ThemeName {

--- a/packages/ui/src/themes.ts
+++ b/packages/ui/src/themes.ts
@@ -1,4 +1,4 @@
-import { contrast, css, hexToOklch, luminance, parseOklch, type Oklch } from "./oklch";
+import { contrast, css, emitted, hexToOklch, luminance, parseOklch, type Oklch } from "./oklch";
 import type { Mode } from "./theme";
 
 /** Custom themes.
@@ -186,6 +186,37 @@ export const INK_GROUNDS = {
   ink3: ["--page", "--canvas", "--surface", "--inset"],
 } as const;
 
+/** The ink ramp's SPREAD, as a user control. 0–100 with 60 the shipped ramp, which is the range and
+ *  the default the control shows.
+ *
+ *  What it moves is the only thing in this palette that is a matter of preference rather than of
+ *  correctness: how far `--ink-2` and `--ink-3` fall below `--ink` against the ground. Those are the
+ *  exponents in `Ramp`, and this is a multiplier on them — a higher exponent puts the secondary and
+ *  hint tiers closer to primary text, a lower one lets them recede. It cannot touch `--ink` itself
+ *  (that is a seed, and the palette's identity) and it cannot touch a hue (a slider that desaturated
+ *  Monokai's pink towards the ground would be a repaint, not a preference).
+ *
+ *  It CANNOT make anything illegible, and not by arithmetic that has to be got right here: `inkStep`
+ *  floors every tier at `CONTRAST_FLOOR` before it walks, so the bottom of this range is where the
+ *  floors start binding rather than where the ramp keeps sinking. The top is bounded too — at 1.28
+ *  the shipped exponents still leave the three tiers a clear step apart on every palette, and a ramp
+ *  collapsed to one flat tier is a hierarchy destroyed rather than a contrast raised. */
+export const CONTRAST_RANGE = { min: 0, max: 100, default: 60 } as const;
+const CONTRAST_SPAN = { lo: 0.72, hi: 1.28 } as const;
+
+export const clampContrast = (x: number): number =>
+  Math.round(clamp(x, CONTRAST_RANGE.min, CONTRAST_RANGE.max));
+
+/** 0 → `lo`, the default → 1, 100 → `hi`. Two linear halves rather than one, because the default is
+ *  not the midpoint: the shipped ramp has to land exactly on 1 or moving the slider to 60 and back
+ *  would not return the palette it started from. */
+const contrastScale = (level: number): number => {
+  const c = clampContrast(level), d = CONTRAST_RANGE.default;
+  return c <= d
+    ? CONTRAST_SPAN.lo + ((1 - CONTRAST_SPAN.lo) * c) / d
+    : 1 + ((CONTRAST_SPAN.hi - 1) * (c - d)) / (CONTRAST_RANGE.max - d);
+};
+
 /** How far a stated colour may be pushed to meet its floor. A theme states hues; this budget is what
  *  separates "the palette lifted Nord's red half a step so error text is readable on Nord's own
  *  surface" from "the palette invented a colour and called it Nord". A seed that needs more than
@@ -205,10 +236,11 @@ const step = (base: Oklch, dl: number, dc = 0): Oklch =>
  *  thing a correctness fix must not quietly edit. */
 function lift(o: Oklch, ground: Oklch, floor: number, budget = LIFT_BUDGET): Oklch {
   const dir = luminance(o) >= luminance(ground) ? 1 : -1;
+  const g = emitted(ground);
   let best = o;
   for (let d = 0; d <= budget + 1e-9; d += 0.002) {
     best = { ...o, l: clamp(o.l + dir * d, 0, 1) };
-    if (contrast(best, ground) >= floor) return best;
+    if (contrast(emitted(best), g) >= floor) return best;
   }
   return best;
 }
@@ -218,12 +250,13 @@ function lift(o: Oklch, ground: Oklch, floor: number, budget = LIFT_BUDGET): Okl
  *  walk is exact to a step no display can resolve, and it stays correct where the naive inverse does
  *  not — at the gamut boundary, where raising L stops raising luminance. */
 function inkStep(ink: Oklch, ground: Oklch, exp: number, floor: number): Oklch {
-  const target = Math.max(floor, contrast(ink, ground) ** exp);
-  const dir = luminance(ink) >= luminance(ground) ? -1 : 1;
+  const g = emitted(ground);
+  const target = Math.max(floor, contrast(ink, g) ** exp);
+  const dir = luminance(ink) >= luminance(g) ? -1 : 1;
   let best = ink;
   for (let d = 0; d <= 1; d += 0.002) {
     const next = { ...ink, l: clamp(ink.l + dir * d, 0, 1) };
-    if (contrast(next, ground) < target) break;
+    if (contrast(emitted(next), g) < target) break;
     best = next;
   }
   return best;
@@ -246,16 +279,19 @@ export const THEME_VARS = [
 /** The palette a seed expands to: `THEME_VARS` → CSS colour. `themeVars` is pure and cheap enough to
  *  call on every switch, which is why the derived palette is not precomputed into a stylesheet — a
  *  generated CSS file would have to be regenerated, checked in, and then checked for staleness. */
-export function themeVars(name: ThemeName, mode: Mode, override: ThemeOverride = {}): Record<string, string> {
+export function themeVars(name: ThemeName, mode: Mode,
+  { override = {}, contrast = CONTRAST_RANGE.default }: { override?: ThemeOverride; contrast?: number } = {},
+): Record<string, string> {
   const seed = seedFor(name, mode, override);
-  return seed ? deriveVars(seed, mode) : {};
+  return seed ? deriveVars(seed, mode, contrast) : {};
 }
 
 /** The derivation itself, on a bare seed. Exported so the guardrail can feed it the seeds tokens.css
  *  was built from and check that what comes out IS tokens.css — the ramp constants above are only
  *  "measured off the shipped palette" for as long as something re-measures them. */
-export function deriveVars(seed: ThemeSeed, mode: Mode): Record<string, string> {
+export function deriveVars(seed: ThemeSeed, mode: Mode, contrastLevel: number = CONTRAST_RANGE.default): Record<string, string> {
   const r = mode === "dark" ? DARK : LIGHT;
+  const spread = contrastScale(contrastLevel);
   const bg = hexToOklch(seed.bg);
   const ink = hexToOklch(seed.ink);
 
@@ -302,8 +338,8 @@ export function deriveVars(seed: ThemeSeed, mode: Mode): Record<string, string> 
    *  the series, not of the themes. */
   const chart = { ...surface, l: clamp(surface.l, r.chartL.min, r.chartL.max) };
 
-  const ink2 = inkStep(ink, worst(["canvas", "surface", "inset", "hover"]), r.ink2, CONTRAST_FLOOR.ink2);
-  const ink3 = inkStep(ink, worst(["canvas", "surface", "inset"]), r.ink3, CONTRAST_FLOOR.ink3);
+  const ink2 = inkStep(ink, worst(["canvas", "surface", "inset", "hover"]), r.ink2 * spread, CONTRAST_FLOOR.ink2);
+  const ink3 = inkStep(ink, worst(["canvas", "surface", "inset"]), r.ink3 * spread, CONTRAST_FLOOR.ink3);
   const tip = r.tooltip({ bg, ink, ink2 });
 
   /** Chrome and syntax are stated as hues and corrected as lightnesses. Every one of these lands on
@@ -382,8 +418,8 @@ export type ContrastMiss = { role: string; ratio: number; floor: number };
  *
  *  Measured on the DERIVED palette, so it reports what will be on screen rather than what the seed
  *  asked for — the same predicate the theme suite holds the shipped palettes to. */
-export function contrastMisses(seed: ThemeSeed, mode: Mode): ContrastMiss[] {
-  const v = deriveVars(seed, mode);
+export function contrastMisses(seed: ThemeSeed, mode: Mode, contrastLevel: number = CONTRAST_RANGE.default): ContrastMiss[] {
+  const v = deriveVars(seed, mode, contrastLevel);
   const at = (token: string): Oklch => parseOklch(v[token]!);
   const out: ContrastMiss[] = [];
   const check = (role: string, token: string, grounds: readonly string[], floor: number): void => {

--- a/packages/ui/src/themes.ts
+++ b/packages/ui/src/themes.ts
@@ -74,7 +74,8 @@ export type ThemeDef = {
   light: ThemeSeed | null;
 };
 
-export type ThemeName = "realm" | "one" | "monokai" | "dracula" | "nord" | "solarized" | "gruvbox";
+export type ThemeName = "realm" | "one" | "monokai" | "dracula" | "nord" | "solarized" | "gruvbox"
+  | "catppuccin" | "github" | "rosepine";
 
 /* ── how a seed becomes a palette ──────────────────────────────────────────────
  * Every constant below was MEASURED off the shipped palette in theme/tokens.css, so a derived theme
@@ -705,6 +706,74 @@ export const THEMES: readonly ThemeDef[] = [
       bg: "#fbf1c7", ink: "#3c3836", accent: "#076678",
       green: "#79740e", orange: "#af3a03", red: "#9d0006",
       syntax: { comment: "#7c6f64", keyword: "#9d0006", string: "#79740e", number: "#8f3f71", title: "#b57614", type: "#427b58", attr: "#076678" },
+    },
+  },
+  {
+    /* Catppuccin — catppuccin/palette (palette.json), MIT © Catppuccin. Mocha and Latte, both faces.
+     * Comments are `overlay2`, which is the one syntax role Catppuccin states globally — its VS Code
+     * port sets the rest PER LANGUAGE, so there is no published keyword-or-string colour to vendor.
+     * The seven hues below are Catppuccin's; the assignment of hue to role is Realm's, and it follows
+     * the convention its ports converge on: mauve for keywords, green for strings, blue for the name
+     * being defined, yellow for types, peach for numbers, teal for attributes. */
+    name: "catppuccin",
+    label: "Catppuccin",
+    credit: "Catppuccin — MIT © Catppuccin",
+    blurb: "Mocha at night, Latte by day.",
+    dark: {
+      bg: "#1e1e2e", ink: "#cdd6f4", accent: "#cba6f7",
+      green: "#a6e3a1", orange: "#fab387", red: "#f38ba8",
+      syntax: { comment: "#9399b2", keyword: "#cba6f7", string: "#a6e3a1", number: "#fab387", title: "#89b4fa", type: "#f9e2af", attr: "#94e2d5" },
+    },
+    light: {
+      bg: "#eff1f5", ink: "#4c4f69", accent: "#8839ef",
+      green: "#40a02b", orange: "#fe640b", red: "#d20f39",
+      syntax: { comment: "#7c7f93", keyword: "#8839ef", string: "#40a02b", number: "#fe640b", title: "#1e66f5", type: "#df8e1d", attr: "#179299" },
+    },
+  },
+  {
+    /* GitHub — primer/github-vscode-theme, MIT © Primer. Values read off the SHIPPED theme JSON
+     * rather than off @primer/primitives: colors.js overrides three of them at build time, so the
+     * primitives' own `fg.default` and `accent.fg` are not what the editor draws.
+     * One deviation, and it is the ladder's rather than a matter of taste: GitHub Light's editor
+     * ground is #ffffff, and a light surface step CLIMBS from the page — off pure white there is
+     * nowhere to climb to, so every card would land back on the page and the ladder would collapse.
+     * The seed is `canvas.subtle` (#f6f8fa), which is GitHub's own chrome ground: what it paints its
+     * sidebar, panel and tab strip with, and the right analogue of Realm's `--page`. */
+    name: "github",
+    label: "GitHub",
+    credit: "GitHub — MIT © Primer",
+    blurb: "GitHub's own two, as the editor draws them.",
+    dark: {
+      bg: "#0d1117", ink: "#e6edf3", accent: "#2f81f7",
+      green: "#3fb950", orange: "#d29922", red: "#f85149",
+      syntax: { comment: "#8b949e", keyword: "#ff7b72", string: "#a5d6ff", number: "#79c0ff", title: "#d2a8ff", type: "#7ee787", attr: "#ffa657" },
+    },
+    light: {
+      bg: "#f6f8fa", ink: "#1f2328", accent: "#0969da",
+      green: "#1a7f37", orange: "#9a6700", red: "#cf222e",
+      syntax: { comment: "#6e7781", keyword: "#cf222e", string: "#0a3069", number: "#0550ae", title: "#8250df", type: "#116329", attr: "#953800" },
+    },
+  },
+  {
+    /* Rosé Pine — rose-pine/rose-pine-palette, MIT © Rosé Pine. Main and Dawn.
+     * Dawn's text is #575279, from the palette's TypeScript source and its shipped VS Code theme.
+     * The palette.json in that repo says #464261; it was added in a commit titled "temp: add json,
+     * toml, yaml", disagrees with every built artifact, and is not what anything renders.
+     * Rosé Pine publishes no green. "It worked" takes foam, the nearest tone it has, because a
+     * semantic colour has to survive a repaint and inventing a green would be inventing a hue. */
+    name: "rosepine",
+    label: "Rosé Pine",
+    credit: "Rosé Pine — MIT © Rosé Pine",
+    blurb: "Muted natural tones, night and dawn.",
+    dark: {
+      bg: "#191724", ink: "#e0def4", accent: "#c4a7e7",
+      green: "#9ccfd8", orange: "#f6c177", red: "#eb6f92",
+      syntax: { comment: "#6e6a86", keyword: "#31748f", string: "#f6c177", number: "#c4a7e7", title: "#ebbcba", type: "#9ccfd8", attr: "#908caa" },
+    },
+    light: {
+      bg: "#faf4ed", ink: "#575279", accent: "#907aa9",
+      green: "#56949f", orange: "#ea9d34", red: "#b4637a",
+      syntax: { comment: "#9893a5", keyword: "#286983", string: "#ea9d34", number: "#907aa9", title: "#d7827e", type: "#56949f", attr: "#797593" },
     },
   },
 ];

--- a/packages/ui/src/themes.ts
+++ b/packages/ui/src/themes.ts
@@ -573,12 +573,17 @@ export const REALM_SEED: Record<Mode, ThemeSeed> = {
   },
 };
 
-/** The four colours a picker shows for a theme: the window, the card that floats on it, the accent,
- *  and the one syntax hue that says most about a code palette. */
-export function themeSwatches(name: ThemeName, mode: Mode): [string, string, string, string] {
+/** The colours a picker shows for a theme: the window, the card that floats on it, the accent, the
+ *  one syntax hue that says most about a code palette — and a hairline in the theme's own hint ink.
+ *
+ *  The hairline is there because the card is painted in the theme it names, so a swatch can land on
+ *  a ground it matches: every light palette's `--surface` is within a step of its `--page`, and that
+ *  dot disappeared into the card entirely. A ring drawn from the theme's own ink is visible on any
+ *  ground the theme can produce, which a fixed black or white one is not. */
+export function themeSwatches(name: ThemeName, mode: Mode): [string, string, string, string, string] {
   const v = themeVars(name, resolveMode(name, mode));
   const s = v["--page"] ? v : deriveVars(REALM_SEED[mode], mode);
-  return [s["--page"]!, s["--surface"]!, s["--accent"]!, s["--syn-string"]!];
+  return [s["--page"]!, s["--surface"]!, s["--accent"]!, s["--syn-string"]!, s["--ink-3"]!];
 }
 
 export function isThemeName(x: unknown): x is ThemeName {

--- a/packages/ui/src/themes.ts
+++ b/packages/ui/src/themes.ts
@@ -1,15 +1,15 @@
-import { contrast, css, hexToOklch, luminance, type Oklch } from "./oklch";
+import { contrast, css, hexToOklch, luminance, parseOklch, type Oklch } from "./oklch";
 import type { Mode } from "./theme";
 
 /** Custom themes.
  *
  *  Realm already had one colour axis — light / dark / system — and a theme is a SECOND axis, not a
  *  replacement for it. `themePref` still says which mode the user wants; a theme says what the
- *  palette looks like in that mode. The two compose through `resolveMode`: a theme that has both
- *  faces takes whichever mode the preference resolves to, and a theme with only a dark face pins the
- *  window dark WITHOUT touching the preference, so switching back to Realm restores "system" intact.
- *  That is why themes carry `dark`/`light` as nullable seeds rather than a single palette and a
- *  boolean — "Monokai has no light variant" is a fact about the theme, and the UI can say it.
+ *  palette looks like in that mode. The two compose through `paletteFor`, over a SLOT PER FACE: the
+ *  light window reads the light slot and the dark window the dark one, so neither axis has to
+ *  overrule the other. That is why themes carry `dark`/`light` as nullable seeds rather than a single
+ *  palette and a boolean — "Monokai has no light variant" is a fact about the theme, and it is what
+ *  keeps Monokai out of the light row rather than something the light row has to cope with.
  *
  *  `realm` is the palette in theme/tokens.css and states NO seeds. Selecting it means writing no
  *  overrides at all, so the default experience is byte-for-byte the static CSS it has always been —
@@ -175,6 +175,17 @@ export const CONTRAST_FLOOR = {
   series: 3,
 } as const;
 
+/** The grounds each ink tier actually lands on, read off styles.css rather than taken as the whole
+ *  ladder: `--ink-2` never appears on `--hover-2` or `--field` (both are written with `--ink` in
+ *  every rule that uses them), and `--ink-3` never leaves the resting surfaces. Widening these to the
+ *  full cross-product would fail palettes over pairings the stylesheet never produces; narrowing them
+ *  past what it does produce is how an unreadable pairing ships. */
+export const INK_GROUNDS = {
+  ink: ["--page", "--canvas", "--surface", "--inset", "--hover", "--hover-2", "--field"],
+  ink2: ["--page", "--canvas", "--surface", "--inset", "--hover"],
+  ink3: ["--page", "--canvas", "--surface", "--inset"],
+} as const;
+
 /** How far a stated colour may be pushed to meet its floor. A theme states hues; this budget is what
  *  separates "the palette lifted Nord's red half a step so error text is readable on Nord's own
  *  surface" from "the palette invented a colour and called it Nord". A seed that needs more than
@@ -235,8 +246,8 @@ export const THEME_VARS = [
 /** The palette a seed expands to: `THEME_VARS` → CSS colour. `themeVars` is pure and cheap enough to
  *  call on every switch, which is why the derived palette is not precomputed into a stylesheet — a
  *  generated CSS file would have to be regenerated, checked in, and then checked for staleness. */
-export function themeVars(name: ThemeName, mode: Mode): Record<string, string> {
-  const seed = seedFor(name, mode);
+export function themeVars(name: ThemeName, mode: Mode, override: ThemeOverride = {}): Record<string, string> {
+  const seed = seedFor(name, mode, override);
   return seed ? deriveVars(seed, mode) : {};
 }
 
@@ -356,10 +367,113 @@ export function deriveVars(seed: ThemeSeed, mode: Mode): Record<string, string> 
   };
 }
 
-const seedFor = (name: ThemeName, mode: Mode): ThemeSeed | null => {
+export type ContrastMiss = { role: string; ratio: number; floor: number };
+
+/** Which of a seed's colours the derivation could not get to their floor, and how far short they
+ *  fell. Two different failures land here, and the difference is why the UI reports rather than
+ *  silently repaints:
+ *
+ *  - The ground and the ink are the two seeds NOTHING corrects. A palette's identity is its paper
+ *    and its text, and a mechanism that moved them would hand back a theme the user did not pick.
+ *    So a `#2b2b2b` ink on a `#282828` page is derived exactly as asked and named here instead.
+ *  - Everything else is corrected along lightness, inside `LIFT_BUDGET`, exactly as a vendored
+ *    palette is. A hue that still misses after its budget is one the ramp genuinely cannot carry,
+ *    and saying which one is more use than a number that quietly stopped being the chosen colour.
+ *
+ *  Measured on the DERIVED palette, so it reports what will be on screen rather than what the seed
+ *  asked for — the same predicate the theme suite holds the shipped palettes to. */
+export function contrastMisses(seed: ThemeSeed, mode: Mode): ContrastMiss[] {
+  const v = deriveVars(seed, mode);
+  const at = (token: string): Oklch => parseOklch(v[token]!);
+  const out: ContrastMiss[] = [];
+  const check = (role: string, token: string, grounds: readonly string[], floor: number): void => {
+    const ratio = Math.min(...grounds.map((g) => contrast(at(token), at(g))));
+    if (ratio < floor) out.push({ role, ratio, floor });
+  };
+  check("Foreground", "--ink", INK_GROUNDS.ink, CONTRAST_FLOOR.ink);
+  check("Secondary text", "--ink-2", INK_GROUNDS.ink2, CONTRAST_FLOOR.ink2);
+  check("Hint text", "--ink-3", INK_GROUNDS.ink3, CONTRAST_FLOOR.ink3);
+  for (const [role, token] of [["Accent", "--accent"], ["Success", "--green"], ["Warning", "--orange"], ["Error", "--red"]] as const) {
+    check(role, token, ["--surface"], CONTRAST_FLOOR.chrome);
+  }
+  check("Link text", "--accent-ink", ["--surface"], CONTRAST_FLOOR.accentInk);
+  check("Button label", "--rl-accent-contrast", ["--accent"], CONTRAST_FLOOR.onAccent);
+  for (const token of THEME_VARS.filter((t) => t.startsWith("--syn-"))) {
+    check(`Code (${token.slice(6)})`, token, ["--surface"], CONTRAST_FLOOR.syntax);
+  }
+  return out;
+}
+
+/** What a user has moved off a palette's own seeds. A PARTIAL SEED rather than a fixed trio of
+ *  fields, because the same shape is what a copied theme has to carry: the picker edits three of the
+ *  twelve (ground, ink, accent — the three that decide what a palette feels like), and an imported
+ *  theme states as many of them as it likes, through one type and one merge.
+ *
+ *  Overrides are keyed by PALETTE as well as by face. Moving One Dark's accent is a statement about
+ *  One Dark; carrying it onto Gruvbox when the palette changes would repaint a theme the user never
+ *  edited, and losing it on the way back would make the picker destructive. */
+export type ThemeOverride = Partial<Omit<ThemeSeed, "syntax">> & { syntax?: Partial<SyntaxSeed> };
+export type ThemeOverrides = Record<string, ThemeOverride>;
+
+export const overrideKey = (name: ThemeName, mode: Mode): string => `${name}:${mode}`;
+
+/** The seed roles an override may state, as the names they carry in the JSON — which are the seed's
+ *  own field names, so a copied theme and a stored override are the same document. */
+export const SEED_ROLES = ["bg", "ink", "accent", "green", "orange", "red"] as const;
+export const SYNTAX_ROLES = ["comment", "keyword", "string", "number", "title", "type", "attr"] as const;
+
+const HEX = /^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/;
+export const isHexColour = (x: unknown): x is string => typeof x === "string" && HEX.test(x);
+
+/** Overrides arrive from a user-editable settings row and from the clipboard, and `hexToOklch`
+ *  THROWS on anything that is not a colour — so an unvalidated `"blue"` in `ui.themeOverrides` is a
+ *  renderer that white-screens at boot with no control left on screen to undo it with. Field by
+ *  field, dropping what does not parse, exactly as the terminal-panel map is read. */
+export function parseThemeOverride(raw: unknown): ThemeOverride {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return {};
+  const src = raw as Record<string, unknown>;
+  const out: ThemeOverride = {};
+  for (const role of SEED_ROLES) if (isHexColour(src[role])) out[role] = src[role];
+  const syn = src["syntax"];
+  if (syn && typeof syn === "object" && !Array.isArray(syn)) {
+    const s = syn as Record<string, unknown>;
+    const kept: Partial<SyntaxSeed> = {};
+    for (const role of SYNTAX_ROLES) if (isHexColour(s[role])) kept[role] = s[role];
+    if (Object.keys(kept).length) out.syntax = kept;
+  }
+  return out;
+}
+
+export function parseThemeOverrides(raw: unknown): ThemeOverrides {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return {};
+  const out: ThemeOverrides = {};
+  for (const [key, value] of Object.entries(raw as Record<string, unknown>)) {
+    const [name, mode] = key.split(":");
+    // A key naming a palette or a face this build does not have would be an override nothing can
+    // ever reach, kept forever in a row the user cannot see.
+    if (!isThemeName(name) || (mode !== "dark" && mode !== "light")) continue;
+    const parsed = parseThemeOverride(value);
+    if (isOverridden(parsed)) out[key] = parsed;
+  }
+  return out;
+}
+
+export const isOverridden = (o: ThemeOverride | undefined): boolean =>
+  !!o && (Object.keys(o).length > (o.syntax ? 1 : 0) || Object.keys(o.syntax ?? {}).length > 0);
+
+/** The seed a face actually derives from: the palette's own, with the user's edits merged in.
+ *
+ *  Null means "write nothing", which is only ever Realm untouched — the default has to stay
+ *  byte-for-byte the static CSS in tokens.css, so the theme mechanism cannot repaint the app for
+ *  someone who never chose a theme. The moment Realm IS edited it needs a ground to move, and
+ *  `REALM_SEED` is that ground, read back out of the stylesheet the default is. */
+export function seedFor(name: ThemeName, mode: Mode, override: ThemeOverride = {}): ThemeSeed | null {
   const def = THEMES.find((t) => t.name === name);
-  return (mode === "dark" ? def?.dark : def?.light) ?? null;
-};
+  const stated = (mode === "dark" ? def?.dark : def?.light) ?? null;
+  const base = stated ?? (name === "realm" ? REALM_SEED[mode] : null);
+  if (!base || (!stated && !isOverridden(override))) return null;
+  return { ...base, ...override, syntax: { ...base.syntax, ...override.syntax } };
+}
 
 /** Which modes a theme actually has a palette for. `realm` has both and states neither — it IS
  *  tokens.css, whose two blocks the mode attribute already flips. */

--- a/packages/ui/src/themes.ts
+++ b/packages/ui/src/themes.ts
@@ -369,11 +369,32 @@ export function themeModes(name: ThemeName): Mode[] {
   return [...(def?.dark ? (["dark"] as const) : []), ...(def?.light ? (["light"] as const) : [])];
 }
 
-/** The composition rule for the two axes. A theme with one face pins the window to it; the MODE
- *  PREFERENCE is untouched, so it comes back the moment a two-faced theme is chosen again. */
+/** Which mode a theme would be worn in if it were the only thing chosen — a one-faced theme answers
+ *  with the face it has. Nothing about the WINDOW hangs off this any more (see `paletteFor`): it is
+ *  what a picker card and a ⌘K hint use to preview and to label, so `themeSwatches("monokai",
+ *  "light")` draws Monokai's dark face rather than fabricating a light one. */
 export function resolveMode(name: ThemeName, mode: Mode): Mode {
   const modes = themeModes(name);
   return modes.includes(mode) ? mode : (modes[0] ?? mode);
+}
+
+/** Which palette each face wears. Two slots rather than one name because the palette that suits a
+ *  lit room is rarely the one that suits a dark one, and a single selection forces one of the two to
+ *  be a compromise — the mode preference already says WHEN to switch, and this says what to switch
+ *  TO. The pickers offer each face only the palettes that have it, so the two axes no longer fight:
+ *  choosing Monokai for the dark slot cannot pin the window dark at noon. */
+export type ThemeSelection = Record<Mode, ThemeName>;
+
+export const DEFAULT_SELECTION: ThemeSelection = { dark: "realm", light: "realm" };
+
+/** The palette a face actually wears. A selection naming a palette with no such face — a hand-edited
+ *  setting, or a palette that loses a face in some later version — falls back to `realm`, whose face
+ *  is the static CSS and therefore always exists. Falling back rather than pinning the mode is the
+ *  point of splitting the selection: the window shows the light the user asked for, in the closest
+ *  palette that has one. */
+export function paletteFor(selection: ThemeSelection, mode: Mode): ThemeName {
+  const name = selection[mode];
+  return themeModes(name).includes(mode) ? name : "realm";
 }
 
 /** Realm's own twelve, read out of theme/tokens.css and written here as hex — the same seeds the

--- a/packages/ui/src/themes.ts
+++ b/packages/ui/src/themes.ts
@@ -532,8 +532,8 @@ export function resolveMode(name: ThemeName, mode: Mode): Mode {
 /** Which palette each face wears. Two slots rather than one name because the palette that suits a
  *  lit room is rarely the one that suits a dark one, and a single selection forces one of the two to
  *  be a compromise — the mode preference already says WHEN to switch, and this says what to switch
- *  TO. The pickers offer each face only the palettes that have it, so the two axes no longer fight:
- *  choosing Monokai for the dark slot cannot pin the window dark at noon. */
+ *  TO. The pickers offer each face only the palettes that have it, which is what keeps the two axes
+ *  independent: choosing Monokai for the dark slot cannot pin the window dark at noon. */
 export type ThemeSelection = Record<Mode, ThemeName>;
 
 export const DEFAULT_SELECTION: ThemeSelection = { dark: "realm", light: "realm" };


### PR DESCRIPTION
Stacked on #36. Closes the gap between what PR #27 shipped (one palette axis plus a translucency slider) and what Codex's Appearance pane actually offers.

**Light and dark are chosen separately.** `themeName` became `themeNames: Record<Mode, ThemeName>`. The mode is now the preference and nothing else — `resolveMode` no longer gates it. A one-face palette is simply **not offered in the row it has no face for**: Monokai, Dracula and Nord appear only in the Dark row. That dissolves the conflict the old pinning existed to resolve, where a dark-only palette held the window dark at noon by overruling the other axis from inside this one. To get Monokai always, you set mode = Dark, which is the control that actually means that. The old key is read once as a per-face-filtered fallback and never written again.

**An override is a partial `ThemeSeed`, merged before `deriveVars`** — so a moved background brings the surface ladder, ink ramp, tints, tooltip chip and chart clamp with it. Writing three raw values past the machinery would leave every contrast floor passing, because they would be measured against the *old* surface, with the cards floating on a page they were never derived from.

On report-vs-correct it does both, split by role, following the architecture already there: `bg` and `ink` are the two seeds nothing corrects — a palette's identity is its paper and its text — so they are handed back exactly as asked and the shortfall is *named*. Every hue keeps the ordinary lightness-only correction inside `LIFT_BUDGET`, exactly as a vendored palette does. A verified consequence: the warning is drawn in `--orange`, which *is* lifted, so the sentence explaining an unreadable window is the one thing on it that stays readable.

**The contrast slider controls the ink ramp's spread**, not any hue — a hue slider would be a repaint wearing the word "contrast". It cannot make anything illegible structurally rather than arithmetically, because `inkStep` floors every tier at `CONTRAST_FLOOR` before it walks; the top is bounded so the three tiers stay a clear step apart, since raising contrast must not destroy the hierarchy contrast is for.

**This found a real latent bug.** `css()` rounds lightness to three decimals — finer than a display, coarser than a WCAG floor — so a tier walked to exactly 3.00:1 could ship at **2.9987**. Both `lift` and `inkStep` now measure the value they will actually emit.

**Fonts reach the terminal, which they previously would not have.** The terminal factory had a hardcoded mono stack that happened to equal the default, so the one surface that is nothing but code would have silently ignored the code font. It reads `--font-mono` now and pushes a change into terminals that are already open, re-fitting each one because cell size is measured off the face. No enumeration of installed fonts: it needs a main-process hop and returns mostly faces this layout cannot use, since the chrome is set against a four-step weight ladder and tabular figures, both lost silently by a display face.

**Import carries the twelve values a theme is made of**, not the derived palette — ninety numbers that go stale when a ramp constant moves, arriving as raw colours the floors never saw. A full seed is required, because an override is an edit and an import is a theme. Refusals name what is wrong, including "this is a dark theme, import it in the Dark theme row", since a dark seed in the light slot inverts the ladder and gets light-mode scrollbars.

Three palettes vendored at their published values: Catppuccin, GitHub and Rosé Pine. No Everforest, Linear or Notion — Linear and Notion publish no palette to vendor, and Everforest could not be verified byte-exactly in the same pass, and vendoring means stating published values rather than approximations.

**All 17 faces were screenshotted and looked at**, which found something nothing asserted could catch: on every light palette `--surface` is within a step of `--page`, so the swatch standing for the card ground vanished into the card — four dots rendering as three, with the right colour, the right ground and the promised contrast.

14 mutants killed. One survived and the **test** was fixed rather than the code: "the default IS the shipped ramp" compared `deriveVars` at the default against `deriveVars` with no argument, so both sides moved together and it could never detect a shifted scale centre.

🤖 Generated with [Claude Code](https://claude.com/claude-code)