### PR TITLE
Say the suggested prompt the way a person would

### DIFF
--- a/apps/desktop/src/renderer/src/panes/session/composer-hint.test.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/composer-hint.test.tsx
@@ -18,7 +18,7 @@ const git = (extra: Partial<GitInfo> = {}): GitInfo =>
 /** The session's cwd from `store.test-fakes`; `gitInfo` is keyed by it. */
 const CWD = "/tmp";
 /** What a fresh session in a dirty checkout is offered (`prompt-hint.ts`, first rung). */
-const HINT = "Audit the 3 uncommitted files on main; find the edge case most likely to escape review.";
+const HINT = "Review my 3 uncommitted files on main.";
 
 async function mount(gitInfo: GitInfo | null = git({ dirty: 3 })) {
   const it0 = item("i9", "s1", { kind: "session", refId: "se1", title: "s" });

--- a/apps/desktop/src/renderer/src/panes/session/prompt-hint.test.ts
+++ b/apps/desktop/src/renderer/src/panes/session/prompt-hint.test.ts
@@ -31,15 +31,15 @@ describe("the session's suggested prompt", () => {
     expect(hint({ blocks, status: "waiting_permission" })).toBeNull();
     // …and comes straight back when it settles.
     expect(hint({ blocks, status: "idle" }))
-      .toBe("Stress-test the changes, then fix what the tests expose.");
+      .toBe("Write tests for the changes.");
   });
 
   describe("a session that has not started", () => {
     it("offers the working tree when there is one to review, naming the branch", () => {
       expect(hint({ gitInfo: git({ dirty: 3, branch: "feature/pane-groups" }) }))
-        .toBe("Take a skeptical pass over the pane groups work: find the edge case this diff is most likely to miss.");
+        .toBe("Review my pane groups changes.");
       expect(hint({ gitInfo: git({ dirty: 1, branch: "main" }) }))
-        .toBe("Audit the 1 uncommitted file on main; find the edge case most likely to escape review.");
+        .toBe("Review my 1 uncommitted file on main.");
     });
 
     it("offers the branch's own commits once the tree is clean, and counts them honestly", () => {
@@ -48,7 +48,7 @@ describe("the session's suggested prompt", () => {
       expect(hint({ gitInfo: git({ ahead: 1 }) })).toBe("Write a PR description for the 1 commit on main.");
       // Uncommitted work outranks committed work — it is the part still being decided.
       expect(hint({ gitInfo: git({ ahead: 4, dirty: 2 }) }))
-        .toBe("Audit the 2 uncommitted files on main; find the edge case most likely to escape review.");
+        .toBe("Review my 2 uncommitted files on main.");
     });
 
     it("says nothing at all when there is no session-specific fact to offer", () => {
@@ -65,21 +65,21 @@ describe("the session's suggested prompt", () => {
       const blocks = [user("go"), { kind: "error", message: "spawn ENOENT", ts: 3 } as Block];
       // Outranks the dirty tree AND the edits — nothing else matters until the session runs again.
       expect(hint({ blocks: [...blocks], gitInfo: git({ dirty: 9 }) }))
-        .toBe("Investigate “spawn ENOENT”, fix the root cause, and retry.");
+        .toBe("Fix “spawn ENOENT”.");
       expect(hint({ blocks: [user("go"), tool("Write"), { kind: "error", message: "x", ts: 3 } as Block] }))
-        .toBe("Investigate “x”, fix the root cause, and retry.");
+        .toBe("Fix “x”.");
     });
 
     it("names the command when a tool failed, instead of quoting a wall of output", () => {
       const failed = tool("Bash", { command: "pnpm vitest run prompt-hint.test.ts" }, { content: "500 lines of output", isError: true });
       expect(hint({ blocks: [user("Improve the suggested prompts"), failed] }))
-        .toBe("Investigate “pnpm vitest run prompt-hint.test.ts” while working on suggested prompts, fix the root cause, and retry.");
+        .toBe("Fix “pnpm vitest run prompt-hint.test.ts” while working on suggested prompts.");
     });
 
     it("says go when a plan is on screen and the agent cannot act on it", () => {
       const blocks = [user("plan it"), plan()];
       expect(hint({ blocks, inPlan: true }))
-        .toBe("Implement the plan, then verify its riskiest assumption.");
+        .toBe("Build the plan.");
       // Out of Plan, it still continues the actual subject rather than falling back to repo state.
       expect(hint({ blocks, inPlan: false })).toBeNull();
     });
@@ -93,7 +93,7 @@ describe("the session's suggested prompt", () => {
     it("suggests the tests once the agent has written to a file", () => {
       for (const name of ["Write", "Edit", "MultiEdit", "NotebookEdit", "apply_patch"]) {
         expect(hint({ blocks: [user("Improve the prompt hints"), tool(name)] }))
-          .toBe("Stress-test prompt hints, then fix what the tests expose.");
+          .toBe("Write tests for prompt hints.");
       }
     });
 
@@ -104,14 +104,14 @@ describe("the session's suggested prompt", () => {
         tool("Write", { file_path: "/repo/apps/composer.test.tsx" }),
       ];
       expect(hint({ blocks })).toBe(
-        "Stress-test composer state in apps/Composer.tsx and apps/composer.test.tsx, then fix what the tests expose.",
+        "Write tests for composer state in apps/Composer.tsx and apps/composer.test.tsx.",
       );
     });
 
     it("extracts changed files from apply_patch input", () => {
       const patch = "*** Begin Patch\n*** Update File: src/hints.ts\n*** Add File: src/hints.test.ts\n*** End Patch";
       expect(hint({ blocks: [user("Improve hint specificity"), tool("apply_patch", { patch })] }))
-        .toBe("Stress-test hint specificity in src/hints.ts and src/hints.test.ts, then fix what the tests expose.");
+        .toBe("Write tests for hint specificity in src/hints.ts and src/hints.test.ts.");
     });
 
     it("does not mistake reading and running for writing", () => {
@@ -119,21 +119,21 @@ describe("the session's suggested prompt", () => {
       // produced anything to test.
       expect(hint({ blocks: [user("go"), tool("Read"), tool("Grep"), tool("Bash")] })).toBeNull();
       expect(hint({ blocks: [user("Explain session restore"), tool("Read", { file_path: "/repo/state/store.ts" }), assistant("It works like this.")] }))
-        .toBe("Trace session restore through state/store.ts, then identify the highest-leverage change.");
+        .toBe("Walk me through session restore in state/store.ts.");
     });
 
     it("only looks at the LAST turn — an edit two turns ago is not what just happened", () => {
       const blocks = [user("edit it"), tool("Edit"), assistant("done"), user("now explain"), assistant("because…")];
       expect(hint({ blocks }))
-        .toBe("Take “now explain” further: show the concrete code path and its weakest edge case.");
+        .toBe("Show me the code behind now explain.");
       // …and the dirty tree cannot displace the continuation of the current conversation.
       expect(hint({ blocks, gitInfo: git({ dirty: 1 }) }))
-        .toBe("Take “now explain” further: show the concrete code path and its weakest edge case.");
+        .toBe("Show me the code behind now explain.");
     });
 
     it("turns a plain conversation into a follow-up anchored to what the user asked", () => {
       expect(hint({ blocks: [user("What is this repo?"), assistant("A desktop app.")], gitInfo: git() }))
-        .toBe("Take “what is this repo” further: show the concrete code path and its weakest edge case.");
+        .toBe("Show me the code behind what is this repo.");
     });
   });
 });

--- a/apps/desktop/src/renderer/src/panes/session/prompt-hint.ts
+++ b/apps/desktop/src/renderer/src/panes/session/prompt-hint.ts
@@ -7,6 +7,9 @@ import type { Block } from "./transcript-model";
  * render of every visible session pane, so it must not call an agent, and a suggestion that changed
  * under the user between renders would be a moving target for the key that accepts it.
  *
+ * The register is plain and short on purpose: this is a sentence someone reads at a glance and
+ * accepts with one key, not a brief. A hint that has to be parsed is slower than typing.
+ *
  * "Based on the current session" means literally that — the transcript's last turn, the working tree
  * and the mode, in that order of specificity. Nothing here falls back to `suggestions.ts`: those
  * static starters are the hero's chips, sitting two inches below this line, and the one thing this
@@ -58,8 +61,8 @@ export function promptHint(ctx: {
   if (failure || status === "error") {
     const target = request ? ` while working on ${request}` : "";
     return failure
-      ? `Investigate “${failure}”${target}, fix the root cause, and retry.`
-      : `Find the failure${target}, fix the root cause, and retry.`;
+      ? `Fix “${failure}”${target}.`
+      : `Find what went wrong${target} and fix it.`;
   }
 
   // Plan mode: retain the subject that caused the plan and ask for the valuable second half of the
@@ -71,8 +74,8 @@ export function promptHint(ctx: {
   // plan under it promised a plan that did not exist. A `plan` event is the agent saying it has one.
   if (inPlan && turn.some((b) => b.kind === "plan")) {
     return request
-      ? `Turn the plan for ${request} into working code, then verify its riskiest assumption.`
-      : "Implement the plan, then verify its riskiest assumption.";
+      ? `Build the plan for ${request}.`
+      : "Build the plan.";
   }
 
   // It wrote code. Name what changed and why it changed; the files are taken from the actual tool
@@ -80,20 +83,20 @@ export function promptHint(ctx: {
   if (turn.some((b) => b.kind === "tool" && WRITE_TOOLS.has(b.name))) {
     const where = files.length ? ` in ${joinFiles(files)}` : "";
     return request
-      ? `Stress-test ${request}${where}, then fix what the tests expose.`
-      : `Stress-test the changes${where}, then fix what the tests expose.`;
+      ? `Write tests for ${request}${where}.`
+      : `Write tests for the changes${where}.`;
   }
 
   // A read-only investigation already established a trail through the repo. Offer to follow that
   // trail instead of collapsing back to the unrelated dirty-tree fallback.
   if (files.length && request) {
-    return `Trace ${request} through ${joinFiles(files)}, then identify the highest-leverage change.`;
+    return `Walk me through ${request} in ${joinFiles(files)}.`;
   }
 
   // Even a tool-free answer has a session-specific subject. The next useful move is to make the
   // answer concrete; this is intentionally absent when there was no user request to anchor it to.
   if (request && turn.some((b) => b.kind === "assistant" && !b.streaming)) {
-    return `Take “${request}” further: show the concrete code path and its weakest edge case.`;
+    return `Show me the code behind ${request}.`;
   }
   return reviewChanges;
 }
@@ -120,9 +123,9 @@ const subjectOf = (text: string): string | null => {
 
 const freshChangesHint = (git: GitInfo): string => {
   const topic = branchTopic(git.branch);
-  if (topic) return `Take a skeptical pass over the ${topic} work: find the edge case this diff is most likely to miss.`;
+  if (topic) return `Review my ${topic} changes.`;
   const files = `${git.dirty} uncommitted ${git.dirty === 1 ? "file" : "files"}`;
-  return `Audit the ${files} on ${git.branch}; find the edge case most likely to escape review.`;
+  return `Review my ${files} on ${git.branch}.`;
 };
 
 /** main/master/develop carry no subject. A descriptive branch does, and is often the only context a

--- a/apps/desktop/src/renderer/src/panes/session/suggestions.ts
+++ b/apps/desktop/src/renderer/src/panes/session/suggestions.ts
@@ -1,58 +1,61 @@
 import type { AgentKind } from "@realm/contracts";
 
 /** Static empty-state prompt starters per agent kind. The Ara refresh (§3) renders them as a
- *  single-column list of title-only rows — `description` stays in the data but is no longer drawn.
+ *  The prompt each one fills is a plain sentence, not a brief: it lands in an empty composer that
+ *  the user is about to edit, so it states the ask and stops. A starter that arrives pre-loaded
+ *  with qualifiers is one the user has to read and delete before they can type.
+ *  Ara refresh (§3) renders them as a single-column list of title-only rows — `description` stays in the data but is no longer drawn.
  *  Clicking fills the composer with `prompt`, never auto-sends. */
 export const SUGGESTIONS: Record<AgentKind, { title: string; description: string; prompt: string }[]> = {
   claude: [
-    { title: "Explore this project", description: "Structure, entry points, how it all fits", prompt: "Give me a tour of this project: structure, entry points, and how the pieces fit together." },
-    { title: "Fix a bug", description: "Describe a symptom, get a guided hunt", prompt: "Help me track down a bug. I'll describe the symptom; ask me what you need." },
-    { title: "Review my changes", description: "Bugs and style in uncommitted work", prompt: "Review my uncommitted changes for bugs and style issues." },
-    { title: "Write tests", description: "Cover what is not covered yet", prompt: "Find the least-covered part of this code and write tests for it." },
+    { title: "Explore this project", description: "Structure, entry points, how it all fits", prompt: "Give me a tour of this project." },
+    { title: "Fix a bug", description: "Describe a symptom, get a guided hunt", prompt: "Help me fix a bug." },
+    { title: "Review my changes", description: "Bugs and style in uncommitted work", prompt: "Review my changes." },
+    { title: "Write tests", description: "Cover what is not covered yet", prompt: "Write tests for whatever needs them most." },
   ],
   codex: [
-    { title: "Build a feature", description: "Plan first, then write the code", prompt: "I want to add a new feature. Let's plan it before writing code." },
-    { title: "Explain code", description: "What this codebase does, and where", prompt: "Explain what this codebase does and where its core logic lives." },
-    { title: "Run the tests", description: "Run the suite and summarize failures", prompt: "Run the test suite and summarize any failures." },
-    { title: "Review my changes", description: "Bugs and style in uncommitted work", prompt: "Review my uncommitted changes for bugs and style issues." },
+    { title: "Build a feature", description: "Plan first, then write the code", prompt: "Help me plan a new feature." },
+    { title: "Explain code", description: "What this codebase does, and where", prompt: "Explain what this codebase does." },
+    { title: "Run the tests", description: "Run the suite and summarize failures", prompt: "Run the tests." },
+    { title: "Review my changes", description: "Bugs and style in uncommitted work", prompt: "Review my changes." },
   ],
   "acp:cursor": [
-    { title: "Refactor something", description: "Find the highest-value refactor", prompt: "Suggest the highest-value refactor in this codebase and carry it out." },
-    { title: "Write tests", description: "Cover the least-tested critical module", prompt: "Find the least-tested critical module and add tests for it." },
+    { title: "Refactor something", description: "Find the highest-value refactor", prompt: "Suggest a refactor worth doing." },
+    { title: "Write tests", description: "Cover the least-tested critical module", prompt: "Write tests for whatever needs them most." },
   ],
   "acp:gemini": [
-    { title: "Summarize this repo", description: "Purpose, stack, and layout", prompt: "Summarize this repository: purpose, stack, and layout." },
+    { title: "Summarize this repo", description: "Purpose, stack, and layout", prompt: "Summarize this repo." },
   ],
   "acp:opencode": [
-    { title: "Explain code", description: "What this codebase does, and where", prompt: "Explain what this codebase does and where its core logic lives." },
-    { title: "Fix a bug", description: "Find and fix the most likely bug", prompt: "Find the most likely bug in this codebase and fix it." },
+    { title: "Explain code", description: "What this codebase does, and where", prompt: "Explain what this codebase does." },
+    { title: "Fix a bug", description: "Find and fix the most likely bug", prompt: "Find a bug and fix it." },
   ],
   "acp:copilot": [
-    { title: "Review my changes", description: "Bugs and style in uncommitted work", prompt: "Review my uncommitted changes for bugs and style issues." },
-    { title: "Write tests", description: "Cover what is not covered yet", prompt: "Find the least-covered part of this code and write tests for it." },
+    { title: "Review my changes", description: "Bugs and style in uncommitted work", prompt: "Review my changes." },
+    { title: "Write tests", description: "Cover what is not covered yet", prompt: "Write tests for whatever needs them most." },
   ],
   "acp:goose": [
-    { title: "Explain code", description: "What this codebase does, and where", prompt: "Explain what this codebase does and where its core logic lives." },
-    { title: "Run the tests", description: "Run the suite and summarize failures", prompt: "Run the test suite and summarize any failures." },
+    { title: "Explain code", description: "What this codebase does, and where", prompt: "Explain what this codebase does." },
+    { title: "Run the tests", description: "Run the suite and summarize failures", prompt: "Run the tests." },
   ],
   "acp:qwen": [
-    { title: "Summarize this repo", description: "Purpose, stack, and layout", prompt: "Summarize this repository: purpose, stack, and layout." },
-    { title: "Refactor something", description: "Find the highest-value refactor", prompt: "Suggest the highest-value refactor in this codebase and carry it out." },
+    { title: "Summarize this repo", description: "Purpose, stack, and layout", prompt: "Summarize this repo." },
+    { title: "Refactor something", description: "Find the highest-value refactor", prompt: "Suggest a refactor worth doing." },
   ],
   "acp:grok": [
-    { title: "Explain code", description: "What this codebase does, and where", prompt: "Explain what this codebase does and where its core logic lives." },
-    { title: "Build a feature", description: "Plan first, then write the code", prompt: "I want to add a new feature. Let's plan it before writing code." },
+    { title: "Explain code", description: "What this codebase does, and where", prompt: "Explain what this codebase does." },
+    { title: "Build a feature", description: "Plan first, then write the code", prompt: "Help me plan a new feature." },
   ],
   "acp:fx": [
-    { title: "Summarize this repo", description: "Purpose, stack, and layout", prompt: "Summarize this repository: purpose, stack, and layout." },
-    { title: "Fix a bug", description: "Find and fix the most likely bug", prompt: "Find the most likely bug in this codebase and fix it." },
+    { title: "Summarize this repo", description: "Purpose, stack, and layout", prompt: "Summarize this repo." },
+    { title: "Fix a bug", description: "Find and fix the most likely bug", prompt: "Find a bug and fix it." },
   ],
   // One-shot work only, matching what the harness can actually show: dsh-acp reports a turn's answer
   // whole, with no tool activity on the wire, so a starter that invites a long exploratory run would
   // stare back at the user in silence.
   "acp:deepseek": [
-    { title: "Explain code", description: "What this codebase does, and where", prompt: "Explain what this codebase does and where its core logic lives." },
-    { title: "Review my changes", description: "Bugs and style in uncommitted work", prompt: "Review my uncommitted changes for bugs and style issues." },
+    { title: "Explain code", description: "What this codebase does, and where", prompt: "Explain what this codebase does." },
+    { title: "Review my changes", description: "Bugs and style in uncommitted work", prompt: "Review my changes." },
   ],
   fake: [{ title: "Say hello", description: "A quick round trip through the fake agent", prompt: "Hello!" }],
 };


### PR DESCRIPTION
Stacked on #38.

The hints read like a brief rather than a sentence. *"Take a skeptical pass over the pane groups work: find the edge case this diff is most likely to miss"* is three clauses and two pieces of jargon to say **"Review my pane groups changes."** — and it landed in a prompter the user was about to type in, so it had to be read, parsed, and then deleted before they could start.

Every hint is now one plain clause. The logic that chooses between them is untouched: same branches, same order of specificity, same session facts. Only the words changed.

```
Investigate “spawn ENOENT”, fix the root cause, and retry.   →  Fix “spawn ENOENT”.
Implement the plan, then verify its riskiest assumption.     →  Build the plan.
Stress-test the changes, then fix what the tests expose.     →  Write tests for the changes.
Trace X through Y, then identify the highest-leverage change →  Walk me through X in Y.
Audit the 2 uncommitted files on main; find the edge case…   →  Review my 2 uncommitted files on main.
```

The chip prompts got the same treatment. They fill an empty composer the user is about to edit, so a starter arriving pre-loaded with qualifiers costs a read and a delete first — *"Give me a tour of this project: structure, entry points, and how the pieces fit together."* becomes *"Give me a tour of this project."*

The thirteen tests that pinned the old wording now pin the new; none was removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)