### PR TITLE
Give every test's scratch directory an owner that removes it, and finish the icon ladder

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -17,6 +17,7 @@
   "devDependencies": {
     "@electron/notarize": "^2.5.0",
     "@realm/contracts": "workspace:*",
+    "@realm/test-utils": "workspace:*",
     "@realm/ui": "workspace:*",
     "@tailwindcss/vite": "^4.3.3",
     "@testing-library/jest-dom": "^6.6.0",

--- a/apps/desktop/src/main/attachments.test.ts
+++ b/apps/desktop/src/main/attachments.test.ts
@@ -1,16 +1,16 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { mkdtemp, mkdir, readFile, readdir, stat, utimes, writeFile } from "node:fs/promises";
+import { mkdir, readFile, readdir, stat, utimes, writeFile } from "node:fs/promises";
 import { rmSync } from "node:fs";
-import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { symlink } from "node:fs/promises";
+import { tempDir } from "@realm/test-utils";
 import {
   describeFiles, openablePath, quickLookThumbnail, safeAttachmentName, saveTempAttachment,
   sweepTempAttachments, TEMP_ATTACHMENT_TTL_MS, tempAttachmentDir,
 } from "./attachments";
 
 let home: string;
-beforeEach(async () => { home = await mkdtemp(join(tmpdir(), "realm-attach-test-")); });
+beforeEach(async () => { home = tempDir("realm-attach-test-"); });
 afterEach(() => { rmSync(home, { recursive: true, force: true }); });
 
 /** Backdate a file so the sweep sees it as stale. */

--- a/apps/desktop/src/main/icon-compress.test.ts
+++ b/apps/desktop/src/main/icon-compress.test.ts
@@ -1,8 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { readFile, writeFile } from "node:fs/promises";
 import { rmSync } from "node:fs";
-import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { tempDir } from "@realm/test-utils";
 
 const { createFromPath } = vi.hoisted(() => ({ createFromPath: vi.fn() }));
 vi.mock("electron", () => ({ nativeImage: { createFromPath } }));
@@ -28,7 +28,7 @@ function fakeImage(opts: { width: number; height: number; png?: Buffer; jpeg?: B
 
 let home: string;
 beforeEach(async () => {
-  home = await mkdtemp(join(tmpdir(), "realm-icon-test-"));
+  home = tempDir("realm-icon-test-");
   createFromPath.mockReset();
 });
 afterEach(() => { rmSync(home, { recursive: true, force: true }); });

--- a/apps/desktop/src/main/media.test.ts
+++ b/apps/desktop/src/main/media.test.ts
@@ -1,8 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { mkdir, mkdtemp, symlink, writeFile } from "node:fs/promises";
+import { mkdir, symlink, writeFile } from "node:fs/promises";
 import { rmSync } from "node:fs";
-import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { tempDir } from "@realm/test-utils";
 
 /* `media.ts` imports `net` and `protocol` for the scheme; neither is touched by anything under
    test here, and pulling in the real electron module in node would fail at import. */
@@ -11,7 +11,7 @@ vi.mock("electron", () => ({ net: {}, protocol: {}, nativeImage: { createFromPat
 const { expandHome, servablePath, statMedia } = await import("./media");
 
 let home: string;
-beforeEach(async () => { home = await mkdtemp(join(tmpdir(), "realm-media-test-")); });
+beforeEach(async () => { home = tempDir("realm-media-test-"); });
 afterEach(() => { rmSync(home, { recursive: true, force: true }); });
 
 const put = async (rel: string, bytes = "x") => {

--- a/apps/desktop/src/renderer/src/components/CommandPalette.tsx
+++ b/apps/desktop/src/renderer/src/components/CommandPalette.tsx
@@ -191,7 +191,7 @@ function PaletteBody() {
     const byRecency = (a: Item, b: Item) => b.updatedAt - a.updatedAt;
 
     const itemEntry = (it: Item, section: string, hint: ReactNode): Entry => ({
-      id: `item:${it.id}`, label: it.title, hint, icon: <Icon name={it.kind} size={15} />, section,
+      id: `item:${it.id}`, label: it.title, hint, icon: <Icon name={it.kind} size={16} />, section,
       run: () => run(async () => {
         if (it.spaceId !== activeSpaceId) await selectSpace(it.spaceId);
         await openItem(it.id);
@@ -213,7 +213,7 @@ function PaletteBody() {
 
     const anyWaiting = Object.values(sessionStatus).includes("waiting_permission");
     const act = (id: string, label: string, icon: string, run_: () => void, hint?: ReactNode): Entry =>
-      ({ id: `act:${id}`, label, icon: <Icon name={icon} size={15} />, run: run_, section: "Actions", hint });
+      ({ id: `act:${id}`, label, icon: <Icon name={icon} size={16} />, run: run_, section: "Actions", hint });
     const actions: Entry[] = [
       // A pending permission anywhere leads the actions — it is the hottest thing in the app (U-H4).
       ...(anyWaiting ? [act("respond-permission", "Respond to pending permission", "alert", () => run(() => jumpToPermission()))] : []),
@@ -224,7 +224,7 @@ function PaletteBody() {
       // (`parseSpaceIcon`), not just a Hugeicons name, so it needs `SpaceIcon`'s resolver — the same
       // reason the `item:` entries above bypass `act()` for `ItemGlyph`.
       ...spaces.map((sp): Entry => ({
-        id: `act:space-${sp.id}`, label: `Switch to ${sp.name}`, icon: <SpaceIcon icon={sp.icon} size={15} />,
+        id: `act:space-${sp.id}`, label: `Switch to ${sp.name}`, icon: <SpaceIcon icon={sp.icon} size={16} />,
         run: () => run(() => selectSpace(sp.id)), section: "Actions", hint: sp.id === activeSpaceId ? "current" : undefined,
       })),
       // Pane groups sit right beside the space switches: they are the same gesture one level in —
@@ -255,7 +255,7 @@ function PaletteBody() {
       // rather than pretending to a "focus the composer with a hint" flow the palette cannot honor
       // (picking an entry closes the palette; a hint nobody sees is not a hint).
       ...(focusedSession ? [{
-        id: "act:dispatch", section: "Actions", icon: <Icon name="send" size={15} />,
+        id: "act:dispatch", section: "Actions", icon: <Icon name="send" size={16} />,
         label: "Dispatch task", hint: (drafts[focusedSession] ?? "").trim() ? <kbd>⌘⇧↵</kbd> : "type a draft first",
         disabled: !(drafts[focusedSession] ?? "").trim(),
         run: () => run(() => dispatchDraft(focusedSession)),
@@ -294,7 +294,7 @@ function PaletteBody() {
 
     const themes = MODES.map<Entry>((t) => ({
       id: `theme:${t}`, label: `Theme: ${t[0]!.toUpperCase()}${t.slice(1)}`, hint: themePref === t ? "current" : undefined,
-      icon: <Icon name={t === "dark" ? "moon" : "sun"} size={15} />, section: "Theme", run: () => run(() => setThemePref(t)),
+      icon: <Icon name={t === "dark" ? "moon" : "sun"} size={16} />, section: "Theme", run: () => run(() => setThemePref(t)),
     }));
 
     // The palette axis, in the same section: light/dark and which colours are the same question to
@@ -304,7 +304,7 @@ function PaletteBody() {
     const palettes = THEMES.filter((t) => themeModes(t.name).includes(mode)).map<Entry>((t) => ({
       id: `palette:${t.name}`, label: `Palette: ${t.label}`, section: "Theme",
       hint: themeNames[mode] === t.name ? `current · ${mode}` : mode,
-      icon: <Icon name="paintBucket" size={15} />, run: () => run(() => setThemeName(mode, t.name)),
+      icon: <Icon name="paintBucket" size={16} />, run: () => run(() => setThemeName(mode, t.name)),
     }));
 
     return [...open, ...activeRest, ...others, ...actions, ...themes, ...palettes];
@@ -336,7 +336,7 @@ function PaletteBody() {
     for (const h of r.sessions) {
       out.push({
         id: `deep-session:${h.sessionId}:${h.seq}`, deep: true, section: "Sessions",
-        label: h.title, icon: <Icon name="session" size={15} />, hint: <Snippet parts={h.snippet} />,
+        label: h.title, icon: <Icon name="session" size={16} />, hint: <Snippet parts={h.snippet} />,
         // Jump = open the session (scroll-to-event is not cheap today: transcript block keys are
         // index-based, not seq-based — the hit's `seq` is on the wire for the day it becomes so).
         run: () => run(async () => {
@@ -350,14 +350,14 @@ function PaletteBody() {
     for (const h of r.skills) {
       out.push({
         id: `deep-skill:${h.id}`, deep: true, section: "Skills", label: h.name,
-        icon: <Icon name="library-page" size={15} />, hint: <Snippet parts={h.snippet} />,
+        icon: <Icon name="library-page" size={16} />, hint: <Snippet parts={h.snippet} />,
         run: () => run(() => openDestinationPage("library-page")),
       });
     }
     for (const h of r.memory) {
       out.push({
         id: `deep-memory:${h.scope}:${h.spaceId ?? h.profileId}`, deep: true, section: "Memory", label: h.title,
-        icon: <Icon name="context" size={15} />, hint: <Snippet parts={h.snippet} />,
+        icon: <Icon name="context" size={16} />, hint: <Snippet parts={h.snippet} />,
         run: () => run(async () => {
           if (h.scope === "profile") { await openProfilePage("memory"); return; }
           if (!h.spaceId) return;
@@ -370,7 +370,7 @@ function PaletteBody() {
       if (shown.has(`item:${h.itemId}`)) continue; // already an instant row above
       out.push({
         id: `deep-item:${h.itemId}`, deep: true, section: "Items", label: h.title,
-        icon: <Icon name={h.itemKind} size={15} />, hint: <Snippet parts={h.snippet} />,
+        icon: <Icon name={h.itemKind} size={16} />, hint: <Snippet parts={h.snippet} />,
         run: () => run(async () => {
           if (h.spaceId !== activeSpaceId) await selectSpace(h.spaceId);
           await openItem(h.itemId);

--- a/apps/desktop/src/renderer/src/components/GroupBar.tsx
+++ b/apps/desktop/src/renderer/src/components/GroupBar.tsx
@@ -65,12 +65,12 @@ export function GroupBar() {
               }}
               onContextMenu={(e) => { e.preventDefault(); setMenu({ group: g, x: e.clientX, y: e.clientY }); }}
               onClick={() => run(() => activatePaneGroup(g.id))}>
-              <Icon name="group" size={13} />
+              <Icon name="group" size={14} />
               <span className="group-tab-name">{g.name}</span>
             </button>
           )))}
           <button className="icon-btn group-add" aria-label="New pane group" title="New pane group"
-            onClick={() => run(() => newPaneGroup())}><Icon name="add" size={13} /></button>
+            onClick={() => run(() => newPaneGroup())}><Icon name="add" size={14} /></button>
         </div>
       )}
       {zoomed && (
@@ -79,7 +79,7 @@ export function GroupBar() {
         // of sight — the bar has to carry what the screen no longer shows.
         <button className="group-unfocus" onClick={() => run(() => unfocusPane())}
           aria-label={zoomedTitle ? `Unfocus ${zoomedTitle}` : "Unfocus pane"} title="Unfocus (⌘⇧F)">
-          <Icon name="unfocusPane" size={13} />
+          <Icon name="unfocusPane" size={14} />
           <span>Focused{zoomedTitle ? `: ${zoomedTitle}` : ""}</span>
           <span className="group-unfocus-hint">Unfocus</span>
         </button>

--- a/apps/desktop/src/renderer/src/components/IconPicker.tsx
+++ b/apps/desktop/src/renderer/src/components/IconPicker.tsx
@@ -99,7 +99,7 @@ function IconPickerPopover({ icon, profileId, anchorRef, onClose, onPick }: {
       </div>
       {(tab === "default" || tab === "emoji") && (
         <div className="ip-search">
-          <Icon name="search" size={13} />
+          <Icon name="search" size={14} />
           <input autoFocus type="text" value={query} onChange={(e) => setQuery(e.target.value)}
             placeholder={tab === "default" ? "Search icons…" : "Search emoji…"} aria-label="Search" />
         </div>
@@ -128,7 +128,7 @@ function IconPickerPopover({ icon, profileId, anchorRef, onClose, onPick }: {
               generation in flight — for the reader and for the stylesheet, which must not grey the
               button out from under the press that started the work. */}
           <button type="button" className="btn primary" aria-busy={generating} disabled={!prompt.trim() || generating} onClick={submitGenerate}>
-            {generating ? <><Spinner size={14} /> Generating…</> : <><Icon name="sparkles" size={13} /> Generate</>}
+            {generating ? <><Spinner size={14} /> Generating…</> : <><Icon name="sparkles" size={14} /> Generate</>}
           </button>
           {genError && <p className="ip-error">{genError}</p>}
           <div className="ip-grid">
@@ -144,7 +144,7 @@ function IconPickerPopover({ icon, profileId, anchorRef, onClose, onPick }: {
       {tab === "uploaded" && (
         <div className="ip-generate">
           <button type="button" className="btn" aria-busy={uploading} disabled={uploading} onClick={doUpload}>
-            <Icon name="attach" size={13} /> {uploading ? "Uploading…" : "Upload image…"}
+            <Icon name="attach" size={14} /> {uploading ? "Uploading…" : "Upload image…"}
           </button>
           <div className="ip-grid">
             {uploaded.map((a) => (

--- a/apps/desktop/src/renderer/src/components/Menu.tsx
+++ b/apps/desktop/src/renderer/src/components/Menu.tsx
@@ -72,7 +72,7 @@ export function Menu({ items, onClose, at, anchorRef, returnFocusRef, align = "l
             onClick={() => { it.onSelect(); if (!it.keepOpen) close(); }}>
             <span className="menu-label">{it.label}</span>
             {it.kbd && <kbd className="menu-kbd">{it.kbd}</kbd>}
-            {it.checked && <Icon name="check" size={13} className="menu-check" />}
+            {it.checked && <Icon name="check" size={14} className="menu-check" />}
           </button>
         ))}
     </div>,

--- a/apps/desktop/src/renderer/src/components/settings/SkillsPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/settings/SkillsPanel.tsx
@@ -76,7 +76,7 @@ export function SkillsPanel({ spaceId }: { spaceId: string }) {
         ) : (
           <>
             <div className="skills-filter">
-              <Icon name="search" size={13} className="skills-filter-glyph" />
+              <Icon name="search" size={14} className="skills-filter-glyph" />
               <input type="text" className="skills-filter-input" placeholder={`Search ${all.length} skills…`}
                 aria-label="Search skills" value={query} onChange={(e) => setQuery(e.target.value)} />
               <label className="skills-filter-toggle">

--- a/apps/desktop/src/renderer/src/components/sidebar/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/components/sidebar/sidebar.test.tsx
@@ -6,14 +6,6 @@ import { StoreContext, createAppStore } from "../../state/store";
 import { fakeApi, iconAsset, item, session, space } from "../../state/store.test-fakes";
 import { paneSlotOf } from "./ItemList";
 
-/** The five rungs of Icon.tsx's ladder — card, tile, row, control, inline. */
-const RUNGS = new Set([20, 18, 16, 14, 12]);
-/* Every component in this directory, as source text. Read through Vite rather than off disk: the
-   paths resolve against this module, so the scan below does not care whether vitest was invoked from
-   the repo root or from apps/desktop, and `import.meta.url` (which Vite rewrites to a non-file scheme
-   under jsdom) never comes into it. */
-const SIDEBAR_SOURCES = import.meta.glob("./*.tsx", { query: "?raw", import: "default", eager: true }) as Record<string, string>;
-
 /** §6's popover exit keeps a dismissed menu or picker mounted for `--dur-press` and tells its parent
  *  at the end of it, so anything that closes one and then opens (or asserts the absence of) another
  *  has to let the first one leave. */
@@ -856,24 +848,5 @@ describe("archiving a session", () => {
     expect(screen.queryByRole("menuitem", { name: "Archive" })).not.toBeInTheDocument();
     fireEvent.click(screen.getByRole("menuitem", { name: "Unarchive" }));
     await waitFor(() => expect(store.getState().items.find((i) => i.id === "i2")?.archived).toBe(false));
-  });
-});
-
-/** The ladder is documented on `Icon` (packages/ui/src/Icon.tsx) and enforceable only here: `size`
- *  is a plain number, so nothing in a type or a render can notice a call site quietly picking 15.
- *  Scanning the source is the whole point — a rendered assertion would only cover the rows a test
- *  happens to mount, and the drift this pins is in the ones nobody mounts. */
-describe("sidebar icon sizes", () => {
-  it("every call site sits on a rung of the ladder", () => {
-    const files = Object.entries(SIDEBAR_SOURCES).filter(([name]) => !name.includes(".test."));
-    expect(files.length, "the source glob found nothing — the scan would pass vacuously").toBeGreaterThan(5);
-    const offenders: string[] = [];
-    for (const [name, src] of files) {
-      for (const m of src.matchAll(/size=\{(\d+)\}/g)) {
-        const size = Number(m[1]);
-        if (!RUNGS.has(size)) offenders.push(`${name.replace("./", "")}: size={${size}}`);
-      }
-    }
-    expect(offenders, "off-ladder icon sizes — pick a rung or move the ladder, do not add a value").toEqual([]);
   });
 });

--- a/apps/desktop/src/renderer/src/icon-ladder.test.ts
+++ b/apps/desktop/src/renderer/src/icon-ladder.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+
+/** The five rungs of Icon.tsx's ladder — card, tile, row, control, inline. */
+const RUNGS = new Set([20, 18, 16, 14, 12]);
+
+/* Every renderer component as source text. Read through Vite rather than off disk so the paths
+   resolve against this module and the scan does not care whether vitest was invoked from the repo
+   root or from apps/desktop. */
+const SOURCES = import.meta.glob("./**/*.tsx", { query: "?raw", import: "default", eager: true }) as Record<string, string>;
+
+/** Opening `<Icon …>` / `<SpaceIcon …>` tags, with the `size` they pass. */
+const ICON_TAG = /<(Icon|SpaceIcon)\b[^<>]*?\bsize=\{(\d+)\}/gs;
+
+/**
+ * The ladder is documented on `Icon` (packages/ui/src/Icon.tsx) and enforceable only here: `size` is
+ * a plain number, so nothing in a type or a render can notice a call site quietly picking 15.
+ * Scanning source is the whole point — a rendered assertion would only cover the components a test
+ * happens to mount, and the drift this pins is in the ones nobody mounts.
+ *
+ * The scan reads the whole renderer, not one directory. While it covered only the sidebar, GroupBar
+ * was written at 13 throughout and nothing noticed: a ladder that governs the folder it was born in
+ * is a house style, not a rule.
+ *
+ * Only `Icon` and `SpaceIcon` are matched. `size` is an ordinary prop on other components (Spinner
+ * takes one) and those are not on this ladder; catching them would make the scan fail for reasons it
+ * cannot explain.
+ */
+describe("icon ladder", () => {
+  const files = Object.entries(SOURCES).filter(([name]) => !name.includes(".test."));
+
+  it("scans the whole renderer", () => {
+    expect(files.length, "the source glob found nothing — the scan would pass vacuously").toBeGreaterThan(50);
+    expect(files.map(([n]) => n)).toContain("./components/GroupBar.tsx");
+    expect(files.map(([n]) => n)).toContain("./components/sidebar/ItemList.tsx");
+  });
+
+  it("every call site sits on a rung, or says at the call site why it cannot", () => {
+    const offenders: string[] = [];
+    for (const [name, src] of files) {
+      for (const m of src.matchAll(ICON_TAG)) {
+        if (RUNGS.has(Number(m[2]))) continue;
+        // An off-ladder size is allowed only where the reason is written at the call site, which is
+        // where the next reader stands. A list of blessed files kept in this test would spare them
+        // the sentence and hide the exception from the code it applies to.
+        const lines = src.slice(0, m.index).split("\n");
+        const context = lines.slice(-4).join("\n");   // room for a two-line reason above the call
+        if (context.includes("off-ladder:")) continue;
+        offenders.push(`${name.replace("./", "")}:${lines.length}: size={${m[2]}}`);
+      }
+    }
+    expect(offenders, "off-ladder icon sizes — pick a rung, or write `off-ladder:` and the reason above the call").toEqual([]);
+  });
+});

--- a/apps/desktop/src/renderer/src/panes/browser/BrowserPane.tsx
+++ b/apps/desktop/src/renderer/src/panes/browser/BrowserPane.tsx
@@ -296,10 +296,10 @@ export function BrowserPane({ item, visible, focused }: PaneProps) {
     <div className="browser-pane">
       <div className="browser-chrome">
         <button className="icon-btn" aria-label="Back" title="Back" disabled={!state?.canGoBack} onClick={() => nav("back")}>
-          <Icon name="chevronLeft" size={15} />
+          <Icon name="chevronLeft" size={14} />
         </button>
         <button className="icon-btn" aria-label="Forward" title="Forward" disabled={!state?.canGoForward} onClick={() => nav("forward")}>
-          <Icon name="chevronRight" size={15} />
+          <Icon name="chevronRight" size={14} />
         </button>
         {state?.loading ? (
           <button className="icon-btn" aria-label="Stop" title="Stop" onClick={() => nav("stop")}>
@@ -348,7 +348,7 @@ export function BrowserPane({ item, visible, focused }: PaneProps) {
           Its height comes out of the view's, which the ResizeObserver already syncs. */}
       {(downloads.top || downloads.note) && (
         <div className="browser-notice" role="status">
-          <Icon name="attach" size={13} />
+          <Icon name="attach" size={12} />
           {/* The note, when there is one, is the answer to what the user just pressed — so it wins the
               text. The entry's own buttons stay put underneath it: a save that failed because the
               space has no project is one the user can retry after adding one, and swallowing the
@@ -375,7 +375,7 @@ export function BrowserPane({ item, visible, focused }: PaneProps) {
       )}
       {picker.note && (
         <div className="browser-notice" role="status">
-          <Icon name="target" size={13} />
+          <Icon name="target" size={12} />
           <span className="browser-notice-text">{picker.note}</span>
           <button type="button" className="icon-btn" aria-label="Dismiss" onClick={picker.clearNote}>
             <Icon name="close" size={12} />

--- a/apps/desktop/src/renderer/src/panes/diff/DiffPane.tsx
+++ b/apps/desktop/src/renderer/src/panes/diff/DiffPane.tsx
@@ -130,7 +130,7 @@ function ReviewSection({ environmentId, review }: { environmentId: string; revie
   return (
     <section className="diff-review" aria-label="Review">
       <div className="diff-review-head">
-        <Icon name="diff" size={13} />
+        <Icon name="diff" size={12} />
         <span className="diff-review-title">Review</span>
         <span className="diff-review-dim">{relativeTime(review.createdAt, Date.now())}</span>
         {reviewerItem && (
@@ -141,7 +141,7 @@ function ReviewSection({ environmentId, review }: { environmentId: string; revie
         <span className="diff-head-spacer" />
         <button type="button" className="icon-btn" aria-label="Dismiss review"
           onClick={() => run(() => dismissReview(environmentId))}>
-          <Icon name="close" size={13} />
+          <Icon name="close" size={14} />
         </button>
       </div>
       {note && <p className="diff-note">{note}</p>}
@@ -162,7 +162,7 @@ function ShipReport({ cwd, environmentId, result }: { cwd: string; environmentId
   const { commit, push, pr } = result;
   return (
     <div className="ship-report" role="status">
-      {commit.state === "committed" && <p><Icon name="commit" size={13} /> Committed <code>{commit.sha?.slice(0, 7)}</code> — {commit.subject}</p>}
+      {commit.state === "committed" && <p><Icon name="commit" size={12} /> Committed <code>{commit.sha?.slice(0, 7)}</code> — {commit.subject}</p>}
       {commit.state === "nothing-to-commit" && <p>Nothing was staged, so no commit was made.</p>}
       {commit.state === "no-identity" && <p className="ship-bad">{commit.reason}</p>}
       {commit.state === "failed" && <p className="ship-bad">Commit failed: {commit.reason}</p>}
@@ -183,7 +183,7 @@ function ShipReport({ cwd, environmentId, result }: { cwd: string; environmentId
       {push.state === "failed" && <p className="ship-bad">Push failed: {push.reason}</p>}
 
       {(pr.state === "created" || pr.state === "existing") && pr.url && (
-        <p><Icon name="pullRequest" size={13} /> {pr.state === "created" ? "Opened" : "Already open"}: <a href={pr.url} target="_blank" rel="noreferrer">{pr.url}</a></p>
+        <p><Icon name="pullRequest" size={12} /> {pr.state === "created" ? "Opened" : "Already open"}: <a href={pr.url} target="_blank" rel="noreferrer">{pr.url}</a></p>
       )}
       {pr.state === "compare" && pr.url && (
         <p>{pr.reason} <a href={pr.url} target="_blank" rel="noreferrer">Open a pull request</a></p>
@@ -262,7 +262,7 @@ export function DiffPane({ item }: PaneProps) {
         <button type="button" className="btn-quiet" title="Checkpoints taken before each turn (W4)"
           onClick={() => run(() => openCheckpoints(environmentId, null))}>History</button>
         <button type="button" className="icon-btn" aria-label="Refresh changes" title="Refresh" onClick={() => run(() => refreshDiff(cwd))}>
-          <Icon name="diff" size={13} />
+          <Icon name="diff" size={14} />
         </button>
       </div>
 

--- a/apps/desktop/src/renderer/src/panes/documents/DocumentsPane.tsx
+++ b/apps/desktop/src/renderer/src/panes/documents/DocumentsPane.tsx
@@ -283,7 +283,7 @@ export function DocumentsPane({ item }: PaneProps) {
             // `alert`, not `status`: the head bar already carries the save state as this pane's one
             // polite status, and a file vanishing under an open editor is not a polite update.
             <div className="documents-bar warn" role="alert">
-              <Icon name="alert" size={13} />
+              <Icon name="alert" size={12} />
               <span>This file was deleted on disk. Saving will re-create it.</span>
             </div>
           )}
@@ -357,7 +357,7 @@ function TabStrip({ tabs, active, buffers, onSelect, onClose, onNew, onOpenExist
                 : b?.dirty ? <span className="documents-dot" aria-label="Unsaved" /> : null}
             </button>
             <button className="documents-tab-close icon-btn" aria-label={`Close ${baseName(path)}`}
-              onClick={() => onClose(path)}><Icon name="close" size={11} /></button>
+              onClick={() => onClose(path)}><Icon name="close" size={12} /></button>
           </div>
         );
       })}
@@ -443,7 +443,7 @@ const structuredLabel = (v: "rich" | "grid" | "preview" | "pdf"): string =>
 function ConflictBar({ onKeepMine, onTakeTheirs }: { onKeepMine: () => void; onTakeTheirs: () => void }) {
   return (
     <div className="documents-bar conflict" role="alert">
-      <Icon name="alert" size={13} />
+      <Icon name="alert" size={12} />
       <span>This file changed on disk while you were editing.</span>
       <button type="button" className="btn-quiet" onClick={onKeepMine}>Keep mine</button>
       <button type="button" className="btn-quiet" onClick={onTakeTheirs}>Take theirs</button>

--- a/apps/desktop/src/renderer/src/panes/documents/RichTextEditor.tsx
+++ b/apps/desktop/src/renderer/src/panes/documents/RichTextEditor.tsx
@@ -73,7 +73,7 @@ function RichToolbar({ editor }: { editor: Ed }) {
   const btn = (label: string, icon: Parameters<typeof Icon>[0]["name"], active: boolean, run: () => void) => (
     <button className="icon-btn" aria-label={label} aria-pressed={active} title={label}
       onClick={() => { run(); editor.commands.focus(); }}>
-      <Icon name={icon} size={13} />
+      <Icon name={icon} size={14} />
     </button>
   );
   return (

--- a/apps/desktop/src/renderer/src/panes/profile/ProfilePage.tsx
+++ b/apps/desktop/src/renderer/src/panes/profile/ProfilePage.tsx
@@ -61,7 +61,7 @@ export function ProfilePage({ item }: PaneProps) {
         {profileSpaces.map((sp) => (
           <button key={sp.id} type="button" className="profile-chip" title={`Switch to ${sp.name}`}
             onClick={() => run(() => selectSpace(sp.id))}>
-            <SpaceIcon icon={sp.icon} size={13} /> {sp.name}
+            <SpaceIcon icon={sp.icon} size={12} /> {sp.name}
           </button>
         ))}
       </div>

--- a/apps/desktop/src/renderer/src/panes/session/AttachmentTile.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/AttachmentTile.tsx
@@ -131,7 +131,7 @@ export function AttachmentTile({ path, mime, name, detail, disposition, onRemove
       </span>
       {onRemove && (
         <button type="button" className="attach-remove" aria-label={`Remove ${label}`} onClick={onRemove}>
-          <Icon name="close" size={9} />
+          <Icon name="close" size={12} />
         </button>
       )}
       {lightbox && file && <MediaLightbox file={file} onClose={close} />}

--- a/apps/desktop/src/renderer/src/panes/session/Composer.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/Composer.tsx
@@ -33,7 +33,7 @@ function GitChip({ gitInfo, onOpenDiff }: { gitInfo: GitInfo | null; onOpenDiff:
     // One button, not three — the whole group means "show me these changes".
     <button type="button" className="composer-git" onClick={onOpenDiff}
       title={gitInfo.dirty > 0 ? `Show ${gitInfo.dirty} changed ${gitInfo.dirty === 1 ? "file" : "files"} on ${gitInfo.branch}` : `Show changes on ${gitInfo.branch}`}>
-      <span className="ghost-chip git-branch"><Icon name="branch" size={13} className="chip-brand" /><span className="chip-label">{gitInfo.branch}</span></span>
+      <span className="ghost-chip git-branch"><Icon name="branch" size={12} className="chip-brand" /><span className="chip-label">{gitInfo.branch}</span></span>
       {(gitInfo.additions > 0 || gitInfo.deletions > 0) && (
         <span className="ghost-chip git-diff">
           <span className="diff-add">+{gitInfo.additions}</span>
@@ -53,7 +53,7 @@ function ChipMenu({ ariaLabel, title, label, icon, items, warning }: { ariaLabel
   const [open, setOpen] = useState(false);
   // A sibling of chip-label, never inside it: chip-label truncates with an ellipsis, which needs a
   // plain inline box — an icon nested in there gets no gap and sits off the text's centre line.
-  const glyph = icon ? <Icon name={icon} size={13} className="chip-brand" /> : null;
+  const glyph = icon ? <Icon name={icon} size={12} className="chip-brand" /> : null;
   if (items.length === 0) {
     return <span className="ghost-chip" data-static title={title ?? ariaLabel} data-warning={warning || undefined}>{glyph}<span className="chip-label">{label}</span></span>;
   }
@@ -818,7 +818,7 @@ export function Composer({ session, status, gitInfo, onOpenDiff, draft, onDraftC
               disabled={!running && !draft.trim() && !deliverable}
               onClick={() => (running ? onStop() : send())}>
               <Icon name="arrowUp" size={16} className="send-icon" />
-              <Icon name="stop" size={13} className="stop-icon" />
+              <Icon name="stop" size={14} className="stop-icon" />
             </button>
           </div>
         </div>

--- a/apps/desktop/src/renderer/src/panes/session/DelegatedRuns.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/DelegatedRuns.tsx
@@ -71,7 +71,7 @@ function Dock({ sessionId, running }: { sessionId: string; running: readonly Del
           unsettled drain, which is precisely what "still running" means. */}
       <button type="button" className="delegation-row" aria-expanded={open} onClick={() => setOpen((o) => !o)}
         aria-label={`${count} in flight for ${title}`}>
-        <Icon name="bot" size={13} />
+        <Icon name="bot" size={12} />
         <span className="delegation-summary">{count} running</span>
         <span className="delegation-elapsed">{formatDuration(elapsed)}</span>
         <Icon name="chevronRight" size={12} className="tool-chevron" />

--- a/apps/desktop/src/renderer/src/panes/session/ModelPicker.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/ModelPicker.tsx
@@ -237,7 +237,7 @@ function ModelPopover({ rows, info, anchorRef, onClose, onPick, onToggleFavorite
                     data-active={r === activeRow || undefined} data-blocked={r.blockedReason ? "" : undefined}
                     onMouseEnter={() => setActiveKey(r.key)}
                     onClick={() => pick(r, routes[r.key])}>
-                    <Icon name={r.icon} size={15} colored className="mp-row-mark" />
+                    <Icon name={r.icon} size={16} colored className="mp-row-mark" />
                     <span className="mp-row-text">
                       <span className="mp-row-name">
                         {r.label}
@@ -261,7 +261,7 @@ function ModelPopover({ rows, info, anchorRef, onClose, onPick, onToggleFavorite
                       aria-label={r.favorite ? `Unfavourite ${r.label}` : `Favourite ${r.label}`}
                       title={r.favorite ? "Unfavourite (⌥↩)" : "Favourite (⌥↩)"}
                       onClick={(e) => { e.stopPropagation(); onToggleFavorite(r.key); }}>
-                      <Icon name="star" size={13} />
+                      <Icon name="star" size={12} />
                     </button>
                   </div>
                 );
@@ -339,7 +339,7 @@ function ModelDetail({ row, route, info, onRoute, onUse, effortItems, overflow, 
               disabled={!!row.blockedReason}
               aria-label={`Run ${row.label} through ${AGENT_META[h].label}`}
               onClick={() => onRoute(h)}>
-              <Icon name={AGENT_META[h].icon} size={13} colored />
+              <Icon name={AGENT_META[h].icon} size={12} colored />
               {AGENT_META[h].label}
             </button>
           ))}
@@ -348,8 +348,8 @@ function ModelDetail({ row, route, info, onRoute, onUse, effortItems, overflow, 
         {/* Billing sits directly under the price, and always: a per-token number is a lie about the
             bill for a harness that runs on a subscription, and this is the line that says so. */}
         <p className="mp-harness-billing">{harness.billing}</p>
-        {harness.limits && <p className="mp-harness-limits"><Icon name="alert" size={11} /> {harness.limits}</p>}
-        {row.blockedReason && <p className="mp-harness-limits"><Icon name="alert" size={11} /> {row.blockedReason}</p>}
+        {harness.limits && <p className="mp-harness-limits"><Icon name="alert" size={12} /> {harness.limits}</p>}
+        {row.blockedReason && <p className="mp-harness-limits"><Icon name="alert" size={12} /> {row.blockedReason}</p>}
       </div>
       </div>
       <div className="mp-detail-foot">

--- a/apps/desktop/src/renderer/src/panes/session/QuestionCard.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/QuestionCard.tsx
@@ -119,12 +119,12 @@ export function QuestionCard({ questions, onAnswer, onSkip, autoFocus = false, e
         <h3 className="question-title">{q.question}</h3>
         {questions.length > 1 && (
           <div className="question-pager">
-            <button className="icon-btn" aria-label="Previous question" disabled={page === 0} onClick={() => setPage(page - 1)}><Icon name="chevronLeft" size={13} /></button>
+            <button className="icon-btn" aria-label="Previous question" disabled={page === 0} onClick={() => setPage(page - 1)}><Icon name="chevronLeft" size={14} /></button>
             <span>{page + 1} of {questions.length}</span>
-            <button className="icon-btn" aria-label="Next question" disabled={page + 1 >= questions.length} onClick={() => setPage(page + 1)}><Icon name="chevronRight" size={13} /></button>
+            <button className="icon-btn" aria-label="Next question" disabled={page + 1 >= questions.length} onClick={() => setPage(page + 1)}><Icon name="chevronRight" size={14} /></button>
           </div>
         )}
-        <button className="icon-btn question-close" aria-label="Skip question" onClick={onSkip}><Icon name="close" size={13} /></button>
+        <button className="icon-btn question-close" aria-label="Skip question" onClick={onSkip}><Icon name="close" size={14} /></button>
       </div>
 
       <div className="question-options">
@@ -138,13 +138,13 @@ export function QuestionCard({ questions, onAnswer, onSkip, autoFocus = false, e
               <span className="question-option-label">{o.label}</span>
               {o.description && <span className="question-option-desc">{o.description}</span>}
             </span>
-            {q.multiSelect && picked.includes(o.label) && <Icon name="check" size={13} />}
+            {q.multiSelect && picked.includes(o.label) && <Icon name="check" size={14} />}
           </button>
         ))}
 
         {othering ? (
           <div className="question-option question-other-edit">
-            <kbd className="question-num"><Icon name="edit" size={11} /></kbd>
+            <kbd className="question-num"><Icon name="edit" size={12} /></kbd>
             <input ref={otherInput} className="question-other-input" value={otherText} placeholder="Type your answer…"
               aria-label="Your answer" onChange={(e) => setOtherText(e.target.value)} />
             <button className="btn primary question-other-submit" disabled={!otherText.trim()} onClick={() => commit(otherText.trim())}>Answer</button>
@@ -153,7 +153,7 @@ export function QuestionCard({ questions, onAnswer, onSkip, autoFocus = false, e
           <button ref={(el) => { rows.current[q.options.length] = el; }} className="question-option question-other"
             aria-label="Something else" data-selected={selected === q.options.length || undefined}
             onFocus={() => setSelected(q.options.length)} onClick={() => setOthering(true)}>
-            <kbd className="question-num"><Icon name="edit" size={11} /></kbd>
+            <kbd className="question-num"><Icon name="edit" size={12} /></kbd>
             <span className="question-option-body"><span className="question-option-label">Something else</span></span>
             <span className="question-skip" role="button" tabIndex={-1}
               onClick={(e) => { e.stopPropagation(); skipQuestion(); }}>Skip</span>

--- a/apps/desktop/src/renderer/src/panes/session/SkillPicker.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/SkillPicker.tsx
@@ -124,7 +124,7 @@ export function SkillPicker({ skills, anchorRef, onToggle, onMention, onClose, o
         visibility: pos ? "visible" : "hidden", transformOrigin: pos?.origin ?? "bottom left" }}
       onKeyDown={onKeyDown}>
       <div className="skill-picker-search">
-        <Icon name="search" size={13} className="skill-picker-search-glyph" />
+        <Icon name="search" size={14} className="skill-picker-search-glyph" />
         <input ref={input} type="text" className="skill-picker-input" placeholder="Search skills…"
           aria-label="Search skills" role="combobox" aria-expanded aria-controls="skill-picker-list"
           value={query} onChange={(e) => setQuery(e.target.value)} />

--- a/apps/desktop/src/renderer/src/panes/session/Transcript.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/Transcript.tsx
@@ -23,7 +23,7 @@ function Thinking({ text, enter }: { text: string; enter?: boolean }) {
   const [open, setOpen] = useState(false);
   return (
     <div className="msg-thinking" data-enter={enter || undefined}>
-      <button className="thinking-toggle" aria-expanded={open} onClick={() => setOpen((o) => !o)}><Icon name="idea" size={13} /><span>Thinking…</span></button>
+      <button className="thinking-toggle" aria-expanded={open} onClick={() => setOpen((o) => !o)}><Icon name="idea" size={12} /><span>Thinking…</span></button>
       {open && <Markdown text={text} className="thinking-body" />}
     </div>
   );
@@ -228,7 +228,7 @@ export function Transcript({ transcript, sessionStatus, onDecide, visible = true
       {/* The transcript dissolves into the prompter instead of being clipped by it — a sibling of the
           scroller (not a child) so its backdrop-filter still sees the text scrolling underneath. */}
       <div className="transcript-fade" aria-hidden="true" />
-      {pill && <button className="new-msgs-pill" onClick={scrollToBottom}><Icon name="arrowDown" size={13} /> New messages</button>}
+      {pill && <button className="new-msgs-pill" onClick={scrollToBottom}><Icon name="arrowDown" size={12} /> New messages</button>}
     </div>
   );
 }

--- a/apps/desktop/src/renderer/src/panes/session/media/MediaView.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/media/MediaView.tsx
@@ -83,6 +83,8 @@ function VideoPlayer({ file, autoFocus = false, onExpand }: { file: MediaFile; a
           thing they came to look at. */}
       {!playing && (
         <button type="button" className="media-play" aria-label={`Play ${basenameOf(file.path)}`} autoFocus={autoFocus} onClick={toggle}>
+          {/* off-ladder: a 52px poster button has no rung. `control` is sized for a 28px one, and
+              every rung above it is for a glyph that IS its container's subject rather than its verb. */}
           <Icon name="play" size={22} />
         </button>
       )}
@@ -91,8 +93,8 @@ function VideoPlayer({ file, autoFocus = false, onExpand }: { file: MediaFile; a
             and cross-fade. A ternary replaces the element instead, and gets no transition at all. */}
         <button type="button" className="media-btn" aria-label={playing ? "Pause" : "Play"} onClick={toggle}>
           <span className="icon-swap" data-on={playing || undefined}>
-            <Icon name="play" size={13} className="swap-off" />
-            <Icon name="pause" size={13} className="swap-on" />
+            <Icon name="play" size={12} className="swap-off" />
+            <Icon name="pause" size={12} className="swap-on" />
           </span>
         </button>
         <span className="media-time">{formatTime(time)}</span>
@@ -107,13 +109,13 @@ function VideoPlayer({ file, autoFocus = false, onExpand }: { file: MediaFile; a
         <span className="media-time media-duration">{formatTime(duration)}</span>
         <button type="button" className="media-btn" aria-label={muted ? "Unmute" : "Mute"} aria-pressed={muted} onClick={() => setMuted((m) => !m)}>
           <span className="icon-swap" data-on={muted || undefined}>
-            <Icon name="volumeOn" size={13} className="swap-off" />
-            <Icon name="volumeOff" size={13} className="swap-on" />
+            <Icon name="volumeOn" size={12} className="swap-off" />
+            <Icon name="volumeOff" size={12} className="swap-on" />
           </span>
         </button>
         {onExpand && (
           <button type="button" className="media-btn" aria-label="Open larger" onClick={onExpand}>
-            <Icon name="focusPane" size={13} />
+            <Icon name="focusPane" size={12} />
           </button>
         )}
       </div>

--- a/apps/desktop/src/renderer/src/panes/session/rich/ToolViews.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/rich/ToolViews.tsx
@@ -110,6 +110,7 @@ export function TodoList({ todos }: { todos: Todo[] }) {
       <ul className="todo-list">
         {todos.map((t, i) => (
           <li key={i} data-status={t.status}>
+            {/* off-ladder: the dot is 13px, so the inline rung would fill it edge to edge. */}
             <span className="todo-dot" aria-hidden="true">{t.status === "completed" && <Icon name="check" size={10} />}</span>
             <span className="todo-text">{t.content}</span>
           </li>
@@ -168,7 +169,7 @@ export function RequestView({ url, query, prompt }: { url: string | null; query:
   return (
     <div className="req">
       <div className="req-head">
-        <Icon name={url ? "browser" : "search"} size={13} />
+        <Icon name={url ? "browser" : "search"} size={12} />
         {host && <span className="req-host">{host}</span>}
         <span className="req-target" title={url ?? query ?? ""}>{url ?? query}</span>
       </div>

--- a/apps/desktop/src/renderer/src/panes/settings/usage/UsagePanel.tsx
+++ b/apps/desktop/src/renderer/src/panes/settings/usage/UsagePanel.tsx
@@ -428,7 +428,7 @@ function Caveats({ data }: { data: UsageSummary }) {
     <section className="usage-caveats" aria-label="Why some numbers are missing">
       {data.unmeasuredKinds.length > 0 && (
         <p>
-          <Icon name="alert" size={13} />{" "}
+          <Icon name="alert" size={12} />{" "}
           <strong>{data.unmeasuredKinds.map((k) => AGENT_META[k].label).join(", ")}</strong>{" "}
           {data.unmeasuredKinds.length === 1 ? "reports" : "report"} no token usage — the ACP protocol these engines speak
           carries no usage message, so their sessions appear in Activity but never in spend.
@@ -436,7 +436,7 @@ function Caveats({ data }: { data: UsageSummary }) {
       )}
       {data.unpricedModels.length > 0 && (
         <p>
-          <Icon name="alert" size={13} />{" "}
+          <Icon name="alert" size={12} />{" "}
           No catalog price for <strong>{data.unpricedModels.slice(0, 4).join(", ")}</strong>
           {data.unpricedModels.length > 4 && ` and ${data.unpricedModels.length - 4} more`}, so their tokens are counted but not costed.
         </p>

--- a/apps/desktop/src/renderer/src/panes/space/SpacePage.tsx
+++ b/apps/desktop/src/renderer/src/panes/space/SpacePage.tsx
@@ -188,10 +188,10 @@ function SessionsTab({ spaceId }: { spaceId: string }) {
         return (
           <li key={s.id}>
             <button type="button" className="page-row" aria-label={label} onClick={() => open(s)}>
-              <Icon name={AGENT_META[s.agentKind].icon} size={15} colored />
+              <Icon name={AGENT_META[s.agentKind].icon} size={16} colored />
               <span className="page-row-title">{s.title}</span>
               {archived && <span className="status-pill" data-tone="muted">Archived</span>}
-              {env?.branch && <span className="page-row-dim"><Icon name="branch" size={11} /> {env.branch}</span>}
+              {env?.branch && <span className="page-row-dim"><Icon name="branch" size={12} /> {env.branch}</span>}
               <span className="page-row-dim">{relativeTime(s.createdAt, Date.now())}</span>
               {status && <span className="status-dot item-status" data-status={status} title={SESSION_STATUS_LABEL[status]} />}
             </button>
@@ -283,9 +283,9 @@ function TasksTab({ spaceId }: { spaceId: string }) {
                       aria-pressed={r.id === selectedRunId}
                       aria-label={`${r.title} — run — ${RUN_STATE_LABEL[r.state]}`}
                       onClick={() => run(() => selectRun(spaceId, r.id === selectedRunId ? null : r.id))}>
-                      <Icon name={RUN_STATE_ICON[r.state]} size={15} />
+                      <Icon name={RUN_STATE_ICON[r.state]} size={16} />
                       <span className="page-row-title">{r.title}</span>
-                      {envLabel && <span className="page-row-dim"><Icon name={env!.kind === "worktree" ? "branch" : "folder"} size={11} /> {envLabel}</span>}
+                      {envLabel && <span className="page-row-dim"><Icon name={env!.kind === "worktree" ? "branch" : "folder"} size={12} /> {envLabel}</span>}
                       {/* Attempts are only worth saying once there has been more than one — a run on
                           its first try should not read like it has already struggled. */}
                       {r.attempt > 1 && <span className="page-row-dim">attempt {r.attempt}/{r.maxAttempts}</span>}
@@ -316,7 +316,7 @@ function TasksTab({ spaceId }: { spaceId: string }) {
                     <button type="button" className="page-row"
                       aria-label={status ? `${s.title} — ${meta.label} — ${SESSION_STATUS_LABEL[status]}` : `${s.title} — ${meta.label}`}
                       onClick={() => jumpTo(s.id)}>
-                      <Icon name={meta.icon} size={15} />
+                      <Icon name={meta.icon} size={16} />
                       <span className="page-row-title">{s.title}</span>
                       {parentId && (
                         // The agent origins link their parent. A span styled as a link, not a nested button
@@ -329,7 +329,7 @@ function TasksTab({ spaceId }: { spaceId: string }) {
                             </span>
                           : <span className="page-row-dim">parent session gone</span>
                       )}
-                      {envLabel && <span className="page-row-dim"><Icon name={env!.kind === "worktree" ? "branch" : "folder"} size={11} /> {envLabel}</span>}
+                      {envLabel && <span className="page-row-dim"><Icon name={env!.kind === "worktree" ? "branch" : "folder"} size={12} /> {envLabel}</span>}
                       <span className="page-row-dim" title={new Date(s.createdAt).toLocaleString()}>started {relativeTime(s.createdAt, Date.now())}</span>
                       {settled && <span className="page-row-dim" title="From the session's last update — no separate settle clock exists">settled {relativeTime(s.updatedAt, Date.now())}</span>}
                       {status && <span className="status-dot item-status" data-status={status} title={SESSION_STATUS_LABEL[status]} />}
@@ -369,7 +369,7 @@ function NewRun({ spaceId }: { spaceId: string }) {
   if (!open) {
     return (
       <div className="task-lens-new">
-        <button type="button" className="btn" onClick={() => setOpen(true)}><Icon name="add" size={13} /> New run</button>
+        <button type="button" className="btn" onClick={() => setOpen(true)}><Icon name="add" size={14} /> New run</button>
       </div>
     );
   }
@@ -426,7 +426,7 @@ function RunDetail({ run: r, spaceId, onJump }: { run: Run; spaceId: string; onJ
         <h3>{r.title}</h3>
         <span className="run-state" data-state={r.state}>{RUN_STATE_LABEL[r.state]}</span>
         <button type="button" className="icon-btn" aria-label="Close run detail" onClick={() => run(() => selectRun(spaceId, null))}>
-          <Icon name="close" size={13} />
+          <Icon name="close" size={14} />
         </button>
       </header>
 
@@ -556,11 +556,11 @@ function HistoryTab({ spaceId }: { spaceId: string }) {
             <span className="cp-kind ship-kind"><Icon name="commit" size={12} /> Ship</span>
             <span className="page-row-title">{row.ship.subject}</span>
             <span className="page-row-dim"><code className="ship-sha">{row.ship.sha.slice(0, 7)}</code></span>
-            {row.ship.branch && <span className="page-row-dim"><Icon name="branch" size={11} /> {row.ship.branch}</span>}
+            {row.ship.branch && <span className="page-row-dim"><Icon name="branch" size={12} /> {row.ship.branch}</span>}
             <span className="page-row-dim">{PUSH_STATE_LABEL[row.ship.pushState]}</span>
             {row.ship.prUrl && (
               <span className="page-row-dim">
-                <a href={row.ship.prUrl} target="_blank" rel="noreferrer"><Icon name="pullRequest" size={11} /> PR</a>
+                <a href={row.ship.prUrl} target="_blank" rel="noreferrer"><Icon name="pullRequest" size={12} /> PR</a>
               </span>
             )}
             <span className="page-row-dim">{relativeTime(row.at, Date.now())}</span>

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -27,6 +27,7 @@
     "zod": "^3.24.0"
   },
   "devDependencies": {
+    "@realm/test-utils": "workspace:*",
     "@types/ws": "^8.5.12",
     "tsup": "^8.3.0",
     "tsx": "^4.19.0"

--- a/apps/server/src/app.test.ts
+++ b/apps/server/src/app.test.ts
@@ -1,7 +1,5 @@
 import { describe, it, expect, afterEach } from "vitest";
-import { mkdtempSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { tempDir } from "@realm/test-utils";
 import { createApp, defaultAdapters, type App } from "./app";
 import { openDatabase } from "./db/database";
 import { dbPath } from "./paths";
@@ -39,7 +37,7 @@ describe("first-boot profile seeding", () => {
   afterEach(async () => { for (const a of apps) await a.close(); apps = []; });
 
   it("a fresh home boots with exactly one default Personal profile; a second boot does not add another", async () => {
-    const home = mkdtempSync(join(tmpdir(), "realm-home-"));
+    const home = tempDir("realm-home-");
     const app1 = await createApp({ home, port: 0 }); apps.push(app1);
     const first = new ProfilesStore(app1.db).list();
     expect(first).toHaveLength(1);
@@ -50,7 +48,7 @@ describe("first-boot profile seeding", () => {
   });
 
   it("does not seed when a profile already exists (a lone user-created profile is never joined by Personal)", async () => {
-    const home = mkdtempSync(join(tmpdir(), "realm-home-"));
+    const home = tempDir("realm-home-");
     const db = openDatabase(dbPath(home));
     new ProfilesStore(db).create({ name: "Work", icon: "briefcase", color: "#123456" });
     db.close();

--- a/apps/server/src/browsers/browser-agent.test.ts
+++ b/apps/server/src/browsers/browser-agent.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it, afterEach } from "vitest";
 import WebSocket from "ws";
-import { mkdtempSync, readdirSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { readdirSync } from "node:fs";
 import { join } from "node:path";
+import { tempDir } from "@realm/test-utils";
 import { FakeAdapter, type AgentHandle, type StartOptions, type FakeScript } from "@realm/adapters";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { createApp, type App } from "../app";
@@ -51,7 +51,7 @@ async function boot(opts: {
   parentKind?: "fake" | "claude"; parentMode?: string; fallbackKind?: "fake" | "claude";
   timeouts?: { baseMs: number; perActMs: number; pollMs: number };
 } = {}) {
-  const home = mkdtempSync(join(tmpdir(), "realm-ba-"));
+  const home = tempDir("realm-ba-");
   const fake = new CaptureFake({ script: opts.script ?? CHILD_SCRIPT, delayMs: opts.delayMs ?? 5 });
   // The same fake serves BOTH registry keys: "claude" here is a stand-in whose only job is to be a
   // kind with AGENT_SKILL_SUPPORT "injected", so kind-selection and skills staging are testable

--- a/apps/server/src/browsers/service.test.ts
+++ b/apps/server/src/browsers/service.test.ts
@@ -1,8 +1,6 @@
 import { describe, expect, it, afterEach } from "vitest";
+import { tempDir } from "@realm/test-utils";
 import WebSocket from "ws";
-import { mkdtempSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
 import { createApp, type App } from "../app";
 import { BrowsersStore } from "../store/browsers";
 
@@ -25,7 +23,7 @@ async function makeSpace(c: Awaited<ReturnType<typeof client>>) {
 
 describe("browsers RPC", () => {
   it("create makes row + item as one unit; url defaults to empty (never navigated)", async () => {
-    const home = mkdtempSync(join(tmpdir(), "realm-home-"));
+    const home = tempDir("realm-home-");
     const app = await createApp({ home, port: 0 }); apps.push(app);
     const c = await client(app.port);
     const space = await makeSpace(c);
@@ -40,7 +38,7 @@ describe("browsers RPC", () => {
   });
 
   it("survives a restart: the row keeps its last committed url/title", async () => {
-    const home = mkdtempSync(join(tmpdir(), "realm-home-"));
+    const home = tempDir("realm-home-");
     const app1 = await createApp({ home, port: 0 }); apps.push(app1);
     const c1 = await client(app1.port);
     const space = await makeSpace(c1);
@@ -60,7 +58,7 @@ describe("browsers RPC", () => {
   });
 
   it("update with a title renames the item and broadcasts items.changed; url-only does not touch the item", async () => {
-    const home = mkdtempSync(join(tmpdir(), "realm-home-"));
+    const home = tempDir("realm-home-");
     const app = await createApp({ home, port: 0 }); apps.push(app);
     const c = await client(app.port);
     const space = await makeSpace(c);
@@ -85,7 +83,7 @@ describe("browsers RPC", () => {
   });
 
   it("close deletes row + item; a second close is NOT_FOUND; items.delete routes through it", async () => {
-    const home = mkdtempSync(join(tmpdir(), "realm-home-"));
+    const home = tempDir("realm-home-");
     const app = await createApp({ home, port: 0 }); apps.push(app);
     const c = await client(app.port);
     const space = await makeSpace(c);
@@ -107,7 +105,7 @@ describe("browsers RPC", () => {
   });
 
   it("space deletion cascades browser rows away", async () => {
-    const home = mkdtempSync(join(tmpdir(), "realm-home-"));
+    const home = tempDir("realm-home-");
     const app = await createApp({ home, port: 0 }); apps.push(app);
     const c = await client(app.port);
     const space = await makeSpace(c);

--- a/apps/server/src/checkpoints/integration.test.ts
+++ b/apps/server/src/checkpoints/integration.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, it, afterEach } from "vitest";
 import WebSocket from "ws";
 import { execFileSync } from "node:child_process";
-import { existsSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
+import { tempDir } from "@realm/test-utils";
 import { FakeAdapter } from "@realm/adapters";
 import { createApp, type App } from "../app";
 import { waitFor } from "../test-utils";
@@ -47,7 +48,7 @@ function initRepo(dir: string): void {
 const script = [{ on: "go", emit: [{ kind: "text" as const, text: "ok" }] }];
 
 async function boot() {
-  const home = mkdtempSync(join(tmpdir(), "realm-cpint-"));
+  const home = tempDir("realm-cpint-");
   if (!resolve(home).startsWith(resolve(tmpdir()))) throw new Error(`refusing to run against ${home}`);
   app = await createApp({ home, port: 0, adapters: { fake: new FakeAdapter({ script, delayMs: 5 }) } });
   const c = await client(app.port);
@@ -117,7 +118,7 @@ describe("checkpoints over rpc", () => {
   });
 
   it("still delivers the message when the checkout is not a git repository", async () => {
-    const home = mkdtempSync(join(tmpdir(), "realm-cpint-"));
+    const home = tempDir("realm-cpint-");
     app = await createApp({ home, port: 0, adapters: { fake: new FakeAdapter({ script, delayMs: 5 }) } });
     const c = await client(app.port);
     const p = (await c.call("profiles.create", { name: "W" })).result;

--- a/apps/server/src/checkpoints/service.test.ts
+++ b/apps/server/src/checkpoints/service.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it, beforeEach } from "vitest";
 import { execFileSync } from "node:child_process";
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
+import { tempDir } from "@realm/test-utils";
 import { openDatabase, type Db } from "../db/database";
 import { ProfilesStore } from "../store/profiles";
 import { SpacesStore } from "../store/spaces";
@@ -35,7 +36,7 @@ let db: Db; let home: string; let envs: EnvironmentsStore; let sessions: Session
 let svc: CheckpointService; let spaceId: string; let folder: string; let busy: Set<string>;
 
 beforeEach(() => {
-  home = mkdtempSync(join(tmpdir(), "realm-cpsvc-"));
+  home = tempDir("realm-cpsvc-");
   // These tests rewrite working trees. Anything outside the scratch dir is a bug worth crashing on.
   if (!resolve(home).startsWith(resolve(tmpdir()))) throw new Error(`refusing to run against ${home}`);
   db = openDatabase(join(home, "realm.db"));
@@ -140,7 +141,7 @@ describe("restore", () => {
 
   it("reaches only the environment the checkpoint belongs to", async () => {
     initRepo(folder);
-    const other = mkdtempSync(join(tmpdir(), "realm-cp-other-"));
+    const other = tempDir("realm-cp-other-");
     try {
       initRepo(other);
       const mine = primary();
@@ -228,7 +229,7 @@ describe("retention", () => {
 
   it("prunes one environment without touching another's refs", async () => {
     initRepo(folder);
-    const other = mkdtempSync(join(tmpdir(), "realm-cp-other-"));
+    const other = tempDir("realm-cp-other-");
     try {
       initRepo(other);
       const mine = primary();
@@ -246,7 +247,7 @@ describe("retention", () => {
 describe("forgetEnvironment", () => {
   it("deletes every ref and row for that environment and nothing else", async () => {
     initRepo(folder);
-    const other = mkdtempSync(join(tmpdir(), "realm-cp-other-"));
+    const other = tempDir("realm-cp-other-");
     try {
       initRepo(other);
       const mine = primary();

--- a/apps/server/src/db/database.test.ts
+++ b/apps/server/src/db/database.test.ts
@@ -1,8 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { DatabaseSync } from "node:sqlite";
-import { mkdtempSync } from "node:fs";
-import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { tempDir } from "@realm/test-utils";
 import { openDatabase } from "./database";
 import { migrations } from "./migrations";
 import { ItemsStore } from "../store/items";
@@ -67,7 +66,7 @@ function v3Fixture(path: string): { spaceId: string; sessionId: string } {
 
 describe("database", () => {
   it("creates schema and records version", () => {
-    const dir = mkdtempSync(join(tmpdir(), "realm-db-"));
+    const dir = tempDir("realm-db-");
     const db = openDatabase(join(dir, "realm.db"));
     const row = db.prepare("SELECT MAX(version) AS v FROM schema_version").get() as { v: number };
     expect(row.v).toBeGreaterThanOrEqual(1);
@@ -77,14 +76,14 @@ describe("database", () => {
     db.close();
   });
   it("is idempotent on reopen", () => {
-    const dir = mkdtempSync(join(tmpdir(), "realm-db-"));
+    const dir = tempDir("realm-db-");
     const p = join(dir, "realm.db");
     openDatabase(p).close();
     expect(() => openDatabase(p).close()).not.toThrow();
   });
 
   it("migrates a populated v3 database to v4, adding sessions.terminal_item_id (NULL) without touching its rows", () => {
-    const p = join(mkdtempSync(join(tmpdir(), "realm-db-")), "realm.db");
+    const p = join(tempDir("realm-db-"), "realm.db");
     const { sessionId } = v3Fixture(p);
 
     const db = openDatabase(p);
@@ -98,7 +97,7 @@ describe("database", () => {
   });
 
   it("re-running the v4 migration is impossible: a second open is a no-op and the data survives", () => {
-    const p = join(mkdtempSync(join(tmpdir(), "realm-db-")), "realm.db");
+    const p = join(tempDir("realm-db-"), "realm.db");
     v3Fixture(p);
     openDatabase(p).close();
     // Second open: schema_version already says 4, so no ALTER re-runs (it would throw "duplicate column").
@@ -180,7 +179,7 @@ const readSessions = (db: ReturnType<typeof openDatabase>) =>
 
 describe("migration v5 — environments", () => {
   const migrated = () => {
-    const p = join(mkdtempSync(join(tmpdir(), "realm-db-")), "realm.db");
+    const p = join(tempDir("realm-db-"), "realm.db");
     v4Fixture(p);
     return { p, db: openDatabase(p) };
   };
@@ -300,7 +299,7 @@ describe("migration v5 — environments", () => {
 
 describe("migration v6 — port blocks", () => {
   const migrated = () => {
-    const p = join(mkdtempSync(join(tmpdir(), "realm-db-")), "realm.db");
+    const p = join(tempDir("realm-db-"), "realm.db");
     v4Fixture(p);
     return { p, db: openDatabase(p) };
   };
@@ -373,7 +372,7 @@ function v8McpFixture(path: string): { serverId: string } {
 
 describe("migration v9 — MCP gateway", () => {
   const migrated = () => {
-    const p = join(mkdtempSync(join(tmpdir(), "realm-db-")), "realm.db");
+    const p = join(tempDir("realm-db-"), "realm.db");
     const { serverId } = v8McpFixture(p);
     return { p, db: openDatabase(p), serverId };
   };
@@ -410,7 +409,7 @@ describe("migration v9 — MCP gateway", () => {
   // the v4 fixture (which openDatabase migrates all the way to v9, mcp_servers included) rather than
   // building a second parallel chain of profiles/spaces/environments just for one row.
   it("server_id survives as NULL once the server row it names is deleted — the log outlives the config", () => {
-    const p = join(mkdtempSync(join(tmpdir(), "realm-db-")), "realm.db");
+    const p = join(tempDir("realm-db-"), "realm.db");
     v4Fixture(p);
     const db = openDatabase(p);
     db.prepare("INSERT INTO mcp_servers (id, name, transport, command, args_json, url, secrets_json, created_at, updated_at) VALUES ('srv1','airtable','stdio','/usr/bin/node','[]','','{}',1,1)").run();
@@ -435,7 +434,7 @@ describe("migration v14 — dispatch origin (Plan 13 W1; renumbered past Plan 14
   // The v4 fixture holds a REAL populated session ('se1'), migrated all the way forward — exactly
   // the row an upgrade must leave alone.
   it("adds dispatched_by_kind/dispatched_by_session_id, NULL for every existing session — nothing backfilled", () => {
-    const p = join(mkdtempSync(join(tmpdir(), "realm-db-")), "realm.db");
+    const p = join(tempDir("realm-db-"), "realm.db");
     v4Fixture(p);
     const db = openDatabase(p);
     const cols = (db.prepare("PRAGMA table_info(sessions)").all() as { name: string }[]).map((c) => c.name);
@@ -450,7 +449,7 @@ describe("migration v14 — dispatch origin (Plan 13 W1; renumbered past Plan 14
 describe("migration v15 — the search index (Plan 16 W1)", () => {
   // The v4 fixture again: real items and sessions, migrated the whole way forward.
   const migrated = () => {
-    const p = join(mkdtempSync(join(tmpdir(), "realm-db-")), "realm.db");
+    const p = join(tempDir("realm-db-"), "realm.db");
     v4Fixture(p);
     // A pre-v15 transcript, inserted raw (no store, so no write-time indexing) before openDatabase
     // replays the chain — exactly what an upgrading home holds.
@@ -478,7 +477,7 @@ describe("migration v15 — the search index (Plan 16 W1)", () => {
   });
 
   it("a fresh (no-history) home gets a closed cursor: done 0, target 0 — nothing to backfill", () => {
-    const db = openDatabase(join(mkdtempSync(join(tmpdir(), "realm-db-")), "realm.db"));
+    const db = openDatabase(join(tempDir("realm-db-"), "realm.db"));
     const cursor = JSON.parse((db.prepare("SELECT value_json FROM settings WHERE key = 'search.backfill'").get() as { value_json: string }).value_json) as { done: number; target: number };
     expect(cursor).toEqual({ done: 0, target: 0 });
     db.close();
@@ -488,7 +487,7 @@ describe("migration v15 — the search index (Plan 16 W1)", () => {
 describe("migration v17 — pane groups", () => {
   /** A v4 home carrying a real layout on one space and none on another. */
   const migrated = () => {
-    const p = join(mkdtempSync(join(tmpdir(), "realm-db-")), "realm.db");
+    const p = join(tempDir("realm-db-"), "realm.db");
     v4Fixture(p);
     const pre = new DatabaseSync(p);
     pre.prepare("UPDATE spaces SET layout_json = ? WHERE id = 'sp1'")
@@ -519,7 +518,7 @@ describe("migration v17 — pane groups", () => {
   });
 
   it("is idempotent: reopening the same home does not re-run the ALTER", () => {
-    const p = join(mkdtempSync(join(tmpdir(), "realm-db-")), "realm.db");
+    const p = join(tempDir("realm-db-"), "realm.db");
     v4Fixture(p);
     const first = openDatabase(p);
     first.prepare("UPDATE spaces SET groups_json = ? WHERE id = 'sp1'").run('{"groups":[]}');
@@ -533,7 +532,7 @@ describe("migration v17 — pane groups", () => {
 
 describe("migration v16 — the icon asset library", () => {
   it("adds icon_assets to a pre-v16 (v4-forward) home, scoped to a profile", () => {
-    const p = join(mkdtempSync(join(tmpdir(), "realm-db-")), "realm.db");
+    const p = join(tempDir("realm-db-"), "realm.db");
     v4Fixture(p);
     const db = openDatabase(p);
     expect((db.prepare("SELECT MAX(version) AS v FROM schema_version").get() as { v: number }).v).toBe(migrations.length);
@@ -545,7 +544,7 @@ describe("migration v16 — the icon asset library", () => {
   });
 
   it("cascades on profile deletion", () => {
-    const p = join(mkdtempSync(join(tmpdir(), "realm-db-")), "realm.db");
+    const p = join(tempDir("realm-db-"), "realm.db");
     v4Fixture(p);
     const db = openDatabase(p);
     db.exec("PRAGMA foreign_keys = ON;");
@@ -561,7 +560,7 @@ describe("migration v18 — archiving (a row put away, not deleted)", () => {
    *  an upgrading home actually holds. `it-term` cannot stand in for it: se1 owns it, so every
    *  listing filters it out for an unrelated reason. */
   const migrated = () => {
-    const p = join(mkdtempSync(join(tmpdir(), "realm-db-")), "realm.db");
+    const p = join(tempDir("realm-db-"), "realm.db");
     v4Fixture(p);
     const raw = new DatabaseSync(p);
     raw.prepare("INSERT INTO items VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)")

--- a/apps/server/src/db/scoping-migration.test.ts
+++ b/apps/server/src/db/scoping-migration.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "vitest";
 import { DatabaseSync } from "node:sqlite";
-import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { tempDir } from "@realm/test-utils";
 import { openDatabase } from "./database";
 import { migrations } from "./migrations";
 import { SettingsStore } from "../store/settings";
@@ -81,7 +81,7 @@ function writeV10Fixture(home: string): string {
 
 describe("v11 scoping migration", () => {
   it("changes NO space's effective set: pre-migration state comes out byte-identical", () => {
-    const home = mkdtempSync(join(tmpdir(), "realm-scoping-mig-"));
+    const home = tempDir("realm-scoping-mig-");
     const path = writeV10Fixture(home);
 
     const db = openDatabase(path); // applies v11 (and whatever came after — W5's v12 rides along)

--- a/apps/server/src/delegation/agent-run.test.ts
+++ b/apps/server/src/delegation/agent-run.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it, afterEach } from "vitest";
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, mkdirSync, readdirSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { mkdirSync, readdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { tempDir } from "@realm/test-utils";
 import { FakeAdapter, type AgentHandle, type StartOptions, type FakeScript } from "@realm/adapters";
 import type { McpServerConfig } from "@realm/adapters";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
@@ -79,7 +79,7 @@ async function boot(opts: {
   timeouts?: { baseMs: number; perTurnMs: number; pollMs: number };
   maxDepth?: number; caps?: { perParent?: number; total?: number };
 } = {}) {
-  const home = mkdtempSync(join(tmpdir(), "realm-ar-"));
+  const home = tempDir("realm-ar-");
   const fake = new CaptureFake({ script: opts.script ?? CHILD_SCRIPT, delayMs: opts.delayMs ?? 5 });
   // The same fake serves BOTH registry keys — "claude" is the stand-in kind with skills injection,
   // exactly the arrangement browser-agent.test.ts uses.

--- a/apps/server/src/delegation/ask.test.ts
+++ b/apps/server/src/delegation/ask.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it, afterEach } from "vitest";
-import { mkdtempSync } from "node:fs";
-import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { tempDir } from "@realm/test-utils";
 import { FakeAdapter, type AgentHandle, type StartOptions, type FakeScript, type UserMessage } from "@realm/adapters";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { createApp, type App } from "../app";
@@ -71,7 +70,7 @@ const SLOW_TO_ANSWER: FakeScript = [
 ];
 
 async function boot(opts: { script?: FakeScript; delayMs?: number; peerKind?: "fake" | "codex"; askerMode?: string; budgetMs?: number } = {}) {
-  const home = mkdtempSync(join(tmpdir(), "realm-ask-"));
+  const home = tempDir("realm-ask-");
   const fake = new InterruptCountingFake({ script: opts.script ?? PEER_SCRIPT, delayMs: opts.delayMs ?? 5 });
   app = await createApp({
     home, port: 0,

--- a/apps/server/src/delegation/review.test.ts
+++ b/apps/server/src/delegation/review.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it, afterEach } from "vitest";
 import WebSocket from "ws";
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { tempDir } from "@realm/test-utils";
 import { FakeAdapter, type FakeScript, type McpServerConfig } from "@realm/adapters";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
@@ -60,7 +60,7 @@ function initRepo(dir: string): void {
 
 async function boot(opts: { script?: FakeScript; delayMs?: number; parentKind?: "fake" | "claude" | "acp:cursor"; parentMode?: string;
   timeouts?: { budgetMs: number; pollMs: number } } = {}) {
-  const home = mkdtempSync(join(tmpdir(), "realm-rv-"));
+  const home = tempDir("realm-rv-");
   const fake = new FakeAdapter({ script: opts.script ?? REVIEW_SCRIPT, delayMs: opts.delayMs ?? 5 });
   app = await createApp({
     home, port: 0, adapters: { fake, claude: fake, "acp:cursor": fake },

--- a/apps/server/src/documents/agent-tools.test.ts
+++ b/apps/server/src/documents/agent-tools.test.ts
@@ -1,13 +1,13 @@
 import { describe, expect, it } from "vitest";
-import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { tempDir } from "@realm/test-utils";
 import { emptyGuideProgress, recordGuideAttempt, type DocumentEntry } from "@realm/contracts";
 import { DOCS_PROVIDER_NAME, createDocsAgentProvider, type DocsAgentToolsDeps } from "./agent-tools";
 import { TextExtractor } from "./text-extract";
 
 function harness(o: { enabled?: boolean } = {}) {
-  const root = mkdtempSync(join(tmpdir(), "realm-docs-tools-"));
+  const root = tempDir("realm-docs-tools-");
   mkdirSync(join(root, "lectures"));
   writeFileSync(join(root, "lectures", "2026-09-01-pipelining.md"), "# Pipelining\n\nforwarding fixes data hazards");
   writeFileSync(join(root, "lectures", "2026-09-03-caches.md"), "# Caches\n\nthrashing");

--- a/apps/server/src/documents/docs-search.test.ts
+++ b/apps/server/src/documents/docs-search.test.ts
@@ -1,13 +1,13 @@
 import { describe, expect, it } from "vitest";
-import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { tempDir } from "@realm/test-utils";
 import { scoreOf, searchDocs, walkFiles } from "./docs-search";
 import { TextExtractor } from "./text-extract";
 import { makePdf } from "./test-pdf";
 
 function course() {
-  const root = mkdtempSync(join(tmpdir(), "realm-course-"));
+  const root = tempDir("realm-course-");
   mkdirSync(join(root, "lectures"));
   mkdirSync(join(root, "guides"));
   mkdirSync(join(root, "slides"));

--- a/apps/server/src/documents/files.test.ts
+++ b/apps/server/src/documents/files.test.ts
@@ -1,13 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
+import { readFile, readdir, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
+import { tempDir } from "@realm/test-utils";
 import { DOCUMENT_MAX_BYTES } from "@realm/contracts";
 import { hashText, isTempArtifact, readDocument, readIfExists, writeAtomic, writeDocument } from "./files";
 
 let dir: string;
 const p = (name: string) => join(dir, name);
-beforeEach(async () => { dir = await mkdtemp(join(tmpdir(), "realm-docs-")); });
+beforeEach(async () => { dir = tempDir("realm-docs-"); });
 afterEach(async () => { await rm(dir, { recursive: true, force: true }); });
 
 describe("hashText", () => {

--- a/apps/server/src/documents/preview.test.ts
+++ b/apps/server/src/documents/preview.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it } from "vitest";
-import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { tempDir } from "@realm/test-utils";
 import { DocumentPreviewServer, GUIDE_CSP, defaultKatexDir, defaultVisNetworkDir, injectHelpers, localizeVisNetwork, wantsKatex } from "./preview";
 import { makePdf } from "./test-pdf";
 
@@ -9,7 +9,7 @@ const servers: DocumentPreviewServer[] = [];
 afterEach(async () => { for (const s of servers.splice(0)) await s.close(); });
 
 async function boot(katexDir?: string | null, visNetworkDir?: string | null) {
-  const root = mkdtempSync(join(tmpdir(), "realm-preview-"));
+  const root = tempDir("realm-preview-");
   const s = new DocumentPreviewServer({ rootOf: (id) => (id === "ws1" ? root : null), katexDir, visNetworkDir });
   servers.push(s);
   const port = await s.listen();

--- a/apps/server/src/documents/school-rpc.test.ts
+++ b/apps/server/src/documents/school-rpc.test.ts
@@ -1,9 +1,8 @@
 import { afterEach, describe, expect, it } from "vitest";
 import WebSocket from "ws";
-import { mkdtempSync } from "node:fs";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { tempDir } from "@realm/test-utils";
 import { progressSidecarPath } from "@realm/contracts";
 import { createApp, type App } from "../app";
 import { waitFor } from "../test-utils";
@@ -21,7 +20,7 @@ async function client(port: number) {
 }
 
 async function setup() {
-  const home = mkdtempSync(join(tmpdir(), "realm-home-"));
+  const home = tempDir("realm-home-");
   const app = await createApp({ home, port: 0 }); apps.push(app);
   const c = await client(app.port);
   const prof = (await c.call("profiles.create", { name: "School" })).result;

--- a/apps/server/src/documents/service.test.ts
+++ b/apps/server/src/documents/service.test.ts
@@ -1,10 +1,9 @@
 import { afterEach, describe, expect, it } from "vitest";
 import WebSocket from "ws";
-import { mkdtempSync } from "node:fs";
 import { readFile, writeFile } from "node:fs/promises";
 import { mkdir } from "node:fs/promises";
-import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { tempDir } from "@realm/test-utils";
 import { createApp, type App } from "../app";
 import { waitFor } from "../test-utils";
 import { hashText } from "./files";
@@ -23,7 +22,7 @@ async function client(port: number) {
 
 /** A space, its primary environment (the space folder), and a documents workspace over it. */
 async function setup() {
-  const home = mkdtempSync(join(tmpdir(), "realm-home-"));
+  const home = tempDir("realm-home-");
   const app = await createApp({ home, port: 0 }); apps.push(app);
   const c = await client(app.port);
   const prof = (await c.call("profiles.create", { name: "Work" })).result;
@@ -56,7 +55,7 @@ describe("documents RPC — lifecycle", () => {
   });
 
   it("persists the tab strip across a restart", async () => {
-    const home = mkdtempSync(join(tmpdir(), "realm-home-"));
+    const home = tempDir("realm-home-");
     const app1 = await createApp({ home, port: 0 }); apps.push(app1);
     const c1 = await client(app1.port);
     const prof = (await c1.call("profiles.create", { name: "Work" })).result;

--- a/apps/server/src/documents/text-extract.test.ts
+++ b/apps/server/src/documents/text-extract.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
-import { mkdtempSync, utimesSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { utimesSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { tempDir } from "@realm/test-utils";
 import { TextExtractor, htmlToText, isExtractable, pdfText } from "./text-extract";
 import { makePdf } from "./test-pdf";
 
@@ -22,7 +22,7 @@ describe("pdfText — the real pdf.js path", () => {
 
 describe("TextExtractor", () => {
   it("extracts text files and PDFs, and answers null for other kinds and oversized files", async () => {
-    const dir = mkdtempSync(join(tmpdir(), "realm-extract-"));
+    const dir = tempDir("realm-extract-");
     writeFileSync(join(dir, "a.md"), "# Caches\n\nMESI protocol");
     writeFileSync(join(dir, "p.pdf"), makePdf(["Snoopy caches"]));
     writeFileSync(join(dir, "bin.zip"), "zip");
@@ -37,7 +37,7 @@ describe("TextExtractor", () => {
   });
 
   it("memoizes on size+mtime and re-reads when either changes", async () => {
-    const dir = mkdtempSync(join(tmpdir(), "realm-extract-"));
+    const dir = tempDir("realm-extract-");
     const f = join(dir, "p.pdf");
     let calls = 0;
     const x = new TextExtractor(async () => { calls++; return `parsed ${calls}`; });
@@ -53,7 +53,7 @@ describe("TextExtractor", () => {
   });
 
   it("swallows a PDF parse failure as empty text rather than failing the search", async () => {
-    const dir = mkdtempSync(join(tmpdir(), "realm-extract-"));
+    const dir = tempDir("realm-extract-");
     const f = join(dir, "broken.pdf");
     writeFileSync(f, "not a pdf at all");
     const x = new TextExtractor(async () => { throw new Error("boom"); });

--- a/apps/server/src/documents/watcher.test.ts
+++ b/apps/server/src/documents/watcher.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { mkdtemp, rm, unlink, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
+import { rm, unlink, writeFile } from "node:fs/promises";
 import { join } from "node:path";
+import { tempDir } from "@realm/test-utils";
 import { waitFor } from "../test-utils";
 import { hashText, writeAtomic } from "./files";
 import { DocumentWatcher } from "./watcher";
@@ -12,7 +12,7 @@ let w: DocumentWatcher;
 const p = (name: string) => join(dir, name);
 
 beforeEach(async () => {
-  dir = await mkdtemp(join(tmpdir(), "realm-watch-"));
+  dir = tempDir("realm-watch-");
   events = [];
   // 5ms debounce: the coalescing behaviour is the same, the test just does not have to wait for it.
   w = new DocumentWatcher((path, hash) => { events.push({ path, hash }); }, 5);

--- a/apps/server/src/environments/service.test.ts
+++ b/apps/server/src/environments/service.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it, beforeEach } from "vitest";
 import { execFileSync } from "node:child_process";
-import { existsSync, mkdtempSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { existsSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { tempDir } from "@realm/test-utils";
 import { openDatabase, type Db } from "../db/database";
 import { ProfilesStore } from "../store/profiles";
 import { SpacesStore } from "../store/spaces";
@@ -26,7 +26,7 @@ let db: Db; let home: string; let spaces: SpacesStore; let envs: EnvironmentsSto
 let svc: EnvironmentService; let spaceId: string; let folder: string;
 
 beforeEach(() => {
-  home = mkdtempSync(join(tmpdir(), "realm-envsvc-"));
+  home = tempDir("realm-envsvc-");
   db = openDatabase(join(home, "realm.db"));
   const p = new ProfilesStore(db).create({ name: "P", icon: "x", color: "#000" });
   spaces = new SpacesStore(db, home);
@@ -111,7 +111,7 @@ describe("EnvironmentService.removeWorktree", () => {
 
   // MUTANT: removal reachable for `checkout` — a working copy the user made and Realm merely noticed.
   it("refuses a checkout Realm did not create, and touches nothing on disk", async () => {
-    const userRepo = mkdtempSync(join(tmpdir(), "realm-user-repo-"));
+    const userRepo = tempDir("realm-user-repo-");
     initRepo(userRepo);
     const env = envs.ensureAt(spaceId, userRepo, "checkout");
     await expect(svc.removeWorktree(env.id, null)).rejects.toMatchObject({ code: "ENVIRONMENT_NOT_WORKTREE" });
@@ -130,7 +130,7 @@ describe("EnvironmentService.removeWorktree", () => {
 
   it("removes a clean worktree and its row", async () => {
     // Cloned so HEAD is on a remote and there are no unpushed commits.
-    const origin = mkdtempSync(join(tmpdir(), "realm-origin-"));
+    const origin = tempDir("realm-origin-");
     initRepo(origin);
     execFileSync("git", ["clone", "-q", origin, folder + "-clone"], { encoding: "utf8" });
     const src = envs.ensureAt(spaceId, folder + "-clone", "checkout");
@@ -150,7 +150,7 @@ describe("EnvironmentService.removeWorktree", () => {
   });
 
   it("frees the port block for reuse once the row is gone", async () => {
-    const origin = mkdtempSync(join(tmpdir(), "realm-origin2-"));
+    const origin = tempDir("realm-origin2-");
     initRepo(origin);
     execFileSync("git", ["clone", "-q", origin, folder + "-clone2"], { encoding: "utf8" });
     const src = envs.ensureAt(spaceId, folder + "-clone2", "checkout");

--- a/apps/server/src/graphify/probe.test.ts
+++ b/apps/server/src/graphify/probe.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeAll } from "vitest";
-import { chmodSync, mkdtempSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { chmodSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { tempDir } from "@realm/test-utils";
 import { probeGraphify } from "./probe";
 
 /**
@@ -22,7 +22,7 @@ let printsTwoLines: string;
 let printsNothing: string;
 let brokenExit: string;
 beforeAll(() => {
-  dir = mkdtempSync(join(tmpdir(), "realm-graphify-probe-"));
+  dir = tempDir("realm-graphify-probe-");
   printsVersion = stub("graphify-ok", `console.log("graphify 0.9.53");`);
   printsTwoLines = stub("graphify-chatty", `console.log("graphify 0.9.53\\nextra diagnostic line");`);
   printsNothing = stub("graphify-mute", `console.log("");`);

--- a/apps/server/src/graphify/service.test.ts
+++ b/apps/server/src/graphify/service.test.ts
@@ -1,14 +1,14 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { tempDir } from "@realm/test-utils";
 import { RpcError } from "../store/rows";
 import { GraphifyService, type GraphifyRun } from "./service";
 
 const SPACE = "01ARZ3NDEKTSV4RRFFQ69G5FAV";
 
 let root: string;
-beforeEach(() => { root = mkdtempSync(join(tmpdir(), "realm-graphify-")); });
+beforeEach(() => { root = tempDir("realm-graphify-"); });
 
 /** The node-link JSON graphify writes: `links`, not `edges`, and a `community` number per node. */
 const writeGraph = (graph: unknown, at = root): void => {

--- a/apps/server/src/import/service.test.ts
+++ b/apps/server/src/import/service.test.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { DatabaseSync } from "node:sqlite";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { tempDir } from "@realm/test-utils";
 import { IMPORT_MEMORY_MARKER_OPEN, IMPORTED_SPACE_NAME } from "@realm/contracts";
 import { openDatabase } from "../db/database";
 import { dbPath } from "../paths";
@@ -60,8 +61,8 @@ type Harness = {
 };
 
 function harness(): Harness {
-  const home = mkdtempSync(join(tmpdir(), "realm-import-home-"));
-  const fixtures = mkdtempSync(join(tmpdir(), "realm-import-src-"));
+  const home = tempDir("realm-import-home-");
+  const fixtures = tempDir("realm-import-src-");
   const roots: ImportRoots = {
     claude: join(fixtures, "claude"), codex: join(fixtures, "codex"), cursor: join(fixtures, "cursor"),
     extraSkillDirs: [join(fixtures, "agents", "skills")],

--- a/apps/server/src/mcp/gateway.test.ts
+++ b/apps/server/src/mcp/gateway.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it, afterEach } from "vitest";
-import { mkdtempSync } from "node:fs";
-import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { tempDir } from "@realm/test-utils";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
@@ -68,7 +67,7 @@ async function setupApp(opts: {
    *  (`string[]`) and Plan 13 W1's exclude mode (`{ exclude }`). */
   sessionToolset?: (sessionId: string) => import("./gateway").SessionToolset;
 } = {}): Promise<App> {
-  const home = mkdtempSync(join(tmpdir(), "realm-mcp-gw-"));
+  const home = tempDir("realm-mcp-gw-");
   const db = openDatabase(join(home, "realm.db"));
   const servers = new McpServersStore(db);
   const calls = new McpCallLogStore(db);
@@ -230,7 +229,7 @@ describe("tools/list — namespacing and policy", () => {
     app.mcp.promote(app.spaceId, row.id);
     const sibling = app.createSpaceAndSession("Sibling");
     const otherProfileId = new ProfilesStore(app.db).create({ name: "Q", icon: "x", color: "#000" }).id;
-    const otherSpaceId = new SpacesStore(app.db, mkdtempSync(join(tmpdir(), "realm-gw-q-"))).create({ profileId: otherProfileId, name: "Elsewhere", icon: "folder" }).id;
+    const otherSpaceId = new SpacesStore(app.db, tempDir("realm-gw-q-")).create({ profileId: otherProfileId, name: "Elsewhere", icon: "folder" }).id;
     const otherEnvId = new EnvironmentsStore(app.db).ensurePrimary(otherSpaceId).id;
     const otherSessionId = new SessionsStore(app.db).create({ spaceId: otherSpaceId, projectId: null, agentKind: "claude", model: null, effort: null, permissionMode: "default", environmentId: otherEnvId, title: "q" }).id;
 

--- a/apps/server/src/mcp/hub.test.ts
+++ b/apps/server/src/mcp/hub.test.ts
@@ -1,8 +1,7 @@
 import { describe, expect, it, beforeEach } from "vitest";
-import { mkdtempSync } from "node:fs";
-import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { tempDir } from "@realm/test-utils";
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import { openDatabase } from "../db/database";
 import { McpServersStore, type McpServerRow } from "../store/mcp";
@@ -14,7 +13,7 @@ const HERE = dirname(fileURLToPath(import.meta.url));
 
 let servers: McpServersStore;
 beforeEach(() => {
-  const db = openDatabase(join(mkdtempSync(join(tmpdir(), "realm-mcp-hub-")), "realm.db"));
+  const db = openDatabase(join(tempDir("realm-mcp-hub-"), "realm.db"));
   servers = new McpServersStore(db);
 });
 

--- a/apps/server/src/mcp/integration.test.ts
+++ b/apps/server/src/mcp/integration.test.ts
@@ -1,8 +1,6 @@
 import { describe, expect, it, afterEach } from "vitest";
+import { tempDir } from "@realm/test-utils";
 import WebSocket from "ws";
-import { mkdtempSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
 import { AsyncQueue, type AgentAdapter, type AgentHandle, type StartOptions } from "@realm/adapters";
 import { sessionEvent, type SessionEvent } from "@realm/contracts";
 import { createApp, type App } from "../app";
@@ -59,7 +57,7 @@ async function client(port: number) {
 }
 
 async function boot() {
-  const home = mkdtempSync(join(tmpdir(), "realm-mcp-int-"));
+  const home = tempDir("realm-mcp-int-");
   const claude = new RecordingAdapter("claude");
   app = await createApp({ home, port: 0, adapters: { claude } });
   const c = await client(app.port);

--- a/apps/server/src/mcp/oauth.test.ts
+++ b/apps/server/src/mcp/oauth.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it, afterEach } from "vitest";
-import { mkdtempSync } from "node:fs";
-import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { tempDir } from "@realm/test-utils";
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import { openDatabase, type Db } from "../db/database";
 import { McpServersStore, type McpServerRow } from "../store/mcp";
@@ -44,7 +43,7 @@ afterEach(async () => {
 
 async function setup(opts: Parameters<typeof makeStubAuthServer>[0] = {}): Promise<Harness> {
   const as = await makeStubAuthServer(opts);
-  const db = openDatabase(join(mkdtempSync(join(tmpdir(), "realm-mcp-oauth-")), "realm.db"));
+  const db = openDatabase(join(tempDir("realm-mcp-oauth-"), "realm.db"));
   open.push({ db, as });
   const servers = new McpServersStore(db);
   const row = servers.create({ name: "remote", transport: "http", command: "", args: [], url: `${as.url}/mcp`, secrets: {} });

--- a/apps/server/src/mcp/service.test.ts
+++ b/apps/server/src/mcp/service.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it, beforeEach } from "vitest";
-import { mkdtempSync } from "node:fs";
-import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { tempDir } from "@realm/test-utils";
 import { openDatabase } from "../db/database";
 import { SettingsStore } from "../store/settings";
 import { RpcError } from "../store/rows";
@@ -17,7 +16,7 @@ let mcp: McpService;
 let servers: McpServersStore;
 let settings: SettingsStore;
 beforeEach(() => {
-  const db = openDatabase(join(mkdtempSync(join(tmpdir(), "realm-mcp-")), "realm.db"));
+  const db = openDatabase(join(tempDir("realm-mcp-"), "realm.db"));
   servers = new McpServersStore(db);
   settings = new SettingsStore(db);
   mcp = new McpService({ servers, settings });

--- a/apps/server/src/memory/claude-files.test.ts
+++ b/apps/server/src/memory/claude-files.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { tempDir } from "@realm/test-utils";
 import { claudeMemoryFiles, parseImports } from "./claude-files";
 
-const scratch = () => mkdtempSync(join(tmpdir(), "realm-claude-files-"));
+const scratch = () => tempDir("realm-claude-files-");
 const write = (dir: string, name: string, text: string) => {
   mkdirSync(dir, { recursive: true });
   writeFileSync(join(dir, name), text);

--- a/apps/server/src/memory/integration.test.ts
+++ b/apps/server/src/memory/integration.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it, afterEach, vi } from "vitest";
 import WebSocket from "ws";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { tempDir } from "@realm/test-utils";
 import { AsyncQueue, type AgentAdapter, type AgentHandle, type StartOptions } from "@realm/adapters";
 import { newId, sessionEvent, type AgentKind, type SessionEvent } from "@realm/contracts";
 import { createApp, type App } from "../app";
@@ -57,7 +57,7 @@ async function client(port: number) {
 }
 
 async function boot() {
-  const home = mkdtempSync(join(tmpdir(), "realm-memory-int-"));
+  const home = tempDir("realm-memory-int-");
   vi.stubEnv("REALM_BUNDLED_SKILLS", join(home, "no-bundle"));
   const claudeDir = join(home, "claude-home");
   const claude = new RecordingAdapter("claude");

--- a/apps/server/src/memory/service.test.ts
+++ b/apps/server/src/memory/service.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { tempDir } from "@realm/test-utils";
 import type { Environment, EnvironmentKind } from "@realm/contracts";
 import { openDatabase } from "../db/database";
 import { SettingsStore } from "../store/settings";
@@ -26,7 +26,7 @@ const envs = (bySpace: Record<string, { path: string; kind: EnvironmentKind }>) 
 });
 
 function harness(kinds: Partial<Record<string, EnvironmentKind>> = {}) {
-  const home = mkdtempSync(join(tmpdir(), "realm-memory-"));
+  const home = tempDir("realm-memory-");
   const claudeDir = join(home, "claude-home");
   const folders: Record<string, { path: string; kind: EnvironmentKind }> = {};
   for (const [i, space] of [SPACE_A, SPACE_B].entries()) {

--- a/apps/server/src/models/catalog.test.ts
+++ b/apps/server/src/models/catalog.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
-import { mkdtempSync } from "node:fs";
-import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { tempDir } from "@realm/test-utils";
 import { MODEL_CATALOG_KEY, MODEL_CATALOG_URL } from "@realm/contracts";
 import { openDatabase } from "../db/database";
 import { SettingsStore } from "../store/settings";
@@ -14,7 +13,7 @@ const body = (name = "Anthropic: Claude Opus 5", completion = "0.000025") => ({
 });
 
 function harness(fetchImpl: typeof fetch, now = () => 1000) {
-  const home = mkdtempSync(join(tmpdir(), "realm-catalog-"));
+  const home = tempDir("realm-catalog-");
   const settings = new SettingsStore(openDatabase(join(home, "realm.db")));
   return { settings, service: new ModelCatalogService({ settings, fetchImpl, now, ttlMs: 100 }) };
 }

--- a/apps/server/src/notifications/integration.test.ts
+++ b/apps/server/src/notifications/integration.test.ts
@@ -1,8 +1,7 @@
 import { describe, expect, it, afterEach } from "vitest";
 import WebSocket from "ws";
-import { mkdtempSync } from "node:fs";
-import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { tempDir } from "@realm/test-utils";
 import { FakeAdapter } from "@realm/adapters";
 import type { Notification } from "@realm/contracts";
 import { createApp, type App } from "../app";
@@ -38,7 +37,7 @@ async function client(port: number) {
 
 const fake = () => new FakeAdapter({ script: [{ on: "go", emit: [{ kind: "text", text: "ok" }, { kind: "tool", name: "Bash", input: { command: "ls" }, needsPermission: true, result: "x" }] }] });
 
-async function boot(home = mkdtempSync(join(tmpdir(), "realm-notif-"))) {
+async function boot(home = tempDir("realm-notif-")) {
   app = await createApp({ home, port: 0, adapters: { fake: fake() } });
   const c = await client(app.port);
   const p = (await c.call("profiles.create", { name: "W" })).result;
@@ -134,7 +133,7 @@ describe("notifications over rpc — the real wiring", () => {
 
 describe("the stale-ack hook (EnvironmentService.removeWorktree)", () => {
   it("a PRESENT-but-stale acknowledgement writes a worktree_hazard row; the ask-first null ack does not", async () => {
-    const home = mkdtempSync(join(tmpdir(), "realm-notifenv-"));
+    const home = tempDir("realm-notifenv-");
     const db = openDatabase(dbPath(home));
     const profiles = new ProfilesStore(db);
     const spaces = new SpacesStore(db, home);

--- a/apps/server/src/notifications/service.test.ts
+++ b/apps/server/src/notifications/service.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it, beforeEach } from "vitest";
-import { mkdtempSync } from "node:fs";
-import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { tempDir } from "@realm/test-utils";
 import { sessionEvent, NOTIFICATIONS_DISABLED_KEY, type Notification, type Session } from "@realm/contracts";
 import { openDatabase, type Db } from "../db/database";
 import { NotificationsStore } from "../store/notifications";
@@ -22,7 +21,7 @@ const session = (extra: Partial<Session> = {}): Session => ({
 const feed = () => store.list({ cursor: null, limit: 100 }).notifications;
 
 beforeEach(() => {
-  db = openDatabase(join(mkdtempSync(join(tmpdir(), "realm-notifsvc-")), "realm.db"));
+  db = openDatabase(join(tempDir("realm-notifsvc-"), "realm.db"));
   store = new NotificationsStore(db);
   settings = new SettingsStore(db);
   broadcasts = [];

--- a/apps/server/src/rpc/methods.test.ts
+++ b/apps/server/src/rpc/methods.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it, afterEach } from "vitest";
 import WebSocket from "ws";
-import { existsSync, mkdtempSync, writeFileSync } from "node:fs";
+import { existsSync, writeFileSync } from "node:fs";
 import { execFileSync } from "node:child_process";
-import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { tempDir } from "@realm/test-utils";
 import { createApp, type App } from "../app";
 import { waitFor } from "../test-utils";
 
@@ -25,7 +25,7 @@ async function client(port: number) {
 }
 
 async function boot() {
-  const home = mkdtempSync(join(tmpdir(), "realm-home-"));
+  const home = tempDir("realm-home-");
   app = await createApp({ home, port: 0 });
   const c = await client(app.port);
   return { home, c };
@@ -198,7 +198,7 @@ describe("rpc methods", () => {
     c.close();
   });
   it("spaces.list is global and spaces.reorder + settings work over rpc", async () => {
-    const home = mkdtempSync(join(tmpdir(), "realm-home-")); app = await createApp({ home, port: 0 });
+    const home = tempDir("realm-home-"); app = await createApp({ home, port: 0 });
     const c = await client(app.port);
     const p1 = (await c.call("profiles.create", { name: "Work" })).result;
     const p2 = (await c.call("profiles.create", { name: "School" })).result;

--- a/apps/server/src/runs/integration.test.ts
+++ b/apps/server/src/runs/integration.test.ts
@@ -1,8 +1,6 @@
 import { describe, expect, it, afterEach } from "vitest";
+import { tempDir } from "@realm/test-utils";
 import WebSocket from "ws";
-import { mkdtempSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
 import { FakeAdapter, type FakeScript } from "@realm/adapters";
 import { RUN_BLOCK_SENTINEL } from "@realm/contracts";
 import { createApp, type App } from "../app";
@@ -43,7 +41,7 @@ async function client(port: number) {
 }
 
 async function boot(script: FakeScript = SCRIPT) {
-  const home = mkdtempSync(join(tmpdir(), "realm-runs-rpc-"));
+  const home = tempDir("realm-runs-rpc-");
   const fake = new FakeAdapter({ script, delayMs: 2 });
   app = await createApp({ home, port: 0, adapters: { fake, claude: fake }, agentRun: { fallbackKind: "fake" } });
   const profile = new ProfilesStore(app.db).create({ name: "P", icon: "x", color: "#000" });

--- a/apps/server/src/runs/service.test.ts
+++ b/apps/server/src/runs/service.test.ts
@@ -1,7 +1,5 @@
 import { describe, expect, it, afterEach } from "vitest";
-import { mkdtempSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { tempDir } from "@realm/test-utils";
 import { FakeAdapter, type AgentHandle, type StartOptions, type FakeScript } from "@realm/adapters";
 import { RUN_BLOCK_SENTINEL } from "@realm/contracts";
 import { createApp, type App } from "../app";
@@ -43,7 +41,7 @@ const DONE_SCRIPT: FakeScript = [{ on: WORKER_OPENER, emit: [
 ] }];
 
 async function boot(opts: { script?: FakeScript; delayMs?: number; home?: string } = {}) {
-  const home = opts.home ?? mkdtempSync(join(tmpdir(), "realm-runs-"));
+  const home = opts.home ?? tempDir("realm-runs-");
   const fake = new CaptureFake({ script: opts.script ?? DONE_SCRIPT, delayMs: opts.delayMs ?? 2 });
   app = await createApp({
     home, port: 0, adapters: { fake, claude: fake },

--- a/apps/server/src/school/school.test.ts
+++ b/apps/server/src/school/school.test.ts
@@ -1,9 +1,9 @@
 import { afterEach, describe, expect, it } from "vitest";
 import WebSocket from "ws";
-import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { mkdirSync, writeFileSync } from "node:fs";
 import { readFile, readdir } from "node:fs/promises";
-import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { tempDir } from "@realm/test-utils";
 import { createApp, type App } from "../app";
 import { waitFor } from "../test-utils";
 import { normalizeBody } from "./plynn";
@@ -21,7 +21,7 @@ async function client(port: number) {
 }
 
 async function setup(o: { plynnDir?: string } = {}) {
-  const home = mkdtempSync(join(tmpdir(), "realm-home-"));
+  const home = tempDir("realm-home-");
   const app = await createApp({ home, port: 0, plynnMeetingsDir: o.plynnDir ?? join(home, "no-plynn") }); apps.push(app);
   const c = await client(app.port);
   const prof = (await c.call("profiles.create", { name: "School" })).result;
@@ -81,7 +81,7 @@ describe("lectures RPC", () => {
 
 describe("plynn RPC", () => {
   function plynnFixture() {
-    const dir = mkdtempSync(join(tmpdir(), "plynn-meetings-"));
+    const dir = tempDir("plynn-meetings-");
     writeFileSync(join(dir, "2026-09-02 14.05 EE 457 lecture.md"), "# EE 457 lecture\n\n- Hazards\n\n---\n\n## Transcript\n\nToday we cover hazards.\n");
     writeFileSync(join(dir, "2026-09-01 09.00 Standup.md"), "Notes without a heading\n\n---\n\n## Transcript\n\nhi\n");
     writeFileSync(join(dir, "README.txt"), "not a meeting");
@@ -173,7 +173,7 @@ describe("imported lecture files are real files", () => {
     c.close();
   });
   function plynnOne() {
-    const dir = mkdtempSync(join(tmpdir(), "plynn-meetings-"));
+    const dir = tempDir("plynn-meetings-");
     writeFileSync(join(dir, "2026-09-02 10.00 L.md"), "# L\n\nnotes\n");
     return dir;
   }

--- a/apps/server/src/search/service.test.ts
+++ b/apps/server/src/search/service.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
-import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { tempDir } from "@realm/test-utils";
 import { sessionEvent, type SearchSnippet } from "@realm/contracts";
 import { openDatabase } from "../db/database";
 import { ProfilesStore } from "../store/profiles";
@@ -16,7 +16,7 @@ import { NotFoundError } from "../store/rows";
 import { BACKFILL_CHUNK, SEARCH_BACKFILL_KEY, SearchService, ftsExpression, liveMatches, liveSnippet, parseFtsSnippet, queryTokens } from "./service";
 
 function harness() {
-  const home = mkdtempSync(join(tmpdir(), "realm-search-"));
+  const home = tempDir("realm-search-");
   const db = openDatabase(join(home, "realm.db"));
   const profiles = new ProfilesStore(db);
   const spaces = new SpacesStore(db, home);

--- a/apps/server/src/sessions/fork-integration.test.ts
+++ b/apps/server/src/sessions/fork-integration.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, it, afterEach } from "vitest";
 import WebSocket from "ws";
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
+import { tempDir } from "@realm/test-utils";
 import { FakeAdapter } from "@realm/adapters";
 import type { StartOptions } from "@realm/adapters";
 import { createApp, type App } from "../app";
@@ -50,7 +51,7 @@ class RecordingFake extends FakeAdapter {
 
 describe("fork + search over rpc (Plan 16)", () => {
   it("indexes live session text profile-scoped; forks into a new worktree whose session starts with the carried context", async () => {
-    const home = mkdtempSync(join(tmpdir(), "realm-forkint-"));
+    const home = tempDir("realm-forkint-");
     if (!resolve(home).startsWith(resolve(tmpdir()))) throw new Error(`refusing to run against ${home}`);
     const fake = new RecordingFake({ script: [{ on: "go", emit: [{ kind: "text", text: "the walrus is assembled" }] }], delayMs: 5 });
     app = await createApp({ home, port: 0, adapters: { fake } });

--- a/apps/server/src/sessions/fork.test.ts
+++ b/apps/server/src/sessions/fork.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "vitest";
 import { execFileSync } from "node:child_process";
-import { existsSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { tempDir } from "@realm/test-utils";
 import { sessionEvent, type Checkpoint } from "@realm/contracts";
 import { openDatabase } from "../db/database";
 import { ProfilesStore } from "../store/profiles";
@@ -30,7 +30,7 @@ function initRepo(dir: string): void {
 }
 
 function harness() {
-  const home = mkdtempSync(join(tmpdir(), "realm-fork-"));
+  const home = tempDir("realm-fork-");
   const db = openDatabase(join(home, "realm.db"));
   const profiles = new ProfilesStore(db);
   const spaces = new SpacesStore(db, home);

--- a/apps/server/src/sessions/service.test.ts
+++ b/apps/server/src/sessions/service.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it, afterEach } from "vitest";
 import WebSocket from "ws";
 import { execFileSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { tempDir } from "@realm/test-utils";
 import { FakeAdapter } from "@realm/adapters";
 import { createApp, type App } from "../app";
 import { DEFAULT_PERMISSION_MODE_KEY } from "@realm/contracts";
@@ -31,7 +31,7 @@ async function client(port: number) {
 }
 
 async function boot(fake = new FakeAdapter({ script: [{ on: "go", emit: [{ kind: "text", text: "ok" }, { kind: "tool", name: "Bash", input: { command: "ls" }, needsPermission: true, result: "x" }] }] })) {
-  const home = mkdtempSync(join(tmpdir(), "realm-"));
+  const home = tempDir("realm-");
   app = await createApp({ home, port: 0, adapters: { fake } });
   const c = await client(app.port);
   const p = (await c.call("profiles.create", { name: "W" })).result;
@@ -142,7 +142,7 @@ describe("SessionService over rpc", () => {
   });
 
   it("upgrades the heuristic title to the configured titleGenerator's summary once it resolves", async () => {
-    const home = mkdtempSync(join(tmpdir(), "realm-"));
+    const home = tempDir("realm-");
     app = await createApp({ home, port: 0, adapters: { fake: new FakeAdapter({ script: [] }) }, titleGenerator: async (text) => `Summary of: ${text}` });
     const c = await client(app.port);
     const p = (await c.call("profiles.create", { name: "W" })).result;
@@ -158,7 +158,7 @@ describe("SessionService over rpc", () => {
   });
 
   it("never clobbers a title a rename already moved past by the time the generator resolves", async () => {
-    const home = mkdtempSync(join(tmpdir(), "realm-"));
+    const home = tempDir("realm-");
     let resolveTitle!: (v: string) => void;
     const slow = new Promise<string>((res) => { resolveTitle = res; });
     app = await createApp({ home, port: 0, adapters: { fake: new FakeAdapter({ script: [] }) }, titleGenerator: () => slow });
@@ -180,7 +180,7 @@ describe("SessionService over rpc", () => {
     expect((await c.call("agents.probe", {})).result).toEqual([{ kind: "fake", available: true, version: "fake", loggedIn: true, reason: null }]);
     c.close(); await app.close();
     class BadProbe extends FakeAdapter { override async probe(): Promise<never> { throw new Error("probe exploded"); } }
-    const home = mkdtempSync(join(tmpdir(), "realm-"));
+    const home = tempDir("realm-");
     app = await createApp({ home, port: 0, adapters: { fake: new FakeAdapter({ script: [] }), claude: Object.assign(new BadProbe({ script: [] }), { kind: "claude" as const }) } });
     const c2 = await client(app.port);
     expect((await c2.call("agents.probe", {})).result).toEqual([
@@ -197,7 +197,7 @@ describe("SessionService over rpc", () => {
     class Counting extends FakeAdapter {
       override async probe() { return { kind: this.kind, available: true, version: `v${++n}`, loggedIn: true, reason: null }; }
     }
-    const home = mkdtempSync(join(tmpdir(), "realm-"));
+    const home = tempDir("realm-");
     app = await createApp({ home, port: 0, adapters: { fake: new Counting({ script: [] }) } });
     const c = await client(app.port);
     expect((await c.call("agents.probe", {})).result[0].version).toBe("v1");
@@ -280,7 +280,7 @@ describe("SessionService over rpc", () => {
   describe("sessions.setAgent", () => {
     /** Two kinds registered so a switch has somewhere to go; both are the scripted fake. */
     async function bootTwo() {
-      const home = mkdtempSync(join(tmpdir(), "realm-"));
+      const home = tempDir("realm-");
       const script = [{ on: "go", emit: [{ kind: "text" as const, text: "ok" }] }];
       app = await createApp({ home, port: 0, adapters: { fake: new FakeAdapter({ script }), codex: new FakeAdapter({ script }) } });
       const c = await client(app.port);
@@ -342,7 +342,7 @@ describe("SessionService over rpc", () => {
      *  that send a message need an event, not a turn parked on a permission prompt at teardown. */
     async function bootTwoEnvs() {
       const booted = await boot(new FakeAdapter({ script: [{ on: "go", emit: [{ kind: "text", text: "ok" }] }] }));
-      const root = mkdtempSync(join(tmpdir(), "realm-checkout-"));
+      const root = tempDir("realm-checkout-");
       const project = (await booted.c.call("projects.create", { spaceId: booted.sp.id, name: "web", rootPath: root })).result;
       const anchor = (await booted.c.call("sessions.create", { spaceId: booted.sp.id, agentKind: "fake", projectId: project.id })).result.session;
       return { ...booted, anchor };
@@ -421,7 +421,7 @@ describe("SessionService over rpc", () => {
 
     it("clears projectId on move — a project is scoped to the space it was left in", async () => {
       const { c, sp, other } = await twoSpaces();
-      const root = mkdtempSync(join(tmpdir(), "realm-checkout-"));
+      const root = tempDir("realm-checkout-");
       const project = (await c.call("projects.create", { spaceId: sp.id, name: "web", rootPath: root })).result;
       const { session } = (await c.call("sessions.create", { spaceId: sp.id, agentKind: "fake", projectId: project.id })).result;
       expect(session.projectId).toBe(project.id);

--- a/apps/server/src/skills/discovery.test.ts
+++ b/apps/server/src/skills/discovery.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, beforeEach, afterEach } from "vitest";
-import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { mkdirSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { tempDir } from "@realm/test-utils";
 import { assignRootKeys, pluginRoots, scan, scanRoots, tildify, type ScanRoot } from "./discovery";
 
 let home: string;
@@ -17,7 +17,7 @@ const write = (path: string, body: string) => {
   writeFileSync(path, body);
 };
 
-beforeEach(() => { home = mkdtempSync(join(tmpdir(), "realm-discovery-")); });
+beforeEach(() => { home = tempDir("realm-discovery-"); });
 afterEach(() => { rmSync(home, { recursive: true, force: true }); });
 
 const library = () => join(home, "Realm", "skills");

--- a/apps/server/src/skills/integration.test.ts
+++ b/apps/server/src/skills/integration.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it, afterEach, vi } from "vitest";
 import WebSocket from "ws";
-import { mkdirSync, mkdtempSync, readdirSync, realpathSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { mkdirSync, readdirSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { tempDir } from "@realm/test-utils";
 import { AsyncQueue, type AgentAdapter, type AgentHandle, type StartOptions, type UserMessage } from "@realm/adapters";
 import { newId, sessionEvent, type SessionEvent } from "@realm/contracts";
 import { createApp, type App } from "../app";
@@ -58,7 +58,7 @@ const skill = (dir: string, id: string) => {
 
 /** A home with no bundled install, so each test's library is exactly what it wrote. */
 async function boot(opts: { bundled?: string } = {}) {
-  const home = mkdtempSync(join(tmpdir(), "realm-skills-int-"));
+  const home = tempDir("realm-skills-int-");
   vi.stubEnv("REALM_BUNDLED_SKILLS", opts.bundled ?? join(home, "no-bundle"));
   const claude = new RecordingAdapter("claude");
   const cursor = new RecordingAdapter("acp:cursor");
@@ -174,7 +174,7 @@ describe("skills over rpc", () => {
   });
 
   it("installs the bundled skills into the library once, on boot", async () => {
-    const bundled = mkdtempSync(join(tmpdir(), "realm-skills-bundle-"));
+    const bundled = tempDir("realm-skills-bundle-");
     skill(bundled, "mac");
     const { c, sp, home } = await boot({ bundled });
     expect(readdirSync(join(home, "skills"))).toEqual(["mac"]);

--- a/apps/server/src/skills/service.test.ts
+++ b/apps/server/src/skills/service.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
-import { mkdirSync, mkdtempSync, readFileSync, readdirSync, realpathSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { mkdirSync, readFileSync, readdirSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { tempDir } from "@realm/test-utils";
 import { openDatabase } from "../db/database";
 import { SettingsStore } from "../store/settings";
 import { RpcError } from "../store/rows";
@@ -19,8 +19,8 @@ const skill = (dir: string, id: string, body = `---\nname: ${id}\ndescription: d
 };
 
 beforeEach(() => {
-  home = mkdtempSync(join(tmpdir(), "realm-skills-home-"));
-  bundled = mkdtempSync(join(tmpdir(), "realm-skills-bundle-"));
+  home = tempDir("realm-skills-home-");
+  bundled = tempDir("realm-skills-bundle-");
   settings = new SettingsStore(openDatabase(join(home, "realm.db")));
   service = new SkillsService({ home, settings, bundledDir: bundled });
 });

--- a/apps/server/src/store/checkpoints.test.ts
+++ b/apps/server/src/store/checkpoints.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it, beforeEach } from "vitest";
-import { mkdtempSync } from "node:fs";
-import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { tempDir } from "@realm/test-utils";
 import { newId } from "@realm/contracts";
 import { openDatabase, type Db } from "../db/database";
 import { ProfilesStore } from "./profiles";
@@ -18,7 +17,7 @@ const state = (n: number): CapturedState =>
   ({ commitSha: `c${n}`, worktreeTree: `w${n}`, indexTree: `i${n}`, headSha: "h", headRef: "refs/heads/main" });
 
 beforeEach(() => {
-  const home = mkdtempSync(join(tmpdir(), "realm-cpstore-"));
+  const home = tempDir("realm-cpstore-");
   db = openDatabase(join(home, "realm.db"));
   const p = new ProfilesStore(db).create({ name: "P", icon: "x", color: "#000" });
   const spaces = new SpacesStore(db, home);

--- a/apps/server/src/store/mcp.test.ts
+++ b/apps/server/src/store/mcp.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it, beforeEach } from "vitest";
-import { mkdtempSync } from "node:fs";
-import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { tempDir } from "@realm/test-utils";
 import { openDatabase, type Db } from "../db/database";
 import { ProfilesStore } from "./profiles";
 import { SpacesStore } from "./spaces";
@@ -15,7 +14,7 @@ const stdio = (name: string): McpServerInput =>
   ({ name, transport: "stdio", command: "/usr/bin/node", args: ["/abs/s.mjs"], url: "", secrets: { KEY: "pat-x" } });
 
 beforeEach(() => {
-  db = openDatabase(join(mkdtempSync(join(tmpdir(), "realm-mcpstore-")), "realm.db"));
+  db = openDatabase(join(tempDir("realm-mcpstore-"), "realm.db"));
   servers = new McpServersStore(db);
   calls = new McpCallLogStore(db);
 });
@@ -68,7 +67,7 @@ describe("McpCallLogStore", () => {
   let sessionId: string; let serverId: string;
 
   beforeEach(() => {
-    const home = mkdtempSync(join(tmpdir(), "realm-mcplog-home-"));
+    const home = tempDir("realm-mcplog-home-");
     const p = new ProfilesStore(db).create({ name: "P", icon: "x", color: "#000" });
     const spaces = new SpacesStore(db, home);
     const envs = new EnvironmentsStore(db);

--- a/apps/server/src/store/notifications.test.ts
+++ b/apps/server/src/store/notifications.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it, beforeEach } from "vitest";
-import { mkdtempSync } from "node:fs";
-import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { tempDir } from "@realm/test-utils";
 import { openDatabase, type Db } from "../db/database";
 import { NotificationsStore, type NotificationInsert } from "./notifications";
 
@@ -11,7 +10,7 @@ const row = (extra: Partial<NotificationInsert> = {}): NotificationInsert =>
   ({ category: "session_done", spaceId: null, sessionId: null, refId: null, title: "t", body: null, ...extra });
 
 beforeEach(() => {
-  db = openDatabase(join(mkdtempSync(join(tmpdir(), "realm-notifstore-")), "realm.db"));
+  db = openDatabase(join(tempDir("realm-notifstore-"), "realm.db"));
   store = new NotificationsStore(db);
 });
 

--- a/apps/server/src/store/runs.test.ts
+++ b/apps/server/src/store/runs.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it, beforeEach } from "vitest";
-import { mkdtempSync, readFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { tempDir } from "@realm/test-utils";
 import { RUN_LIVE_STATES } from "@realm/contracts";
 import { openDatabase, type Db } from "../db/database";
 import { ProfilesStore } from "./profiles";
@@ -17,7 +17,7 @@ const insert = (extra: Partial<RunInsert> = {}): RunInsert => ({
 });
 
 beforeEach(() => {
-  const home = mkdtempSync(join(tmpdir(), "realm-runstore-"));
+  const home = tempDir("realm-runstore-");
   db = openDatabase(join(home, "realm.db"));
   const profile = new ProfilesStore(db).create({ name: "P", icon: "x", color: "#000" });
   const spaces = new SpacesStore(db, home);

--- a/apps/server/src/store/sessions.test.ts
+++ b/apps/server/src/store/sessions.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { mkdtempSync } from "node:fs"; import { tmpdir } from "node:os"; import { join } from "node:path";
+import { join } from "node:path";
+import { tempDir } from "@realm/test-utils";
 import { sessionEvent } from "@realm/contracts";
 import { openDatabase } from "../db/database";
 import { ProfilesStore } from "./profiles";
@@ -9,7 +10,7 @@ import { EnvironmentsStore } from "./environments";
 import { NotFoundError } from "./rows";
 
 function fresh() {
-  const home = mkdtempSync(join(tmpdir(), "realm-"));
+  const home = tempDir("realm-");
   const db = openDatabase(join(home, "realm.db"));
   const p = new ProfilesStore(db).create({ name: "W", icon: "x", color: "#000" });
   const space = new SpacesStore(db, home).create({ profileId: p.id, name: "S", icon: "f" });

--- a/apps/server/src/store/settings.test.ts
+++ b/apps/server/src/store/settings.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { mkdtempSync } from "node:fs"; import { tmpdir } from "node:os"; import { join } from "node:path";
+import { join } from "node:path";
+import { tempDir } from "@realm/test-utils";
 import { openDatabase } from "../db/database"; import { SettingsStore } from "./settings";
 describe("SettingsStore", () => {
   it("get returns null for missing, set/get roundtrips JSON", () => {
-    const db = openDatabase(join(mkdtempSync(join(tmpdir(), "realm-")), "realm.db"));
+    const db = openDatabase(join(tempDir("realm-"), "realm.db"));
     const s = new SettingsStore(db);
     expect(s.get("ui.activeSpaceId")).toBeNull();
     s.set("ui.theme", { mode: "system" });

--- a/apps/server/src/store/ships.test.ts
+++ b/apps/server/src/store/ships.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it, beforeEach } from "vitest";
-import { mkdtempSync } from "node:fs";
-import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { tempDir } from "@realm/test-utils";
 import { openDatabase, type Db } from "../db/database";
 import { ShipsStore, type ShipInsert } from "./ships";
 
@@ -12,7 +11,7 @@ const row = (extra: Partial<ShipInsert> = {}): ShipInsert =>
     sha: "abc123", subject: "a change", prUrl: null, pushState: "pushed", ...extra });
 
 beforeEach(() => {
-  db = openDatabase(join(mkdtempSync(join(tmpdir(), "realm-shipstore-")), "realm.db"));
+  db = openDatabase(join(tempDir("realm-shipstore-"), "realm.db"));
   store = new ShipsStore(db);
 });
 

--- a/apps/server/src/store/store.test.ts
+++ b/apps/server/src/store/store.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, beforeEach } from "vitest";
-import { mkdtempSync, existsSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { existsSync } from "node:fs";
 import { join } from "node:path";
+import { tempDir } from "@realm/test-utils";
 import { openDatabase, type Db } from "../db/database";
 import { ProfilesStore } from "./profiles";
 import { SpacesStore } from "./spaces";
@@ -15,7 +15,7 @@ import { emptyLayout, type Layout } from "@realm/contracts";
 
 let db: Db; let home: string;
 beforeEach(() => {
-  home = mkdtempSync(join(tmpdir(), "realm-home-"));
+  home = tempDir("realm-home-");
   db = openDatabase(join(home, "realm.db"));
 });
 

--- a/apps/server/src/terminals/service.test.ts
+++ b/apps/server/src/terminals/service.test.ts
@@ -1,8 +1,7 @@
 import { describe, expect, it, afterEach } from "vitest";
 import WebSocket from "ws";
-import { mkdtempSync } from "node:fs";
-import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { tempDir } from "@realm/test-utils";
 import { createApp, type App } from "../app";
 import { TerminalsStore } from "../store/terminals";
 import { waitFor } from "../test-utils";
@@ -21,7 +20,7 @@ async function client(port: number) {
 
 describe("TerminalService.restoreAll", () => {
   it("respawns ptys for persisted terminal rows on boot; prunes rows whose cwd is gone", async () => {
-    const home = mkdtempSync(join(tmpdir(), "realm-home-"));
+    const home = tempDir("realm-home-");
     const app1 = await createApp({ home, port: 0 }); apps.push(app1);
     const c1 = await client(app1.port);
     const prof = (await c1.call("profiles.create", { name: "Work" })).result;
@@ -55,7 +54,7 @@ describe("terminal port blocks", () => {
     c.events.filter((e) => e.event === "terminal.data" && e.payload.terminalId === terminalId).map((e) => String(e.payload.data)).join("");
 
   it("exports the environment's port block into the shell, and keeps it across a restart", async () => {
-    const home = mkdtempSync(join(tmpdir(), "realm-home-"));
+    const home = tempDir("realm-home-");
     const app1 = await createApp({ home, port: 0 }); apps.push(app1);
     const c1 = await client(app1.port);
     const prof = (await c1.call("profiles.create", { name: "Work" })).result;
@@ -78,7 +77,7 @@ describe("terminal port blocks", () => {
   });
 
   it("gives two spaces' terminals different blocks", async () => {
-    const home = mkdtempSync(join(tmpdir(), "realm-home-"));
+    const home = tempDir("realm-home-");
     const app1 = await createApp({ home, port: 0 }); apps.push(app1);
     const c = await client(app1.port);
     const prof = (await c.call("profiles.create", { name: "Work" })).result;

--- a/apps/server/src/usage/service.test.ts
+++ b/apps/server/src/usage/service.test.ts
@@ -1,7 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { mkdtempSync } from "node:fs";
-import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { tempDir } from "@realm/test-utils";
 import { USAGE_BUDGET_KEY, sessionEvent, type AgentKind, type ModelInfo, type Session, type SessionEventPayload } from "@realm/contracts";
 import { openDatabase, type Db } from "../db/database";
 import { ProfilesStore } from "../store/profiles";
@@ -56,7 +55,7 @@ const appendEvent = (sessionId: string, ts: number, type: string, payload: unkno
   db.prepare("INSERT INTO session_events (session_id, ts, type, payload_json) VALUES (?, ?, ?, ?)").run(sessionId, ts, type, JSON.stringify(payload));
 
 beforeEach(() => {
-  const home = mkdtempSync(join(tmpdir(), "realm-usage-"));
+  const home = tempDir("realm-usage-");
   db = openDatabase(join(home, "realm.db"));
   settings = new SettingsStore(db);
   profileId = new ProfilesStore(db).create({ name: "P", icon: "x", color: "#000" }).id;

--- a/apps/server/src/workspace/checkpoints.test.ts
+++ b/apps/server/src/workspace/checkpoints.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from "vitest";
 import { execFileSync } from "node:child_process";
-import { chmodSync, existsSync, mkdirSync, mkdtempSync, lstatSync, readFileSync, readdirSync, readlinkSync, rmSync, statSync, symlinkSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, lstatSync, readFileSync, readdirSync, readlinkSync, rmSync, statSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
+import { tempDir } from "@realm/test-utils";
 import { newId } from "@realm/contracts";
 import { CHECKPOINT_REF_PREFIX, CheckpointGit, checkpointRef } from "./checkpoints";
 
@@ -19,7 +20,7 @@ function git(cwd: string, ...args: string[]): string {
   return execFileSync("git", [...IDENT, ...args], { cwd, encoding: "utf8" });
 }
 function makeRepo(): string {
-  const dir = mkdtempSync(join(tmpdir(), "realm-cp-"));
+  const dir = tempDir("realm-cp-");
   const scratch = resolve(tmpdir());
   if (!resolve(dir).startsWith(scratch)) throw new Error(`refusing to run against ${dir}: not a scratch directory`);
   git(dir, "init", "-q", "-b", "main");
@@ -34,7 +35,7 @@ function makeRepo(): string {
 }
 /** A repository that has been `git init`ed and nothing more: no HEAD, no index file. */
 function makeEmptyRepo(): string {
-  const dir = mkdtempSync(join(tmpdir(), "realm-cp-empty-"));
+  const dir = tempDir("realm-cp-empty-");
   if (!resolve(dir).startsWith(resolve(tmpdir()))) throw new Error(`refusing to run against ${dir}`);
   git(dir, "init", "-q", "-b", "main");
   git(dir, "config", "user.email", "t@example.com");
@@ -451,7 +452,7 @@ describe("refs", () => {
 describe("worktrees", () => {
   it("checkpoints a worktree without touching its sibling's tree", async () => {
     const repo = makeRepo();
-    const wt = mkdtempSync(join(tmpdir(), "realm-cp-wt-"));
+    const wt = tempDir("realm-cp-wt-");
     try {
       rmSync(wt, { recursive: true, force: true }); // git worktree add wants a path that does not exist
       git(repo, "worktree", "add", "-q", "-b", "realm/side", wt, "HEAD");

--- a/apps/server/src/workspace/git-diff.test.ts
+++ b/apps/server/src/workspace/git-diff.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "vitest";
 import { execFileSync } from "node:child_process";
-import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { tempDir } from "@realm/test-utils";
 import { DIFF_MAX_FILES, FILE_DIFF_MAX_LINES, GitDiffService, parseNumstat, parseStatus, parsePatch, statusOf } from "./git-diff";
 
 /**
@@ -14,7 +14,7 @@ function git(cwd: string, ...args: string[]): string {
   return execFileSync("git", ["-c", "user.email=t@example.com", "-c", "user.name=t", "-c", "commit.gpgsign=false", ...args], { cwd, encoding: "utf8" });
 }
 function makeRepo(): string {
-  const dir = mkdtempSync(join(tmpdir(), "realm-diff-"));
+  const dir = tempDir("realm-diff-");
   git(dir, "init", "-q", "-b", "main");
   writeFileSync(join(dir, "a.txt"), "one\ntwo\nthree\n");
   writeFileSync(join(dir, "b.txt"), "x\n");
@@ -74,7 +74,7 @@ describe("parseStatus", () => {
 
 describe("summary", () => {
   it("returns null outside a repository", async () => {
-    const dir = mkdtempSync(join(tmpdir(), "realm-nodiff-"));
+    const dir = tempDir("realm-nodiff-");
     try { expect(await svc().summary(dir)).toBeNull(); } finally { rmSync(dir, { recursive: true, force: true }); }
   });
 
@@ -152,7 +152,7 @@ describe("summary", () => {
   }, 30_000);
 
   it("survives a repository with no commits", async () => {
-    const dir = mkdtempSync(join(tmpdir(), "realm-empty-"));
+    const dir = tempDir("realm-empty-");
     try {
       git(dir, "init", "-q", "-b", "main");
       writeFileSync(join(dir, "first.txt"), "hello\n");

--- a/apps/server/src/workspace/git-info.test.ts
+++ b/apps/server/src/workspace/git-info.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it, beforeAll } from "vitest";
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, writeFileSync } from "node:fs";
+import { writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { tempDir } from "@realm/test-utils";
 import { GitInfoService } from "./git-info";
 
 /** Run git in `cwd` with identity/config pinned so the host machine's config never leaks in. */
@@ -11,7 +12,7 @@ function git(cwd: string, ...args: string[]): string {
 }
 
 function makeRepo(): string {
-  const dir = mkdtempSync(join(tmpdir(), "realm-git-"));
+  const dir = tempDir("realm-git-");
   git(dir, "init", "-b", "main");
   writeFileSync(join(dir, "a.txt"), "one\ntwo\nthree\n");
   git(dir, "add", ".");
@@ -30,7 +31,7 @@ describe("GitInfoService", () => {
   });
 
   it("returns null for a directory that is not a git repo", async () => {
-    const dir = mkdtempSync(join(tmpdir(), "realm-notgit-"));
+    const dir = tempDir("realm-notgit-");
     expect(await new GitInfoService().get(dir)).toBeNull();
   });
 
@@ -54,7 +55,7 @@ describe("GitInfoService", () => {
 
   it("ahead/behind come from the upstream in the right order", async () => {
     const upstream = makeRepo();
-    const dir = mkdtempSync(join(tmpdir(), "realm-clone-"));
+    const dir = tempDir("realm-clone-");
     git(dir, "clone", upstream, "clone");
     const clone = join(dir, "clone");
     writeFileSync(join(clone, "b.txt"), "local\n");

--- a/apps/server/src/workspace/git-write.test.ts
+++ b/apps/server/src/workspace/git-write.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from "vitest";
 import { execFileSync } from "node:child_process";
-import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { tempDir } from "@realm/test-utils";
 import { GitWriteService, compareUrl, parseGitHubRemote } from "./git-write";
 
 /**
@@ -15,7 +16,7 @@ function git(cwd: string, ...args: string[]): string {
   return execFileSync("git", [...IDENT, ...args], { cwd, encoding: "utf8" });
 }
 function makeRepo(): string {
-  const dir = mkdtempSync(join(tmpdir(), "realm-write-"));
+  const dir = tempDir("realm-write-");
   git(dir, "init", "-q", "-b", "main");
   git(dir, "config", "user.email", "t@example.com");
   git(dir, "config", "user.name", "t");
@@ -28,14 +29,14 @@ function makeRepo(): string {
 }
 /** A bare repository on disk, wired up as `origin`. Push works; nothing leaves the machine. */
 function attachRemote(repo: string, name = "origin"): string {
-  const bare = mkdtempSync(join(tmpdir(), "realm-remote-"));
+  const bare = tempDir("realm-remote-");
   execFileSync("git", ["init", "-q", "--bare", "-b", "main", bare]);
   git(repo, "remote", "add", name, bare);
   return bare;
 }
 /** A `gh` that is not gh: a script that prints what the test wants and exits how the test says. */
 function stubGh(body: string): string {
-  const dir = mkdtempSync(join(tmpdir(), "realm-gh-"));
+  const dir = tempDir("realm-gh-");
   const path = join(dir, "gh");
   writeFileSync(path, `#!/bin/sh\n${body}\n`);
   chmodSync(path, 0o755);
@@ -92,7 +93,7 @@ describe("stage / unstage", () => {
   });
 
   it("unstages in a repository that has no commits yet", async () => {
-    const repo = mkdtempSync(join(tmpdir(), "realm-unborn-"));
+    const repo = tempDir("realm-unborn-");
     try {
       git(repo, "init", "-q", "-b", "main");
       writeFileSync(join(repo, "a.txt"), "one\n");
@@ -155,7 +156,7 @@ describe("ship — commit", () => {
   });
 
   it("explains a missing git identity instead of returning git's four paragraphs", async () => {
-    const repo = mkdtempSync(join(tmpdir(), "realm-noident-"));
+    const repo = tempDir("realm-noident-");
     try {
       execFileSync("git", ["init", "-q", "-b", "main", repo]);
       // Local config that BLANKS the identity: set to empty, which git treats as absent even when a
@@ -221,7 +222,7 @@ describe("ship — push", () => {
 
   it("explains a rejected push instead of forcing it", async () => {
     const repo = makeRepo(); const bare = attachRemote(repo);
-    const other = mkdtempSync(join(tmpdir(), "realm-other-"));
+    const other = tempDir("realm-other-");
     try {
       git(repo, "push", "-u", "origin", "main");
       // Someone else moves the remote on.
@@ -267,7 +268,7 @@ describe("ship — push", () => {
  * URL, `git remote get-url` still reports the fetch URL, and github.com is never contacted.
  */
 function attachGitHubLookalike(repo: string, address = "https://github.com/acme/widgets.git"): string {
-  const bare = mkdtempSync(join(tmpdir(), "realm-remote-"));
+  const bare = tempDir("realm-remote-");
   execFileSync("git", ["init", "-q", "--bare", "-b", "main", bare]);
   git(repo, "remote", "add", "origin", address);
   git(repo, "remote", "set-url", "--push", "origin", bare);
@@ -390,7 +391,7 @@ describe("ship — the durable log", () => {
 
   it("a commit whose push was rejected logs with pushState rejected — never pushed (the named mutant)", async () => {
     const repo = makeRepo(); const bare = attachRemote(repo);
-    const other = mkdtempSync(join(tmpdir(), "realm-other-"));
+    const other = tempDir("realm-other-");
     const { service, entries } = logSvc();
     try {
       git(repo, "push", "-u", "origin", "main");

--- a/apps/server/src/workspace/ports.test.ts
+++ b/apps/server/src/workspace/ports.test.ts
@@ -1,8 +1,7 @@
 import { describe, expect, it, beforeEach } from "vitest";
 import { createServer, type Server } from "node:net";
-import { mkdtempSync } from "node:fs";
-import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { tempDir } from "@realm/test-utils";
 import { openDatabase, type Db } from "../db/database";
 import { ProfilesStore } from "../store/profiles";
 import { SpacesStore } from "../store/spaces";
@@ -13,7 +12,7 @@ let db: Db; let home: string; let spaces: SpacesStore; let envs: EnvironmentsSto
 let spaceIds: string[];
 
 beforeEach(() => {
-  home = mkdtempSync(join(tmpdir(), "realm-ports-"));
+  home = tempDir("realm-ports-");
   db = openDatabase(join(home, "realm.db"));
   const p = new ProfilesStore(db).create({ name: "P", icon: "x", color: "#000" });
   spaces = new SpacesStore(db, home);

--- a/apps/server/src/workspace/worktrees.test.ts
+++ b/apps/server/src/workspace/worktrees.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it, beforeEach } from "vitest";
 import { execFileSync } from "node:child_process";
-import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { tempDir } from "@realm/test-utils";
 import { BRANCH_PREFIX, NAME_ATTEMPTS, SLUG_MAX, UNNAMED_BRANCH, WorktreeService, slugifyBranch } from "./worktrees";
 
 /**
@@ -15,10 +16,10 @@ function git(cwd: string, ...args: string[]): string {
 }
 
 let home: string;
-beforeEach(() => { home = mkdtempSync(join(tmpdir(), "realm-wt-home-")); });
+beforeEach(() => { home = tempDir("realm-wt-home-"); });
 
 function makeRepo(name = "repo"): string {
-  const dir = mkdtempSync(join(tmpdir(), `realm-wt-${name}-`));
+  const dir = tempDir(`realm-wt-${name}-`);
   git(dir, "init", "-b", "main");
   writeFileSync(join(dir, "a.txt"), "one\n");
   git(dir, "add", ".");
@@ -82,7 +83,7 @@ describe("WorktreeService.create", () => {
   });
 
   it("refuses a directory that is not a git repository — a plain space must not break", async () => {
-    const plain = mkdtempSync(join(tmpdir(), "realm-wt-plain-"));
+    const plain = tempDir("realm-wt-plain-");
     await expect(svc().create({ spaceId: SPACE, sourcePath: plain, title: "x" }))
       .rejects.toMatchObject({ code: "NOT_A_REPOSITORY" });
     expect(existsSync(join(home, "worktrees", SPACE, "x"))).toBe(false);
@@ -94,7 +95,7 @@ describe("WorktreeService.create", () => {
   });
 
   it("refuses a repository with no commits, naming what to do about it", async () => {
-    const empty = mkdtempSync(join(tmpdir(), "realm-wt-empty-"));
+    const empty = tempDir("realm-wt-empty-");
     git(empty, "init", "-b", "main");
     await expect(svc().create({ spaceId: SPACE, sourcePath: empty, title: "x" }))
       .rejects.toMatchObject({ code: "WORKTREE_NO_COMMITS", message: expect.stringContaining("no commits") });
@@ -159,7 +160,7 @@ describe("WorktreeService.hazard", () => {
 
   it("counts only commits absent from every remote", async () => {
     const origin = makeRepo("origin");
-    const clone = mkdtempSync(join(tmpdir(), "realm-wt-clone-"));
+    const clone = tempDir("realm-wt-clone-");
     rmSync(clone, { recursive: true, force: true });
     execFileSync("git", ["clone", "-q", origin, clone], { encoding: "utf8" });
     const wt = await svc().create({ spaceId: SPACE, sourcePath: clone, title: "pushed" });
@@ -186,7 +187,7 @@ describe("WorktreeService.hazard", () => {
 describe("WorktreeService.remove", () => {
   it("removes a clean worktree and deletes its branch", async () => {
     const origin = makeRepo("origin2");
-    const clone = mkdtempSync(join(tmpdir(), "realm-wt-clone2-"));
+    const clone = tempDir("realm-wt-clone2-");
     rmSync(clone, { recursive: true, force: true });
     execFileSync("git", ["clone", "-q", origin, clone], { encoding: "utf8" });
     const wt = await svc().create({ spaceId: SPACE, sourcePath: clone, title: "clean" });
@@ -211,7 +212,7 @@ describe("WorktreeService.remove", () => {
   // dirty-tree check stands between `--force` and an hour of uncommitted work.
   it("refuses a dirty tree even when nothing is unpushed", async () => {
     const origin = makeRepo("origin4");
-    const clone = mkdtempSync(join(tmpdir(), "realm-wt-clone4-"));
+    const clone = tempDir("realm-wt-clone4-");
     rmSync(clone, { recursive: true, force: true });
     execFileSync("git", ["clone", "-q", origin, clone], { encoding: "utf8" });
     const wt = await svc().create({ spaceId: SPACE, sourcePath: clone, title: "onlydirty" });
@@ -262,7 +263,7 @@ describe("WorktreeService.remove", () => {
   // service must ask first, not lean on git's refusal after the directory is already gone.
   it("refuses a clean worktree whose branch holds unpushed commits", async () => {
     const origin = makeRepo("origin3");
-    const clone = mkdtempSync(join(tmpdir(), "realm-wt-clone3-"));
+    const clone = tempDir("realm-wt-clone3-");
     rmSync(clone, { recursive: true, force: true });
     execFileSync("git", ["clone", "-q", origin, clone], { encoding: "utf8" });
     const wt = await svc().create({ spaceId: SPACE, sourcePath: clone, title: "unpushed" });
@@ -354,7 +355,7 @@ describe("renameBranch", () => {
 
   it("refuses to rename a branch a remote already carries", async () => {
     const src = makeRepo();
-    const bare = mkdtempSync(join(tmpdir(), "realm-wt-bare-"));
+    const bare = tempDir("realm-wt-bare-");
     execFileSync("git", ["init", "-q", "--bare", "-b", "main", bare]);
     const wt = await svc().create({ spaceId: SPACE, sourcePath: src, title: null });
     git(wt.path, "remote", "add", "origin", bare);

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "release": "node scripts/release.mjs"
   },
   "devDependencies": {
+    "@realm/test-utils": "workspace:*",
     "@types/node": "^22.13.0",
     "typescript": "^5.6.0",
     "vitest": "^3.2.0"

--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -7,5 +7,5 @@
   "types": "./src/index.ts",
   "scripts": { "typecheck": "tsc -p tsconfig.json --noEmit" },
   "dependencies": { "@realm/contracts": "workspace:*", "@anthropic-ai/claude-agent-sdk": "^0.3.251" },
-  "devDependencies": { "tsx": "^4.19.0" }
+  "devDependencies": { "@realm/test-utils": "workspace:*", "tsx": "^4.19.0" }
 }

--- a/packages/adapters/src/acp/acp-adapter.test.ts
+++ b/packages/adapters/src/acp/acp-adapter.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect, afterEach, vi } from "vitest";
 import { fileURLToPath } from "node:url";
 import { existsSync } from "node:fs";
-import { mkdir, mkdtemp, readFile, realpath, symlink, truncate, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
+import { mkdir, readFile, realpath, symlink, truncate, writeFile } from "node:fs/promises";
 import { join } from "node:path";
+import { tempDir } from "@realm/test-utils";
 import type { SessionEvent, SessionEventOf, SessionEventType } from "@realm/contracts";
 import { AcpAdapter, acpBootFailureMessage, acpMcpServers, MAX_FS_READ_BYTES, pickAcpOption, sliceLines, type AcpAgentSpec } from "./acp-adapter";
 import { JsonRpcCallError } from "../jsonrpc/stdio";
@@ -209,7 +209,7 @@ describe("AcpAdapter", () => {
   });
 
   it("spawns the child in the session's cwd and lets session env override the spec's", async () => {
-    const dir = await realpath(await mkdtemp(join(tmpdir(), "realm-acp-")));
+    const dir = await realpath(tempDir("realm-acp-"));
     const png = join(dir, "shot.png");
     await writeFile(png, Buffer.from([1, 2, 3, 4]));
     // The spec's env is a default for the agent; a session's own env is the more specific value and wins.
@@ -441,7 +441,7 @@ describe("AcpAdapter", () => {
   });
 
   it("serves fs/read_text_file, honouring line and limit", async () => {
-    const dir = await mkdtemp(join(tmpdir(), "realm-acp-"));
+    const dir = tempDir("realm-acp-");
     const path = join(dir, "NOTES.txt");
     await writeFile(path, "one\ntwo\nthree\nfour\n");
     const { handle, evs } = await booted({ cwd: dir });
@@ -457,7 +457,7 @@ describe("AcpAdapter", () => {
   });
 
   it("serves fs/write_text_file", async () => {
-    const dir = await mkdtemp(join(tmpdir(), "realm-acp-"));
+    const dir = tempDir("realm-acp-");
     const path = join(dir, "OUT.txt"); // does not exist yet: the target is resolved through its parent
     const { handle, evs } = await booted({ cwd: dir });
     await turn(handle, evs, `WRITEFILE ${path} written by the agent`);
@@ -470,7 +470,7 @@ describe("AcpAdapter", () => {
     // Absolute paths are all an agent needs to ask for ~/.ssh/id_rsa or ~/.aws/credentials, and none of this
     // reaches a permission card. Declaring fs:false would not take the capability away — but confining our own
     // handlers costs a well-behaved agent nothing, it just falls back to its own I/O.
-    const dir = await realpath(await mkdtemp(join(tmpdir(), "realm-acp-")));
+    const dir = await realpath(tempDir("realm-acp-"));
     const work = join(dir, "work");
     await mkdir(work);
     const outside = join(dir, "SECRET.txt");
@@ -487,7 +487,7 @@ describe("AcpAdapter", () => {
   });
 
   it("refuses to write outside the working directory and leaves the target untouched", async () => {
-    const dir = await realpath(await mkdtemp(join(tmpdir(), "realm-acp-")));
+    const dir = await realpath(tempDir("realm-acp-"));
     const work = join(dir, "work");
     await mkdir(work);
     const outside = join(dir, "ZSHRC");
@@ -504,7 +504,7 @@ describe("AcpAdapter", () => {
   });
 
   it("refuses a symlink inside the working directory that points outside it", async () => {
-    const dir = await realpath(await mkdtemp(join(tmpdir(), "realm-acp-")));
+    const dir = await realpath(tempDir("realm-acp-"));
     const work = join(dir, "work");
     await mkdir(work);
     const outside = join(dir, "SECRET.txt");
@@ -523,7 +523,7 @@ describe("AcpAdapter", () => {
 
   it("refuses a sibling directory whose name merely starts with the working directory's", async () => {
     // /…/work-evil is not inside /…/work, however much a naive prefix test would like it to be.
-    const dir = await realpath(await mkdtemp(join(tmpdir(), "realm-acp-")));
+    const dir = await realpath(tempDir("realm-acp-"));
     const work = join(dir, "work");
     await mkdir(work);
     await mkdir(join(dir, "work-evil"));
@@ -537,7 +537,7 @@ describe("AcpAdapter", () => {
   });
 
   it("refuses to read a file past the size cap", async () => {
-    const dir = await realpath(await mkdtemp(join(tmpdir(), "realm-acp-")));
+    const dir = await realpath(tempDir("realm-acp-"));
     const huge = join(dir, "HUGE.bin");
     await writeFile(huge, "");
     await truncate(huge, MAX_FS_READ_BYTES + 1); // sparse: no real bytes written
@@ -589,7 +589,7 @@ describe("AcpAdapter", () => {
   });
 
   it("inlines image attachments as base64 when the agent accepts images", async () => {
-    const dir = await mkdtemp(join(tmpdir(), "realm-acp-"));
+    const dir = tempDir("realm-acp-");
     const png = join(dir, "shot.png");
     await writeFile(png, Buffer.from([1, 2, 3, 4]));
     const { handle, evs } = await booted();
@@ -602,7 +602,7 @@ describe("AcpAdapter", () => {
   });
 
   it("links images instead of inlining them when the agent does not accept images", async () => {
-    const dir = await mkdtemp(join(tmpdir(), "realm-acp-"));
+    const dir = tempDir("realm-acp-");
     const png = join(dir, "shot.png");
     await writeFile(png, Buffer.from([1, 2, 3, 4]));
     const { handle, evs } = await booted({}, { env: { FAKE_ACP_NOIMAGE: "1" } });
@@ -830,7 +830,7 @@ describe("AcpAdapter", () => {
   });
 
   it("takes the child process down with the session", async () => {
-    const dir = await mkdtemp(join(tmpdir(), "realm-acp-"));
+    const dir = tempDir("realm-acp-");
     const marker = join(dir, "child-exited");
     const { handle } = await booted({}, { env: { FAKE_ACP_EXIT_MARKER: marker } });
     expect(existsSync(marker)).toBe(false);
@@ -904,7 +904,7 @@ describe("AcpAdapter", () => {
   it("bounds initialize so a child that spawns and answers nothing cannot hang the session", async () => {
     // No timeout here and boot stays pending forever: dispose() -> App.close() never returns and the desktop
     // main process SIGTERMs the server out from under its agent children.
-    const dir = await mkdtemp(join(tmpdir(), "realm-acp-"));
+    const dir = tempDir("realm-acp-");
     const marker = join(dir, "child-exited");
     const adapter = newAdapter({ bootTimeoutMs: 200, env: { FAKE_ACP_MUTE_INITIALIZE: "1", FAKE_ACP_EXIT_MARKER: marker } });
     const handle = adapter.start(startOpts());
@@ -942,7 +942,7 @@ describe("AcpAdapter", () => {
   it("completes dispose even when the boot itself never settles", async () => {
     // The boot timeout is deliberately far longer than DISPOSE_TIMEOUT_MS here, so the only thing that can
     // resolve this dispose is the race in dispose() itself.
-    const dir = await mkdtemp(join(tmpdir(), "realm-acp-"));
+    const dir = tempDir("realm-acp-");
     const marker = join(dir, "child-exited");
     const adapter = newAdapter({ bootTimeoutMs: 60_000, env: { FAKE_ACP_MUTE_SESSION_NEW: "1", FAKE_ACP_EXIT_MARKER: marker } });
     const handle = adapter.start(startOpts());
@@ -955,7 +955,7 @@ describe("AcpAdapter", () => {
   });
 
   it("serves fs callbacks during a replay but cancels permission requests raised by it", async () => {
-    const dir = await mkdtemp(join(tmpdir(), "realm-acp-"));
+    const dir = tempDir("realm-acp-");
     const path = join(dir, "REPLAY.txt");
     await writeFile(path, "replayed content");
     const { handle, evs } = await booted(

--- a/packages/adapters/src/claude/claude-adapter.test.ts
+++ b/packages/adapters/src/claude/claude-adapter.test.ts
@@ -2,7 +2,8 @@ import { describe, expect, it } from "vitest";
 import { ClaudeAdapter, claudeAllowedTools, claudeAskTools, claudeMcpServers, claudeSdkPermissionMode } from "./claude-adapter";
 import type { SessionEvent } from "@realm/contracts";
 import type { StartOptions } from "../types";
-import { readFileSync, writeFileSync } from "node:fs"; import { tmpdir } from "node:os"; import { join, dirname } from "node:path"; import { fileURLToPath } from "node:url";
+import { readFileSync, writeFileSync } from "node:fs"; import { join, dirname } from "node:path"; import { fileURLToPath } from "node:url";
+import { tempDir } from "@realm/test-utils";
 const fixture = JSON.parse(readFileSync(join(dirname(fileURLToPath(import.meta.url)), "fixtures", "turn.json"), "utf8")) as unknown[];
 
 type FakeOpts = {
@@ -203,7 +204,7 @@ describe("ClaudeAdapter", () => {
   });
   it("attachment-only: an image carries the message with NO empty text block (Plan 14 W5)", async () => {
     // The Messages API rejects `text: ""` — an image-only send must be image blocks alone.
-    const png = join(tmpdir(), `realm-claude-attach-${Date.now()}.png`);
+    const png = join(tempDir("realm-claude-attach-"), "shot.png");
     writeFileSync(png, Buffer.from([1, 2, 3, 4]));
     const capture: unknown[] = [];
     const a = new ClaudeAdapter({ query: fakeQuery({ capture }) as never });

--- a/packages/adapters/src/codex/codex-adapter.test.ts
+++ b/packages/adapters/src/codex/codex-adapter.test.ts
@@ -1,8 +1,7 @@
 import { describe, it, expect, afterEach, vi } from "vitest";
-import { mkdtempSync } from "node:fs";
-import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { tempDir } from "@realm/test-utils";
 import type { SessionEvent, SessionEventOf, SessionEventType } from "@realm/contracts";
 import { CodexAdapter, REALM_APPLICATION_CONTEXT, codexMcpConfig, codexPolicyFor, pickCodexDecision } from "./codex-adapter";
 import type { AgentHandle, StartOptions } from "../types";
@@ -929,8 +928,8 @@ describe("CodexAdapter memory", () => {
     // Two sessions on ONE adapter: the shared-process design is exactly where a cross-thread mixup would live.
     // The spawn needs a real cwd (the first session's); the second thread's cwd is only a thread/start param.
     const adapter = newAdapter();
-    const cwdA = mkdtempSync(join(tmpdir(), "realm-mem-a-"));
-    const cwdB = mkdtempSync(join(tmpdir(), "realm-mem-b-"));
+    const cwdA = tempDir("realm-mem-a-");
+    const cwdB = tempDir("realm-mem-b-");
     const a = adapter.start(startOpts({ cwd: cwdA }));
     const evsA = drain(a).evs;
     const b = adapter.start(startOpts({ cwd: cwdB }));

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@realm/test-utils",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "scripts": { "typecheck": "tsc -p tsconfig.json --noEmit" },
+  "devDependencies": { "vitest": "^3.2.0" }
+}

--- a/packages/test-utils/src/index.ts
+++ b/packages/test-utils/src/index.ts
@@ -1,0 +1,1 @@
+export { tempDir } from "./temp";

--- a/packages/test-utils/src/temp.test.ts
+++ b/packages/test-utils/src/temp.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { dirname, join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * The structural half of `tempDir` — the same grep discipline delegation/structure.test.ts uses, for
+ * the same reason: nothing in the type system stops the next test file reaching for `mkdtemp` again,
+ * and one that does leaks silently. A green suite is not evidence of cleanup, so the enforcement has
+ * to be on the call site rather than on the outcome.
+ *
+ * The scan deliberately covers test files only. Production code (workspace/checkpoints.ts) and the
+ * hand-run live scripts create scratch directories outside any vitest lifecycle and remove them on
+ * their own exit paths; they have no `afterAll` to hang cleanup on.
+ */
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
+const SELF = "packages/test-utils/src/temp.test.ts";
+const SKIP = new Set(["node_modules", "dist", "out", ".git", "fixtures"]);
+
+function testFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const name of readdirSync(dir)) {
+    if (SKIP.has(name)) continue;
+    const p = join(dir, name);
+    if (statSync(p).isDirectory()) { out.push(...testFiles(p)); continue; }
+    if (/\.test\.(ts|tsx|mts|mjs)$/.test(p)) out.push(p);
+  }
+  return out;
+}
+
+const suite = ["apps", "packages", "scripts"]
+  .flatMap((d) => testFiles(join(ROOT, d)))
+  .map((p) => relative(ROOT, p))
+  .filter((p) => p !== SELF)
+  .sort();
+
+describe("temp directories go through tempDir", () => {
+  it("finds the suite it is meant to police", () => {
+    // A scan that silently matched nothing would pass forever, and a path shape that stopped lining
+    // up with what the filter reads would matter just as much as the count.
+    expect(suite.length).toBeGreaterThan(200);
+    expect(suite).toContain("apps/server/src/sessions/fork.test.ts");
+  });
+
+  it("no test file calls mkdtemp itself", () => {
+    const offenders = suite.filter((p) => readFileSync(join(ROOT, p), "utf8").includes("mkdtemp"));
+    expect(offenders).toEqual([]);
+  });
+
+  it("tempDir has exactly one implementation", () => {
+    const defined = suite
+      .concat("packages/test-utils/src/temp.ts")
+      .filter((p) => /function tempDir\b/.test(readFileSync(join(ROOT, p), "utf8")));
+    expect(defined).toEqual(["packages/test-utils/src/temp.ts"]);
+  });
+});

--- a/packages/test-utils/src/temp.ts
+++ b/packages/test-utils/src/temp.ts
@@ -1,0 +1,28 @@
+import { afterAll } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const created: string[] = [];
+
+/**
+ * A scratch directory under $TMPDIR, removed when the calling test file finishes.
+ *
+ * Bare `mkdtemp` removed nothing: one full suite run left 974 `realm-*` directories behind, and the
+ * accumulated pile reached 93 GB — at which point parallel vitest workers failed their scratch
+ * writes and the run reported the resulting ENOSPC as ordinary test failures.
+ *
+ * Cleanup is `afterAll` rather than `afterEach` because most callers open theirs at module scope or
+ * in `beforeAll` and share it across the file's tests. The hook is registered when this module is
+ * imported, which vitest evaluates once per test file, so a file only ever removes its own
+ * directories — and the hook still runs when a test throws.
+ */
+export function tempDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  created.push(dir);
+  return dir;
+}
+
+afterAll(() => {
+  for (const dir of created.splice(0)) rmSync(dir, { recursive: true, force: true });
+});

--- a/packages/test-utils/tsconfig.json
+++ b/packages/test-utils/tsconfig.json
@@ -1,0 +1,1 @@
+{ "extends": "../../tsconfig.base.json", "include": ["src"] }

--- a/packages/test-utils/vitest.config.ts
+++ b/packages/test-utils/vitest.config.ts
@@ -1,0 +1,2 @@
+import { defineConfig } from "vitest/config";
+export default defineConfig({ test: { name: "test-utils", environment: "node" } });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     devDependencies:
+      '@realm/test-utils':
+        specifier: workspace:*
+        version: link:packages/test-utils
       '@types/node':
         specifier: ^22.13.0
         version: 22.20.1
@@ -26,6 +29,9 @@ importers:
       '@realm/contracts':
         specifier: workspace:*
         version: link:../../packages/contracts
+      '@realm/test-utils':
+        specifier: workspace:*
+        version: link:../../packages/test-utils
       '@realm/ui':
         specifier: workspace:*
         version: link:../../packages/ui
@@ -171,6 +177,9 @@ importers:
         specifier: ^3.24.0
         version: 3.25.76
     devDependencies:
+      '@realm/test-utils':
+        specifier: workspace:*
+        version: link:../../packages/test-utils
       '@types/ws':
         specifier: ^8.5.12
         version: 8.18.1
@@ -190,6 +199,9 @@ importers:
         specifier: workspace:*
         version: link:../contracts
     devDependencies:
+      '@realm/test-utils':
+        specifier: workspace:*
+        version: link:../test-utils
       tsx:
         specifier: ^4.19.0
         version: 4.23.12
@@ -202,6 +214,12 @@ importers:
       zod:
         specifier: ^3.24.0
         version: 3.25.76
+
+  packages/test-utils:
+    devDependencies:
+      vitest:
+        specifier: ^3.2.0
+        version: 3.2.7(@types/debug@4.1.13)(@types/node@22.20.1)(jiti@2.7.0)(jsdom@25.0.1)(lightningcss@1.32.0)(tsx@4.23.12)
 
   packages/ui:
     dependencies:

--- a/scripts/install-local.test.ts
+++ b/scripts/install-local.test.ts
@@ -1,7 +1,7 @@
-import { mkdirSync, mkdtempSync, rmSync, utimesSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { mkdirSync, rmSync, utimesSync } from "node:fs";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import { tempDir } from "@realm/test-utils";
 import { findBuiltApp, installLocal, installPaths } from "./install-local.mjs";
 
 describe("findBuiltApp", () => {
@@ -9,7 +9,7 @@ describe("findBuiltApp", () => {
   afterEach(() => { for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true }); });
 
   it("selects the newest unpacked Realm.app and ignores packaged artifacts", () => {
-    const release = mkdtempSync(join(tmpdir(), "realm-local-build-"));
+    const release = tempDir("realm-local-build-");
     dirs.push(release);
     const old = join(release, "mac", "Realm.app");
     const current = join(release, "mac-arm64", "Realm.app");
@@ -21,7 +21,7 @@ describe("findBuiltApp", () => {
   });
 
   it("fails honestly when no directory build exists", () => {
-    const release = mkdtempSync(join(tmpdir(), "realm-local-build-"));
+    const release = tempDir("realm-local-build-");
     dirs.push(release);
     expect(() => findBuiltApp(release)).toThrow(/no unpacked Realm\.app/);
   });

--- a/scripts/release.test.ts
+++ b/scripts/release.test.ts
@@ -1,8 +1,8 @@
 import { execFileSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { tempDir } from "@realm/test-utils";
 import {
   bumpPackageJsonText, bumpVersion, changelogEntries, entriesFromGh, missingArtifacts, nextStepsText,
   parseReleaseArgs, prEntryFromSubject, prependChangelog, release, renderStub,
@@ -172,7 +172,7 @@ describe("release() end to end in a scratch repo (no pushing, no publishing — 
 
   beforeEach(() => {
     logs.length = 0;
-    root = mkdtempSync(join(tmpdir(), "realm-release-"));
+    root = tempDir("realm-release-");
     realExec("git", ["init", "-q", "-b", "main"], { cwd: root });
     realExec("git", ["config", "user.email", "t@t"], { cwd: root });
     realExec("git", ["config", "user.name", "t"], { cwd: root });


### PR DESCRIPTION
Stacked on #37.

**The leak.** 151 `mkdtemp` sites across 67 test files, most of which never removed the directory — enumerated, not estimated. On this machine that had left **~355,000 `realm-*` directories consuming 93 GB** in `$TMPDIR`, the largest single thing on the volume. Measured with a marker file on the unfixed tree: **974 directories created and abandoned by one full suite run**. That same baseline run reproduced the flake it causes — `documents/watcher.test.ts` timed out.

Two harms, both real. Disk: when the volume fills, parallel vitest workers fail on scratch writes and the run reports mass failures that are pure `ENOSPC` — 162 "failed" tests across 48 files on one recorded occasion, every one fake. And flakiness under load: `sessions/fork.test.ts`, `documents/watcher.test.ts` and `documents/service.test.ts` flake first, each passing in isolation, which is exactly what makes them expensive to debug.

The fix is one shared helper, not 67 hand-written `afterEach`es — `@realm/test-utils`' `tempDir(prefix)` registers cleanup in an `afterAll` declared at module import time, so vitest evaluates it once per test file, each file removes exactly its own directories, and it still runs when a test throws. All three properties were verified with throwaway probes before the design was committed to.

After: **0 leaked directories** from a full run in a private `$TMPDIR`, 0 before and 0 after, repeated. (Counts on the shared volume were unusable because peer agents were running suites concurrently — the count jumped by thousands between runs — which is itself why the measurement had to be isolated.)

A structural test keeps it from coming back, mirroring `delegation/structure.test.ts`: no test file may call `mkdtemp`, `tempDir` has exactly one implementation, and the scan asserts it found the suite it polices so a broken path shape fails rather than passing vacuously.

Deliberately left alone: 31 live scripts that already clean up on their own exit path and 5 that do not — none can use the helper, because they run outside any vitest lifecycle and so have no `afterAll` to hang cleanup on, and they are not part of the per-run leak since a human invokes them by hand. Also the ~15 files with existing hand-written cleanup: only the *creation* was replaced, because removing their cleanup would change when the directory disappears.

**The icon ladder** now covers the whole renderer rather than `components/sidebar/` alone, which is where the scan had been pointed. `GroupBar` moves to the control rung. The wider scan surfaced **68 more off-ladder call sites in 21 files**, audited against each one's actual CSS box and font size rather than rewritten mechanically — 18 to control, 14 to row (they vary with the row, so they say what the row *is*), 34 to inline (in a ≤22px box or leading ≤12.5px text). Two exceptions are recorded at the call site with a reason rather than allowlisted in the test, and the escape hatch is enforced: an off-ladder size passes only if `off-ladder:` and a reason appear in the two lines above it.

The scan was also tightened to `Icon`/`SpaceIcon` only — the old loose `size={n}` regex was silently policing `Spinner`, which is not on this ladder and would have failed for a reason the test could not explain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)