### PR TITLE
Give the attachment tile a display, and centre Appearance against the shell it ships in

### DIFF
--- a/apps/desktop/scripts/attachment-tiles-live.mjs
+++ b/apps/desktop/scripts/attachment-tiles-live.mjs
@@ -15,6 +15,12 @@
  *   5. the lightbox that opens from a PROMPTER tile covers the prompter. It is portalled to <body>,
  *      so it escapes the pane; nothing in jsdom can see whether it actually paints on top
  *
+ * Then the same file is SENT, and the tile in the bubble is held to the same guarantees. The two
+ * tiles are one component, but they are reached by different routes — the prompter's is built from
+ * the picker's own record, the bubble's is rebuilt from the server's echo of the event, which keeps
+ * only `{path, mime}`. Whether the picture survives that round trip is a question about the real
+ * `attachment-thumbnail` bridge over the real path, and jsdom decodes no images.
+ *
  * Ports: env-overridable, defaulting to a high pair that will not contend with a running Realm.
  * Touches only a scratch dir (REALM_HOME + userData); kills only the process it started.
  */
@@ -106,6 +112,28 @@ window.__live = window.__live ?? {
 };
 void 0`;
 
+/** The server's own socket, for the one thing the UI cannot do here: put the session on the fake
+ *  agent so a send completes on a machine with no CLI installed. */
+function rpc(port) {
+  const ws = new WebSocket(`ws://127.0.0.1:${port}`);
+  let id = 0;
+  const pending = new Map();
+  const ready = new Promise((res) => ws.addEventListener("open", res));
+  ws.addEventListener("message", (m) => {
+    const msg = JSON.parse(m.data);
+    if (msg.id !== undefined) pending.get(msg.id)?.(msg);
+  });
+  return {
+    ready,
+    call: (method, params) => new Promise((res, rej) => {
+      const i = String(++id);
+      pending.set(i, (msg) => (msg.ok ? res(msg.result) : rej(new Error(`${method}: ${msg.error?.message}`))));
+      ws.send(JSON.stringify({ id: i, method, params }));
+    }),
+    close: () => ws.close(),
+  };
+}
+
 async function evalIn(c, expr) {
   const r = await c.send("Runtime.evaluate", { expression: HELPERS + ";\n" + expr, awaitPromise: true, returnByValue: true });
   if (r.exceptionDetails) throw new Error(`page exception: ${r.exceptionDetails.exception?.description ?? r.exceptionDetails.text}`);
@@ -159,6 +187,9 @@ async function main() {
     env: {
       ...process.env,
       REALM_HOME: path.join(scratch, "home"),
+      // The sent half needs a turn that completes without a CLI on the box; the tiles under test are
+      // on the USER's bubble, which the server echoes either way, but a send that throws never gets there.
+      REALM_ENABLE_FAKE_AGENT: "1",
       REALM_PORT: String(SERVER_PORT),
       REALM_DEVTOOLS_PORT: String(CDP_PORT),
       REALM_SERVER_ENTRY: path.join(repoRoot, "apps/server/dist/main.js"),
@@ -305,6 +336,100 @@ async function main() {
   const shotPath = path.join(os.tmpdir(), "realm-attachment-tiles-live.png");
   fs.writeFileSync(shotPath, Buffer.from(shot.data, "base64"));
   console.log("SCREENSHOT " + shotPath);
+
+  /* ── The same two files, SENT ──────────────────────────────────────────────────────────────
+     Everything above measured the PROMPTER's tile, which is built from the picker's own record and
+     still has the File in hand. The bubble's tile is rebuilt from the server's echo of the
+     `user_message` event, which carries only `{path, mime}` — the name and the size are dropped on
+     the wire. So this is a round trip, not a re-render, and the question is whether the picture
+     survives it. */
+  const api = rpc(SERVER_PORT);
+  await api.ready;
+  const session = await until(async () => {
+    const all = await api.call("sessions.listAll", {});
+    return all.length ? all[0] : null;
+  }, 15000, "a session");
+  await api.call("sessions.setAgent", { id: session.id, agentKind: "fake" });
+
+  // The button rather than Enter: which key sends is a user preference, and this check is not about it.
+  await evalIn(c, `(() => {
+    const ta = document.querySelector('.composer textarea');
+    __live.setInput(ta, 'here are the files');
+    return true; })()`);
+  await until(() => evalIn(c, `!document.querySelector('.composer-send[disabled]')`), 8000, "send enabled");
+  await evalIn(c, `(() => { document.querySelector('.composer-send').click(); return true; })()`);
+
+  const sent = await until(() => evalIn(c, `(() => {
+    const tiles = [...document.querySelectorAll('.msg-user-files .attach-tile')];
+    return tiles.length === 2 ? tiles.length : null; })()`), 20000, "two sent tiles");
+  check("the attachments survive the send and land in the bubble", sent === 2, { tiles: sent });
+
+  // The prompter's row is emptied by the same send — the files moved, they were not duplicated.
+  check("the prompter's row is cleared by the send that carried them",
+    (await evalIn(c, `document.querySelectorAll('.composer-attachments .attach-tile').length`)) === 0);
+
+  /* The picture, after the round trip. This is the failure the report would look like: a tile that
+     renders but falls back to the grey glyph because the path no longer resolves. `naturalWidth`
+     is the decode actually happening, not the src merely being set. */
+  const sentArt = await until(() => evalIn(c, `(() => {
+    const imgs = [...document.querySelectorAll('.msg-user-files .attach-thumb')];
+    if (imgs.length < 2) return null;
+    return imgs.map((i) => ({ src: i.src.slice(0, 22), w: i.naturalWidth, h: i.naturalHeight }));
+  })()`), 25000, "both sent thumbnails");
+  check("the sent image still renders its own pixels, not the fallback glyph",
+    sentArt[0].src.startsWith("data:image/") && sentArt[0].w > 0, sentArt[0]);
+  check("the sent PDF still renders its first page", sentArt[1].src.startsWith("data:image/") && sentArt[1].w > 0, sentArt[1]);
+  check("no sent tile fell back to the glyph",
+    (await evalIn(c, `document.querySelectorAll('.msg-user-files .attach-glyph').length`)) === 0);
+
+  /* The bubble's tile is deliberately a size of its own (56 against the prompter's 44), so this
+     pins the size it is MEANT to be rather than equality with the prompter. Still square, and still
+     without the filename written on it. */
+  const sentShape = await evalIn(c, `(() => {
+    const t = document.querySelector('.msg-user-files .attach-tile');
+    const b = t.getBoundingClientRect();
+    const bare = t.cloneNode(true);
+    for (const h of bare.querySelectorAll('.visually-hidden, .attach-tip')) h.remove();
+    return { w: Math.round(b.width), h: Math.round(b.height), visible: bare.textContent.trim() }; })()`);
+  check("the sent tile is a square, and larger than the prompter's",
+    sentShape.w === sentShape.h && sentShape.w === 56, sentShape);
+  check("the sent tile does not spell its filename out either — only the extension badge",
+    !sentShape.visible.includes("shot"), sentShape);
+
+  // The name is still one hover away, off the path's basename now that the picker's name is gone.
+  const sentTip = await evalIn(c, `(() => {
+    const t = document.querySelector('.msg-user-files .attach-tile');
+    return { tip: t.querySelector('.attach-tip')?.textContent ?? null,
+             label: t.querySelector('.visually-hidden')?.textContent ?? null }; })()`);
+  check("the sent tile still names its file in the tip", (sentTip.tip ?? "").includes("shot.png"), sentTip);
+
+  // Openable, and sorted into the same two openings by the same rule the prompter's tile used.
+  const sentMarks = await evalIn(c, `[...document.querySelectorAll('.msg-user-files .attach-tile')].map((t) => ({
+    button: t.querySelector('.attach-open')?.tagName === 'BUTTON', media: t.hasAttribute('data-media') }))`);
+  check("every sent tile is a real button", sentMarks.every((m) => m.button), sentMarks);
+  check("only the sent image is marked as media — the PDF is not",
+    sentMarks.filter((m) => m.media).length === 1 && sentMarks[0].media, sentMarks);
+
+  await evalIn(c, `(() => { document.querySelector('.msg-user-files .attach-tile[data-media] .attach-open').click(); return true; })()`);
+  await until(() => evalIn(c, `!!document.querySelector('.media-lightbox')`), 8000, "sent lightbox");
+  check("a sent image opens in the lightbox, the same as a pending one", true);
+  const sentShot = await c.send("Page.captureScreenshot", { format: "png" });
+  fs.writeFileSync(path.join(os.tmpdir(), "realm-sent-attachments-live.png"), Buffer.from(sentShot.data, "base64"));
+  console.log("SCREENSHOT " + path.join(os.tmpdir(), "realm-sent-attachments-live.png"));
+  await c.send("Input.dispatchKeyEvent", { type: "keyDown", key: "Escape", code: "Escape", windowsVirtualKeyCode: 27 });
+  await c.send("Input.dispatchKeyEvent", { type: "keyUp", key: "Escape", code: "Escape", windowsVirtualKeyCode: 27 });
+  await until(() => evalIn(c, `!document.querySelector('.media-lightbox')`), 5000, "sent lightbox closed");
+
+  // The bubble, with the tip up, for the human verdict on whether the tile is findable at all.
+  const sentBox = await evalIn(c, `(() => {
+    const b = document.querySelector('.msg-user-files .attach-tile').getBoundingClientRect();
+    return { x: b.x + b.width / 2, y: b.y + b.height / 2 }; })()`);
+  await c.send("Input.dispatchMouseEvent", { type: "mouseMoved", x: sentBox.x, y: sentBox.y });
+  await sleep(400);
+  const bubbleShot = await c.send("Page.captureScreenshot", { format: "png" });
+  fs.writeFileSync(path.join(os.tmpdir(), "realm-sent-attachments-bubble.png"), Buffer.from(bubbleShot.data, "base64"));
+  console.log("SCREENSHOT " + path.join(os.tmpdir(), "realm-sent-attachments-bubble.png"));
+  api.close();
 
   const errs = c.events.filter((e) => !e.includes("Autofill"));
   check("no renderer console errors", errs.length === 0, errs.slice(0, 5));

--- a/apps/desktop/scripts/page-measure-live.mjs
+++ b/apps/desktop/scripts/page-measure-live.mjs
@@ -139,6 +139,32 @@ window.__live = window.__live ?? {
   },
   box(e) { if (!e) return null; const r = e.getBoundingClientRect();
     return { l: Math.round(r.left), r: Math.round(r.right), t: Math.round(r.top), w: Math.round(r.width), h: Math.round(r.height) }; },
+  /** Open a Settings rail tab by its visible label. */
+  async settingsTab(label) {
+    const hit = [...document.querySelectorAll('.page-rail .settings-tab')].find((l) => l.textContent.trim() === label);
+    if (!hit) throw new Error('no settings tab: ' + label);
+    hit.querySelector('input').click();
+    for (let i = 0; i < 60; i++) {
+      await new Promise((r) => setTimeout(r, 25));
+      if (document.querySelector('.page-content')) return true;
+    }
+    throw new Error('tab did not open: ' + label);
+  },
+  /** The App tab's two card grids, against the column the shared shell gives them. The grids are the
+   *  widest things on any Settings tab, so they are where a measure that does not hold shows first. */
+  appearance() {
+    const content = document.querySelector('.page-content');
+    const grids = ['.mode-grid', '.theme-grid'].map((sel) => {
+      const g = document.querySelector(sel);
+      if (!g) return { sel, box: null };
+      const cards = [...g.children].map((k) => k.getBoundingClientRect()).filter((r) => r.width > 0);
+      return { sel, box: this.box(g), overflowX: g.scrollWidth - g.clientWidth,
+        cards: cards.length ? { n: cards.length,
+          min: Math.round(Math.min(...cards.map((r) => r.width))), max: Math.round(Math.max(...cards.map((r) => r.width))),
+          l: Math.round(Math.min(...cards.map((r) => r.left))), r: Math.round(Math.max(...cards.map((r) => r.right))) } : null };
+    });
+    return { content: this.box(content), grids, overflowX: content.scrollWidth - content.clientWidth };
+  },
   /** The horizontal extent of a band's visible children — what the eye reads as the column's edges.
    *  The band ELEMENT is full-bleed today and would report itself centred either way. */
   span(el) {
@@ -292,6 +318,9 @@ async function main() {
       LIVE_MAIN: path.join(repoRoot, "apps/desktop/out/main/index.js"),
     },
     stdio: ["ignore", "pipe", "pipe"],
+    // Its own process group. Main spawns the server as a GRANDCHILD, so killing the Electron pid
+    // alone orphans a listener on SERVER_PORT and the next run refuses to start on a busy port.
+    detached: true,
   });
   electron.stderr.on("data", () => {}); electron.stdout.on("data", () => {});
 
@@ -407,6 +436,69 @@ async function main() {
     tasks.filter((r) => r.page.w >= 1400).every((r) => r.lens.w >= 1000),
     tasks.map((r) => ({ pane: r.page.w, lens: r.lens?.w })));
 
+  await evalIn(c, `__live.destination('Settings')`);
+  await sleep(500);
+  /* ── Settings → App: the Appearance controls, against the other tabs ─────────────────────────
+     "Fix the padding here" reads most naturally as Appearance disagreeing with the tabs above it,
+     so the gutters are measured on every tab rather than on the one that was complained about — a
+     number from Appearance alone cannot tell an inconsistency from a taste. The App tab is also the
+     only one whose content is a GRID of cards, which is the thing that escapes a measure first. */
+  const SETTINGS_TABS = ["Engines", "Usage", "App", "Sign-ins", "Import", "Permissions"];
+  const perTab = [];
+  for (const width of WIDTHS) {
+    await c.send("Emulation.setDeviceMetricsOverride", { width, height: 900, deviceScaleFactor: 1, mobile: false });
+    await sleep(250);
+    for (const label of SETTINGS_TABS) {
+      await evalIn(c, `__live.settingsTab(${JSON.stringify(label)})`);
+      await sleep(140);
+      const p = await evalIn(c, `__live.page()`);
+      perTab.push({ width, label, content: p.content, body: p.body });
+    }
+  }
+  console.log("\n── Settings tabs, one column each ───────────────────────────────");
+  for (const width of WIDTHS) {
+    const at = perTab.filter((r) => r.width === width);
+    console.log(`  window ${String(width).padStart(4)}  ` +
+      at.map((r) => `${r.label} w${r.content.w}@${r.content.l}`).join("  "));
+  }
+  check("settings: every tab is set in the same column — Appearance has no gutters of its own",
+    WIDTHS.every((w) => {
+      const at = perTab.filter((r) => r.width === w);
+      return at.every((r) => r.content.l === at[0].content.l && r.content.w === at[0].content.w);
+    }),
+    WIDTHS.map((w) => {
+      const at = perTab.filter((r) => r.width === w);
+      return { width: w, distinct: [...new Set(at.map((r) => `${r.content.w}@${r.content.l}`))] };
+    }));
+
+  const appearance = [];
+  for (const width of WIDTHS) {
+    await c.send("Emulation.setDeviceMetricsOverride", { width, height: 900, deviceScaleFactor: 1, mobile: false });
+    await sleep(250);
+    await evalIn(c, `__live.settingsTab("App")`);
+    await sleep(200);
+    appearance.push({ width, ...(await evalIn(c, `__live.appearance()`)) });
+  }
+  console.log("\n── Settings → App: the theme grids ──────────────────────────────");
+  for (const a of appearance) {
+    console.log(`  window ${String(a.width).padStart(4)}  column w${a.content.w}@${a.content.l}  ` +
+      a.grids.map((g) => `${g.sel} ${g.cards.n}×${g.cards.min}–${g.cards.max}@[${g.cards.l},${g.cards.r}]`).join("  "));
+  }
+  check("appearance: the cards stay inside the reading column — no grid escapes the measure",
+    appearance.every((a) => a.grids.every((g) => g.cards.l >= a.content.l - 1 && g.cards.r <= a.content.r + 1)),
+    appearance.map((a) => ({ width: a.width, col: [a.content.l, a.content.r],
+      grids: a.grids.map((g) => [g.cards.l, g.cards.r]) })));
+  check("appearance: nothing in the App tab scrolls sideways at any width",
+    appearance.every((a) => a.overflowX <= 0 && a.grids.every((g) => g.overflowX <= 0)),
+    appearance.map((a) => ({ width: a.width, content: a.overflowX, grids: a.grids.map((g) => g.overflowX) })));
+
+  // Back to the widest and to the tab the page opens on, the way `sweep` leaves it. The App tab is
+  // not a neutral thing to leave behind: it re-renders every palette card on a theme change, which
+  // is exactly what the scrollbar pass below does next.
+  await evalIn(c, `__live.settingsTab("Engines")`);
+  await c.send("Emulation.setDeviceMetricsOverride", { width: WIDTHS[0], height: 900, deviceScaleFactor: 1, mobile: false });
+  await sleep(300);
+
   /* ── Scrollbars, in both modes, on a scroller that is actually overflowing ───────────────── */
   await evalIn(c, `__live.destination('Settings')`);
   await sleep(400);
@@ -441,6 +533,11 @@ async function main() {
 main()
   .catch((e) => { console.error("ERROR", e.message); process.exitCode = 1; })
   .finally(() => {
-    electron?.kill("SIGTERM");
-    setTimeout(() => { electron?.kill("SIGKILL"); fs.rmSync(scratch, { recursive: true, force: true }); process.exit(process.exitCode ?? 0); }, 1200);
+    const killGroup = (sig) => { try { if (electron?.pid) process.kill(-electron.pid, sig); } catch { /* already gone */ } };
+    killGroup("SIGTERM");
+    setTimeout(() => {
+      killGroup("SIGKILL");
+      fs.rmSync(scratch, { recursive: true, force: true });
+      process.exit(process.exitCode ?? 0);
+    }, 1200);
   });

--- a/apps/desktop/scripts/page-measure-live.mjs
+++ b/apps/desktop/scripts/page-measure-live.mjs
@@ -1,0 +1,446 @@
+/**
+ * Live check for the page panes' measure (run with: node apps/desktop/scripts/page-measure-live.mjs)
+ *
+ * Boots the REAL app on a scratch REALM_HOME and measures where a page's parts actually land: the
+ * head's glyph, the rail, the reading column, and the notifications split, at pane widths from 340
+ * to ~1500. Alignment is the one property jsdom cannot hold an opinion about — it has no layout, so
+ * `max-width` and `margin-inline: auto` are to it just two declarations that parse.
+ *
+ * The pane, not the window, is the thing being swept: `.page` is an inline-size container and a page
+ * is as likely to be a third of a split as it is to be the whole screen. Widths below are WINDOW
+ * widths; every assertion is against the measured `.page` rect.
+ *
+ * The second half is the scrollbar report: whether a track is painted in either mode. That is a
+ * question about composited pixels, so it is answered by sampling the screenshot down the gutter of
+ * a scroller that is actually overflowing, not by reading the stylesheet.
+ *
+ * Ports: env-overridable. Touches only a scratch dir; kills only the process it started.
+ */
+import { spawn } from "node:child_process";
+import { connect } from "node:net";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
+const CDP_PORT = Number(process.env.LIVE_CDP_PORT ?? 9347), SERVER_PORT = Number(process.env.LIVE_SERVER_PORT ?? 8913);
+const scratch = fs.mkdtempSync(path.join(os.tmpdir(), "realm-page-measure-"));
+let electron = null;
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+/** Window widths. The sidebar takes 280 of each, so the pane sweeps ~340…~1520 — across the 640px
+ *  narrow breakpoint, the notifications page's 760, and both sides of every measure. */
+const WIDTHS = [1800, 1400, 1200, 1000, 860, 700, 620];
+
+/** `scrollbar-color`'s second value is the track. Chromium serialises the computed value, so the
+ *  authored `transparent` comes back as a zero-alpha colour and never as the keyword. */
+const TRACKLESS = /\brgba\(0, 0, 0, 0\)\s*$/;
+
+async function portFree(port) {
+  return new Promise((resolve) => {
+    const s = connect({ port, host: "127.0.0.1" });
+    s.once("connect", () => { s.destroy(); resolve(false); });
+    s.once("error", () => resolve(true));
+  });
+}
+
+async function until(fn, ms, tag) {
+  const t0 = Date.now();
+  for (;;) {
+    const v = await fn();
+    if (v) return v;
+    if (Date.now() - t0 > ms) throw new Error(`timeout:${tag}`);
+    await sleep(150);
+  }
+}
+
+function cdp(wsUrl) {
+  const ws = new WebSocket(wsUrl);
+  let id = 0;
+  const pending = new Map();
+  const events = [];
+  const ready = new Promise((res) => ws.addEventListener("open", res));
+  ws.addEventListener("message", (m) => {
+    const msg = JSON.parse(m.data);
+    if (msg.id !== undefined) pending.get(msg.id)?.(msg);
+    else if (msg.method === "Runtime.consoleAPICalled" && msg.params.type === "error") {
+      events.push(msg.params.args.map((a) => a.value ?? a.description ?? "").join(" "));
+    }
+  });
+  return {
+    ready, events,
+    send: (method, params) => new Promise((res, rej) => {
+      const i = ++id;
+      pending.set(i, (msg) => (msg.error ? rej(new Error(msg.error.message)) : res(msg.result)));
+      ws.send(JSON.stringify({ id: i, method, params }));
+    }),
+    close: () => ws.close(),
+  };
+}
+
+function rpc(port) {
+  const ws = new WebSocket(`ws://127.0.0.1:${port}`);
+  let id = 0;
+  const pending = new Map();
+  const ready = new Promise((res) => ws.addEventListener("open", res));
+  ws.addEventListener("message", (m) => {
+    const msg = JSON.parse(m.data);
+    if (msg.id !== undefined) pending.get(msg.id)?.(msg);
+  });
+  return {
+    ready,
+    call: (method, params) => new Promise((res, rej) => {
+      const i = String(++id);
+      pending.set(i, (msg) => (msg.ok ? res(msg.result) : rej(new Error(`${method}: ${msg.error?.message}`))));
+      ws.send(JSON.stringify({ id: i, method, params }));
+    }),
+    close: () => ws.close(),
+  };
+}
+
+const HELPERS = `
+window.__live = window.__live ?? {
+  /** Click a sidebar destination by its label, and wait for its page to be the one on screen. */
+  async destination(label) {
+    const row = [...document.querySelectorAll('.sb-destinations .dest-row')].find((b) => b.textContent.trim().startsWith(label));
+    if (!row) throw new Error('no destination: ' + label);
+    row.click();
+    for (let i = 0; i < 60; i++) {
+      if (document.querySelector('.page')) return true;
+      await new Promise((r) => setTimeout(r, 25));
+    }
+    throw new Error('destination did not open: ' + label);
+  },
+  /** Run a command palette entry by its visible label. Profile and space pages have no sidebar row —
+   *  the palette is how a user reaches them. */
+  async palette(label) {
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'k', metaKey: true, bubbles: true }));
+    for (let i = 0; i < 60 && !document.querySelector('.palette input'); i++) await new Promise((r) => setTimeout(r, 25));
+    const input = document.querySelector('.palette input');
+    if (!input) throw new Error('the palette did not open');
+    Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value').set.call(input, label);
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    for (let i = 0; i < 80; i++) {
+      const hit = [...document.querySelectorAll('.palette-list [role=option]')]
+        .find((o) => o.querySelector('.palette-label')?.textContent.trim() === label);
+      if (hit) { hit.click(); return true; }
+      await new Promise((r) => setTimeout(r, 25));
+    }
+    throw new Error('no palette entry: ' + label);
+  },
+  async menu(label) {
+    document.querySelector('[aria-label="Space menu"]').click();
+    for (let i = 0; i < 40 && !document.querySelector('[role="menu"]'); i++) await new Promise((r) => setTimeout(r, 25));
+    const hit = [...document.querySelectorAll('[role="menu"] button')].find((b) => b.textContent.trim() === label);
+    if (!hit) { document.querySelector('[role="menu"]')?.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true })); throw new Error('no menu item: ' + label); }
+    hit.click();
+    return true;
+  },
+  box(e) { if (!e) return null; const r = e.getBoundingClientRect();
+    return { l: Math.round(r.left), r: Math.round(r.right), t: Math.round(r.top), w: Math.round(r.width), h: Math.round(r.height) }; },
+  /** The horizontal extent of a band's visible children — what the eye reads as the column's edges.
+   *  The band ELEMENT is full-bleed today and would report itself centred either way. */
+  span(el) {
+    if (!el) return null;
+    const rs = [...el.children].map((c) => c.getBoundingClientRect()).filter((r) => r.width > 0);
+    if (!rs.length) return null;
+    return { l: Math.round(Math.min(...rs.map((r) => r.left))), r: Math.round(Math.max(...rs.map((r) => r.right))) };
+  },
+  page() {
+    const page = document.querySelector('.page');
+    if (!page) return null;
+    const q = (s) => this.box(page.querySelector(s));
+    const head = page.querySelector('.page-head'), body = page.querySelector('.page-body');
+    const headSpan = this.span(head), bodySpan = this.span(body);
+    const p = this.box(page);
+    const band = bodySpan && headSpan
+      ? { l: Math.min(headSpan.l, bodySpan.l), r: Math.max(headSpan.r, bodySpan.r) } : null;
+    return {
+      page: p, head: this.box(head), body: this.box(body), headSpan, bodySpan,
+      rail: q('.page-rail'), content: q('.page-content'), split: q('.notif-split'), chips: this.span(page.querySelector('.profile-spaces')),
+      list: q('.notif-list'), detail: q('.notif-detail'), lens: q('.task-lens'), lensDetail: q('.task-detail'),
+      gaps: band ? { left: band.l - p.l, right: p.r - band.r } : null,
+    };
+  },
+  /** Any CSS colour as the sRGB triple the compositor will paint, via the compositor itself. */
+  srgb(color) {
+    const g = (this._cv ??= document.createElement('canvas').getContext('2d', { willReadFrequently: true }));
+    g.clearRect(0, 0, 1, 1); g.fillStyle = color; g.fillRect(0, 0, 1, 1);
+    return [...g.getImageData(0, 0, 1, 1).data].slice(0, 3).join(',');
+  },
+  /** A scroller that is actually overflowing, with the gutter its bar reserves. A gutter of 0 means
+   *  the platform is drawing overlay bars, which paint no track at all. The ground is the page's own
+   *  colour and not a pixel read from inside the scroller — that lands on a row, not on the page. */
+  scroller(sel) {
+    const e = document.querySelector(sel);
+    if (!e) return null;
+    const cs = getComputedStyle(e);
+    const r = e.getBoundingClientRect();
+    return { sel, gutter: e.offsetWidth - e.clientWidth, overflow: e.scrollHeight - e.clientHeight,
+      scrollTop: e.scrollTop, width: cs.scrollbarWidth, color: cs.scrollbarColor,
+      ground: this.srgb(getComputedStyle(e.closest('.page')).backgroundColor),
+      box: { l: Math.round(r.left), r: Math.round(r.right), t: Math.round(r.top), b: Math.round(r.bottom) } };
+  },
+  /** Pixels down the gutter of a scroller, read out of the screenshot the compositor produced. */
+  async gutterPixels(b64, box, gutter) {
+    const img = new Image();
+    img.src = 'data:image/png;base64,' + b64;
+    await img.decode();
+    const cv = document.createElement('canvas');
+    cv.width = img.width; cv.height = img.height;
+    cv.getContext('2d').drawImage(img, 0, 0);
+    const g = cv.getContext('2d');
+    const x = Math.round(box.r - gutter / 2);
+    const out = [];
+    for (let i = 1; i < 40; i++) {
+      const y = Math.round(box.t + ((box.b - box.t) * i) / 40);
+      out.push([...g.getImageData(x, y, 1, 1).data].slice(0, 3).join(','));
+    }
+    return out;
+  },
+};
+`;
+
+async function evalIn(c, expr) {
+  const r = await c.send("Runtime.evaluate", { expression: `${HELPERS};\n${expr}`, awaitPromise: true, returnByValue: true });
+  if (r.exceptionDetails) throw new Error(`page exception: ${r.exceptionDetails.exception?.description ?? r.exceptionDetails.text}`);
+  return r.result.value;
+}
+
+const check = (name, cond, detail) => {
+  if (!cond) process.exitCode = 1;
+  console.log(`${cond ? "PASS" : "FAIL"} ${name}${detail !== undefined ? " " + JSON.stringify(detail) : ""}`);
+};
+
+async function shot(c, tag) {
+  const s = await c.send("Page.captureScreenshot", { format: "png" });
+  const out = path.join(os.tmpdir(), `realm-page-${tag}.png`);
+  fs.writeFileSync(out, Buffer.from(s.data, "base64"));
+  console.log(`SCREENSHOT ${tag} ${out}`);
+  return s.data;
+}
+
+/** The composited proof that no track is drawn: every pixel down the scroller's gutter is either the
+ *  page's own ground or the thumb, and nothing else. A gutter of 0 means the platform is drawing
+ *  overlay bars, which have no track to draw. */
+async function gutter(c, mode, s, b64) {
+  const tag = mode.toLowerCase();
+  if (!s || s.gutter <= 0) {
+    console.log(`  NOTE ${tag} ${s?.sel}: overlay scrollbars (gutter 0) — there is no track to paint.`);
+    return;
+  }
+  const samples = await evalIn(c, `__live.gutterPixels(${JSON.stringify(b64)}, ${JSON.stringify(s.box)}, ${s.gutter})`);
+  /* Within a channel of the ground: the canvas fill the ground is read through and the composited
+     screenshot round the last bit differently in light mode. A track would be off by far more — the
+     thumb, the thing that is SUPPOSED to differ, is 14 away. */
+  const near = (p) => p.split(",").every((v, i) => Math.abs(Number(v) - Number(s.ground.split(",")[i])) <= 2);
+  const onGround = samples.filter(near).length;
+  check(`${tag}: no track down ${s.sel}'s gutter — only the thumb differs from the page`,
+    onGround > 0 && [...new Set(samples)].length <= 2,
+    { ground: s.ground, matching: onGround, of: samples.length, distinct: [...new Set(samples)] });
+}
+
+/** Sweep one page across the widths, report the measured rects, and leave a shot of the widest —
+ *  the width the complaint was about, and the one a number cannot settle. */
+async function sweep(c, label, tag) {
+  const rows = [];
+  for (const width of WIDTHS) {
+    await c.send("Emulation.setDeviceMetricsOverride", { width, height: 900, deviceScaleFactor: 1, mobile: false });
+    await sleep(250);
+    rows.push({ width, ...(await evalIn(c, `__live.page()`)) });
+  }
+  console.log(`\n── ${label} ───────────────────────────────────────────────`);
+  for (const r of rows) {
+    console.log(`  pane ${String(r.page.w).padStart(4)}  gaps L${String(r.gaps?.left ?? "-").padStart(4)} R${String(r.gaps?.right ?? "-").padStart(4)}` +
+      `  head[${r.headSpan?.l},${r.headSpan?.r}] body[${r.bodySpan?.l},${r.bodySpan?.r}]` +
+      (r.rail ? `  rail w${r.rail.w}@${r.rail.l}` : "") +
+      (r.content ? `  content w${r.content.w}@${r.content.l}` : "") +
+      (r.list ? `  list w${r.list.w}@${r.list.l} detail w${r.detail?.w}@${r.detail?.l}` : ""));
+  }
+  if (tag) {
+    await c.send("Emulation.setDeviceMetricsOverride", { width: WIDTHS[0], height: 900, deviceScaleFactor: 1, mobile: false });
+    await sleep(250);
+    await shot(c, tag);
+  }
+  return rows;
+}
+
+async function main() {
+  for (const p of [CDP_PORT, SERVER_PORT]) {
+    if (!(await portFree(p))) throw new Error(`port ${p} is in use — refusing to run`);
+  }
+
+  const wrapper = path.join(scratch, "wrapper.mjs");
+  fs.writeFileSync(wrapper, [
+    'import { app } from "electron";',
+    'app.setPath("userData", process.env.LIVE_USER_DATA);',
+    "await import(process.env.LIVE_MAIN);",
+  ].join("\n"));
+  const electronBin = process.platform === "darwin"
+    ? path.join(repoRoot, "node_modules/.pnpm/electron@37.10.3/node_modules/electron/dist/Electron.app/Contents/MacOS/Electron")
+    : path.join(repoRoot, "apps/desktop/node_modules/.bin/electron");
+  electron = spawn(electronBin, [wrapper], {
+    env: {
+      ...process.env,
+      REALM_HOME: path.join(scratch, "home"),
+      REALM_ENABLE_FAKE_AGENT: "1",
+      REALM_PORT: String(SERVER_PORT),
+      REALM_DEVTOOLS_PORT: String(CDP_PORT),
+      REALM_SERVER_ENTRY: path.join(repoRoot, "apps/server/dist/main.js"),
+      LIVE_USER_DATA: path.join(scratch, "userData"),
+      LIVE_MAIN: path.join(repoRoot, "apps/desktop/out/main/index.js"),
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  electron.stderr.on("data", () => {}); electron.stdout.on("data", () => {});
+
+  const targets = () => fetch(`http://127.0.0.1:${CDP_PORT}/json/list`).then((r) => r.json()).catch(() => []);
+  const rendererTarget = await until(async () => (await targets()).find((t) => t.type === "page" && t.url.startsWith("file://")), 30000, "renderer target");
+  const c = cdp(rendererTarget.webSocketDebuggerUrl);
+  await c.ready;
+  await c.send("Runtime.enable");
+  await c.send("Page.enable");
+
+  await until(() => evalIn(c, `!!document.querySelector('.onboarding input:not([type=radio])')`), 20000, "onboarding");
+  await evalIn(c, `(() => {
+    const input = document.querySelector('.onboarding input:not([type=radio])');
+    const set = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value').set;
+    set.call(input, 'Live'); input.dispatchEvent(new Event('input', { bubbles: true }));
+    input.closest('form').requestSubmit();
+    return true; })()`);
+  await until(() => evalIn(c, `!!document.querySelector('.composer')`), 20000, "composer");
+
+  /* A feed with rows in it. `session_done` is the notification a finished turn raises, and the fake
+     agent finishes one immediately — the page's empty state would measure a single paragraph and
+     say nothing about the split. */
+  const api = rpc(SERVER_PORT);
+  await api.ready;
+  const first = (await until(async () => {
+    const all = await api.call("sessions.listAll", {});
+    return all.length ? all : null;
+  }, 15000, "a session"))[0];
+  const spaceId = first.spaceId;
+  const TITLES = ["Rename the pane group", "Port the importer", "Trim the transcript", "Fix the diff gutter",
+    "Teach the rail to wrap", "Drop the dead migration", "Seed the scratch repo", "Re-probe the engines",
+    "Widen the commit field", "Collapse the sidebar"];
+  for (const title of TITLES) {
+    const made = await api.call("sessions.create", { spaceId, agentKind: "fake", title });
+    await api.call("sessions.send", { id: made.session.id, text: "hello", attachments: [], mentions: [] });
+  }
+  await api.call("sessions.setAgent", { id: first.id, agentKind: "fake" });
+  await api.call("sessions.send", { id: first.id, text: "hello", attachments: [], mentions: [] });
+  await until(() => evalIn(c, `(window.__realmUnread ?? 0) >= 0 && !!document.querySelector('.sb-destinations')`), 10000, "the sidebar");
+  await sleep(2500);
+
+  /* ── Settings: rail + reading column ─────────────────────────────────────────────────────── */
+  await evalIn(c, `__live.destination('Settings')`);
+  await sleep(500);
+  const settings = await sweep(c, "Settings", "wide-settings");
+
+  const wide = settings.filter((r) => r.page.w >= 1000);
+  check("settings: the column is centred in the pane — equal air on both sides",
+    wide.every((r) => Math.abs(r.gaps.left - r.gaps.right) <= 1),
+    wide.map((r) => ({ pane: r.page.w, l: r.gaps.left, r: r.gaps.right })));
+  check("settings: the head sits over the column it introduces, not off at the pane's left edge",
+    wide.every((r) => Math.abs(r.headSpan.l - r.bodySpan.l) <= 1),
+    wide.map((r) => ({ pane: r.page.w, head: r.headSpan.l, body: r.bodySpan.l })));
+  check("settings: the reading column keeps its 720px measure at every width",
+    settings.every((r) => r.content.w <= 720), settings.map((r) => ({ pane: r.page.w, content: r.content.w })));
+  check("settings: the rail stays beside the column at the body's own 20px gap",
+    settings.filter((r) => r.page.w > 640).every((r) => r.content.l - r.rail.r === 20),
+    settings.map((r) => ({ pane: r.page.w, gap: r.content.l - r.rail.r })));
+  const narrow = settings.filter((r) => r.page.w <= 640);
+  check("settings: a narrow pane is spent on content, not on margins — the column stays full-bleed",
+    narrow.length > 0 && narrow.every((r) => r.gaps.left <= 16),
+    narrow.map((r) => ({ pane: r.page.w, l: r.gaps.left })));
+
+  /* ── Notifications: a two-column split, not a form ───────────────────────────────────────── */
+  await evalIn(c, `__live.destination('Notifications')`);
+  await sleep(500);
+  const notifs = await sweep(c, "Notifications", "wide-notifications");
+  check("notifications: the feed has rows to lay out", notifs.every((r) => r.list && r.detail),
+    notifs.map((r) => ({ pane: r.page.w, list: !!r.list })));
+  const nWide = notifs.filter((r) => r.page.w >= 1200);
+  check("notifications: the split is centred as one unit",
+    nWide.length > 0 && nWide.every((r) => Math.abs(r.gaps.left - r.gaps.right) <= 1),
+    nWide.map((r) => ({ pane: r.page.w, l: r.gaps.left, r: r.gaps.right })));
+  check("notifications: both columns stay readable — the detail never falls under the list's width",
+    notifs.filter((r) => r.page.w > 760).every((r) => r.detail.w >= 300),
+    notifs.map((r) => ({ pane: r.page.w, list: r.list?.w, detail: r.detail?.w })));
+  const nStack = notifs.filter((r) => r.page.w <= 760);
+  check("notifications: under 760 of pane the columns stack and the page is full-bleed again",
+    nStack.length > 0 && nStack.every((r) => r.detail.t > r.list.t && r.gaps.left <= 24),
+    nStack.map((r) => ({ pane: r.page.w, listTop: r.list?.t, detailTop: r.detail?.t, l: r.gaps.left })));
+
+  /* ── The other three shapes on the same shell ────────────────────────────────────────────── */
+  await evalIn(c, `__live.destination('Connections')`);
+  await sleep(500);
+  const conns = await sweep(c, "Connections (no rail)", "wide-connections");
+  check("connections: a page with no rail centres the column it does have",
+    conns.filter((r) => r.page.w >= 1000).every((r) => Math.abs(r.gaps.left - r.gaps.right) <= 1),
+    conns.map((r) => ({ pane: r.page.w, l: r.gaps.left, r: r.gaps.right })));
+
+  await evalIn(c, `__live.palette('Open profile')`);
+  await until(() => evalIn(c, `!!document.querySelector('.profile-page-pane')`), 10000, "the profile page");
+  await sleep(500);
+  const profile = await sweep(c, "Profile", "wide-profile");
+  check("profile: the space chips share the column, rather than starting at the pane's edge",
+    profile.every((r) => Math.abs(r.chips.l - r.bodySpan.l) <= 1),
+    profile.map((r) => ({ pane: r.page.w, chips: r.chips?.l, body: r.bodySpan?.l })));
+
+  await evalIn(c, `__live.palette('Open space')`);
+  await until(() => evalIn(c, `!!document.querySelector('.space-page-pane')`), 10000, "the space page");
+  await sleep(500);
+  const general = await sweep(c, "Space · General", "wide-space-general");
+  await evalIn(c, `(() => { [...document.querySelectorAll('.page-rail .settings-tab')].find((l) => l.textContent.trim() === 'Tasks').querySelector('input').click(); return true; })()`);
+  await until(() => evalIn(c, `!!document.querySelector('.task-lens')`), 10000, "the tasks lens");
+  await sleep(500);
+  const tasks = await sweep(c, "Space · Tasks lens", "wide-tasks");
+  check("space: switching to the Tasks tab widens the page — the head and rail move with it",
+    general[0].gaps.left > tasks[0].gaps.left,
+    { general: general[0].gaps.left, tasks: tasks[0].gaps.left });
+  check("tasks: the lens still opts out of the reading measure — it is wider than 720 where there is room",
+    tasks.filter((r) => r.page.w >= 1400).every((r) => r.content.w > 720),
+    tasks.map((r) => ({ pane: r.page.w, content: r.content?.w, lens: r.lens?.w })));
+  check("tasks: the lens keeps room for a list AND a 340px panel beside it, which 720 would not leave",
+    tasks.filter((r) => r.page.w >= 1400).every((r) => r.lens.w >= 1000),
+    tasks.map((r) => ({ pane: r.page.w, lens: r.lens?.w })));
+
+  /* ── Scrollbars, in both modes, on a scroller that is actually overflowing ───────────────── */
+  await evalIn(c, `__live.destination('Settings')`);
+  await sleep(400);
+  await c.send("Emulation.setDeviceMetricsOverride", { width: 1400, height: 620, deviceScaleFactor: 1, mobile: false });
+  await sleep(400);
+  for (const mode of ["Dark", "Light"]) {
+    await evalIn(c, `__live.menu(${JSON.stringify(`Theme: ${mode}`)})`);
+    await sleep(500);
+    const s = await evalIn(c, `__live.scroller('.page-content')`);
+    check(`${mode.toLowerCase()}: the settings column is genuinely overflowing, so there is a bar to judge`,
+      s && s.overflow > 40, s);
+    check(`${mode.toLowerCase()}: the track is transparent — the thumb is the only thing the bar paints`,
+      TRACKLESS.test(s.color) && s.width === "thin", { color: s.color, width: s.width, gutter: s.gutter });
+    await gutter(c, mode, s, await shot(c, `settings-${mode.toLowerCase()}`));
+
+    await evalIn(c, `__live.destination('Notifications')`);
+    await sleep(400);
+    const n = await evalIn(c, `__live.scroller('.notif-list')`);
+    check(`${mode.toLowerCase()}: the notifications list is overflowing too, and its bar is the same thin one`,
+      n && n.overflow > 40 && TRACKLESS.test(n.color) && n.width === "thin", n);
+    await gutter(c, mode, n, await shot(c, `notifications-${mode.toLowerCase()}`));
+    await evalIn(c, `__live.destination('Settings')`);
+    await sleep(300);
+  }
+
+  const errs = c.events.filter((e) => !e.includes("Autofill"));
+  check("no renderer console errors", errs.length === 0, errs.slice(0, 5));
+  api.close();
+  c.close();
+}
+
+main()
+  .catch((e) => { console.error("ERROR", e.message); process.exitCode = 1; })
+  .finally(() => {
+    electron?.kill("SIGTERM");
+    setTimeout(() => { electron?.kill("SIGKILL"); fs.rmSync(scratch, { recursive: true, force: true }); process.exit(process.exitCode ?? 0); }, 1200);
+  });

--- a/apps/desktop/src/renderer/src/panes/notifications/notifications-page.test.tsx
+++ b/apps/desktop/src/renderer/src/panes/notifications/notifications-page.test.tsx
@@ -48,6 +48,15 @@ describe("the Notifications page (Plan 12 W5)", () => {
     expect(within(old).queryByLabelText("Unread")).toBeNull();
   });
 
+  it("the page body IS the split, which is how the page earns a measure wide enough for two columns", async () => {
+    // styles.css caps `.page:has(.notif-split)` alongside the rail pages rather than at the bare
+    // 720px reading column, because the list alone claims 480 of it. Rename the class and the detail
+    // silently becomes a gutter too narrow for a title.
+    const { container } = await mount({ notifications: [notification("n1", { title: "a row" })] });
+    await waitFor(() => expect(screen.getByText("a row")).toBeInTheDocument());
+    expect(container.querySelector(".page > .page-body")).toHaveClass("notif-split");
+  });
+
   it("shows a quiet, honest empty state", async () => {
     await mount();
     await waitFor(() => expect(screen.getByText(/Nothing has needed you/)).toBeInTheDocument());

--- a/apps/desktop/src/renderer/src/panes/profile/profile-page.test.tsx
+++ b/apps/desktop/src/renderer/src/panes/profile/profile-page.test.tsx
@@ -32,6 +32,14 @@ describe("ProfilePage · header", () => {
     await waitFor(() => expect(store.getState().activeSpaceId).toBe("s3"));
   });
 
+  it("the chip strip is a BAND of the page, a sibling of the head and the body", async () => {
+    // It takes the page's measure and gutter from the band rule in styles.css, which reaches it only
+    // as a direct child of `.page`. Nested inside the head or the body it would take the gutter
+    // twice and sit 24px inside the column every other band starts at.
+    const { container } = await mount();
+    expect(container.querySelector(".page > .profile-spaces")).toBe(screen.getByLabelText("Spaces of Work"));
+  });
+
   it("derives the profile LIVE from the item's space — a space moved between profiles moves the page's subject", async () => {
     const { store } = await mount();
     expect(screen.getByRole("heading", { name: "Work" })).toBeInTheDocument();

--- a/apps/desktop/src/renderer/src/panes/settings/settings-page.test.tsx
+++ b/apps/desktop/src/renderer/src/panes/settings/settings-page.test.tsx
@@ -47,6 +47,16 @@ describe("the Settings page (Plan 12 W6)", () => {
     }
   });
 
+  it("the tabs ARE the page's rail, which is what widens the page's measure to hold them", async () => {
+    // styles.css caps `.page:has(.page-rail)` at the rail plus the reading column, and every other
+    // page at the column alone. Rename the class here and the whole page narrows by 200px with
+    // nothing in the stylesheet to say why.
+    const { container } = await mount();
+    const rail = container.querySelector(".page > .page-body > .page-rail");
+    expect(rail).not.toBeNull();
+    expect(within(rail as HTMLElement).getByRole("radio", { name: "Engines" })).toBeInTheDocument();
+  });
+
   it("opens the Usage tab without the rest of Settings paying for it", async () => {
     // The panel reads a whole time range on mount, so it must not run for someone who came here to
     // check an engine version — which is what tabbing rather than stacking buys.

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -2336,6 +2336,22 @@ button.panel-title:hover { background: var(--rl-hover); }
    with three panes open: the Sessions tab was overflowing by 179px and the Tasks lens by 247px,
    which put the run detail panel's Approve/Decline under the session pane. jsdom has no layout, so
    no test in the suite could see it. */
+/* ——— The measure. A page is a column of content in a pane that is routinely twice as wide as the
+   column wants to be. Head, rail and content are therefore centred TOGETHER, as one block: centring
+   the content alone would leave the title at the pane's left edge introducing a form in the middle,
+   and centring it in the space BESIDE the rail would put the rail outside the thing it belongs to.
+   The number is what the page's own parts add up to, so below it nothing moves and above it the
+   surplus becomes equal margins rather than a right-hand void. */
+.page { --page-measure: 768px; }                                 /* 24px gutter + 720px column + 24px */
+.page:has(.page-rail, .notif-split) { --page-measure: 968px; }   /* + the 180px rail and its 20px gap */
+.page:has(.page-content[data-wide]) { --page-measure: 1348px; }  /* the Tasks lens's own 1100px cap */
+/* `width: 100%` is load-bearing: an auto cross-axis margin switches off a flex item's stretch, so
+   without it each band would shrink to fit its own longest line instead of filling the cap. */
+.page-head, .page-body, .profile-spaces { width: 100%; max-width: var(--page-measure); margin-inline: auto; }
+/* The profile page's chip strip is a third band between the head and the body, so its gutter is
+   stated here rather than with its own look — after the narrow block below, it could not be
+   overridden there (a container query carries no extra specificity). */
+.profile-spaces { padding-inline: 24px; }
 .page-head { flex: none; display: flex; align-items: center; gap: 12px; padding: 20px 24px 14px; }
 .page-glyph { flex: none; display: grid; place-items: center; width: 36px; height: 36px; border-radius: var(--r-ctl);
   background: color-mix(in srgb, currentColor 14%, transparent); }
@@ -2375,6 +2391,7 @@ button.panel-title:hover { background: var(--rl-hover); }
     overflow-x: auto; overscroll-behavior-x: contain; scrollbar-width: none; }
   .page-rail .settings-tab { white-space: nowrap; }
   .page-content { max-width: none; padding-right: 0; }
+  .profile-spaces { padding-inline: 16px; }
   /* The `1fr auto` row grid, stood up: the actions keep their own width and the path/name column
      gets all of it back. */
   .env-row { grid-template-columns: minmax(0, 1fr); }
@@ -2473,7 +2490,9 @@ button.panel-title:hover { background: var(--rl-hover); }
 .task-attempt-outcome[data-outcome="failed"], .task-attempt-outcome[data-outcome="expired"] { color: var(--rl-danger); }
 
 /* The profile page's space chips (Plan 14 W2): the profile's spaces as jump targets, under the head. */
-.profile-spaces { display: flex; flex-wrap: wrap; gap: 6px; margin: 2px 0 10px; }
+/* The inline margin is left to the band rule up in the page section — a `margin` shorthand here
+   would zero the auto that centres it. */
+.profile-spaces { display: flex; flex-wrap: wrap; gap: 6px; margin-block: 2px 10px; }
 .profile-chip { display: inline-flex; align-items: center; gap: 5px; padding: 3px 10px; font-size: 12px;
   border: 1px solid var(--rl-line-strong); border-radius: 999px; background: none; color: var(--rl-text-dim); cursor: pointer; }
 .profile-chip:hover { background: var(--rl-hover); color: var(--rl-text-bright); }
@@ -2497,11 +2516,11 @@ button.panel-title:hover { background: var(--rl-hover); }
 /* ——— Plan 12 W5: the Notifications page. Quiet feed rows on the page pattern; unread is a dot and a
    brighter title, never a wash. The inline permission card is the session pane's own component. ——— */
 .notifications-page-pane .page-head { align-items: flex-start; }
-/* The feed is SCANNED, not read: it takes the whole pane instead of the ~720px reading column the
-   other destination pages cap themselves at (there is no `.page-content` here at all), and spends
-   the width on a second column. It answers to the PANE's width and not the window's — `.page` is the
-   inline-size container every page shares — because this page is as likely to be half of a split as
-   it is to be the whole screen. */
+/* The feed is SCANNED, not read: it spends its width on a second column instead of the ~720px
+   reading column the other destination pages cap themselves at (there is no `.page-content` here at
+   all), which is why it shares the rail pages' measure rather than the bare column's. It answers
+   to the PANE's width and not the window's — `.page` is the inline-size container every page shares
+   — because this page is as likely to be half of a split as it is to be the whole screen. */
 .notif-split { gap: 0; }
 .notif-list { flex: 1 1 380px; min-width: 0; max-width: 480px; overflow-y: auto; padding-right: 16px; }
 .notif-detail { flex: 2 1 0; min-width: 0; overflow-y: auto; padding-left: 20px; border-left: 1px solid var(--rl-hairline); }

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -1533,7 +1533,12 @@ button.panel-title:hover { background: var(--rl-hover); }
 /* Two elements, not one, and the split is load-bearing: `attach-art` clips the picture to the
    rounded well, and the TILE must not clip, because the hover tip lives outside its box. Merging
    them makes the tip invisible. */
-.attach-tile { position: relative; width: 44px; height: 44px; flex: none; vertical-align: middle; }
+/* The tile names its own display rather than waiting to be blockified by an ancestor, because its
+   two callers do not agree about that: the composer's <li> is `display: contents`, which makes the
+   tile a direct flex item, while the transcript's <li> is an ordinary flex item and leaves it
+   INLINE — where the width and height below are ignored, the square collapses, and `.attach-art`'s
+   `inset: 0` collapses with it. That is how sent attachments came to render as a 0×0 box. */
+.attach-tile { position: relative; display: inline-block; width: 44px; height: 44px; flex: none; vertical-align: middle; }
 .attach-art { position: absolute; inset: 0; display: grid; place-items: center;
   border-radius: var(--r-ctl); background: var(--field); box-shadow: var(--shadow-hairline);
   color: var(--rl-text-faint); overflow: hidden; }

--- a/apps/desktop/src/renderer/src/styles.test.ts
+++ b/apps/desktop/src/renderer/src/styles.test.ts
@@ -1273,6 +1273,94 @@ describe("row and control layout", () => {
   });
 });
 
+/** The page measure. Where a column actually LANDS is settled by scripts/page-measure-live.mjs, which
+ *  measures the real rects at seven pane widths — jsdom has no layout, so to it `margin-inline: auto`
+ *  is a declaration that parses and nothing more. What is checkable here is the arithmetic: that each
+ *  page shape is capped at what that shape's own parts add up to, read from the rules that state
+ *  those parts, so a drift in either place fails. */
+describe("the page measure", () => {
+  /** A declaration from the first rule that states it for `sel` — the base rule, which the narrow
+   *  container block further down the file overrides rather than replaces. */
+  function decl(sel: string, prop: string): string {
+    for (const body of bodiesFor(sel)) {
+      const m = body.match(new RegExp(`(?:^|;\\s*)${prop}:\\s*([^;]+)`));
+      if (m) return m[1]!.trim();
+    }
+    throw new Error(`no ${prop} on ${sel}`);
+  }
+  const px = (v: string): number => Number(v.match(/(\d+(?:\.\d+)?)px/)?.[1] ?? NaN);
+
+  const GUTTER = px(decl(".page-body", "padding").split(" ")[1]!);
+  const GAP = px(decl(".page-body", "gap"));
+  const RAIL = px(decl(".page-rail", "width"));
+  const COLUMN = px(decl(".page-content", "max-width"));
+  const LENS = px(decl(".task-lens", "max-width"));
+
+  /** Every `--page-measure` in the stylesheet, by the selector that sets it. */
+  const MEASURES = new Map(RULES
+    .filter((r) => /--page-measure:/.test(r.body))
+    .map((r) => [r.selectors.join(", "), px(r.body.match(/--page-measure:\s*([^;]+)/)![1]!)]));
+  const measure = (sel: string): number => {
+    expect(MEASURES.get(sel), `no --page-measure on \`${sel}\``).toBeGreaterThan(0);
+    return MEASURES.get(sel)!;
+  };
+
+  it("head, rail and content are ONE centred block — the title stays over the column it introduces", () => {
+    // The mutant: drop `.page-head` from this rule. The form centres itself in the pane and the title
+    // that names it stays at the pane's left edge, introducing nothing.
+    const band = RULES.filter((r) => r.selectors.includes(".page-head") && r.body.includes("margin-inline: auto"));
+    expect(band).toHaveLength(1);
+    for (const sel of [".page-body", ".profile-spaces"]) expect(band[0]!.selectors).toContain(sel);
+    // The load-bearing one: an auto cross-axis margin switches a flex item's stretch OFF, so without
+    // an explicit width each band shrinks to fit its own longest line instead of filling the cap.
+    expect(band[0]!.body).toContain("width: 100%");
+    expect(band[0]!.body).toContain("max-width: var(--page-measure)");
+  });
+
+  it("each shape is capped at what ITS parts add up to, never at a number typed in twice", () => {
+    // Bare column, column beside the rail, and the Tasks lens beside the rail. Change `.page-rail`'s
+    // width or `.page-content`'s measure and the cap that no longer matches fails here.
+    expect(measure(".page")).toBe(GUTTER * 2 + COLUMN);
+    expect(measure(".page:has(.page-rail, .notif-split)")).toBe(GUTTER * 2 + RAIL + GAP + COLUMN);
+    expect(measure(".page:has(.page-content[data-wide])")).toBe(GUTTER * 2 + RAIL + GAP + LENS);
+  });
+
+  it("the Tasks tab, which matches two of them, takes the wider", () => {
+    // The space page has a rail AND a wide content, so both selectors hit it; `[data-wide]` is what
+    // makes the wider one win. Losing that is a lens squeezed into the reading measure.
+    expect(measure(".page:has(.page-content[data-wide])"))
+      .toBeGreaterThan(measure(".page:has(.page-rail, .notif-split)"));
+  });
+
+  it("the notifications split shares the rail pages' cap, because 720 leaves it no second column", () => {
+    // The mutant: let it fall through to the bare default. The list alone claims 480, so the detail
+    // becomes the ~220px gutter that could not hold a title — the failure the 760px stacking
+    // threshold exists to avoid, reintroduced above that threshold where stacking cannot save it.
+    const detail = measure(".page:has(.page-rail, .notif-split)") - GUTTER * 2
+      - px(decl(".notif-list", "max-width")) - px(decl(".notif-detail", "padding-left"));
+    expect(detail).toBeGreaterThan(300);
+  });
+
+  it("no cap can bind inside the narrow pass, so the two never fight", () => {
+    // Every measure is wider than the widest pane the responsive rules claim (the notifications
+    // split's 760). Below them a page is full-bleed and the cap is inert; above them nothing
+    // re-flows. A measure that fell between would centre a page that was busy standing itself up.
+    for (const [sel, value] of MEASURES) expect(value, sel).toBeGreaterThan(760);
+  });
+
+  it("the profile page's chip strip is a band of the page, and can still shed its gutter when narrow", () => {
+    // Its own rule sits BELOW the narrow block. Stated there, `padding-inline: 24px` would beat the
+    // query's 16px — a container query carries no extra specificity — and the chips would hang past
+    // the head at every narrow width.
+    const base = css.indexOf(".profile-spaces { padding-inline: 24px");
+    const narrow = css.indexOf(".profile-spaces { padding-inline: 16px");
+    expect(base).toBeGreaterThan(-1);
+    expect(narrow).toBeGreaterThan(base);
+    // A `margin` shorthand anywhere would zero the auto that centres it.
+    for (const body of bodiesFor(".profile-spaces")) expect(body, body).not.toMatch(/(^|;\s*)margin:/);
+  });
+});
+
 /** A pane is not a window: `minSize={10}` in PaneHost means a leaf can be a tenth of the host, and a
  *  three-way split routinely leaves one under 300px. These assert the two halves of the fix — the
  *  flex minimums that stop a pane sizing itself to its WIDEST child (and being clipped by

--- a/apps/desktop/src/renderer/src/styles.test.ts
+++ b/apps/desktop/src/renderer/src/styles.test.ts
@@ -812,6 +812,11 @@ describe("Plan 9 W3 — composer + chrome in BUI language", () => {
     // The well clips the picture; the TILE must not, or it would clip its own hover tip off.
     expect(art).toContain("overflow: hidden");
     expect(tile).not.toContain("overflow: hidden");
+    /* The tile is a <span>, so without a display of its own it is an INLINE box and both lengths
+       above are dead letters. The composer never noticed — its <li> is `display: contents`, which
+       makes the tile a flex item and blockifies it — but the transcript's <li> is an ordinary flex
+       item, and there the sent tile collapsed to 0×0 and painted nothing. */
+    expect(tile).toContain("display: inline-block");
   });
 
   it("the open control fills the tile and draws nothing — the well underneath already has the ring", () => {


### PR DESCRIPTION
Stacked on #40.

**Sent attachments were rendering 0×0.** Not missing — *invisible*. `.attach-tile` is a `<span>` carrying `width`/`height` and no `display`. In the composer its `<li>` is `display: contents`, so the tile becomes a direct flex item and gets blockified to its stated size. In the transcript the `<li>` is an ordinary flex item, so the tile stayed `display: inline`, where width and height are simply ignored. Measured: tile 0×0, `.attach-art` 0×0, the whole `<ul>` 8px wide (the flex gap alone) and 0 tall.

Everything else about them was already correct and was left alone: they were in the DOM, named to a screen reader, real `<button>`s, correctly sorted into lightbox versus OS handoff, with paths surviving the round trip byte-for-byte and thumbnails resolving after send. One declaration fixes it, and a new live check sends a message and asserts the tile has a size — which is what caught it.

**The Appearance "padding" was a measurement, not a hunch.** At a 1600px window the column sat 224px from the left and **376px** from the right: a 720px `max-width` with no auto-margin. Three of the four hypotheses in the brief were disproved by measuring rather than argued away — the six Settings tabs report an identical column at all seven widths, `overflowX` is 0 everywhere, and the theme cards' 120–147px range is `repeat(auto-fill, minmax(116px, 1fr))` behaving as its existing comment documents, so it was left alone.

The fix was to merge the page-measure work rather than write a second centring rule that would fight the first — and its approach is the right one: centring `.page-content` alone would have pushed the column to 680 while the head stayed at 304, *widening* the head/content misalignment from 200px to 376px. Capping head and body together keeps them aligned.

Also fixed: the live harness orphaned its server on every run, because main spawns it as a grandchild, so it could never run twice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)