### PR TITLE
Pin the agent's plan to the top of the prompter

### DIFF
--- a/apps/desktop/scripts/todo-strip-live.mjs
+++ b/apps/desktop/scripts/todo-strip-live.mjs
@@ -333,15 +333,25 @@ async function main() {
      which would make an identical pair prove nothing. */
   await evalIn(c, `__live.freeze(true)`);
   await sleep(300);
-  /* Forced visible and given real height, because at rest the band may not reach the strip at all —
-     which would make an identical pair prove nothing. */
-  await evalIn(c, `(() => { const f = document.querySelector(".transcript-fade");
-    f.style.display = "block"; f.style.setProperty("--fade-h", "320px"); return true; })()`);
+  /* Moved ONTO the pair, not merely made taller. The band is anchored to the transcript's bottom and
+     grows upward, so at any height it stops where the dock begins and never overlaps the strip at
+     all — and a comparison of two shots it could not have touched passes whatever the z-order is.
+     Its bottom edge is pushed past the card's so the whole pair is underneath it. */
+  const covered = await evalIn(c, `(() => {
+    const f = document.querySelector(".transcript-fade");
+    const s = document.querySelector(".composer-todos").getBoundingClientRect();
+    const b = document.querySelector(".composer").getBoundingClientRect();
+    const w = document.querySelector(".transcript-wrap").getBoundingClientRect();
+    const h = Math.ceil(b.bottom - s.top) + 80;
+    f.style.display = "block"; f.style.bottom = "auto"; f.style.height = h + "px";
+    f.style.top = Math.floor(s.top - w.top - 40) + "px";
+    f.style.setProperty("--fade-h", h + "px");
+    const r = f.getBoundingClientRect();
+    return { fade: [Math.round(r.top), Math.round(r.bottom)], pair: [Math.round(s.top), Math.round(b.bottom)] }; })()`);
   await sleep(400);
   const withFade = await hashOf(c);
-  check("the band was actually made to reach the strip, so the comparison below can fail",
-    await evalIn(c, `(() => { const f = document.querySelector(".transcript-fade").getBoundingClientRect();
-      return f.top < document.querySelector(".composer-todos").getBoundingClientRect().top; })()`));
+  check("the band was actually moved over the whole pair, so the comparison below can fail",
+    covered.fade[0] <= covered.pair[0] && covered.fade[1] >= covered.pair[1], covered);
   await evalIn(c, `(() => { document.querySelector(".transcript-fade").remove(); return true; })()`);
   await sleep(400);
   const withoutFade = await hashOf(c);

--- a/apps/desktop/scripts/todo-strip-live.mjs
+++ b/apps/desktop/scripts/todo-strip-live.mjs
@@ -1,0 +1,402 @@
+/**
+ * Live check for the to-do strip above the prompter
+ * (run with: node apps/desktop/scripts/todo-strip-live.mjs)
+ *
+ * The claim the strip exists to make is that it and the prompter read as ONE object. That is a
+ * statement about composited pixels and about boxes, and jsdom has neither: every rect there is
+ * zero, `background: paint(rl-squircle)` and `border-radius: 36px` are the same declaration, and a
+ * strip painted straight over by the transcript's blur band measures exactly like one that is not.
+ * So the suite pins the wiring (which list, when it collapses, where in the tree it sits) and this
+ * pins the four things only a screenshot can answer:
+ *
+ *   - It is the under-strip's tab, mirrored: the same inset each side, on the card's centre line.
+ *     Read off the laid-out boxes, because a margin that computes is not a margin that centres.
+ *   - Its top corner is the painter's superellipse at the card's own radius, and its BOTTOM corners
+ *     are square — both by counting pixels, exactly as squircle-live.mjs does. The bottom pair only
+ *     exists 10px behind the card, so it is lifted clear to be measured and put back.
+ *   - Nothing paints over it. `.composer-dock` carries a transform, which makes it a stacking
+ *     context; the last time that mattered, `.composer`'s own z-index was trapped inside and the
+ *     transcript's fade band blurred a stripe across the prompter (see prompter-fade-live.mjs). The
+ *     strip is the new top edge of that dock and is the part the band now reaches first.
+ *   - It does not shove the prompter. Items arriving grow the strip UPWARD into the transcript and
+ *     stop at its cap; the card's own box must not move by a pixel while that happens.
+ *
+ * Driven end to end through the real path — the fake agent's `todos` script writes a real TodoWrite,
+ * the server persists it, the store folds it, React draws the strip. Nothing here injects the strip.
+ *
+ * REBUILD FIRST (`pnpm build`): this boots apps/desktop/out, not the sources.
+ * Ports: env-overridable. Touches only a scratch dir; kills only the process it started.
+ */
+import { spawn } from "node:child_process";
+import { connect } from "node:net";
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
+const CDP_PORT = Number(process.env.LIVE_CDP_PORT ?? 9351), SERVER_PORT = Number(process.env.LIVE_SERVER_PORT ?? 8918);
+const scratch = fs.mkdtempSync(path.join(os.tmpdir(), "realm-todo-strip-live-"));
+let electron = null;
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+/** Area of a quadrant of |x|ⁿ + |y|ⁿ = 1 as a fraction of the unit square — the same two curves
+ *  squircle-live.mjs tells apart: n = 2 is the arc a border-radius draws, n = 4 the worklet's. */
+const CIRCLE = Math.PI / 4, SQUIRCLE = 0.874;
+const TOL = (SQUIRCLE - CIRCLE) / 2;
+const near = (v, target) => typeof v === "number" && Math.abs(v - target) < TOL;
+
+async function portFree(port) {
+  return new Promise((resolve) => {
+    const s = connect({ port, host: "127.0.0.1" });
+    s.once("connect", () => { s.destroy(); resolve(false); });
+    s.once("error", () => resolve(true));
+  });
+}
+
+async function until(fn, ms, tag) {
+  const t0 = Date.now();
+  for (;;) {
+    const v = await fn();
+    if (v) return v;
+    if (Date.now() - t0 > ms) throw new Error(`timeout:${tag}`);
+    await sleep(150);
+  }
+}
+
+function cdp(wsUrl) {
+  const ws = new WebSocket(wsUrl);
+  let id = 0;
+  const pending = new Map();
+  const events = [];
+  const ready = new Promise((res) => ws.addEventListener("open", res));
+  ws.addEventListener("message", (m) => {
+    const msg = JSON.parse(m.data);
+    if (msg.id !== undefined) pending.get(msg.id)?.(msg);
+    else if (msg.method === "Runtime.consoleAPICalled" && msg.params.type === "error") {
+      events.push(msg.params.args.map((a) => a.value ?? a.description ?? "").join(" "));
+    }
+  });
+  return {
+    ready, events,
+    send: (method, params) => new Promise((res, rej) => {
+      const i = ++id;
+      pending.set(i, (msg) => (msg.error ? rej(new Error(msg.error.message)) : res(msg.result)));
+      ws.send(JSON.stringify({ id: i, method, params }));
+    }),
+    close: () => ws.close(),
+  };
+}
+
+function rpc(port) {
+  const ws = new WebSocket(`ws://127.0.0.1:${port}`);
+  let id = 0;
+  const pending = new Map();
+  const ready = new Promise((res) => ws.addEventListener("open", res));
+  ws.addEventListener("message", (m) => {
+    const msg = JSON.parse(m.data);
+    if (msg.id !== undefined) pending.get(msg.id)?.(msg);
+  });
+  return {
+    ready,
+    call: (method, params) => new Promise((res, rej) => {
+      const i = String(++id);
+      pending.set(i, (msg) => (msg.ok ? res(msg.result) : rej(new Error(`${method}: ${msg.error?.message}`))));
+      ws.send(JSON.stringify({ id: i, method, params }));
+    }),
+    close: () => ws.close(),
+  };
+}
+
+const HELPERS = `
+window.__live = window.__live ?? {
+  setInput(el, value) {
+    const proto = el instanceof HTMLTextAreaElement ? HTMLTextAreaElement.prototype : HTMLInputElement.prototype;
+    Object.getOwnPropertyDescriptor(proto, "value").set.call(el, value);
+    el.dispatchEvent(new Event("input", { bubbles: true }));
+  },
+  box(el) { const b = el.getBoundingClientRect(); return { l: +b.left.toFixed(1), r: +b.right.toFixed(1), t: +b.top.toFixed(1), b: +b.bottom.toFixed(1), w: +b.width.toFixed(1), h: +b.height.toFixed(1) }; },
+  async sampler(b64) {
+    const img = new Image();
+    img.src = "data:image/png;base64," + b64;
+    await img.decode();
+    const cv = document.createElement("canvas");
+    cv.width = img.width; cv.height = img.height;
+    const g = cv.getContext("2d");
+    g.drawImage(img, 0, 0);
+    const px = g.getImageData(0, 0, cv.width, cv.height).data;
+    const dpr = img.width / window.innerWidth;
+    /* floor, not round: coordinates arrive as pixel CENTRES, so rounding slides the sampling window
+       one pixel inward on each axis — worth most of the gap between the two curves at this radius. */
+    const lum = (x, y) => {
+      const i = ((Math.floor(y * dpr) * cv.width) + Math.floor(x * dpr)) * 4;
+      return 0.299 * px[i] + 0.587 * px[i + 1] + 0.114 * px[i + 2];
+    };
+    const median = (xs) => xs.slice().sort((a, b) => a - b)[xs.length >> 1];
+    /* Median, not mean: a reference tone read off a live surface lands on a glyph sooner or later,
+       and one stray dark pixel drags a mean far enough to move the threshold. */
+    const tone = (x0, y0, x1, y1) => {
+      const xs = [];
+      for (let i = 0; i < 7; i++) for (let j = 0; j < 7; j++) xs.push(lum(x0 + ((x1 - x0) * i) / 6, y0 + ((y1 - y0) * j) / 6));
+      return median(xs);
+    };
+    return { lum, tone, dpr };
+  },
+  /** Fraction of an element's R×R corner square that the element's own fill covers. */
+  async cornerFill(b64, sel, corner, forceR) {
+    const s = await this.sampler(b64);
+    const el = document.querySelector(sel);
+    const box = el.getBoundingClientRect();
+    const cs = getComputedStyle(el);
+    const key = corner === "bl" ? "--sq-radius-bottom" : "--sq-radius-top";
+    const fallback = corner === "bl" ? cs.borderBottomLeftRadius : cs.borderTopLeftRadius;
+    /* A corner asserted to be SQUARE has no radius to read, so the window it is measured over has to
+       be handed in — otherwise the one case worth checking is the one that cannot be. */
+    const R = forceR ?? Math.round(parseFloat(cs.getPropertyValue(key)) || parseFloat(fallback) || 0);
+    if (R < 8) return { error: "radius too small to measure", R };
+    const inset = R + 8;
+    const inside = s.tone(box.left + inset, box.top + inset, box.right - inset, box.top + inset + 10);
+    const gy = corner === "bl" ? box.bottom + 8 : box.top - 30;
+    const outside = s.tone(box.left - 30, gy, box.left - 8, gy + 22);
+    if (Math.abs(inside - outside) < 3) return { error: "fill and ground are indistinguishable", inside, outside };
+    const mid = (inside + outside) / 2;
+    const isFill = (x, y) => (inside > outside ? s.lum(x, y) > mid : s.lum(x, y) < mid);
+    const x0 = Math.floor(box.left);
+    const y0 = Math.floor(corner === "bl" ? box.bottom - R : box.top);
+    let filled = 0;
+    for (let dy = 0; dy < R; dy++) for (let dx = 0; dx < R; dx++) if (isFill(x0 + dx + 0.5, y0 + dy + 0.5)) filled++;
+    return { fraction: +(filled / (R * R)).toFixed(3), R, inside: Math.round(inside), outside: Math.round(outside) };
+  },
+  /* Every screenshot comparison below is of a surface carrying a live shimmer (the in-flight item's
+     label). Frozen, or no two frames of it are ever identical and the stacking check can only fail. */
+  freeze(on) {
+    let el = document.getElementById("live-freeze");
+    if (!on) { el?.remove(); return true; }
+    el = el ?? document.head.appendChild(Object.assign(document.createElement("style"), { id: "live-freeze" }));
+    el.textContent = "*, *::before, *::after { animation: none !important; transition: none !important; }";
+    return true;
+  },
+};
+void 0`;
+
+async function evalIn(c, expr) {
+  const r = await c.send("Runtime.evaluate", { expression: HELPERS + ";\n" + expr, awaitPromise: true, returnByValue: true });
+  if (r.exceptionDetails) throw new Error(`page exception: ${r.exceptionDetails.exception?.description ?? r.exceptionDetails.text}`);
+  return r.result.value;
+}
+
+const check = (name, cond, detail) => {
+  if (!cond) process.exitCode = 1;
+  console.log(`${cond ? "PASS" : "FAIL"} ${name}${detail !== undefined ? " " + JSON.stringify(detail) : ""}`);
+};
+const shotOf = async (c) => (await c.send("Page.captureScreenshot", { format: "png" })).data;
+/** Only the pair's own rectangle, so a change anywhere else in the pane cannot decide the answer. */
+const hashOf = async (c) => {
+  /* Strictly the pair's INTERIOR: inset past the rounded corner columns at both ends, because the
+     ground showing through those curves is ground the fade is entitled to blur. Include it and the
+     comparison fails on the band doing its job. */
+  const clip = await evalIn(c, `(() => {
+    const a = document.querySelector(".composer-todos").getBoundingClientRect();
+    const b = document.querySelector(".composer").getBoundingClientRect();
+    const R = Math.round(parseFloat(getComputedStyle(document.documentElement).getPropertyValue("--r-squircle"))) || 36;
+    return { x: Math.floor(a.left) + R, y: Math.floor(a.top) + 2, width: Math.ceil(b.right - a.left) - 2 * R, height: Math.ceil(b.bottom - a.top) - 4, scale: 1 };
+  })()`);
+  const shot = (await c.send("Page.captureScreenshot", { format: "png", clip })).data;
+  return crypto.createHash("sha256").update(shot).digest("hex").slice(0, 16);
+};
+
+async function main() {
+  for (const p of [CDP_PORT, SERVER_PORT]) {
+    if (!(await portFree(p))) throw new Error(`port ${p} is in use — refusing to run`);
+  }
+  const mainEntry = path.join(repoRoot, "apps/desktop/out/main/index.js");
+  if (!fs.existsSync(mainEntry)) throw new Error("apps/desktop/out is missing — run `pnpm build` first");
+
+  const wrapper = path.join(scratch, "wrapper.mjs");
+  fs.writeFileSync(wrapper, [
+    'import { app } from "electron";',
+    'app.setPath("userData", process.env.LIVE_USER_DATA);',
+    "await import(process.env.LIVE_MAIN);",
+  ].join("\n"));
+  const electronBin = process.platform === "darwin"
+    ? path.join(repoRoot, "node_modules/.pnpm/electron@37.10.3/node_modules/electron/dist/Electron.app/Contents/MacOS/Electron")
+    : path.join(repoRoot, "apps/desktop/node_modules/.bin/electron");
+  electron = spawn(electronBin, [wrapper], {
+    env: {
+      ...process.env,
+      REALM_HOME: path.join(scratch, "home"),
+      REALM_PORT: String(SERVER_PORT),
+      REALM_DEVTOOLS_PORT: String(CDP_PORT),
+      REALM_SERVER_ENTRY: path.join(repoRoot, "apps/server/dist/main.js"),
+      REALM_ENABLE_FAKE_AGENT: "1",
+      LIVE_USER_DATA: path.join(scratch, "userData"),
+      LIVE_MAIN: mainEntry,
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  electron.stderr.on("data", () => {}); electron.stdout.on("data", () => {});
+
+  const targets = () => fetch(`http://127.0.0.1:${CDP_PORT}/json/list`).then((r) => r.json()).catch(() => []);
+  const rendererTarget = await until(async () => (await targets()).find((t) => t.type === "page" && t.url.startsWith("file://")), 30000, "renderer target");
+  const c = cdp(rendererTarget.webSocketDebuggerUrl);
+  await c.ready;
+  await c.send("Runtime.enable");
+  await c.send("Page.enable");
+
+  await until(() => evalIn(c, `!!document.querySelector('.onboarding input:not([type=radio])')`), 20000, "onboarding");
+  await evalIn(c, `(() => {
+    const input = document.querySelector('.onboarding input:not([type=radio])');
+    __live.setInput(input, "Live");
+    input.closest("form").requestSubmit();
+    return true; })()`);
+  await until(() => evalIn(c, `!!document.querySelector('.composer')`), 20000, "composer");
+  await c.send("Emulation.setDeviceMetricsOverride", { width: 1200, height: 900, deviceScaleFactor: 1, mobile: false });
+  await sleep(600);
+
+  check("the painter loaded in the real bundle, so the surfaces are off their fallback",
+    await evalIn(c, `document.documentElement.hasAttribute("data-squircle")`));
+
+  // ── a session with nothing to read draws no strip at all ────────────────
+  const api = rpc(SERVER_PORT);
+  await api.ready;
+  const sessions = await until(async () => {
+    const all = await api.call("sessions.listAll", {});
+    return all.length ? all : null;
+  }, 15000, "a session to drive");
+  const session = sessions[0];
+  await api.call("sessions.setAgent", { id: session.id, agentKind: "fake" });
+  await sleep(400);
+  check("an empty session has no strip in the tree — nothing to pin costs no height",
+    (await evalIn(c, `!document.querySelector(".composer-todos")`)));
+
+  // ── the real path: the fake agent writes a real TodoWrite ───────────────
+  await api.call("sessions.send", { id: session.id, text: "write some todos", attachments: [], mentions: [] });
+  await until(() => evalIn(c, `!!document.querySelector(".composer-todos")`), 20000, "the strip");
+  await sleep(700);
+  const restCard = await evalIn(c, `__live.box(document.querySelector(".composer"))`);
+  check("the strip arrived from a persisted TodoWrite, open, with the agent's own words for the live step",
+    await evalIn(c, `(() => { const s = document.querySelector(".composer-todos");
+      return s.hasAttribute("data-open") && s.querySelector(".todo-active")?.textContent === "Drawing it as a plan"
+        && s.querySelectorAll(".todo-list li").length === 3; })()`));
+
+  // ── one object: same width, and no ground anywhere down the shared side ──
+  const boxes = await evalIn(c, `({ strip: __live.box(document.querySelector(".composer-todos")),
+    card: __live.box(document.querySelector(".composer")), under: __live.box(document.querySelector(".composer-understrip")) })`);
+  const insets = { strip: [boxes.strip.l - boxes.card.l, boxes.card.r - boxes.strip.r], under: [boxes.under.l - boxes.card.l, boxes.card.r - boxes.under.r] };
+  check("the strip is inset exactly as far as the under-strip below — one card, two matching tabs",
+    Math.abs(insets.strip[0] - insets.under[0]) < 0.6 && Math.abs(insets.strip[1] - insets.under[1]) < 0.6, insets);
+  check("and it sits on the card's centre line, not merely at the right width",
+    Math.abs((boxes.strip.l + boxes.strip.r) / 2 - (boxes.card.l + boxes.card.r) / 2) < 0.6
+      && Math.abs(insets.strip[0] - insets.strip[1]) < 0.6, boxes);
+  check("the strip's bottom is BEHIND the card, not resting on it — there is no edge to draw a seam on",
+    await evalIn(c, `(() => { const a = document.querySelector(".composer-todos").getBoundingClientRect(),
+      b = document.querySelector(".composer").getBoundingClientRect(); return a.bottom > b.top + 4; })()`));
+
+  const restShot = await shotOf(c);
+
+  // ── the corner itself, counted rather than read ─────────────────────────
+  /* The edge stroke comes off first: a 0.5px ring lands precisely on the boundary pixels the count is
+     deciding and is worth ~0.04 to either curve. `--card-ring` is the one lever — the painter reads
+     it as --sq-ring — so it drops out of the worklet path and the fallback path symmetrically. */
+  await evalIn(c, `(() => { document.documentElement.style.setProperty("--card-ring", "transparent"); return true; })()`);
+  await sleep(250);
+  const silhouette = await shotOf(c);
+  const painted = await evalIn(c, `__live.cornerFill(${JSON.stringify(silhouette)}, ".composer-todos", "tl")`);
+  check(`the strip's top corner is a superellipse (${SQUIRCLE}), not a circular arc (${CIRCLE.toFixed(3)})`,
+    near(painted.fraction, SQUIRCLE), painted);
+  check("and it is drawn at the CARD's radius, not the under-strip's smaller rung",
+    painted.R === Math.round(await evalIn(c, `parseFloat(getComputedStyle(document.documentElement).getPropertyValue("--r-squircle"))`)),
+    { R: painted.R });
+  /* The bottom pair is the half the user asked for and the half that is never on screen — it lives
+     10px behind the card. Lifted clear of it, the same count answers over the same window.
+     Against the ROUNDED alternative rather than against 1.0: the window's outer row and column land
+     on the antialiased edge whatever the shape, so even a perfect right angle counts short of full
+     and an absolute threshold would be measuring the sampler. Putting the radius back and counting
+     again calibrates that away, and is this check's own mutant. */
+  await evalIn(c, `(() => { document.querySelector(".composer-todos").style.marginBottom = "14px"; return true; })()`);
+  await sleep(300);
+  const squareR = await evalIn(c, `__live.cornerFill(${JSON.stringify(await shotOf(c))}, ".composer-todos", "bl", ${painted.R})`);
+  await evalIn(c, `(() => { document.querySelector(".composer-todos").style.setProperty("--sq-radius-bottom", "var(--r-squircle)");
+    document.querySelector(".composer-todos").style.borderBottomLeftRadius = "var(--r-squircle)"; return true; })()`);
+  await sleep(300);
+  const roundedR = await evalIn(c, `__live.cornerFill(${JSON.stringify(await shotOf(c))}, ".composer-todos", "bl", ${painted.R})`);
+  check("the strip's bottom corners are SQUARE — they fill more of the corner than the same corner rounded does",
+    squareR.fraction > roundedR.fraction + TOL, { square: squareR.fraction, rounded: roundedR.fraction, R: painted.R });
+  await evalIn(c, `(() => { const el = document.querySelector(".composer-todos");
+    el.style.removeProperty("--sq-radius-bottom"); el.style.borderBottomLeftRadius = ""; el.style.marginBottom = ""; return true; })()`);
+  await evalIn(c, `(() => { document.documentElement.style.removeProperty("--card-ring"); return true; })()`);
+  await sleep(250);
+
+  // ── nothing paints over it (the .composer-dock stacking trap) ───────────
+  /* Forced visible and given real height, because at rest the band may not reach the strip at all —
+     which would make an identical pair prove nothing. */
+  await evalIn(c, `__live.freeze(true)`);
+  await sleep(300);
+  /* Forced visible and given real height, because at rest the band may not reach the strip at all —
+     which would make an identical pair prove nothing. */
+  await evalIn(c, `(() => { const f = document.querySelector(".transcript-fade");
+    f.style.display = "block"; f.style.setProperty("--fade-h", "320px"); return true; })()`);
+  await sleep(400);
+  const withFade = await hashOf(c);
+  check("the band was actually made to reach the strip, so the comparison below can fail",
+    await evalIn(c, `(() => { const f = document.querySelector(".transcript-fade").getBoundingClientRect();
+      return f.top < document.querySelector(".composer-todos").getBoundingClientRect().top; })()`));
+  await evalIn(c, `(() => { document.querySelector(".transcript-fade").remove(); return true; })()`);
+  await sleep(400);
+  const withoutFade = await hashOf(c);
+  check("the transcript's fade band passes UNDER the strip — the dock still outranks it",
+    withFade === withoutFade, { withFade, withoutFade });
+  await evalIn(c, `__live.freeze(false)`);
+
+  // ── items arriving grow the strip upward and stop; the card holds still ──
+  const grown = await evalIn(c, `(() => {
+    const list = document.querySelector(".composer-todos .todo-list");
+    const li = list.querySelector("li");
+    for (let i = 0; i < 24; i++) list.appendChild(li.cloneNode(true));
+    return true; })()`);
+  void grown;
+  await sleep(400);
+  const afterCard = await evalIn(c, `__live.box(document.querySelector(".composer"))`);
+  check("a plan of any length does not move the prompter — the strip grows into the transcript instead",
+    Math.abs(afterCard.t - restCard.t) < 1 && Math.abs(afterCard.b - restCard.b) < 1, { rest: restCard, grown: afterCard });
+  const list = await evalIn(c, `(() => { const l = document.querySelector(".composer-todos .todo-list");
+    return { client: l.clientHeight, scroll: l.scrollHeight, cap: Math.round(parseFloat(getComputedStyle(l).maxHeight)) }; })()`);
+  check("and it is bounded: the list stops at its cap and scrolls past it",
+    list.client <= list.cap + 1 && list.scroll > list.client + 20, list);
+
+  // ── a finished plan shuts itself, and still reports ─────────────────────
+  await api.call("sessions.send", { id: session.id, text: "all done", attachments: [], mentions: [] });
+  await until(() => evalIn(c, `document.querySelector(".composer-todos .todo-count")?.textContent === "3 of 3"`), 20000, "the finished plan");
+  await sleep(700);
+  const doneShot = await shotOf(c);
+  const shut = await evalIn(c, `(() => { const s = document.querySelector(".composer-todos");
+    return { open: s.hasAttribute("data-open"), h: Math.round(s.getBoundingClientRect().height),
+      barW: document.querySelector(".composer-todos .todo-fill").getBoundingClientRect().width,
+      trackW: document.querySelector(".composer-todos .todo-track").getBoundingClientRect().width,
+      card: __live.box(document.querySelector(".composer")) }; })()`);
+  check("a finished plan shuts itself rather than holding prompter height open",
+    !shut.open && shut.h < 70, { open: shut.open, height: shut.h });
+  check("but the filled bar is still on screen — a shut strip still says how the run went",
+    Math.abs(shut.barW - shut.trackW) < 1 && shut.trackW > 100, { bar: Math.round(shut.barW), track: Math.round(shut.trackW) });
+  check("and the prompter did not move while it shut",
+    Math.abs(shut.card.t - restCard.t) < 1 && Math.abs(shut.card.b - restCard.b) < 1, { rest: restCard, done: shut.card });
+
+  for (const [tag, data] of [["open", restShot], ["silhouette", silhouette], ["done", doneShot]]) {
+    const out = path.join(os.tmpdir(), `realm-todo-strip-${tag}.png`);
+    fs.writeFileSync(out, Buffer.from(data, "base64"));
+    console.log(`SCREENSHOT ${tag} ${out}`);
+  }
+
+  const errs = c.events.filter((e) => !e.includes("Autofill"));
+  check("no renderer console errors", errs.length === 0, errs.slice(0, 5));
+  api.close();
+  c.close();
+}
+
+main()
+  .catch((e) => { console.error("ERROR", e.message); process.exitCode = 1; })
+  .finally(() => {
+    electron?.kill("SIGTERM");
+    setTimeout(() => { electron?.kill("SIGKILL"); fs.rmSync(scratch, { recursive: true, force: true }); process.exit(process.exitCode ?? 0); }, 1200);
+  });

--- a/apps/desktop/src/renderer/src/panes/session/Composer.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/Composer.tsx
@@ -13,6 +13,8 @@ import { SUGGESTIONS } from "./suggestions";
 import { heroGreeting } from "./greeting";
 import { chipAround, chipSpans, continueList, deleteChipAt, highlightSegments, indentList, isChipKind, stepOverChip, toggleList, type DraftEdit } from "./draft-format";
 import { AttachmentTile } from "./AttachmentTile";
+import { TodoStrip } from "./TodoStrip";
+import type { Todo } from "./rich/tool-view";
 
 // ~10 lines of 15px/1.55 plus the vertical padding (Ara refresh §1 raises the input to 15px; §4:
 // autogrows to 10 lines). Matches .composer-input's max-height in styles.css.
@@ -251,11 +253,13 @@ function modeMeaning(mode: Exclude<SessionMode, "build">, kind: AgentKind, acpMo
   return "Plan means the agent researches and proposes, but does not edit";
 }
 
-export function Composer({ session, status, gitInfo, onOpenDiff, draft, onDraftChange, attachments, onAttachPick, onAttachFiles, onRemoveAttachment, onSend, onStop, onOptions, onPickModel, onMode, planReturn, canSwitchAgent, agentProbe, modelFavorites, modelInfo, onToggleModelFavorite, hero, spaceName, userName = "", onSuggestion, mentionSkills = [], allSkills = [], onToggleSkill, onManageSkills, staleMentions = [], machineName = "", environments = [], onSelectEnvironment, onNewWorktree, connectors = null, onConnectorsOpened, onAddFolder, onManageConnections, acpModes = null, submitKey = "enter", promptHint = null }: {
+export function Composer({ session, status, gitInfo, onOpenDiff, draft, onDraftChange, attachments, onAttachPick, onAttachFiles, onRemoveAttachment, onSend, onStop, onOptions, onPickModel, onMode, planReturn, canSwitchAgent, agentProbe, modelFavorites, modelInfo, onToggleModelFavorite, hero, spaceName, userName = "", onSuggestion, mentionSkills = [], allSkills = [], onToggleSkill, onManageSkills, staleMentions = [], machineName = "", environments = [], onSelectEnvironment, onNewWorktree, connectors = null, onConnectorsOpened, onAddFolder, onManageConnections, acpModes = null, submitKey = "enter", promptHint = null, todos = [] }: {
   session: Session; status: SessionStatus; gitInfo: GitInfo | null;
   /** Open the diff pane for the session's checkout (W3) — what the branch/diff chips do. */
   onOpenDiff: () => void;
   draft: string; onDraftChange: (text: string) => void;
+  /** The session's plan as it stands, pinned above the card. Empty draws nothing at all. */
+  todos?: readonly Todo[];
   /** Part of the draft, and store-owned for the same reason: a remount must not drop them. */
   attachments: PickedAttachment[];
   /** The attach button — the native multi-select picker. */
@@ -697,6 +701,10 @@ export function Composer({ session, status, gitInfo, onOpenDiff, draft, onDraftC
           {greeting.map((part, i) => (part.em ? <em key={i}>{part.text}</em> : <Fragment key={i}>{part.text}</Fragment>))}
         </div>
       )}
+      {/* Above the card and inside the dock, so the hero→docked move carries it and it cannot be
+          left behind mid-transition. In flow, so it grows UPWARD into the transcript rather than
+          pushing the prompter's own controls off their bottom edge. */}
+      <TodoStrip todos={todos} />
       {/* The whole card is the drop target — aiming at a 44px textarea with a file in hand is a chore.
           §6 forbids animating during a drag, so the state change is a static ring, not a transition. */}
       <div className="composer" data-dropping={drop.dropping || undefined} {...drop.handlers}>

--- a/apps/desktop/src/renderer/src/panes/session/SessionPane.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/SessionPane.tsx
@@ -13,6 +13,7 @@ import { Transcript } from "./Transcript";
 import { DelegatedRuns } from "./DelegatedRuns";
 import { emptyTranscript } from "./transcript-model";
 import { promptHint } from "./prompt-hint";
+import { latestTodos } from "./session-todos";
 
 /** Stable empty array: a fresh `[]` from the selector on every render makes useSyncExternalStore
  *  re-render (and warn) forever. */
@@ -299,6 +300,9 @@ export function SessionPane({ item, visible, focused = false }: PaneProps) {
   const hint = promptHint({
     blocks: transcript.blocks, gitInfo, status, inPlan: session.permissionMode === PLAN_PERMISSION_MODE,
   });
+  // Derived at render like the hint above, not memoised and not stored: one backward walk over
+  // blocks the pane already holds, and a slice beside the transcript could only disagree with it.
+  const todos = latestTodos(transcript.blocks);
   const blocked = isBlocked(availability) && status !== "running" && status !== "waiting_permission";
   const body = (
     <div className="session-pane" data-visible={visible || undefined} data-composer={hero ? "hero" : "docked"}
@@ -314,7 +318,7 @@ export function SessionPane({ item, visible, focused = false }: PaneProps) {
       {blocked && isBlocked(availability)
         ? <InstallCard availability={availability} onRetry={reprobe}
             onOpenInTerminal={(command) => run(() => prefillTerminal(id, command))} />
-        : <Composer session={session} status={status} gitInfo={gitInfo}
+        : <Composer session={session} status={status} gitInfo={gitInfo} todos={todos}
             onOpenDiff={() => run(() => openDiff(session.environmentId))} draft={draft} onDraftChange={(t) => setDraft(id, t)}
             attachments={attachments}
             onAttachPick={() => run(() => attachFromPicker(id))}

--- a/apps/desktop/src/renderer/src/panes/session/TodoStrip.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/TodoStrip.tsx
@@ -1,0 +1,45 @@
+import { Icon } from "@realm/ui";
+import { useState } from "react";
+import { TodoHeadline, TodoItems, TodoTrack } from "./rich/ToolViews";
+import type { Todo } from "./rich/tool-view";
+
+/**
+ * The session's plan, attached to the top of the prompter.
+ *
+ * A plan is standing context, not a moment in the log. Drawn only inside its TodoWrite card it
+ * scrolls away the moment the agent does anything else, so the reader who wants to know what is
+ * left has to go hunting back through the run for it. The card keeps its copy — that is what the
+ * plan was then — and this is what it is now.
+ *
+ * The card is not touched. It is closed by default and each one holds the list as written at that
+ * point, so there is no second copy on screen unless a reader opens one; and making the newest card
+ * draw itself differently from every older one would be a rule nobody could learn from watching.
+ */
+export function TodoStrip({ todos }: { todos: readonly Todo[] }) {
+  const done = todos.filter((t) => t.status === "completed").length;
+  const allDone = todos.length > 0 && done === todos.length;
+  // Same shape as the run group's header (ToolCard.tsx): a derived default a click can override.
+  // The override sticks once made, including across a later plan — an agent updating its list must
+  // not reopen a strip the reader deliberately shut and shove the prompter down under their hands.
+  const [manual, setManual] = useState<boolean | null>(null);
+  const open = manual ?? !allDone;
+  // Nothing to pin, so nothing to take room: no header, no rule above the card, no gap.
+  if (todos.length === 0) return null;
+  return (
+    <div className="composer-todos" data-open={open || undefined}>
+      <button type="button" className="composer-todos-head" aria-expanded={open}
+        aria-label={allDone ? "Plan complete" : "Plan"} onClick={() => setManual(!open)}>
+        <TodoHeadline todos={todos} />
+        <Icon name="chevronRight" size={12} className="composer-todos-caret" />
+      </button>
+      {/* Outside the collapse: finished or shut, the filled bar is what says how the run went, and
+          it is the only part of this legible without reading. */}
+      <TodoTrack todos={todos} />
+      <div className="composer-todos-wrap">
+        <div className="composer-todos-clip" inert={!open || undefined}>
+          <TodoItems todos={todos} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/src/panes/session/TodoStrip.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/TodoStrip.tsx
@@ -11,9 +11,9 @@ import type { Todo } from "./rich/tool-view";
  * left has to go hunting back through the run for it. The card keeps its copy — that is what the
  * plan was then — and this is what it is now.
  *
- * The card is not touched. It is closed by default and each one holds the list as written at that
- * point, so there is no second copy on screen unless a reader opens one; and making the newest card
- * draw itself differently from every older one would be a rule nobody could learn from watching.
+ * The TodoWrite card keeps its own copy. It is closed by default and each one holds the list as it
+ * was written at that point, so nothing is doubled on screen unless a reader opens one — and a
+ * newest card that drew itself differently from every older one would be a rule nobody could learn.
  */
 export function TodoStrip({ todos }: { todos: readonly Todo[] }) {
   const done = todos.filter((t) => t.status === "completed").length;

--- a/apps/desktop/src/renderer/src/panes/session/rich/ToolViews.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/rich/ToolViews.tsx
@@ -90,32 +90,54 @@ export function TerminalView({ output, exitCode }: { output: string; exitCode: n
   );
 }
 
-/** TodoWrite's plan (AICSS "To-do List"). The bar is the plan's real arithmetic — completed over
- *  total — and it is the one thing in the card readable from across the room, which is the point: a
- *  reader scrolling past a long run of tool calls wants to know how far through the agent is. */
-export function TodoList({ todos }: { todos: Todo[] }) {
+/** How far through, and what is happening right now. A fragment rather than a box, so the card's
+ *  head row and the strip's header button can each lay it out their own way. */
+export function TodoHeadline({ todos }: { todos: readonly Todo[] }) {
   const done = todos.filter((t) => t.status === "completed").length;
   const active = todos.find((t) => t.status === "in_progress");
   return (
+    <>
+      <span className="todo-count">{done} of {todos.length}</span>
+      {/* The in-flight item's own words for what it is doing ("Running the suite"), which is what
+          `activeForm` is for; without one the item's title stands in. */}
+      {active && <span className="todo-active shimmer-text">{active.activeForm ?? active.content}</span>}
+    </>
+  );
+}
+
+/** The plan's real arithmetic — completed over total. The one part readable from across the room,
+ *  which is why the strip keeps it out of the collapse. */
+export function TodoTrack({ todos }: { todos: readonly Todo[] }) {
+  const done = todos.filter((t) => t.status === "completed").length;
+  return (
+    <div className="todo-track" role="progressbar" aria-valuenow={done} aria-valuemin={0} aria-valuemax={todos.length}>
+      <div className="todo-fill" style={{ width: `${todos.length ? (done / todos.length) * 100 : 0}%` }} />
+    </div>
+  );
+}
+
+export function TodoItems({ todos }: { todos: readonly Todo[] }) {
+  return (
+    <ul className="todo-list">
+      {todos.map((t, i) => (
+        <li key={i} data-status={t.status}>
+          {/* off-ladder: the dot is 13px, so the inline rung would fill it edge to edge. */}
+          <span className="todo-dot" aria-hidden="true">{t.status === "completed" && <Icon name="check" size={10} />}</span>
+          <span className="todo-text">{t.content}</span>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+/** TodoWrite's plan (AICSS "To-do List"), as the tool card draws it: the whole list, at the point in
+ *  the log where the agent wrote it. The card is one moment; the strip above the prompter is now. */
+export function TodoList({ todos }: { todos: Todo[] }) {
+  return (
     <div className="todo">
-      <div className="todo-head">
-        <span className="todo-count">{done} of {todos.length}</span>
-        {/* The in-flight item's own words for what it is doing ("Running the suite"), which is what
-            `activeForm` is for; without one the item's title stands in. */}
-        {active && <span className="todo-active shimmer-text">{active.activeForm ?? active.content}</span>}
-      </div>
-      <div className="todo-track" role="progressbar" aria-valuenow={done} aria-valuemin={0} aria-valuemax={todos.length}>
-        <div className="todo-fill" style={{ width: `${todos.length ? (done / todos.length) * 100 : 0}%` }} />
-      </div>
-      <ul className="todo-list">
-        {todos.map((t, i) => (
-          <li key={i} data-status={t.status}>
-            {/* off-ladder: the dot is 13px, so the inline rung would fill it edge to edge. */}
-            <span className="todo-dot" aria-hidden="true">{t.status === "completed" && <Icon name="check" size={10} />}</span>
-            <span className="todo-text">{t.content}</span>
-          </li>
-        ))}
-      </ul>
+      <div className="todo-head"><TodoHeadline todos={todos} /></div>
+      <TodoTrack todos={todos} />
+      <TodoItems todos={todos} />
     </div>
   );
 }

--- a/apps/desktop/src/renderer/src/panes/session/session-todos.test.ts
+++ b/apps/desktop/src/renderer/src/panes/session/session-todos.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { sessionEvent } from "@realm/contracts";
+import { reduceAll } from "./transcript-model";
+import { latestTodos } from "./session-todos";
+
+const todo = (content: string, status: "pending" | "in_progress" | "completed") => ({ content, status, activeForm: null });
+
+/** Built through `reduceAll` rather than as hand-made blocks: what the pinned plan has to survive is
+ *  a reload, and a reload is exactly this fold over the session's persisted events. */
+const write = (id: string, todos: unknown, parentToolUseId: string | null = null) =>
+  sessionEvent("tool_call", { toolUseId: id, name: "TodoWrite", input: { todos }, parentToolUseId });
+
+describe("latestTodos", () => {
+  it("is empty for a session that has never written a plan", () => {
+    expect(latestTodos(reduceAll([sessionEvent("user_message", { text: "hi", attachments: [] })]).blocks)).toEqual([]);
+  });
+
+  it("reads the newest plan, not the first — every TodoWrite restates the whole list", () => {
+    const t = reduceAll([
+      write("t1", [{ content: "Read the spec", status: "pending" }]),
+      sessionEvent("assistant_text", { messageId: "m", text: "working" }),
+      write("t2", [{ content: "Read the spec", status: "completed" }, { content: "Write it", status: "in_progress" }]),
+    ]);
+    expect(latestTodos(t.blocks)).toEqual([todo("Read the spec", "completed"), todo("Write it", "in_progress")]);
+  });
+
+  it("carries activeForm through, since the strip says what the agent is doing in its own words", () => {
+    const t = reduceAll([write("t1", [{ content: "Run the suite", status: "in_progress", activeForm: "Running the suite" }])]);
+    expect(latestTodos(t.blocks)[0]!.activeForm).toBe("Running the suite");
+  });
+
+  it("clears when the agent drops its plan, rather than restoring the one before it", () => {
+    const t = reduceAll([
+      write("t1", [{ content: "Read the spec", status: "pending" }]),
+      write("t2", []),
+    ]);
+    expect(latestTodos(t.blocks)).toEqual([]);
+  });
+
+  it("ignores a sub-agent's list — a delegated child's plan is not this session's", () => {
+    const t = reduceAll([
+      write("t1", [{ content: "Read the spec", status: "pending" }]),
+      write("t2", [{ content: "Child's own step", status: "in_progress" }], "task1"),
+    ]);
+    expect(latestTodos(t.blocks)).toEqual([todo("Read the spec", "pending")]);
+  });
+
+  it("is empty when the newest payload is not the shape TodoWrite documents", () => {
+    const t = reduceAll([write("t1", [{ content: "Read the spec", status: "hurrying" }])]);
+    expect(latestTodos(t.blocks)).toEqual([]);
+  });
+});

--- a/apps/desktop/src/renderer/src/panes/session/session-todos.ts
+++ b/apps/desktop/src/renderer/src/panes/session/session-todos.ts
@@ -1,0 +1,26 @@
+import { parseTodos, type Todo } from "./rich/tool-view";
+import type { Block } from "./transcript-model";
+
+/**
+ * The session's plan as it stands now: its most recent TodoWrite, because every TodoWrite restates
+ * the whole list rather than amending the last one.
+ *
+ * Derived from the transcript rather than held beside it. The transcript is folded from the
+ * session's persisted events, so this survives a re-render and a reload with no state of its own to
+ * keep in step — a store slice would have to be rebuilt from the same events anyway, and could
+ * disagree with the cards the reader is scrolling through.
+ *
+ * A sub-agent's list is not the session's. A Task's child restates ITS plan through the same tool,
+ * and pinning that above the prompter would show the reader work they did not ask for in place of
+ * the work they are watching.
+ */
+export function latestTodos(blocks: readonly Block[]): Todo[] {
+  for (let i = blocks.length - 1; i >= 0; i--) {
+    const b = blocks[i]!;
+    if (b.kind !== "tool" || b.name !== "TodoWrite" || b.parentToolUseId) continue;
+    // First match wins, even when it does not parse: an agent drops its plan by writing an empty
+    // list, and reaching further back for one that does parse would put the abandoned plan back.
+    return parseTodos(b.input) ?? [];
+  }
+  return [];
+}

--- a/apps/desktop/src/renderer/src/panes/session/todo-strip.test.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/todo-strip.test.tsx
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { sessionEvent } from "@realm/contracts";
+import { StoreContext, createAppStore } from "../../state/store";
+import { fakeApi, item, session } from "../../state/store.test-fakes";
+import { SessionPane } from "./SessionPane";
+import { TodoStrip } from "./TodoStrip";
+import { reduceAll } from "./transcript-model";
+import type { Todo } from "./rich/tool-view";
+
+const q = (sel: string) => [...document.querySelectorAll<HTMLElement>(sel)];
+const strip = () => document.querySelector(".composer-todos");
+const items = () => q(".composer-todos .todo-list li").map((li) => li.textContent);
+
+const todo = (content: string, status: Todo["status"]): Todo => ({ content, status, activeForm: null });
+const HALF: Todo[] = [todo("Parse the payload", "completed"), todo("Draw the strip", "in_progress"), todo("Test it", "pending")];
+const ALL_DONE: Todo[] = HALF.map((t) => ({ ...t, status: "completed" }));
+
+/** The pane, seeded from persisted events — the same fold a relaunch performs. */
+async function mountPane(events: Parameters<typeof reduceAll>[0]) {
+  const api = fakeApi({ sessions: [session("se1", "s1", { status: "idle" })] });
+  const store = createAppStore(api); await store.getState().boot();
+  store.setState({ sessionStatus: { se1: "idle" }, transcripts: { se1: { lastSeq: events.length, t: reduceAll(events) } } });
+  const r = render(<StoreContext.Provider value={store}><SessionPane item={item("i9", "s1", { kind: "session", refId: "se1", title: "s" })} visible /></StoreContext.Provider>);
+  return { store, ...r };
+}
+
+const write = (id: string, todos: unknown) =>
+  sessionEvent("tool_call", { toolUseId: id, name: "TodoWrite", input: { todos }, parentToolUseId: null });
+
+describe("TodoStrip", () => {
+  it("draws nothing at all for a session with no plan — no header, no rule, no gap", () => {
+    render(<TodoStrip todos={[]} />);
+    expect(strip()).toBeNull();
+  });
+
+  it("is open while work remains, and the list is reachable", () => {
+    render(<TodoStrip todos={HALF} />);
+    expect(strip()).toHaveAttribute("data-open");
+    expect(items()).toEqual(["Parse the payload", "Draw the strip", "Test it"]);
+    expect(document.querySelector(".composer-todos-clip")).not.toHaveAttribute("inert");
+  });
+
+  it("collapses itself once every item is done, rather than holding prompter height open", () => {
+    render(<TodoStrip todos={ALL_DONE} />);
+    expect(strip()).not.toHaveAttribute("data-open");
+    // Collapsed, not unmounted: the shut strip is still the record that the plan finished.
+    expect(document.querySelector(".composer-todos-clip")).toHaveAttribute("inert");
+    expect(screen.getByRole("button", { name: "Plan complete" })).toBeInTheDocument();
+  });
+
+  it("keeps the progress bar and the count outside the collapse — a shut strip still reports", () => {
+    render(<TodoStrip todos={ALL_DONE} />);
+    const track = document.querySelector<HTMLElement>(".composer-todos > .todo-track");
+    expect(track).not.toBeNull();
+    expect(document.querySelector(".composer-todos-wrap")!.contains(track!)).toBe(false);
+    expect(document.querySelector(".composer-todos .todo-fill")!.getAttribute("style")).toContain("width: 100%");
+    expect(document.querySelector(".composer-todos .todo-count")).toHaveTextContent("3 of 3");
+  });
+
+  it("a click closes an open strip, and the choice outlives the next plan update", () => {
+    const { rerender } = render(<TodoStrip todos={HALF} />);
+    fireEvent.click(screen.getByRole("button", { name: "Plan" }));
+    expect(strip()).not.toHaveAttribute("data-open");
+    // An agent rewriting its list must not shove the prompter down under a reader's hands.
+    rerender(<TodoStrip todos={[...HALF, todo("And this", "pending")]} />);
+    expect(strip()).not.toHaveAttribute("data-open");
+  });
+
+  it("names what is in flight in the agent's own words", () => {
+    render(<TodoStrip todos={[todo("Run the suite", "pending"), { content: "Build", status: "in_progress", activeForm: "Building the app" }]} />);
+    expect(document.querySelector(".composer-todos .todo-active")).toHaveTextContent("Building the app");
+  });
+});
+
+describe("the strip on the pane", () => {
+  it("sits inside the prompter's dock and ABOVE the card, so the two are one object that moves as one", async () => {
+    await mountPane([write("t1", [{ content: "Parse the payload", status: "pending" }])]);
+    const dock = document.querySelector(".composer-dock")!;
+    const s = dock.querySelector(":scope > .composer-todos");
+    const card = dock.querySelector(":scope > .composer");
+    expect(s).not.toBeNull();
+    expect(card).not.toBeNull();
+    expect(s!.compareDocumentPosition(card!) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it("shows the newest plan, and a session rebuilt from its persisted events shows it again", async () => {
+    const events = [
+      write("t1", [{ content: "Parse the payload", status: "pending" }]),
+      sessionEvent("assistant_text", { messageId: "m", text: "on it" }),
+      write("t2", [{ content: "Parse the payload", status: "completed" }, { content: "Draw the strip", status: "in_progress" }]),
+    ];
+    const first = await mountPane(events);
+    expect(items()).toEqual(["Parse the payload", "Draw the strip"]);
+    first.unmount();
+    // A relaunch holds no strip state of its own: the same event log folds back to the same plan.
+    await mountPane(events);
+    expect(items()).toEqual(["Parse the payload", "Draw the strip"]);
+  });
+
+  it("stays away from the hero prompter — a session with nothing to read has no plan to pin", async () => {
+    await mountPane([]);
+    expect(document.querySelector(".session-pane")).toHaveAttribute("data-composer", "hero");
+    expect(strip()).toBeNull();
+  });
+
+  it("leaves the TodoWrite card alone — the log keeps the plan as it was written", async () => {
+    await mountPane([write("t1", [{ content: "Parse the payload", status: "pending" }])]);
+    const card = screen.getByRole("button", { name: /TodoWrite tool call/ });
+    expect(card).toHaveAttribute("aria-expanded", "false");
+    fireEvent.click(card);
+    expect(q(".tool-body .todo-list li").map((li) => li.textContent)).toEqual(["Parse the payload"]);
+  });
+});

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -1735,19 +1735,21 @@ button.panel-title:hover { background: var(--rl-hover); }
 .composer-send:disabled { background: var(--line-strong); color: var(--ink-2); box-shadow: none; opacity: 1; }
 
 /* ── To-do strip (§4): the session's plan, attached to the TOP of the card ─────────────
-   The under-strip below is the same attachment in the other direction, but one of its constraints
-   does not carry: that strip caps at --r-panel because only ~26px of it shows and a corner cannot be
-   rounder than half its box. A list is tall enough for the card's own --r-squircle, and taking it is
-   what makes the two read as one silhouette instead of a card resting on a card.
-   Flush to the dock's width rather than inset like the strip below — the side edges have to continue
-   the card's, or the two rings draw two boxes. The bottom edge overlaps the card and is square, so
-   the seam that would cross the join is hidden underneath it (.composer holds z-index 1).
+   The under-strip below, mirrored: same frame fill, same 10px inset, same overlap sliding it behind
+   the card, and the radii swapped end for end — so the prompter reads as one card with a narrower
+   tab above it and a narrower tab below. The three-value margin is what keeps the insets equal; a
+   four-value one could hold a strip that is the right WIDTH and still off the card's centre.
+   Only one of the under-strip's constraints fails to carry. That strip caps its rounding at
+   --r-panel because barely 26px of it shows and a corner cannot be rounder than half its box; a list
+   is tall enough to take the card's own --r-squircle, so it does.
+   The bottom corners are square because that edge is not an edge — it is 10px behind the card, which
+   paints over it (.composer holds z-index 1). Rounding them would round nothing and the two would
+   still meet flush; leaving them square is what the strip's own painted path has to say.
    In normal flow inside .composer-dock, so the hero→docked transform carries it and it grows UPWARD
    into the transcript: the prompter's own controls never leave the bottom edge they sit on. ── */
 .composer-todos { display: flex; flex-direction: column; min-width: 0;
-  margin: 0 0 -12px; padding: 12px 16px 22px; background: var(--rl-frame);
-  border-radius: var(--r-squircle) var(--r-squircle) 0 0; corner-shape: squircle;
-  box-shadow: var(--shadow-card); }
+  margin: 0 10px -10px; padding: 10px 14px 20px; background: var(--rl-frame);
+  border-radius: var(--r-squircle) var(--r-squircle) 0 0; corner-shape: squircle; }
 .composer-todos-head { display: flex; align-items: baseline; gap: 8px; width: 100%; text-align: left; font-size: 11.5px; }
 .composer-todos-caret { flex: none; margin-left: auto; align-self: center; color: var(--rl-text-faint);
   transition: transform var(--dur-pop) var(--ease-out-strong); }
@@ -1853,10 +1855,9 @@ button.panel-title:hover { background: var(--rl-hover); }
 /* The hint lies inset:0 over the card, so it takes the card's own radius or it would square off
    inside a rounded corner. No ring: the card underneath is already wearing the drop target's. */
 :root[data-squircle] .composer-drop-hint { --sq-fill: color-mix(in srgb, var(--rl-raised) 82%, transparent); }
-/* The to-do strip's bottom edge is hidden beneath the card, so only its top corners are drawn — and
-   it wears the card's ring, at the card's width, because the join has to read as one outline. */
-:root[data-squircle] .composer-todos { --sq-fill: var(--rl-frame); --sq-radius-bottom: 0px;
-  --sq-ring: var(--card-ring); --sq-ring-w: var(--hairline-w); box-shadow: var(--shadow-card-lift); }
+/* The to-do strip's bottom edge is hidden beneath the card, so only its top corners are drawn — the
+   under-strip's rule with the two radii swapped, and ringless for the same reason it is. */
+:root[data-squircle] .composer-todos { --sq-fill: var(--rl-frame); --sq-radius-bottom: 0px; }
 /* The under-strip's top edge is hidden beneath the card, so only its bottom corners are drawn. */
 :root[data-squircle] .composer-understrip { --sq-fill: var(--rl-frame); --sq-radius-top: 0px; --sq-radius-bottom: var(--r-panel); }
 :root[data-squircle] .install-card {

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -1742,9 +1742,8 @@ button.panel-title:hover { background: var(--rl-hover); }
    Only one of the under-strip's constraints fails to carry. That strip caps its rounding at
    --r-panel because barely 26px of it shows and a corner cannot be rounder than half its box; a list
    is tall enough to take the card's own --r-squircle, so it does.
-   The bottom corners are square because that edge is not an edge — it is 10px behind the card, which
-   paints over it (.composer holds z-index 1). Rounding them would round nothing and the two would
-   still meet flush; leaving them square is what the strip's own painted path has to say.
+   The bottom corners are square because the strip has no bottom edge to round: it sits 10px behind
+   the card, which paints over it (.composer holds z-index 1).
    In normal flow inside .composer-dock, so the hero→docked transform carries it and it grows UPWARD
    into the transcript: the prompter's own controls never leave the bottom edge they sit on. ── */
 .composer-todos { display: flex; flex-direction: column; min-width: 0;

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -1734,6 +1734,36 @@ button.panel-title:hover { background: var(--rl-hover); }
 .composer-send:hover:not(:disabled) { background: var(--accent-ink); }
 .composer-send:disabled { background: var(--line-strong); color: var(--ink-2); box-shadow: none; opacity: 1; }
 
+/* ── To-do strip (§4): the session's plan, attached to the TOP of the card ─────────────
+   The under-strip below is the same attachment in the other direction, but one of its constraints
+   does not carry: that strip caps at --r-panel because only ~26px of it shows and a corner cannot be
+   rounder than half its box. A list is tall enough for the card's own --r-squircle, and taking it is
+   what makes the two read as one silhouette instead of a card resting on a card.
+   Flush to the dock's width rather than inset like the strip below — the side edges have to continue
+   the card's, or the two rings draw two boxes. The bottom edge overlaps the card and is square, so
+   the seam that would cross the join is hidden underneath it (.composer holds z-index 1).
+   In normal flow inside .composer-dock, so the hero→docked transform carries it and it grows UPWARD
+   into the transcript: the prompter's own controls never leave the bottom edge they sit on. ── */
+.composer-todos { display: flex; flex-direction: column; min-width: 0;
+  margin: 0 0 -12px; padding: 12px 16px 22px; background: var(--rl-frame);
+  border-radius: var(--r-squircle) var(--r-squircle) 0 0; corner-shape: squircle;
+  box-shadow: var(--shadow-card); }
+.composer-todos-head { display: flex; align-items: baseline; gap: 8px; width: 100%; text-align: left; font-size: 11.5px; }
+.composer-todos-caret { flex: none; margin-left: auto; align-self: center; color: var(--rl-text-faint);
+  transition: transform var(--dur-pop) var(--ease-out-strong); }
+.composer-todos[data-open] .composer-todos-caret { transform: rotate(90deg); }
+.composer-todos .todo-track { margin-top: 7px; }
+/* The house collapse (.tool-body-wrap): 0fr→1fr on a grid row animates to the height the content
+   actually wants, so a plan of any length opens without being measured first. Margins that space the
+   list live INSIDE the clip, or they would survive the collapse as a gap under a shut strip. */
+.composer-todos-wrap { display: grid; grid-template-rows: 0fr;
+  transition: grid-template-rows var(--dur-base) var(--ease-in-out-strong); }
+.composer-todos[data-open] .composer-todos-wrap { grid-template-rows: 1fr; }
+.composer-todos-clip { overflow: hidden; min-height: 0; }
+/* Bounded, or a twenty-step plan eats the transcript it is supposed to sit above. `contain` because
+   running off the end of the list must not carry the scroll into the log behind it. */
+.composer-todos .todo-list { margin-top: 8px; max-height: 248px; overflow-y: auto; overscroll-behavior: contain; }
+
 /* ── Under-strip (§4 + Plan 12 W1): machine label + workspace selector, one size quieter than the
    control row (11px on faint vs 12px on dim), on a frame fill sliding out from beneath the card
    (z-index 1 on .composer keeps the card on top). Drawn unconditionally — where a session runs is
@@ -1798,6 +1828,7 @@ button.panel-title:hover { background: var(--rl-hover); }
      painting the fill — would have clipped it away entirely. */
 :root[data-squircle] .composer,
 :root[data-squircle] .composer-drop-hint,
+:root[data-squircle] .composer-todos,
 :root[data-squircle] .composer-understrip,
 :root[data-squircle] .install-card,
 :root[data-squircle] .commit-card {
@@ -1822,6 +1853,10 @@ button.panel-title:hover { background: var(--rl-hover); }
 /* The hint lies inset:0 over the card, so it takes the card's own radius or it would square off
    inside a rounded corner. No ring: the card underneath is already wearing the drop target's. */
 :root[data-squircle] .composer-drop-hint { --sq-fill: color-mix(in srgb, var(--rl-raised) 82%, transparent); }
+/* The to-do strip's bottom edge is hidden beneath the card, so only its top corners are drawn — and
+   it wears the card's ring, at the card's width, because the join has to read as one outline. */
+:root[data-squircle] .composer-todos { --sq-fill: var(--rl-frame); --sq-radius-bottom: 0px;
+  --sq-ring: var(--card-ring); --sq-ring-w: var(--hairline-w); box-shadow: var(--shadow-card-lift); }
 /* The under-strip's top edge is hidden beneath the card, so only its bottom corners are drawn. */
 :root[data-squircle] .composer-understrip { --sq-fill: var(--rl-frame); --sq-radius-top: 0px; --sq-radius-bottom: var(--r-panel); }
 :root[data-squircle] .install-card {
@@ -1900,7 +1935,9 @@ button.panel-title:hover { background: var(--rl-hover); }
   .cp-list, .activity-list, .task-detail-result, .notif-list, .notif-detail, .notif-split, .delegation-list,
   .lecture-list, .install-cmd code, .code-preview,
   /* documents */
-  .documents-tabs, .documents-picker, .documents-rich-surface, .documents-rich .tiptap, .documents-raw
+  .documents-tabs, .documents-picker, .documents-rich-surface, .documents-rich .tiptap, .documents-raw,
+  /* the prompter — only the pinned strip's copy of the list is bounded enough to scroll */
+  .composer-todos .todo-list
 ) { scrollbar-width: thin; }
 /* xterm keeps an explicit treatment rather than inheriting the app's. It owns this element: it
    measures the viewport to decide the terminal's column count, and its interior is a dark world in

--- a/apps/desktop/src/renderer/src/styles.test.ts
+++ b/apps/desktop/src/renderer/src/styles.test.ts
@@ -1011,7 +1011,7 @@ describe("squircle surfaces", () => {
   const tokens = readFileSync(repoFile("apps/desktop/src/renderer/src/theme/tokens.css"), "utf8");
   const worklet = readFileSync(repoFile("apps/desktop/src/renderer/public/squircle-paint.js"), "utf8");
   const registrar = readFileSync(repoFile("apps/desktop/src/renderer/src/theme/squircle.ts"), "utf8");
-  const SURFACES = [".composer", ".composer-drop-hint", ".composer-understrip", ".install-card", ".commit-card"];
+  const SURFACES = [".composer", ".composer-drop-hint", ".composer-todos", ".composer-understrip", ".install-card", ".commit-card"];
 
   it("every squircle surface keeps a circular-corner fallback AND the declarative form", () => {
     // `corner-shape` is a no-op on Chromium 138 (measured in squircle-live.mjs) and takes over at
@@ -1409,6 +1409,36 @@ describe("Plan 24 W1: inline UI in the transcript", () => {
   it("the todo bar is the one accent fill, and finished items are struck through rather than dropped", () => {
     expect(bodiesFor(".todo-fill").join(" ")).toContain("background: var(--rl-accent)");
     expect(bodiesFor('.todo-list li[data-status="completed"] .todo-text').join(" ")).toContain("line-through");
+  });
+
+  it("the to-do strip takes the card's top radius, squares its bottom, and tucks under the card", () => {
+    // The whole point of the strip is that it is not a second card. Rounding the bottom, or letting
+    // the two boxes meet edge to edge instead of overlapping, puts a seam across the join and the
+    // pair reads as stacked cards again — which is the state this replaced.
+    const body = bodiesFor(".composer-todos").join(" ");
+    expect(body).toContain("border-radius: var(--r-squircle) var(--r-squircle) 0 0");
+    expect(body).toMatch(/margin:\s*0 0 -\d+px/);
+    // Full-width, so the side edges continue the card's rather than starting a narrower box. The
+    // under-strip below is inset on purpose; this one must not inherit that.
+    expect(body).not.toMatch(/margin:[^;]*\b(?!0)\d+px\s+-?\d+px\s*;/);
+    // Under the gate the corner is the painter's, and the bottom radius has to go with it.
+    const painted = bodiesFor(":root[data-squircle] .composer-todos").join(" ");
+    expect(painted).toContain("--sq-radius-bottom: 0px");
+    expect(painted).toContain("--sq-ring: var(--card-ring)");
+  });
+
+  it("the strip collapses on the house grid-row idiom, at the rung for a box changing size", () => {
+    expect(bodiesFor(".composer-todos-wrap").join(" "))
+      .toContain(`transition: grid-template-rows ${dur("--dur-base")} var(--ease-in-out-strong)`);
+    expect(bodiesFor(".composer-todos[data-open] .composer-todos-wrap").join(" ")).toContain("grid-template-rows: 1fr");
+    // Without the clip the collapsed rows still take their natural height and 0fr animates nothing.
+    expect(bodiesFor(".composer-todos-clip").join(" ")).toContain("overflow: hidden");
+  });
+
+  it("the strip's list is bounded and does not hand its scroll to the transcript behind it", () => {
+    const list = bodiesFor(".composer-todos .todo-list").join(" ");
+    expect(list).toMatch(/max-height:\s*\d+px/);
+    expect(list).toContain("overscroll-behavior: contain");
   });
 });
 

--- a/apps/desktop/src/renderer/src/styles.test.ts
+++ b/apps/desktop/src/renderer/src/styles.test.ts
@@ -1411,20 +1411,34 @@ describe("Plan 24 W1: inline UI in the transcript", () => {
     expect(bodiesFor('.todo-list li[data-status="completed"] .todo-text').join(" ")).toContain("line-through");
   });
 
-  it("the to-do strip takes the card's top radius, squares its bottom, and tucks under the card", () => {
-    // The whole point of the strip is that it is not a second card. Rounding the bottom, or letting
-    // the two boxes meet edge to edge instead of overlapping, puts a seam across the join and the
-    // pair reads as stacked cards again — which is the state this replaced.
-    const body = bodiesFor(".composer-todos").join(" ");
-    expect(body).toContain("border-radius: var(--r-squircle) var(--r-squircle) 0 0");
-    expect(body).toMatch(/margin:\s*0 0 -\d+px/);
-    // Full-width, so the side edges continue the card's rather than starting a narrower box. The
-    // under-strip below is inset on purpose; this one must not inherit that.
-    expect(body).not.toMatch(/margin:[^;]*\b(?!0)\d+px\s+-?\d+px\s*;/);
-    // Under the gate the corner is the painter's, and the bottom radius has to go with it.
-    const painted = bodiesFor(":root[data-squircle] .composer-todos").join(" ");
-    expect(painted).toContain("--sq-radius-bottom: 0px");
-    expect(painted).toContain("--sq-ring: var(--card-ring)");
+  it("the to-do strip is the under-strip mirrored: same inset, same overlap, radii swapped end for end", () => {
+    // The prompter is one card with a narrower tab at each end. A strip at the card's own width, or
+    // at the under-strip's width but nudged off its centre, is a different object.
+    const strip = bodiesFor(".composer-todos").join(" ");
+    const under = bodiesFor(".composer-understrip").join(" ");
+    // Three values, not four: the shorthand itself is what makes the two insets equal, so a strip
+    // that is the right width can never also be off-centre.
+    const margin = (body: string) => /margin:\s*(-?\d+(?:px)?) (-?\d+(?:px)?) (-?\d+(?:px)?)\s*[;}]/.exec(body);
+    const s = margin(strip), u = margin(under);
+    expect(s, ".composer-todos needs a three-value margin").not.toBeNull();
+    expect(u, ".composer-understrip needs a three-value margin").not.toBeNull();
+    expect(s![2], "the strip's side inset is the under-strip's").toBe(u![2]);
+    // Mirrored overlap: the under-strip slides up behind the card, this one slides down behind it.
+    expect(s![3]).toBe(u![1]);
+    expect(s![1], "the strip adds no gap above itself").toBe("0");
+    expect(strip).toContain("border-radius: var(--r-squircle) var(--r-squircle) 0 0");
+    // Under the gate the corner is the painter's, and the swap has to go with it — the under-strip
+    // zeroes its TOP, so this one zeroes its bottom.
+    expect(bodiesFor(":root[data-squircle] .composer-todos").join(" ")).toContain("--sq-radius-bottom: 0px");
+    expect(bodiesFor(":root[data-squircle] .composer-understrip").join(" ")).toContain("--sq-radius-top: 0px");
+  });
+
+  it("the prompter's own corners are untouched — the strip attaching above it changes nothing", () => {
+    // The strip is the only thing that squares an edge here. A rule reaching for `.composer` to make
+    // the join work would be the strip redesigning the card to fit itself.
+    const reaching = RULES.flatMap((r) => r.selectors).filter((sel) => /\.composer-todos\s*[+~]\s*\.composer\b/.test(sel));
+    expect(reaching).toEqual([]);
+    expect(bodiesFor(".composer").join(" ")).toContain("border-radius: var(--r-squircle)");
   });
 
   it("the strip collapses on the house grid-row idiom, at the rung for a box changing size", () => {

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -174,14 +174,26 @@ export function defaultAdapters(): AdapterRegistry {
   // The offline-dev script: enough to reach the surfaces that only exist for one event type. A plan
   // is here because it is drawn by a card of its own, and without a scripted one the fake agent —
   // whose whole purpose is UI development — can never produce it. Revised in place, since a plan that
-  // updates is the behaviour worth looking at.
+  // updates is the behaviour worth looking at. A to-do list is here for the same reason, in two
+  // triggers rather than one run: the strip above the prompter shuts itself once every item is done,
+  // and both sides of that have to be reachable and holdable long enough to look at.
   if (process.env.REALM_ENABLE_FAKE_AGENT === "1") reg.fake = new FakeAdapter({ delayMs: 15, script: [{ on: "plan", emit: [
     { kind: "text", text: "Here is how I would go about it." },
     { kind: "plan", planId: "fake-plan", text: "## Rework the mapper\n\n1. Carry the plan as its own event.\n2. Draw it as a plan.", steps: [
       { text: "Carry the plan as its own event", status: "in_progress" }, { text: "Draw it as a plan", status: "pending" }] },
     { kind: "plan", planId: "fake-plan", text: "## Rework the mapper\n\n1. Carry the plan as its own event.\n2. Draw it as a plan.", steps: [
       { text: "Carry the plan as its own event", status: "completed" }, { text: "Draw it as a plan", status: "in_progress" }] },
-  ] }] });
+  ] }, {
+    on: "todos", emit: [{ kind: "tool", name: "TodoWrite", result: "Todos have been modified successfully", input: { todos: [
+      { content: "Carry the plan as its own event", status: "completed", activeForm: "Carrying the plan as its own event" },
+      { content: "Draw it as a plan", status: "in_progress", activeForm: "Drawing it as a plan" },
+      { content: "Test it", status: "pending", activeForm: "Testing it" }] } }],
+  }, {
+    on: "all done", emit: [{ kind: "tool", name: "TodoWrite", result: "Todos have been modified successfully", input: { todos: [
+      { content: "Carry the plan as its own event", status: "completed", activeForm: "Carrying the plan as its own event" },
+      { content: "Draw it as a plan", status: "completed", activeForm: "Drawing it as a plan" },
+      { content: "Test it", status: "completed", activeForm: "Testing it" }] } }],
+  }] });
   return reg;
 }
 


### PR DESCRIPTION
Stacked on #39.

The to-do list lived inside a tool card in the transcript, so it scrolled away with the conversation — the one thing you want visible while an agent works was the thing that left the screen. It now sits above the prompter as a tab, square on the bottom so it meets the card flush.

**No new state and no new persistence.** `latestTodos(blocks)` is a pure backward walk for the newest un-parented `TodoWrite` block, reusing the existing `parseTodos`, called at render beside `promptHint` — the same not-memoised pure-function-over-blocks pattern already there. The transcript is already folded from persisted `session_events`, so a store slice would have been rebuilt from the same events and could disagree with the cards on screen. Two consequences fall out and are tested: an agent clearing its plan clears the strip rather than resurrecting the old one, and a sub-agent's `TodoWrite` is passed over.

**The tool card is unchanged.** It is closed by default and each card holds the list *as written at that point*, so nothing is doubled unless a reader opens one — and a newest card that drew itself differently from every older one would be a rule nobody could learn by watching.

**Geometry, measured rather than eyeballed.** Insets `[10,10]`, identical to the under-strip's, with its centre matching the card's — so the assembly reads as a card with a narrower tab above and below. The top corner is the painter's superellipse (0.84 against a circular arc's 0.785) at the card's own `--r-squircle`; the bottom corners are square (0.945 against 0.728 for the same corner rounded). **The prompter's own corners are untouched.**

Empty returns `null` — no header, no rule, no gap. Complete auto-collapses to a header that keeps the count and the accent bar, so a shut strip still reports. An explicit collapse sticks across a later plan update, deliberately: an agent rewriting its list must not shove the prompter down under the reader's hands. 24 items move `.composer` by 0px; the list stops at 248px and scrolls.

21 mutants killed. One is worth naming: the z-index check **survived at first**, because the transcript's fade band is anchored to the bottom and grows upward, so it never overlapped the strip and the comparison passed at any z-order. The band is now moved over the pair before the question is asked, and the mutant dies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)