### PR TITLE
Check every agent CLI and model catalog for updates, and install one visibly when asked

### DIFF
--- a/apps/desktop/scripts/cli-job-live.mjs
+++ b/apps/desktop/scripts/cli-job-live.mjs
@@ -1,0 +1,220 @@
+/**
+ * Live check for the install-output panel's box (run with: node apps/desktop/scripts/cli-job-live.mjs)
+ *
+ * The panel is a monospace block of text nobody controls the size of — a package manager can print
+ * two lines or two thousand, with single tokens longer than the pane is wide. Whether that stays
+ * inside a floating card that sits in the composer dock is a question about BOXES, and jsdom answers
+ * every box with zeros.
+ *
+ * It also pins the one fact no single-layer test can state: with the CLI genuinely absent from a
+ * real PATH, a real probe, a real `cli.status` and a real card agree, and the card grows a button
+ * offering the real install command.
+ *
+ * Then three boxes, all of them CSS:
+ *
+ *   1. The card stays inside its pane. The install card floats over the transcript, so a panel that
+ *      grows without bound pushes the card's top off the top of the pane and the "Install" button
+ *      out of reach — the exact failure the 180px cap exists to prevent.
+ *   2. Long output SCROLLS rather than growing. `scrollHeight > clientHeight` with a clamped
+ *      `clientHeight` is the shape that proves the cap is doing the work.
+ *   3. A single unbroken 400-character token does not widen the card. `word-break: break-word` is
+ *      the rule under test, and an npm error path or a base64 integrity hash is a real 400-char token.
+ *
+ * **It runs no package manager.** The panel's markup is injected into the real card, in the real
+ * stylesheet, at a real viewport — so what is proven is the CSS, which is the only thing here that
+ * can go wrong in a way a unit test cannot see. The behaviour that fills the panel is covered by
+ * install.test.ts and cli-manager.test.ts against fakes.
+ *
+ * Ports: env-overridable. Touches only a scratch dir; kills only the process it started.
+ */
+import { spawn } from "node:child_process";
+import { connect } from "node:net";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
+const CDP_PORT = Number(process.env.LIVE_CDP_PORT ?? 9347), SERVER_PORT = Number(process.env.LIVE_SERVER_PORT ?? 8914);
+const scratch = fs.mkdtempSync(path.join(os.tmpdir(), "realm-clijob-live-"));
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+let electron = null;
+let failures = 0;
+
+const check = (label, cond, detail) => {
+  console.log(`  ${cond ? "PASS" : "FAIL"}  ${label}${detail ? ` — ${JSON.stringify(detail)}` : ""}`);
+  if (!cond) failures += 1;
+};
+
+async function portFree(port) {
+  return new Promise((resolve) => {
+    const s = connect({ port, host: "127.0.0.1" });
+    s.once("connect", () => { s.destroy(); resolve(false); });
+    s.once("error", () => resolve(true));
+  });
+}
+
+async function until(fn, ms, tag) {
+  const t0 = Date.now();
+  for (;;) {
+    const v = await fn();
+    if (v) return v;
+    if (Date.now() - t0 > ms) throw new Error(`timeout:${tag}`);
+    await sleep(150);
+  }
+}
+
+function cdp(wsUrl) {
+  const ws = new WebSocket(wsUrl);
+  let id = 0;
+  const pending = new Map();
+  const ready = new Promise((res) => ws.addEventListener("open", res));
+  ws.addEventListener("message", (m) => {
+    const msg = JSON.parse(m.data);
+    if (msg.id !== undefined) pending.get(msg.id)?.(msg);
+  });
+  return {
+    ready,
+    send: (method, params) => new Promise((res, rej) => {
+      const i = ++id;
+      pending.set(i, (msg) => (msg.error ? rej(new Error(msg.error.message)) : res(msg.result)));
+      ws.send(JSON.stringify({ id: i, method, params }));
+    }),
+    close: () => ws.close(),
+  };
+}
+
+const evalIn = async (c, expr) => (await c.send("Runtime.evaluate", { expression: expr, awaitPromise: true, returnByValue: true })).result.value;
+
+/** The panel exactly as CliJobPanel and InstallCard build it — same elements, same classes, same
+ *  nesting. Anything less would be measuring a box this stylesheet never draws. */
+const INJECT = (text) => `(() => {
+  const card = document.querySelector('.install-card');
+  if (!card) return null;
+  card.querySelector('.cli-job')?.remove();
+  const job = document.createElement('div');
+  job.className = 'cli-job';
+  job.dataset.state = 'running';
+  const head = document.createElement('div');
+  head.className = 'cli-job-head';
+  const state = document.createElement('span');
+  state.className = 'cli-job-state';
+  state.textContent = 'Running…';
+  head.appendChild(state);
+  const pre = document.createElement('pre');
+  pre.className = 'cli-job-output';
+  pre.textContent = ${JSON.stringify(text)};
+  job.appendChild(head); job.appendChild(pre);
+  card.insertBefore(job, card.querySelector('.install-actions'));
+  return true;
+})()`;
+
+const MEASURE = `(() => {
+  const box = (n) => { const b = n.getBoundingClientRect(); return { top: Math.round(b.top), bottom: Math.round(b.bottom), left: Math.round(b.left), right: Math.round(b.right), w: Math.round(b.width), h: Math.round(b.height) }; };
+  const pane = document.querySelector('.session-pane');
+  const card = document.querySelector('.install-card');
+  const pre = document.querySelector('.cli-job-output');
+  const actions = document.querySelector('.install-actions');
+  return {
+    pane: box(pane), card: box(card), actions: box(actions),
+    pre: pre ? { ...box(pre), scrollH: Math.round(pre.scrollHeight), clientH: Math.round(pre.clientHeight), scrollW: Math.round(pre.scrollWidth), clientW: Math.round(pre.clientWidth) } : null,
+  };
+})()`;
+
+async function main() {
+  for (const p of [CDP_PORT, SERVER_PORT]) {
+    if (!(await portFree(p))) throw new Error(`port ${p} is in use — refusing to run`);
+  }
+  const wrapper = path.join(scratch, "wrapper.mjs");
+  fs.writeFileSync(wrapper, [
+    'import { app } from "electron";',
+    'app.setPath("userData", process.env.LIVE_USER_DATA);',
+    "await import(process.env.LIVE_MAIN);",
+  ].join("\n"));
+  const electronBin = process.platform === "darwin"
+    ? path.join(repoRoot, "node_modules/.pnpm/electron@37.10.3/node_modules/electron/dist/Electron.app/Contents/MacOS/Electron")
+    : path.join(repoRoot, "apps/desktop/node_modules/.bin/electron");
+  electron = spawn(electronBin, [wrapper], {
+    env: {
+      ...process.env,
+      REALM_HOME: path.join(scratch, "home"),
+      REALM_PORT: String(SERVER_PORT),
+      REALM_DEVTOOLS_PORT: String(CDP_PORT),
+      REALM_SERVER_ENTRY: path.join(repoRoot, "apps/server/dist/main.js"),
+      LIVE_USER_DATA: path.join(scratch, "userData"),
+      LIVE_MAIN: path.join(repoRoot, "apps/desktop/out/main/index.js"),
+      // The whole point: the default agent's CLI must probe as MISSING, which is the one state that
+      // draws the install card at all.
+      REALM_CLAUDE_BIN: path.join(scratch, "no-such-claude"),
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  electron.stderr.on("data", () => {}); electron.stdout.on("data", () => {});
+
+  const targets = () => fetch(`http://127.0.0.1:${CDP_PORT}/json/list`).then((r) => r.json()).catch(() => []);
+  const t = await until(async () => (await targets()).find((x) => x.type === "page" && x.url.startsWith("file://")), 30000, "renderer target");
+  const c = cdp(t.webSocketDebuggerUrl);
+  await c.ready;
+  await c.send("Runtime.enable");
+  await c.send("Page.enable");
+
+  await until(() => evalIn(c, `!!document.querySelector('.onboarding input:not([type=radio])')`), 20000, "onboarding");
+  await evalIn(c, `(() => {
+    const input = document.querySelector('.onboarding input:not([type=radio])');
+    const set = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value").set;
+    set.call(input, "Live"); input.dispatchEvent(new Event("input", { bubbles: true }));
+    input.closest("form").requestSubmit();
+    return true; })()`);
+
+  // A short viewport on purpose: the card has the least room here, so this is where an uncapped
+  // panel would push it out of the pane.
+  await c.send("Emulation.setDeviceMetricsOverride", { width: 900, height: 700, deviceScaleFactor: 1, mobile: false });
+  await until(() => evalIn(c, `!!document.querySelector('.install-card')`), 30000, "install card");
+  await sleep(400);
+
+  // Before any injection: the real chain, end to end. The probe found no claude, the server offered
+  // an install, and the card grew a button — none of which a jsdom test can say together.
+  console.log("== the offer, from a real probe ==");
+  const offer = await evalIn(c, `(() => {
+    const card = document.querySelector('.install-card');
+    return {
+      command: card.querySelector('.install-cmd code')?.textContent ?? null,
+      buttons: [...card.querySelectorAll('button')].map((b) => b.textContent.trim()),
+    };
+  })()`);
+  console.log(`  --    ${JSON.stringify(offer)}`);
+  check("the card shows the real install command", offer.command === "npm install -g @anthropic-ai/claude-code", offer);
+  check("the card offers to run it", offer.buttons.includes("Install"), offer);
+  check("and still offers the terminal route it always had", offer.buttons.includes("Open in terminal"), offer);
+
+  console.log("\n== the panel's box ==");
+  const long = Array.from({ length: 400 }, (_, i) => `npm http fetch GET 200 https://registry.npmjs.org/pkg-${i} 812ms`).join("\n");
+  check("the card injects", await evalIn(c, INJECT(long)) === true);
+  await sleep(200);
+  const m = await evalIn(c, MEASURE);
+  console.log(`  --    pane ${m.pane.h}px, card ${m.card.h}px, pre ${m.pre.clientH}px of ${m.pre.scrollH}px`);
+  check("400 lines of output scroll instead of growing", m.pre.scrollH > m.pre.clientH && m.pre.clientH <= 200, m.pre);
+  check("the card stays inside its pane", m.card.top >= m.pane.top - 1 && m.card.bottom <= m.pane.bottom + 1, { card: m.card, pane: m.pane });
+  check("the Install button is still inside the pane", m.actions.bottom <= m.pane.bottom + 1, m.actions);
+
+  console.log("\n== a single unbreakable token ==");
+  // A real one: npm prints integrity hashes and long registry URLs with no space to break at.
+  const token = "sha512-" + "wbHDmit7SYvBGVX1DQmk13xtWblZ2cApeJpB7xDZ10C".repeat(9);
+  await evalIn(c, INJECT(token));
+  await sleep(200);
+  const w = await evalIn(c, MEASURE);
+  console.log(`  --    token ${token.length} chars, pre ${w.pre.clientW}px wide, content ${w.pre.scrollW}px`);
+  check("the token wraps rather than widening the card", w.pre.scrollW <= w.pre.clientW + 1, w.pre);
+  check("the card is no wider than the pane", w.card.w <= w.pane.w, { card: w.card.w, pane: w.pane.w });
+
+  c.close();
+  console.log(`\n${failures === 0 ? "ALL CHECKS PASSED" : `${failures} CHECK(S) FAILED`}`);
+}
+
+main()
+  .catch((e) => { console.error(e); failures += 1; })
+  .finally(() => {
+    electron?.kill();
+    fs.rmSync(scratch, { recursive: true, force: true });
+    process.exit(failures === 0 ? 0 : 1);
+  });

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -261,6 +261,16 @@ export function App() {
       // was never opened has nothing to go stale.
       for (const spaceId of Object.keys(st.connectors)) st.run(() => st.refreshConnectors(spaceId));
     });
+    // A running install's narration and its outcome. Broadcast, so both the Settings engines list and
+    // a session's install card follow the same install; the store drops anything it did not start.
+    const offCO = rpc().on("cli.output", (e) => store.getState().applyCliOutput(e));
+    const offCD = rpc().on("cli.done", (e) => {
+      const st = store.getState();
+      st.applyCliDone(e);
+      // The server re-probed before sending this, so an unforced read is already the new truth.
+      st.run(() => st.refreshCliStatus());
+      st.run(() => st.probeAgents(true));
+    });
     const offMS = rpc().on("mcp.serverStatus", (payload) => store.getState().applyMcpServerStatus(payload));
     // Broadcast for EVERY space/session (binding rule 5) — applyMcpCall itself is the gate on whether
     // Activity is even open and whether the row matches its filter, same as mcp.serverStatus above.
@@ -277,7 +287,7 @@ export function App() {
     window.addEventListener("dragover", swallowDrop);
     window.addEventListener("drop", swallowDrop);
     return () => {
-      offS(); offI(); offV(); offW(); offSh(); offRun(); offP(); offK(); offMem(); offB(); offDO(); offSA(); offBA(); offBD(); offE(); offT(); offN(); offDN?.(); offR(); offDel(); offM(); offMS(); offMC(); offC();
+      offS(); offI(); offV(); offW(); offSh(); offRun(); offP(); offK(); offMem(); offB(); offDO(); offSA(); offBA(); offBD(); offE(); offT(); offN(); offDN?.(); offR(); offDel(); offM(); offMS(); offMC(); offCO(); offCD(); offC();
       window.removeEventListener("pagehide", onPageHide);
       window.removeEventListener("dragover", swallowDrop);
       window.removeEventListener("drop", swallowDrop);

--- a/apps/desktop/src/renderer/src/panes/session/InstallCard.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/InstallCard.tsx
@@ -1,6 +1,7 @@
 import { Icon } from "@realm/ui";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { AgentAvailability } from "../../state/agent-availability";
+import type { CliJob } from "../../state/store";
 
 /**
  * Replaces the prompter when the session's agent can't run (design-language §5 floating card: raised,
@@ -9,30 +10,45 @@ import type { AgentAvailability } from "../../state/agent-availability";
  * - *missing* — the CLI isn't there. Offers the INSTALL command.
  * - *logged_out* — the CLI is there but signed out. Offers the LOGIN command.
  *
- * "Open in terminal" opens the session's own terminal panel with the command **typed but not run**
- * (`prefillTerminal` sends no newline). Realm never executes an installer; the user presses Return.
+ * "Install" is offered only when the server's `cli.status` says so — one click that runs the command
+ * shown above it and streams what it says. Everything the server will not run stays as it always was:
+ * "Open in terminal" types the command into the session's own terminal **without a newline**, and the
+ * user presses Return. A signed-out agent is always the second case, because logging in is a browser
+ * flow or an API key, not a command Realm can run to completion on someone's behalf.
  *
  * Re-probing happens on BOTH triggers, because the user's fix happens outside Realm: window focus
  * (they alt-tabbed to a terminal, installed, and came back) and an explicit "Check again". Both force
  * past the server's probe cache — a cached "not installed" is precisely what they just fixed.
  */
-export function InstallCard({ availability, onRetry, onOpenInTerminal }: {
+export function InstallCard({ availability, onRetry, onOpenInTerminal, offer, job, onInstall, onDismissJob }: {
   availability: Extract<AgentAvailability, { command: string | null }>;
   onRetry: () => void;
   onOpenInTerminal: (command: string) => void;
+  /** The command the server is currently willing to run here, or null when there is none. Null is
+   *  the whole story for a signed-out agent and for any CLI with no install route. */
+  offer: string | null;
+  /** The install this card started, while it runs and after it ends. */
+  job: CliJob | null;
+  onInstall: () => void;
+  onDismissJob: () => void;
 }) {
   const { title, reason, command, state } = availability;
   const [copied, setCopied] = useState(false);
+  const tail = useRef<HTMLPreElement>(null);
+  useEffect(() => { const el = tail.current; if (el) el.scrollTop = el.scrollHeight; }, [job?.output]);
   useEffect(() => {
     if (!copied) return;
     const t = setTimeout(() => setCopied(false), 1600);
     return () => clearTimeout(t);
   }, [copied]);
-  // Window focus re-probe: the whole point of this card is that the fix happens in another app.
+  // Window focus re-probe: the whole point of this card is that the fix can happen in another app.
+  // Still true now that Realm can install one itself — Homebrew, a downloaded binary and a login all
+  // still happen elsewhere.
   useEffect(() => {
     window.addEventListener("focus", onRetry);
     return () => window.removeEventListener("focus", onRetry);
   }, [onRetry]);
+  const running = job?.state === "running";
   return (
     <div className="composer-dock">
       <div className="install-card" role="group" aria-label={title} data-state={state}>
@@ -52,18 +68,36 @@ export function InstallCard({ availability, onRetry, onOpenInTerminal }: {
             </button>
           </div>
         )}
+        {job && (
+          <div className="cli-job" data-state={job.state}>
+            <div className="cli-job-head">
+              <span className="cli-job-state">
+                {running ? "Running…" : job.state === "ok" ? "Finished" : job.error ?? "Failed"}
+              </span>
+              {!running && <button type="button" className="btn" onClick={onDismissJob}>Dismiss</button>}
+            </div>
+            <pre className="cli-job-output" ref={tail}>{job.output || "Waiting for output…"}</pre>
+          </div>
+        )}
         <div className="install-actions">
-          <button type="button" className="btn" onClick={onRetry}>Check again</button>
+          <button type="button" className="btn" onClick={onRetry} disabled={running}>Check again</button>
           {command && (
-            <button type="button" className="btn primary" onClick={() => onOpenInTerminal(command)}>
+            <button type="button" className="btn" onClick={() => onOpenInTerminal(command)}>
               Open in terminal
+            </button>
+          )}
+          {offer && (
+            <button type="button" className="btn primary" onClick={onInstall} disabled={running}>
+              {running ? "Installing…" : "Install"}
             </button>
           )}
         </div>
         <p className="install-note">
-          {command
-            ? "Realm types the command into this session’s terminal — you press Return."
-            : "Realm can’t offer a single command for this one; the reason above says what it needs."}
+          {offer
+            ? "Realm runs the command above and shows you what it says."
+            : command
+              ? "Realm types the command into this session’s terminal — you press Return."
+              : "Realm can’t offer a single command for this one; the reason above says what it needs."}
         </p>
       </div>
     </div>

--- a/apps/desktop/src/renderer/src/panes/session/SessionPane.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/SessionPane.tsx
@@ -249,6 +249,12 @@ export function SessionPane({ item, visible, focused = false }: PaneProps) {
   const refreshModelFavorites = useApp((s) => s.refreshModelFavorites);
   const toggleModelFavorite = useApp((s) => s.toggleModelFavorite);
   const prefillTerminal = useApp((s) => s.prefillTerminal);
+  const cliStatus = useApp((s) => s.cliStatus);
+  const cliJob = useApp((s) => (session ? s.cliJobs[session.agentKind] : undefined));
+  const runCliAction = useApp((s) => s.runCliAction);
+  const dismissCliJob = useApp((s) => s.dismissCliJob);
+  const refreshCliStatus = useApp((s) => s.refreshCliStatus);
+  const cliRow = session ? cliStatus.find((r) => r.kind === session.agentKind) : undefined;
   const openDiff = useApp((s) => s.openDiff);
   const submitKey = useApp((s) => s.submitKey);
   // Stable across renders: InstallCard registers it as a window "focus" listener.
@@ -269,6 +275,9 @@ export function SessionPane({ item, visible, focused = false }: PaneProps) {
   // Cheap by construction: the store dedups concurrent calls and the server holds a TTL cache, so a
   // four-pane split (or a tab-back) costs one round trip, not a process spawn per agent.
   useEffect(() => { run(() => probeAgents()); }, [id, probeAgents, run]);
+  // Alongside the probe and just as cheap: the server caches this for six hours and the store
+  // collapses concurrent calls, so a split of four panes costs one round trip and no network.
+  useEffect(() => { run(() => refreshCliStatus()); }, [id, refreshCliStatus, run]);
   // One settings read, alongside the probe. Favourites only ever change through this app's own
   // toggle (which writes through and updates the store), so there is nothing to poll for.
   useEffect(() => { run(() => refreshModelFavorites()); }, [refreshModelFavorites, run]);
@@ -294,6 +303,10 @@ export function SessionPane({ item, visible, focused = false }: PaneProps) {
   // mid-stream (its 5s timeout losing a race under load) would otherwise take away the one control that
   // can end the turn — and an agent that is streaming has self-evidently started.
   const availability = agentAvailability(session.agentKind, agentProbe);
+  // Only an INSTALL is offered here, and only on the card that is about a missing CLI. A signed-out
+  // agent's fix is a login — a browser flow or an API key, not a command that finishes on its own —
+  // so this card never grows a button for it even if the two answers disagreed for a moment.
+  const cliOffer = availability.state === "missing" && cliRow?.action === "install" ? cliRow.command : null;
   // The prompter's suggested prompt, derived from THIS session (prompt-hint.ts): the last turn, the
   // working tree, the mode. Computed here rather than in Composer because everything it reads is
   // already the pane's — Composer only draws it and fills it in on ⇥.
@@ -317,7 +330,10 @@ export function SessionPane({ item, visible, focused = false }: PaneProps) {
       <DelegatedRuns sessionId={id} />
       {blocked && isBlocked(availability)
         ? <InstallCard availability={availability} onRetry={reprobe}
-            onOpenInTerminal={(command) => run(() => prefillTerminal(id, command))} />
+            onOpenInTerminal={(command) => run(() => prefillTerminal(id, command))}
+            offer={cliOffer} job={cliJob ?? null}
+            onInstall={() => run(() => runCliAction(session.agentKind, "install"))}
+            onDismissJob={() => dismissCliJob(session.agentKind)} />
         : <Composer session={session} status={status} gitInfo={gitInfo} todos={todos}
             onOpenDiff={() => run(() => openDiff(session.environmentId))} draft={draft} onDraftChange={(t) => setDraft(id, t)}
             attachments={attachments}

--- a/apps/desktop/src/renderer/src/panes/session/session-pane.test.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/session-pane.test.tsx
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { render, screen, fireEvent, createEvent, waitFor, act, within } from "@testing-library/react";
-import { AGENT_CLI_COMMANDS, AGENT_NOTES, MODEL_NOTES, canonicalModelKey, sessionEvent, type Environment } from "@realm/contracts";
+import { render, screen, fireEvent, createEvent, waitFor, act, within, cleanup } from "@testing-library/react";
+import { AGENT_CLI_COMMANDS, AGENT_NOTES, MODEL_NOTES, canonicalModelKey, sessionEvent, type CliStatus, type Environment } from "@realm/contracts";
 import { StoreContext, createAppStore, type AgentProbe } from "../../state/store";
 import { fakeApi, item, mcpServer, session, skillRow, externalSkillRow } from "../../state/store.test-fakes";
 import { PanelBar } from "../../components/PanelBar";
@@ -1675,9 +1675,9 @@ describe("the CLI-missing install card (W4)", () => {
   const missing: AgentProbe = { kind: "claude", available: false, version: null, loggedIn: null, reason: "spawn claude ENOENT" };
   const signedOut: AgentProbe = { kind: "claude", available: true, version: "2.0.1", loggedIn: false, reason: "not logged in — run `claude auth login`" };
 
-  async function mountAgent(agentProbe: AgentProbe[], status: "idle" | "running" = "idle") {
+  async function mountAgent(agentProbe: AgentProbe[], status: "idle" | "running" = "idle", cliStatus: CliStatus[] = []) {
     setTerminalHubForTests(fakeHub());
-    const api = fakeApi({ sessions: [session("se1", "s1", { status, agentKind: "claude" })], agentProbe });
+    const api = fakeApi({ sessions: [session("se1", "s1", { status, agentKind: "claude" })], agentProbe, cliStatus });
     const store = createAppStore(api); await store.getState().boot();
     store.setState({ sessionStatus: { se1: status }, transcripts: { se1: { lastSeq: 0, t: reduceAll([]) } } });
     const r = render(
@@ -1739,6 +1739,49 @@ describe("the CLI-missing install card (W4)", () => {
     expect(api.calls).toContain(`prefillTerminal:term-se1=${AGENT_CLI_COMMANDS.claude.install}`);
     expect(api.calls.find((c) => c.startsWith("prefillTerminal:"))).not.toMatch(/[\r\n]$/);
     await waitFor(() => expect(document.querySelector(".terminal-pane")).not.toBeNull());
+  });
+
+  /** claude missing, with the server offering to install it — the only shape that grows a button. */
+  const offersInstall: CliStatus[] = [{
+    kind: "claude", installed: false, version: null, binPath: null, provenance: "unknown", latest: null,
+    channel: true, updateAvailable: false, action: "install",
+    command: AGENT_CLI_COMMANDS.claude.install, refusal: null,
+  }];
+
+  it("grows an Install button only when the server is offering one", async () => {
+    // The named mutant: a button rendered from the card's own idea of "missing". The offer is the
+    // server's, so a CLI it will not install shows the command to copy and nothing to press.
+    await mountAgent([missing]);
+    await waitFor(() => expect(document.querySelector(".install-card")).not.toBeNull());
+    expect(screen.queryByRole("button", { name: "Install" })).toBeNull();
+
+    cleanup();
+    await mountAgent([missing], "idle", offersInstall);
+    await waitFor(() => expect(screen.getByRole("button", { name: "Install" })).toBeInTheDocument());
+    // The command is still readable above the button that runs it.
+    expect(screen.getByText(AGENT_CLI_COMMANDS.claude.install)).toBeInTheDocument();
+  });
+
+  it("Install runs the command and streams what it says, without leaving the pane", async () => {
+    const { api, store } = await mountAgent([missing], "idle", offersInstall);
+    await waitFor(() => screen.getByRole("button", { name: "Install" }));
+    expect(api.calls.some((c) => c.startsWith("runCli:"))).toBe(false);
+    fireEvent.click(screen.getByRole("button", { name: "Install" }));
+    await waitFor(() => expect(api.calls).toContain("runCli:claude:install"));
+
+    const id = store.getState().cliJobs.claude!.id;
+    store.getState().applyCliOutput({ id, kind: "claude", chunk: "added 128 packages\n" });
+    await waitFor(() => expect(screen.getByText(/added 128 packages/)).toBeInTheDocument());
+    // Nothing else may be pressed while a package manager is writing to the machine.
+    expect(screen.getByRole("button", { name: "Installing…" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Check again" })).toBeDisabled();
+  });
+
+  it("a SIGNED-OUT card never grows an Install button — logging in is not a command Realm can run", async () => {
+    await mountAgent([signedOut], "idle", offersInstall);
+    await waitFor(() => expect(screen.getByRole("group", { name: /isn’t signed in/ })).toBeInTheDocument());
+    expect(screen.queryByRole("button", { name: "Install" })).toBeNull();
+    expect(screen.getByText(AGENT_CLI_COMMANDS.claude.login)).toBeInTheDocument();
   });
 
   it("'Check again' re-probes past the cache and the prompter comes back — no restart", async () => {

--- a/apps/desktop/src/renderer/src/panes/session/session-pane.test.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/session-pane.test.tsx
@@ -1744,7 +1744,7 @@ describe("the CLI-missing install card (W4)", () => {
   /** claude missing, with the server offering to install it — the only shape that grows a button. */
   const offersInstall: CliStatus[] = [{
     kind: "claude", installed: false, version: null, binPath: null, provenance: "unknown", latest: null,
-    channel: true, updateAvailable: false, action: "install",
+    updateAvailable: false, action: "install",
     command: AGENT_CLI_COMMANDS.claude.install, refusal: null,
   }];
 

--- a/apps/desktop/src/renderer/src/panes/settings/SettingsPage.tsx
+++ b/apps/desktop/src/renderer/src/panes/settings/SettingsPage.tsx
@@ -101,8 +101,6 @@ function CommandCopy({ command, action }: { command: string; action?: React.Reac
 }
 
 /**
- * A running or finished install, with its output.
- *
  * The output pane is scrolled to the tail on every chunk: a package manager's interesting line is
  * almost always its last, and a user watching an install is watching the end of it.
  */
@@ -194,8 +192,8 @@ function EngineRow({ kind }: { kind: AgentKind }) {
   // Signed-in identity, exactly as far as the probe carries it: a boolean at best (Claude's keychain
   // and both ACP agents report null = "couldn't tell", which renders as nothing, not as either claim).
   const identity = p?.loggedIn === true ? "signed in" : p?.loggedIn === false ? "signed out" : null;
-  // An available update is part of the row's status line, not a separate badge: "what version am I
-  // on" and "is there a newer one" are one sentence.
+  // Folded into the status line rather than shown as its own badge: "what version am I on" and "is
+  // there a newer one" are one sentence.
   const behind = cli?.updateAvailable && cli.latest ? `${engineVersionLabel(cli.latest)} available` : null;
   const status = !p ? "Checking…"
     : p.available ? ["Installed", p.version ? engineVersionLabel(p.version) : null, identity, behind].filter(Boolean).join(" · ")
@@ -227,8 +225,10 @@ function EngineRow({ kind }: { kind: AgentKind }) {
         {/* Signing in is never Realm's to run — it is a browser flow or an API key, and a command
             that would sit waiting on a prompt Realm has closed. */}
         {offer && a.state === "logged_out" && login && <CommandCopy command={login} />}
-        {/* An update Realm found but will not apply says why, right where the button would be. */}
-        {cli?.refusal && <p className="settings-hint">{cli.refusal}</p>}
+        {/* An update Realm found but will not apply says why, right where the button would be — with
+            the copy it is talking about, because "which one?" is the next question for anyone who
+            has ended up with two of something on their PATH. */}
+        {cli?.refusal && <p className="settings-hint">{cli.refusal}{cli.binPath ? ` (${cli.binPath})` : ""}</p>}
         {job && <CliJobPanel job={job} onDismiss={() => dismissCliJob(kind)} />}
         {/* The login hint on ANY blocked row, not just un-offered ones. It used to hang off `!offered`,
             which was fine only while every kind with something awkward to explain was also withheld.

--- a/apps/desktop/src/renderer/src/panes/settings/SettingsPage.tsx
+++ b/apps/desktop/src/renderer/src/panes/settings/SettingsPage.tsx
@@ -9,7 +9,7 @@ import { CONTRAST_RANGE, DEFAULT_GROUND_ALPHA, FONT_FACES, FONT_WEIGHTS, GROUND_
   type FontId, type FontWeight, type Mode, type ThemeName, type ThemeOverride, type ThemeSeed } from "@realm/ui";
 import { useEffect, useRef, useState, type CSSProperties } from "react";
 import { agentAvailability, isBlocked } from "../../state/agent-availability";
-import { useApp, type SubmitKey } from "../../state/store";
+import { useApp, type CliJob, type SubmitKey } from "../../state/store";
 import type { PaneProps } from "../registry";
 import { hasWindowMaterial, useResolvedMode, type ThemePref } from "../../theme/useTheme";
 import { ImportPanel } from "../../components/settings/ImportPanel";
@@ -74,8 +74,12 @@ export function SettingsPage(_props: PaneProps) {
 }
 
 /** A command offered for copying — the install card's affordance, re-rendered. The command travels
- *  to the clipboard verbatim: no trailing newline anywhere near a terminal (typed-never-run). */
-function CommandCopy({ command }: { command: string }) {
+ *  to the clipboard verbatim: no trailing newline anywhere near a terminal (typed-never-run).
+ *
+ *  `action`, when given, is the button that RUNS this exact string. It sits beside the command rather
+ *  than replacing it, because the promise the CLI manager makes is that the command is readable
+ *  before it is run — a button whose command is hidden behind it would be a different promise. */
+function CommandCopy({ command, action }: { command: string; action?: React.ReactNode }) {
   const [copied, setCopied] = useState(false);
   useEffect(() => {
     if (!copied) return;
@@ -91,6 +95,32 @@ function CommandCopy({ command }: { command: string }) {
         <Icon name="copy" size={12} className="copy-icon" />
         <Icon name="check" size={12} className="copied-icon" />
       </button>
+      {action}
+    </div>
+  );
+}
+
+/**
+ * A running or finished install, with its output.
+ *
+ * The output pane is scrolled to the tail on every chunk: a package manager's interesting line is
+ * almost always its last, and a user watching an install is watching the end of it.
+ */
+function CliJobPanel({ job, onDismiss }: { job: CliJob; onDismiss: () => void }) {
+  const tail = useRef<HTMLPreElement>(null);
+  useEffect(() => { const el = tail.current; if (el) el.scrollTop = el.scrollHeight; }, [job.output]);
+  const state = job.state === "running" ? "Running…" : job.state === "ok" ? "Finished" : job.error ?? "Failed";
+  return (
+    <div className="cli-job" data-state={job.state} role="group" aria-label={`${job.command}: ${state}`}>
+      <div className="cli-job-head">
+        <span className="cli-job-state">{state}</span>
+        {/* No dismiss while it runs: hiding a package manager's output while it is still writing to
+            the machine is the one moment that output matters most. */}
+        {job.state !== "running" && (
+          <button type="button" className="btn" onClick={onDismiss}>Dismiss</button>
+        )}
+      </div>
+      <pre className="cli-job-output" ref={tail}>{job.output || "Waiting for output…"}</pre>
     </div>
   );
 }
@@ -107,18 +137,36 @@ const ENGINE_ORDER: AgentKind[] = [...SELECTABLE_AGENT_KINDS];
 function EnginesTab() {
   const agentProbe = useApp((s) => s.agentProbe);
   const probeAgents = useApp((s) => s.probeAgents);
+  const refreshCliStatus = useApp((s) => s.refreshCliStatus);
+  const checkForNewModels = useApp((s) => s.checkForNewModels);
+  const modelCheck = useApp((s) => s.modelCheck);
   const run = useApp((s) => s.run);
-  // Mount rides the server's TTL cache; only "Re-check" forces past it.
-  useEffect(() => { void run(() => probeAgents(false)); }, [run, probeAgents]);
+  // Mount rides both server caches — the 30s probe and the six-hour version sweep. Only the buttons
+  // force past them, and only the buttons reach the network.
+  useEffect(() => { void run(() => probeAgents(false)); void run(() => refreshCliStatus(false)); }, [run, probeAgents, refreshCliStatus]);
   const kinds: AgentKind[] = [...ENGINE_ORDER, ...agentProbe.map((p) => p.kind).filter((k) => !ENGINE_ORDER.includes(k))];
   return (
     <div className="form">
       <div className="engines-head">
         <p className="page-lede">The agent CLIs Realm can run, as they look on this machine right now.</p>
-        {/* The named mutant: a cached probe shown as fresh. Forced, so what renders after the click
-            is what a child process just reported — never the TTL cache the mount ride uses. */}
-        <button type="button" className="btn" onClick={() => run(() => probeAgents(true))}>Re-check</button>
+        {/* The named mutant: a cached answer shown as fresh. Both are forced, so what renders after
+            a click is what a child process and a registry just reported — never the caches the mount
+            ride uses. The probe is forced alongside the status because the two answer different
+            halves of a row: the status knows versions, only the probe knows sign-in. */}
+        <button type="button" className="btn" onClick={() => run(async () => {
+          await Promise.all([probeAgents(true), refreshCliStatus(true)]);
+        })}>Check for updates</button>
+        {/* Nothing here is a new list Realm made up: it re-asks each provider for the catalog it
+            reports live, and refetches the public price rows. */}
+        <button type="button" className="btn" onClick={() => run(() => checkForNewModels())}>Check for new models</button>
       </div>
+      {modelCheck && (
+        <p className="settings-hint" role="status">
+          {modelCheck.added.length === 0
+            ? "No new models — every provider is reporting the same catalog as before."
+            : `New models: ${modelCheck.added.map((m) => `${AGENT_META[m.kind].label} ${m.label}`).join(", ")}.`}
+        </p>
+      )}
       {agentProbe.length === 0
         ? <p className="env-empty">Checking the installed CLIs…</p>
         : <ul className="page-list engines-list">{kinds.map((k) => <EngineRow key={k} kind={k} />)}</ul>}
@@ -128,16 +176,29 @@ function EnginesTab() {
 
 function EngineRow({ kind }: { kind: AgentKind }) {
   const agentProbe = useApp((s) => s.agentProbe);
+  const cli = useApp((s) => s.cliStatus).find((r) => r.kind === kind);
+  const job = useApp((s) => s.cliJobs[kind]);
+  const runCliAction = useApp((s) => s.runCliAction);
+  const dismissCliJob = useApp((s) => s.dismissCliJob);
+  const run = useApp((s) => s.run);
   const p = agentProbe.find((x) => x.kind === kind);
   const meta = AGENT_META[kind];
   const a = agentAvailability(kind, agentProbe);
   const { install, login } = AGENT_CLI_COMMANDS[kind];
+  // The one command a click would run, and the label for the click. The server decided both; the
+  // row only renders them, so a button can never offer something the server would refuse.
+  const offer = cli && cli.action !== "none" && cli.command
+    ? { command: cli.command, action: cli.action, label: cli.action === "install" ? "Install" : "Update" }
+    : null;
   const offered = (SELECTABLE_AGENT_KINDS as readonly AgentKind[]).includes(kind);
   // Signed-in identity, exactly as far as the probe carries it: a boolean at best (Claude's keychain
   // and both ACP agents report null = "couldn't tell", which renders as nothing, not as either claim).
   const identity = p?.loggedIn === true ? "signed in" : p?.loggedIn === false ? "signed out" : null;
+  // An available update is part of the row's status line, not a separate badge: "what version am I
+  // on" and "is there a newer one" are one sentence.
+  const behind = cli?.updateAvailable && cli.latest ? `${engineVersionLabel(cli.latest)} available` : null;
   const status = !p ? "Checking…"
-    : p.available ? ["Installed", p.version ? engineVersionLabel(p.version) : null, identity].filter(Boolean).join(" · ")
+    : p.available ? ["Installed", p.version ? engineVersionLabel(p.version) : null, identity, behind].filter(Boolean).join(" · ")
     : "Not installed";
   return (
     <li className="engine-row" aria-label={`${meta.label}: ${status}`}>
@@ -150,8 +211,25 @@ function EngineRow({ kind }: { kind: AgentKind }) {
         {/* A kind Realm keeps registered but will not offer says so, and only that — the how-to-fix
             sentence below is shared with every other blocked row. */}
         {!offered && kind !== "fake" && <p className="settings-hint">Not offered for new sessions.</p>}
-        {a.state === "missing" && install && <CommandCopy command={install} />}
-        {a.state === "logged_out" && login && <CommandCopy command={login} />}
+        {offer
+          ? <CommandCopy command={offer.command} action={
+              <button type="button" className="btn primary engine-run" disabled={job?.state === "running"}
+                onClick={() => run(() => runCliAction(kind, offer.action as "install" | "update"))}>
+                {offer.label}
+              </button>
+            } />
+          // No offer: the command is still shown, because a user who must run it themselves needs to
+          // read it. This is the whole surface for a kind Realm will not install for them.
+          : <>
+              {a.state === "missing" && install && <CommandCopy command={install} />}
+              {a.state === "logged_out" && login && <CommandCopy command={login} />}
+            </>}
+        {/* Signing in is never Realm's to run — it is a browser flow or an API key, and a command
+            that would sit waiting on a prompt Realm has closed. */}
+        {offer && a.state === "logged_out" && login && <CommandCopy command={login} />}
+        {/* An update Realm found but will not apply says why, right where the button would be. */}
+        {cli?.refusal && <p className="settings-hint">{cli.refusal}</p>}
+        {job && <CliJobPanel job={job} onDismiss={() => dismissCliJob(kind)} />}
         {/* The login hint on ANY blocked row, not just un-offered ones. It used to hang off `!offered`,
             which was fine only while every kind with something awkward to explain was also withheld.
             Gemini broke that the moment it was offered again: `login` is null for it (there is no login

--- a/apps/desktop/src/renderer/src/panes/settings/engines-cli.test.tsx
+++ b/apps/desktop/src/renderer/src/panes/settings/engines-cli.test.tsx
@@ -13,7 +13,7 @@ const installedCodex: AgentProbe[] = [
 ];
 
 const status = (over: Partial<CliStatus> & { kind: AgentKind }): CliStatus => ({
-  installed: true, version: null, binPath: null, provenance: "npm", latest: null, channel: true,
+  installed: true, version: null, binPath: null, provenance: "npm", latest: null,
   updateAvailable: false, action: "none", command: null, refusal: null, ...over,
 });
 
@@ -81,7 +81,7 @@ describe("an engine row with an update available", () => {
 describe("an engine row Realm will not update", () => {
   const brewInstalled = status({
     kind: "codex", version: "codex-cli 0.146.0", provenance: "brew", latest: "0.153.4",
-    updateAvailable: true, action: "none", command: null,
+    binPath: "/opt/homebrew/bin/codex", updateAvailable: true, action: "none", command: null,
     refusal: "Installed with Homebrew, so Realm won’t update it with npm — that would leave a second copy on your PATH instead of upgrading this one.",
   });
 
@@ -89,7 +89,8 @@ describe("an engine row Realm will not update", () => {
     // The named mutant: hiding the update because it cannot be applied. Both halves are the user's.
     await mount({ cliStatus: [brewInstalled] });
     await waitFor(() => expect(codexRow()).toHaveAccessibleName(/v0\.153\.4 available/));
-    expect(within(codexRow()).getByText(/Homebrew/)).toBeInTheDocument();
+    // With the copy it means: "which one?" is the next question for anyone with two on their PATH.
+    expect(within(codexRow()).getByText(/Homebrew.*\/opt\/homebrew\/bin\/codex/)).toBeInTheDocument();
     expect(within(codexRow()).queryByRole("button", { name: "Update" })).toBeNull();
     expect(within(codexRow()).queryByRole("button", { name: "Install" })).toBeNull();
   });

--- a/apps/desktop/src/renderer/src/panes/settings/engines-cli.test.tsx
+++ b/apps/desktop/src/renderer/src/panes/settings/engines-cli.test.tsx
@@ -1,0 +1,143 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { PAGE_REF_IDS, type AgentKind, type CliStatus } from "@realm/contracts";
+import { SettingsPage } from "./SettingsPage";
+import { StoreContext, createAppStore } from "../../state/store";
+import { fakeApi, item, type FakeData } from "../../state/store.test-fakes";
+import type { AgentProbe } from "../../state/store";
+
+const pageItem = item("set-s1", "s1", { kind: "settings-page", title: "Settings", refId: PAGE_REF_IDS["settings-page"] });
+
+const installedCodex: AgentProbe[] = [
+  { kind: "codex", available: true, version: "0.146.0", loggedIn: true, reason: null },
+];
+
+const status = (over: Partial<CliStatus> & { kind: AgentKind }): CliStatus => ({
+  installed: true, version: null, binPath: null, provenance: "npm", latest: null, channel: true,
+  updateAvailable: false, action: "none", command: null, refusal: null, ...over,
+});
+
+/** codex, installed by npm, one release behind — the row that has something to offer. */
+const behind = status({
+  kind: "codex", version: "codex-cli 0.146.0", provenance: "npm", latest: "0.153.4",
+  updateAvailable: true, action: "update", command: "npm install -g @openai/codex@0.153.4",
+});
+
+async function mount(overrides: FakeData = {}) {
+  const api = fakeApi({ agentProbe: installedCodex, ...overrides });
+  const store = createAppStore(api);
+  await store.getState().boot();
+  const r = render(<StoreContext.Provider value={store}><SettingsPage item={pageItem} visible /></StoreContext.Provider>);
+  return { store, api, ...r };
+}
+
+afterEach(cleanup);
+
+const codexRow = () => screen.getByRole("listitem", { name: /^Codex:/ });
+
+describe("an engine row with an update available", () => {
+  it("says which version is available in the same sentence as the one installed", async () => {
+    await mount({ cliStatus: [behind] });
+    await waitFor(() => expect(codexRow()).toHaveAccessibleName(/v0\.146\.0 · signed in · v0\.153\.4 available/));
+  });
+
+  it("shows the exact command before the button that runs it", async () => {
+    await mount({ cliStatus: [behind] });
+    await waitFor(() => expect(within(codexRow()).getByText("npm install -g @openai/codex@0.153.4")).toBeInTheDocument());
+    expect(within(codexRow()).getByRole("button", { name: "Update" })).toBeInTheDocument();
+  });
+
+  it("runs that command only on the click, and streams what it says", async () => {
+    const { store, api } = await mount({ cliStatus: [behind] });
+    await waitFor(() => within(codexRow()).getByRole("button", { name: "Update" }));
+    expect(api.calls.some((c) => c.startsWith("runCli:"))).toBe(false);
+
+    fireEvent.click(within(codexRow()).getByRole("button", { name: "Update" }));
+    await waitFor(() => expect(api.calls).toContain("runCli:codex:update"));
+
+    const id = store.getState().cliJobs.codex!.id;
+    store.getState().applyCliOutput({ id, kind: "codex", chunk: "changed 1 package\n" });
+    await waitFor(() => expect(screen.getByText(/changed 1 package/)).toBeInTheDocument());
+    // Nothing may be dismissed while it is still writing to the machine.
+    expect(screen.queryByRole("button", { name: "Dismiss" })).toBeNull();
+
+    store.getState().applyCliDone({ id, kind: "codex", ok: true, code: 0, error: null });
+    await waitFor(() => expect(screen.getByRole("button", { name: "Dismiss" })).toBeInTheDocument());
+  });
+
+  it("keeps a failure's output on screen with the reason it failed", async () => {
+    const { store } = await mount({ cliStatus: [behind] });
+    await waitFor(() => within(codexRow()).getByRole("button", { name: "Update" }));
+    fireEvent.click(within(codexRow()).getByRole("button", { name: "Update" }));
+    await waitFor(() => expect(store.getState().cliJobs.codex).toBeDefined());
+    const id = store.getState().cliJobs.codex!.id;
+    store.getState().applyCliOutput({ id, kind: "codex", chunk: "npm error EACCES\n" });
+    store.getState().applyCliDone({ id, kind: "codex", ok: false, code: 1, error: "exited with code 1" });
+    await waitFor(() => expect(screen.getByText(/exited with code 1/)).toBeInTheDocument());
+    expect(screen.getByText(/EACCES/)).toBeInTheDocument();
+  });
+});
+
+describe("an engine row Realm will not update", () => {
+  const brewInstalled = status({
+    kind: "codex", version: "codex-cli 0.146.0", provenance: "brew", latest: "0.153.4",
+    updateAvailable: true, action: "none", command: null,
+    refusal: "Installed with Homebrew, so Realm won’t update it with npm — that would leave a second copy on your PATH instead of upgrading this one.",
+  });
+
+  it("still says a newer version exists, and says why it is not offering a button", async () => {
+    // The named mutant: hiding the update because it cannot be applied. Both halves are the user's.
+    await mount({ cliStatus: [brewInstalled] });
+    await waitFor(() => expect(codexRow()).toHaveAccessibleName(/v0\.153\.4 available/));
+    expect(within(codexRow()).getByText(/Homebrew/)).toBeInTheDocument();
+    expect(within(codexRow()).queryByRole("button", { name: "Update" })).toBeNull();
+    expect(within(codexRow()).queryByRole("button", { name: "Install" })).toBeNull();
+  });
+});
+
+describe("an engine row with nothing to offer", () => {
+  it("shows a missing CLI's install command with a button that runs it", async () => {
+    await mount({
+      agentProbe: [{ kind: "codex", available: false, version: null, loggedIn: null, reason: "spawn codex ENOENT" }],
+      cliStatus: [status({ kind: "codex", installed: false, action: "install", command: "npm install -g @openai/codex" })],
+    });
+    await waitFor(() => expect(within(codexRow()).getByText("npm install -g @openai/codex")).toBeInTheDocument());
+    expect(within(codexRow()).getByRole("button", { name: "Install" })).toBeInTheDocument();
+  });
+
+  it("offers no button for a CLI Realm has no route for, and still explains it", async () => {
+    await mount({
+      agentProbe: [{ kind: "codex", available: true, version: "0.146.0", loggedIn: false, reason: "not logged in — run `codex login`" }],
+      cliStatus: [status({ kind: "codex", action: "none" })],
+    });
+    const row = await waitFor(() => codexRow());
+    // Signing in is a browser flow or an API key, so the command is shown to copy and never run.
+    expect(within(row).getByText("codex login")).toBeInTheDocument();
+    expect(within(row).queryByRole("button", { name: "Install" })).toBeNull();
+    expect(within(row).queryByRole("button", { name: "Update" })).toBeNull();
+  });
+});
+
+describe("checking for new models", () => {
+  const withModels = (ids: string[]): AgentProbe[] => [{
+    kind: "codex", available: true, version: "0.146.0", loggedIn: true, reason: null,
+    models: ids.map((id) => ({ id, label: id })),
+  }];
+
+  it("forces the live probe and the public catalog, and names what is new", async () => {
+    const { api } = await mount({ agentProbe: withModels(["gpt-5.6"]) });
+    await waitFor(() => expect(api.calls).toContain("probeAgents:false"));
+    api.data.agentProbe = withModels(["gpt-5.6", "gpt-6-astra"]);
+    fireEvent.click(screen.getByRole("button", { name: "Check for new models" }));
+    await waitFor(() => expect(api.calls).toContain("probeAgents:true"));
+    expect(api.calls).toContain("modelCatalog:true");
+    await waitFor(() => expect(screen.getByRole("status")).toHaveTextContent(/New models: Codex gpt-6-astra/));
+  });
+
+  it("says nothing-new as an answer rather than saying nothing", async () => {
+    const { api } = await mount({ agentProbe: withModels(["gpt-5.6"]) });
+    await waitFor(() => expect(api.calls).toContain("probeAgents:false"));
+    fireEvent.click(screen.getByRole("button", { name: "Check for new models" }));
+    await waitFor(() => expect(screen.getByRole("status")).toHaveTextContent(/No new models/));
+  });
+});

--- a/apps/desktop/src/renderer/src/panes/settings/settings-page.test.tsx
+++ b/apps/desktop/src/renderer/src/panes/settings/settings-page.test.tsx
@@ -69,12 +69,33 @@ describe("the Settings page (Plan 12 W6)", () => {
 });
 
 describe("Engines tab", () => {
-  it("mounting rides the probe cache; Re-check FORCES (the named mutant: a cached probe shown as fresh)", async () => {
+  it("mounting rides both caches; Check for updates FORCES both (the named mutant: a cached answer shown as fresh)", async () => {
+    // Two halves of one row: only the probe knows sign-in, only the status knows versions, so a
+    // click that forced one and not the other would leave half the row stale.
     const { api } = await mount();
     await waitFor(() => expect(api.calls).toContain("probeAgents:false"));
+    await waitFor(() => expect(api.calls).toContain("cliStatus:false"));
     expect(api.calls).not.toContain("probeAgents:true");
-    fireEvent.click(screen.getByRole("button", { name: "Re-check" }));
+    expect(api.calls).not.toContain("cliStatus:true");
+    fireEvent.click(screen.getByRole("button", { name: "Check for updates" }));
     await waitFor(() => expect(api.calls).toContain("probeAgents:true"));
+    await waitFor(() => expect(api.calls).toContain("cliStatus:true"));
+  });
+
+  it("mounting never runs an installer, however much the status is offering", async () => {
+    // The cadence rule, at the surface the user actually opens: opening Settings LOOKS.
+    const { api } = await mount({
+      cliStatus: [
+        { kind: "codex", installed: true, version: "0.48.0", binPath: "/opt/homebrew/bin/codex", provenance: "npm",
+          latest: "0.153.4", channel: true, updateAvailable: true, action: "update",
+          command: "npm install -g @openai/codex@0.153.4", refusal: null },
+      ],
+    });
+    await waitFor(() => expect(api.calls).toContain("cliStatus:false"));
+    expect(api.calls.some((c) => c.startsWith("runCli:"))).toBe(false);
+    // And the offer is on screen, command first.
+    expect(screen.getByText("npm install -g @openai/codex@0.153.4")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Update" })).toBeInTheDocument();
   });
 
   it("renders each CLI's honest state: installed + version, signed-out, missing — and login-unknowable renders as NOTHING, not a claim", async () => {

--- a/apps/desktop/src/renderer/src/panes/settings/settings-page.test.tsx
+++ b/apps/desktop/src/renderer/src/panes/settings/settings-page.test.tsx
@@ -87,7 +87,7 @@ describe("Engines tab", () => {
     const { api } = await mount({
       cliStatus: [
         { kind: "codex", installed: true, version: "0.48.0", binPath: "/opt/homebrew/bin/codex", provenance: "npm",
-          latest: "0.153.4", channel: true, updateAvailable: true, action: "update",
+          latest: "0.153.4", updateAvailable: true, action: "update",
           command: "npm install -g @openai/codex@0.153.4", refusal: null },
       ],
     });

--- a/apps/desktop/src/renderer/src/state/cli-manager.test.ts
+++ b/apps/desktop/src/renderer/src/state/cli-manager.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from "vitest";
+import type { AgentKind, CliStatus } from "@realm/contracts";
+import { createAppStore } from "./store";
+import { fakeApi, profile, space, type FakeApi } from "./store.test-fakes";
+
+const tick = () => new Promise((r) => setTimeout(r, 0));
+
+const status = (over: Partial<CliStatus> & { kind: AgentKind }): CliStatus => ({
+  installed: true, version: null, binPath: null, provenance: "npm", latest: null, channel: true,
+  updateAvailable: false, action: "none", command: null, refusal: null, ...over,
+});
+
+function booted(over: Parameters<typeof fakeApi>[0] = {}): Promise<{ a: FakeApi; store: ReturnType<typeof createAppStore> }> {
+  const a = fakeApi({ profiles: [profile("p1", "P")], spaces: [space("s1", "p1", "S")], ...over });
+  const store = createAppStore(a);
+  return store.getState().boot().then(() => ({ a, store }));
+}
+
+describe("cli status", () => {
+  it("checks on launch, unforced, without boot waiting for it", async () => {
+    // The whole cadence rule: launch LOOKS. It must ride the server's cache (unforced) and must not
+    // be awaited by boot, or a slow registry becomes a slow first paint.
+    const { a, store } = await booted({ cliStatus: [status({ kind: "codex" })] });
+    expect(store.getState().booted).toBe(true);
+    await tick();
+    expect(a.calls).toContain("cliStatus:false");
+    expect(a.calls).not.toContain("cliStatus:true");
+    expect(store.getState().cliStatus).toHaveLength(1);
+  });
+
+  it("launch never runs an install, whatever the rows say", async () => {
+    // The named mutant: a launch path that "helpfully" applies what it found. Every row here is
+    // offering something, and none of it may be taken up without a click.
+    const { a } = await booted({
+      cliStatus: [
+        status({ kind: "codex", action: "update", updateAvailable: true, latest: "9.9.9", command: "npm install -g @openai/codex@9.9.9" }),
+        status({ kind: "acp:goose", installed: false, action: "install", command: "brew install block-goose-cli" }),
+      ],
+    });
+    await tick();
+    expect(a.calls.some((c) => c.startsWith("runCli:"))).toBe(false);
+  });
+
+  it("forces past both caches when the user asks to check", async () => {
+    const { a, store } = await booted();
+    await store.getState().refreshCliStatus(true);
+    expect(a.calls).toContain("cliStatus:true");
+  });
+
+  it("collapses a mount storm, but a cheap call never satisfies a forced one", async () => {
+    const { a, store } = await booted();
+    await tick(); // let the launch check settle, so what follows is only this test's calls
+    a.delays["cliStatus"] = 10;
+    a.calls.length = 0;
+    await Promise.all([store.getState().refreshCliStatus(), store.getState().refreshCliStatus(), store.getState().refreshCliStatus(true)]);
+    expect(a.calls.filter((c) => c === "cliStatus:false")).toHaveLength(1);
+    expect(a.calls.filter((c) => c === "cliStatus:true")).toHaveLength(1);
+  });
+});
+
+describe("running an install", () => {
+  const offering = [status({ kind: "codex", installed: false, action: "install", command: "npm install -g @openai/codex" })];
+
+  it("holds the command the server says is running, not the one the button rendered", async () => {
+    const { store } = await booted({ cliStatus: offering });
+    await store.getState().runCliAction("codex", "install");
+    expect(store.getState().cliJobs.codex).toMatchObject({
+      command: "npm install -g @openai/codex", state: "running", output: "", error: null,
+    });
+  });
+
+  it("refuses an action the server is not offering", async () => {
+    const { store } = await booted({ cliStatus: [status({ kind: "codex", action: "none" })] });
+    await expect(store.getState().runCliAction("codex", "install")).rejects.toThrow(/not offering/);
+    expect(store.getState().cliJobs.codex).toBeUndefined();
+  });
+
+  it("rejoins output split at arbitrary byte boundaries", async () => {
+    const { store } = await booted({ cliStatus: offering });
+    await store.getState().runCliAction("codex", "install");
+    const id = store.getState().cliJobs.codex!.id;
+    store.getState().applyCliOutput({ id, kind: "codex", chunk: "added 1 pac" });
+    store.getState().applyCliOutput({ id, kind: "codex", chunk: "kage\n" });
+    expect(store.getState().cliJobs.codex!.output).toBe("added 1 package\n");
+  });
+
+  it("ignores output and outcomes from a job it did not start", async () => {
+    // These events are broadcast to every window, so a second Realm window's install arrives here too.
+    const { store } = await booted({ cliStatus: offering });
+    await store.getState().runCliAction("codex", "install");
+    store.getState().applyCliOutput({ id: "someone-else", kind: "codex", chunk: "not mine" });
+    store.getState().applyCliDone({ id: "someone-else", kind: "codex", ok: false, code: 1, error: "not mine" });
+    expect(store.getState().cliJobs.codex).toMatchObject({ output: "", state: "running" });
+  });
+
+  it("records how it ended, keeping the output that explains it", async () => {
+    const { store } = await booted({ cliStatus: offering });
+    await store.getState().runCliAction("codex", "install");
+    const id = store.getState().cliJobs.codex!.id;
+    store.getState().applyCliOutput({ id, kind: "codex", chunk: "npm error EACCES\n" });
+    store.getState().applyCliDone({ id, kind: "codex", ok: false, code: 1, error: "exited with code 1" });
+    expect(store.getState().cliJobs.codex).toMatchObject({ state: "failed", error: "exited with code 1" });
+    expect(store.getState().cliJobs.codex!.output).toContain("EACCES");
+  });
+
+  it("will not dismiss a job that is still running", async () => {
+    // Hiding a package manager's output while it is still writing to the machine is the one moment
+    // that output matters most.
+    const { store } = await booted({ cliStatus: offering });
+    await store.getState().runCliAction("codex", "install");
+    store.getState().dismissCliJob("codex");
+    expect(store.getState().cliJobs.codex).toBeDefined();
+    const id = store.getState().cliJobs.codex!.id;
+    store.getState().applyCliDone({ id, kind: "codex", ok: true, code: 0, error: null });
+    store.getState().dismissCliJob("codex");
+    expect(store.getState().cliJobs.codex).toBeUndefined();
+  });
+});
+
+describe("checking for new models", () => {
+  const withModels = (ids: string[]) => [{
+    kind: "codex" as AgentKind, available: true, version: "codex-cli 1.0.0", loggedIn: true, reason: null,
+    models: ids.map((id) => ({ id, label: id })),
+  }];
+
+  it("forces both existing seams — the live probe and the public catalog", async () => {
+    const { a, store } = await booted({ agentProbe: withModels(["gpt-5.6"]) });
+    a.calls.length = 0;
+    await store.getState().checkForNewModels();
+    expect(a.calls).toContain("probeAgents:true");
+    expect(a.calls).toContain("modelCatalog:true");
+  });
+
+  it("names the ids the provider started reporting", async () => {
+    const { a, store } = await booted({ agentProbe: withModels(["gpt-5.6"]) });
+    await store.getState().probeAgents();
+    a.data.agentProbe = withModels(["gpt-5.6", "gpt-6-astra"]);
+    await store.getState().checkForNewModels();
+    expect(store.getState().modelCheck!.added).toEqual([{ kind: "codex", id: "gpt-6-astra", label: "gpt-6-astra" }]);
+  });
+
+  it("reports nothing new as nothing new, not as no answer", async () => {
+    const { store } = await booted({ agentProbe: withModels(["gpt-5.6"]) });
+    await store.getState().probeAgents();
+    await store.getState().checkForNewModels();
+    expect(store.getState().modelCheck).toMatchObject({ added: [] });
+  });
+
+  it("does not call a first-ever enumeration 'new'", async () => {
+    // The named mutant: treating an absent previous list as an empty one, which would announce a
+    // provider's entire catalog as newly published the first time Realm managed to ask.
+    const a = fakeApi({ profiles: [profile("p1", "P")], spaces: [space("s1", "p1", "S")], agentProbe: withModels(["a", "b", "c"]) });
+    const store = createAppStore(a);
+    await store.getState().boot();
+    // agentProbe has never been read, so there is no previous answer to diff against.
+    expect(store.getState().agentProbe).toEqual([]);
+    await store.getState().checkForNewModels();
+    expect(store.getState().modelCheck!.added).toEqual([]);
+  });
+
+  it("ignores a kind that cannot enumerate rather than reading it as empty", async () => {
+    const { a, store } = await booted({ agentProbe: withModels(["gpt-5.6"]) });
+    await store.getState().probeAgents();
+    a.data.agentProbe = [{ kind: "codex", available: true, version: "codex-cli 1.0.0", loggedIn: true, reason: null, models: null }];
+    await store.getState().checkForNewModels();
+    expect(store.getState().modelCheck!.added).toEqual([]);
+  });
+});

--- a/apps/desktop/src/renderer/src/state/cli-manager.test.ts
+++ b/apps/desktop/src/renderer/src/state/cli-manager.test.ts
@@ -6,7 +6,7 @@ import { fakeApi, profile, space, type FakeApi } from "./store.test-fakes";
 const tick = () => new Promise((r) => setTimeout(r, 0));
 
 const status = (over: Partial<CliStatus> & { kind: AgentKind }): CliStatus => ({
-  installed: true, version: null, binPath: null, provenance: "npm", latest: null, channel: true,
+  installed: true, version: null, binPath: null, provenance: "npm", latest: null,
   updateAvailable: false, action: "none", command: null, refusal: null, ...over,
 });
 

--- a/apps/desktop/src/renderer/src/state/live-api.ts
+++ b/apps/desktop/src/renderer/src/state/live-api.ts
@@ -88,6 +88,8 @@ export const liveApi = (): Api => ({
   writeTerminal: async (terminalId, data) => { await rpc().call("terminals.write", { terminalId, data }); },
   prefillTerminal: async (terminalId, command) => { await rpc().call("terminals.prefill", { terminalId, command }); },
   probeAgents: (force) => rpc().call("agents.probe", { force }),
+  cliStatus: async (force) => (await rpc().call("cli.status", { force })).rows,
+  runCli: (kind, action) => rpc().call("cli.run", { kind, action }),
   modelCatalog: async (force) => (await rpc().call("models.catalog", { force })).rows,
   usageSummary: (p) => rpc().call("usage.summary", p),
   setUsageBudget: (budget) => rpc().call("usage.setBudget", budget),

--- a/apps/desktop/src/renderer/src/state/store.test-fakes.ts
+++ b/apps/desktop/src/renderer/src/state/store.test-fakes.ts
@@ -2,7 +2,7 @@
 import { activeLayout, setActiveLayout, MCP_SECRET_STORAGE_NOTE, MEMORY_DOC_MAX, type ElementChip } from "@realm/contracts";
 import type { GuideProgress, Lecture, PlynnMeeting, AgentsFileState, Attachment, BrowserCredential, Checkpoint, DiffSummary, Environment, FileDiff, GitInfo, IconAsset, ImportApplyParams, ImportResult, ImportScan, Item, McpCall, McpServer, McpTool, MemorySources, MemoryState, Notification, Profile, Project, RestorePreview, ReviewResult, DelegatedRun, Session, Ship, ShipResult, Skill, Space, StoredSessionEvent, WorktreeStatus, SkillSource, DocumentWorkspace, Run, RunAttempt } from "@realm/contracts";
 import type { AddMcpServerInput, AgentProbe, Api, CredentialStatus, McpTestResult, PickedAttachment, UpdateMcpServerInput } from "./store";
-import type { ModelInfo, SearchResults, UsageBudget, UsageSummary, UsageTotals } from "@realm/contracts";
+import type { CliStatus, ModelInfo, SearchResults, UsageBudget, UsageSummary, UsageTotals } from "@realm/contracts";
 
 /** Zeroed usage totals — the shape every row of a `UsageSummary` carries. */
 export const usageTotals = (extra: Partial<UsageTotals> = {}): UsageTotals =>
@@ -170,6 +170,9 @@ export type FakeData = {
   /** What `agents.probe` answers. Mutate `api.data.agentProbe` between calls to simulate the user
    *  installing (or logging into) a CLI while the install card is up. */
   agentProbe?: AgentProbe[];
+  /** What `cli.status` answers. Empty by default: a test that is not about the CLI manager should
+   *  see no install or update offers at all. */
+  cliStatus?: CliStatus[];
   modelCatalog?: ModelInfo[];
   /** What the main-process TCC probe answers (W6's Permissions tab). Defaults to the two honest
    *  can't-check rows plus three probed ones, mirroring main/tcc.ts's shape. */
@@ -304,6 +307,7 @@ export function fakeApi(overrides: FakeData = {}): FakeApi {
     memorySources: overrides.memorySources ?? {},
     pickFiles: overrides.pickFiles ?? [],
     agentProbe: overrides.agentProbe ?? [{ kind: "fake", available: true, version: "fake", loggedIn: true, reason: null }],
+    cliStatus: overrides.cliStatus ?? [],
     // The model catalog the picker's detail pane reads. Empty by default because that is the state
     // every test but a catalog test wants: prices are additive, and a fixture that invented them
     // would put numbers into snapshots that have nothing to do with what is being tested.
@@ -855,6 +859,19 @@ export function fakeApi(overrides: FakeData = {}): FakeApi {
       calls.push(`probeAgents:${force}`);
       await wait("probeAgents");
       return data.agentProbe;
+    },
+    cliStatus: async (force) => {
+      calls.push(`cliStatus:${force}`);
+      await wait("cliStatus");
+      return data.cliStatus;
+    },
+    // No child process anywhere near a test: the fake answers the job the real route would have
+    // started, and the test drives its output through applyCliOutput/applyCliDone by hand.
+    runCli: async (kind, action) => {
+      calls.push(`runCli:${kind}:${action}`);
+      const row = data.cliStatus.find((r) => r.kind === kind);
+      if (!row || row.action !== action) throw new Error(`Realm is not offering to ${action} ${kind} right now`);
+      return { id: `job-${kind}`, kind, action, command: row.command ?? "" };
     },
     modelCatalog: async (force) => {
       calls.push(`modelCatalog:${force}`);

--- a/apps/desktop/src/renderer/src/state/store.ts
+++ b/apps/desktop/src/renderer/src/state/store.ts
@@ -1071,7 +1071,6 @@ export type AppState = {
   /** Refresh `cliStatus`. Unforced rides the server's caches; `force` is "Check for updates" and the
    *  refresh after an install finishes. */
   refreshCliStatus(force?: boolean): Promise<void>;
-  /** Start the install or update the server is offering for this kind. */
   runCliAction(kind: AgentKind, action: "install" | "update"): Promise<void>;
   applyCliOutput(e: CliJobOutput): void;
   applyCliDone(e: CliJobEnd): void;
@@ -3319,10 +3318,9 @@ export function createAppStore(api: Api): StoreApi<AppState> {
         await catalogPending[slot];
       },
       async checkForNewModels() {
-        // Both halves are existing `force` seams: the probe re-asks each provider for its LIVE
-        // catalog (Codex over model/list, the ACP agents through session/new), and the model catalog
-        // refetches the public price/context rows. Nothing new is invented here — the diff below only
-        // reports what the providers themselves started saying.
+        // The probe re-asks each provider for its LIVE catalog (Codex over model/list, the ACP
+        // agents through session/new). Nothing new is invented here — the diff below only reports
+        // what the providers themselves started saying.
         const before = modelIdsByKind(get().agentProbe);
         await Promise.all([get().probeAgents(true), get().refreshModelCatalog(true)]);
         const added: { kind: AgentKind; id: string; label: string }[] = [];

--- a/apps/desktop/src/renderer/src/state/store.ts
+++ b/apps/desktop/src/renderer/src/state/store.ts
@@ -7,7 +7,7 @@ import {
   AGENT_SKILL_SUPPORT, AGENT_SUPPORTS_PERMISSION_MODES, basenameOf, elementChipLabel, elementChipToken, formatAttachmentSize, keepLiveChips, MAX_ELEMENT_CHIPS, MAX_ATTACHMENT_BYTES, mentionIds, mimeForPath, PAGE_REF_IDS,
   DEFAULT_PERMISSION_MODE_KEY, NOTIFICATIONS_DESKTOP_KEY, NOTIFICATIONS_DISABLED_KEY, NOTIFICATION_CATEGORIES, PERMISSION_MODES, MODEL_FAVORITES_KEY, parseSpaceIcon, type ModelInfo,
   type DestinationPageKind, type NotificationCategory, type NavEntry, type PaneHistory, type DocumentEntry, type DocumentKind, type DocumentWorkspace,
-  type AgentKind, type Attachment, type BrowserCredential, type BrowserPickedElement, type DelegatedRun, type ElementChip, type BrowserCredentialInput, type Checkpoint, type DiffSummary, type Environment, type FileDiff, type GitInfo, type IconAsset, type ImportApplyParams, type ImportResult, type ImportScan, type Item, type GuideProgress, type Lecture, type PlynnImportResult, type PlynnMeeting, type StartLectureResult, type Layout, type McpCall, type McpOauthStatus, type McpServer, type McpServerStatus, type McpTransport, type MemorySources, type MemoryState, type MethodResult, type Notification, type PaneGroup, type PresetName, type Profile, type Project, type RestorePreview, type RestoreResult, type ReviewResult, type SearchResults, type Session, type SessionMode, type SessionStatus, type Ship, type ShipResult, type Skill, type Space, type SpaceGroups, type StoredSessionEvent, type WorktreeAck, type WorktreeStatus, type SkillSource, type Run, type RunAttempt, type RunState, type UsageBudget, type UsageBucketKind, type UsageSummary,
+  type AgentKind, type Attachment, type CliJobEnd, type CliJobOutput, type CliJobStart, type CliStatus, type BrowserCredential, type BrowserPickedElement, type DelegatedRun, type ElementChip, type BrowserCredentialInput, type Checkpoint, type DiffSummary, type Environment, type FileDiff, type GitInfo, type IconAsset, type ImportApplyParams, type ImportResult, type ImportScan, type Item, type GuideProgress, type Lecture, type PlynnImportResult, type PlynnMeeting, type StartLectureResult, type Layout, type McpCall, type McpOauthStatus, type McpServer, type McpServerStatus, type McpTransport, type MemorySources, type MemoryState, type MethodResult, type Notification, type PaneGroup, type PresetName, type Profile, type Project, type RestorePreview, type RestoreResult, type ReviewResult, type SearchResults, type Session, type SessionMode, type SessionStatus, type Ship, type ShipResult, type Skill, type Space, type SpaceGroups, type StoredSessionEvent, type WorktreeAck, type WorktreeStatus, type SkillSource, type Run, type RunAttempt, type RunState, type UsageBudget, type UsageBucketKind, type UsageSummary,
 } from "@realm/contracts";
 import { createContext, useCallback, useContext, useMemo, useSyncExternalStore } from "react";
 import { SHEET_MIN_WIDTH, complementOf, snapBrowserLeaves } from "./no-overlay";
@@ -64,6 +64,31 @@ export type AgentProbe = MethodResult<"agents.probe">[number];
 export type McpTestResult = { reached: boolean; detail: string };
 /** A `session.event` broadcast: persisted rows carry their seq; ephemeral ones (deltas) have seq -1. */
 export type LiveSessionEvent = StoredSessionEvent & { ephemeral: boolean };
+
+/** Each kind's currently-known model ids, for kinds that could enumerate at all. A kind absent from
+ *  the map is one whose catalog is unknown, which is not the same as one whose catalog is empty. */
+function modelIdsByKind(probe: AgentProbe[]): Map<AgentKind, Set<string>> {
+  const out = new Map<AgentKind, Set<string>>();
+  for (const p of probe) if (p.models) out.set(p.kind, new Set(p.models.map((m) => m.id)));
+  return out;
+}
+
+/**
+ * One install or update as the renderer follows it: the exact command that is running, everything it
+ * has said so far, and how it ended.
+ *
+ * `output` is one growing string rather than a list of chunks because that is what it is — a package
+ * manager's narration arrives split at arbitrary byte boundaries, and rejoining it is the only way
+ * a half-written line reads as a line.
+ */
+export type CliJob = {
+  id: string;
+  kind: AgentKind;
+  command: string;
+  output: string;
+  state: "running" | "ok" | "failed";
+  error: string | null;
+};
 export type TranscriptEntry = { lastSeq: number; t: Transcript };
 
 /** Everything the store needs from the outside world: realm-server RPC plus the two platform
@@ -210,6 +235,12 @@ export type Api = {
   prefillTerminal(terminalId: string, command: string): Promise<void>;
   /** `force` bypasses the server's probe cache (the install card's retry / focus refresh). */
   probeAgents(force: boolean): Promise<AgentProbe[]>;
+  /** `cli.status` — install/update situation per agent CLI. `force` bypasses the server's probe
+   *  cache AND its six-hour version sweep; that is the "Check for updates" gesture. */
+  cliStatus(force: boolean): Promise<CliStatus[]>;
+  /** `cli.run` — start the install or update the status offered. Rejects when the server is not
+   *  offering that action, which is the only place that decision is ever made. */
+  runCli(kind: AgentKind, action: "install" | "update"): Promise<CliJobStart>;
   /** `models.catalog` — prices, context windows and reasoning efforts for the picker. Never rejects
    *  on a dead network: the server answers with its cache, or with nothing. */
   modelCatalog(force: boolean): Promise<ModelInfo[]>;
@@ -621,6 +652,15 @@ export type AppState = {
    *  a toast that only worked after a visit to Settings would be a toast that does not work. */
   desktopNotifications: boolean;
   agentProbe: AgentProbe[];
+  /** Per-agent install/update situation. Empty until something asks; the engines list and the
+   *  install card both read it, and neither may block on it. */
+  cliStatus: CliStatus[];
+  /** What the last "Check for new models" turned up. Null until one has run; an empty `added` is a
+   *  real answer ("nothing new"), which is why this is not just an array. */
+  modelCheck: { at: number; added: { kind: AgentKind; id: string; label: string }[] } | null;
+  /** The install or update running (or just finished) for each kind, keyed by kind rather than by job
+   *  id because that is how every reader asks: "is this row busy, and what did it say". */
+  cliJobs: Record<string, CliJob>;
   /** The Settings page's App-tab preferences (Plan 12 W6), read from the server's settings rows:
    *  which notification categories are switched OFF (`NOTIFICATIONS_DISABLED_KEY` — default-on
    *  polarity, matching the service), and the permission mode new sessions start in
@@ -1028,6 +1068,16 @@ export type AppState = {
   /** Refresh `agentProbe`. Unforced calls (prompter mount, onboarding) ride the server's TTL cache and
    *  are deduped here too; `force` is the install card's "Check again" and its window-focus refresh. */
   probeAgents(force?: boolean): Promise<void>;
+  /** Refresh `cliStatus`. Unforced rides the server's caches; `force` is "Check for updates" and the
+   *  refresh after an install finishes. */
+  refreshCliStatus(force?: boolean): Promise<void>;
+  /** Start the install or update the server is offering for this kind. */
+  runCliAction(kind: AgentKind, action: "install" | "update"): Promise<void>;
+  applyCliOutput(e: CliJobOutput): void;
+  applyCliDone(e: CliJobEnd): void;
+  /** Drop a finished job's output panel. A running job cannot be dismissed — hiding output while a
+   *  package manager is still writing to the machine is the one moment it matters most. */
+  dismissCliJob(kind: AgentKind): void;
   /** The Usage tab's read. Returns rather than stores, for the same reason `importScan` does: it is
    *  a range's worth of rows that only one panel ever looks at, and parking it globally would keep
    *  it alive for every pane that never opens Settings. */
@@ -1208,7 +1258,10 @@ export type AppState = {
   refreshModelFavorites(): Promise<void>;
   /** Read the model catalog into `modelInfo`. Cheap and idempotent: the server holds a day-long
    *  cache, so every session pane calling this on mount costs one round trip. */
-  refreshModelCatalog(): Promise<void>;
+  refreshModelCatalog(force?: boolean): Promise<void>;
+  /** Ask every provider for its model list again and refetch the public catalog, then record which
+   *  ids are new since the last answer. Both halves force past a cache that is otherwise correct. */
+  checkForNewModels(): Promise<void>;
   /** Star or un-star ONE model by canonical key, persisting the whole list. Recomputed from the held
    *  list so a double-click can't write a duplicate, and so only THIS key ever moves. */
   toggleModelFavorite(key: string): Promise<void>;
@@ -1617,9 +1670,10 @@ export function createAppStore(api: Api): StoreApi<AppState> {
     /** In-flight `agents.probe` calls, kept apart by force: a forced probe must never be satisfied by a
      *  cheap one already in flight (that one may predate the install the user just ran). */
     const probing: { plain: Promise<void> | null; forced: Promise<void> | null } = { plain: null, forced: null };
+  const cliChecking: { plain: Promise<void> | null; forced: Promise<void> | null } = { plain: null, forced: null };
     // The catalog's in-flight read, collapsed the same way the probe's is — one round trip per tick
     // however many panes mounted at once.
-    let catalogPending: Promise<void> | null = null;
+    const catalogPending: { plain: Promise<void> | null; forced: Promise<void> | null } = { plain: null, forced: null };
     /** Flush a pending debounced persist before the active space changes (persist reads the current space). */
     const flushPersist = async () => {
       if (panelTimer) await persistPanels();
@@ -1839,7 +1893,7 @@ export function createAppStore(api: Api): StoreApi<AppState> {
       connectionState: "connected",
       paletteOpen: false, spacesOpen: false, lastSpaceByProfile: {}, sheet: null, browserRects: [], sheetSnap: null, browserActions: {}, browserDriving: {},
       spacePageTab: {}, profilePageTab: {}, mcpPanelSpaceId: null,
-      sessions: {}, sessionStatus: {}, sessionSpace: {}, transcripts: {}, agentProbe: [], settingsPrefs: null, tccRows: null, credentials: null, credentialStatus: null, macAccess: null, macGranting: null, macGrantQueue: [], computerAccess: null, computerRequesting: null, updateStatus: null, drafts: {}, pendingAttachments: {}, draftMentions: {}, draftElements: {}, spaceSkills: {}, skillsRoot: "", spaceMemory: {}, sessionMemorySources: {}, planReturn: {}, gitInfo: {}, iconAssets: {}, modelFavorites: [], modelInfo: {}, spaceSkillSources: {},
+      sessions: {}, sessionStatus: {}, sessionSpace: {}, transcripts: {}, agentProbe: [], cliStatus: [], cliJobs: {}, modelCheck: null, settingsPrefs: null, tccRows: null, credentials: null, credentialStatus: null, macAccess: null, macGranting: null, macGrantQueue: [], computerAccess: null, computerRequesting: null, updateStatus: null, drafts: {}, pendingAttachments: {}, draftMentions: {}, draftElements: {}, spaceSkills: {}, skillsRoot: "", spaceMemory: {}, sessionMemorySources: {}, planReturn: {}, gitInfo: {}, iconAssets: {}, modelFavorites: [], modelInfo: {}, spaceSkillSources: {},
       diffs: {}, diffLoading: {}, patches: {}, commitMessages: {}, shipResults: {}, shipping: {}, reviews: {}, reviewing: {},
       worktreeStatuses: {}, worktreeAckStale: null,
       checkpoints: {}, ships: {}, runs: {}, selectedRunId: {}, runAttempts: {}, delegatedRuns: {}, checkpointPreview: null, checkpointAckStale: false, restoreResult: null,
@@ -1891,6 +1945,11 @@ export function createAppStore(api: Api): StoreApi<AppState> {
         if (feed) applyUnread(feed.unread);
         // Last, so `booted && spaces.length === 0` is only ever true for a genuinely empty home.
         set({ booted: true });
+        // The launch check: what agent CLIs are here, and has anything published a newer version.
+        // AFTER booted and never awaited, so it cannot delay the first paint or make a session wait
+        // on a network call — and unforced, so it rides the server's six-hour cache rather than
+        // asking a registry on every launch. It only ever LOOKS; applying an update stays a click.
+        void get().refreshCliStatus().catch(() => {});
       },
       async selectSpace(id) {
         await flushPersist();
@@ -2764,6 +2823,42 @@ export function createAppStore(api: Api): StoreApi<AppState> {
         probing[force ? "forced" : "plain"] = p;
         await p;
       },
+      async refreshCliStatus(force = false) {
+        // Same mount-storm collapse as probeAgents, keyed by force for the same reason: an unforced
+        // call already in flight may have read the machine before an install finished, which is
+        // exactly what the forced one is asking to escape.
+        const pending = cliChecking[force ? "forced" : "plain"];
+        if (pending) { await pending; return; }
+        const p = api.cliStatus(force)
+          .then((cliStatus) => { set({ cliStatus }); })
+          .finally(() => { cliChecking[force ? "forced" : "plain"] = null; });
+        cliChecking[force ? "forced" : "plain"] = p;
+        await p;
+      },
+      async runCliAction(kind, action) {
+        const started = await api.runCli(kind, action);
+        // The command comes back from the server rather than being remembered from the status that
+        // rendered the button: what is shown running is what the server says is running.
+        set({ cliJobs: { ...get().cliJobs, [kind]: { ...started, output: "", state: "running", error: null } } });
+      },
+      applyCliOutput({ id, kind, chunk }) {
+        const job = get().cliJobs[kind];
+        // A chunk from a job this client did not start (another window's install, broadcast to
+        // everyone) has nowhere to go — the panel showing it is the one that has the job.
+        if (!job || job.id !== id) return;
+        set({ cliJobs: { ...get().cliJobs, [kind]: { ...job, output: job.output + chunk } } });
+      },
+      applyCliDone({ id, kind, ok, error }) {
+        const job = get().cliJobs[kind];
+        if (!job || job.id !== id) return;
+        set({ cliJobs: { ...get().cliJobs, [kind]: { ...job, state: ok ? "ok" : "failed", error } } });
+      },
+      dismissCliJob(kind) {
+        const job = get().cliJobs[kind];
+        if (!job || job.state === "running") return;
+        const { [kind]: _gone, ...rest } = get().cliJobs;
+        set({ cliJobs: rest });
+      },
       async setDefaultAgent(kind) {
         set({ lastAgentKind: kind });
         await api.setSetting(SETTING_LAST_AGENT, kind);
@@ -3207,17 +3302,38 @@ export function createAppStore(api: Api): StoreApi<AppState> {
         const raw = await api.getSetting(MODEL_FAVORITES_KEY);
         set({ modelFavorites: (Array.isArray(raw) ? raw : []).filter((k): k is string => typeof k === "string") });
       },
-      async refreshModelCatalog() {
+      async refreshModelCatalog(force = false) {
         // Same mount-storm shape as probeAgents, for the same reason: a four-pane split asks four
         // times in one tick. Failures are swallowed — a picker with no prices is the fallback the
         // whole catalog path is designed around, so there is nothing to report to the user here.
-        if (!catalogPending) {
-          catalogPending = api.modelCatalog(false)
+        //
+        // Keyed by force like probeAgents: a mount-time call already in flight was answered from the
+        // day-long cache, which is exactly what "Check for new models" is asking to get past.
+        const slot = force ? "forced" : "plain";
+        if (!catalogPending[slot]) {
+          catalogPending[slot] = api.modelCatalog(force)
             .then((rows) => { set({ modelInfo: Object.fromEntries(rows.map((r) => [r.key, r])) }); })
             .catch(() => {})
-            .finally(() => { catalogPending = null; });
+            .finally(() => { catalogPending[slot] = null; });
         }
-        await catalogPending;
+        await catalogPending[slot];
+      },
+      async checkForNewModels() {
+        // Both halves are existing `force` seams: the probe re-asks each provider for its LIVE
+        // catalog (Codex over model/list, the ACP agents through session/new), and the model catalog
+        // refetches the public price/context rows. Nothing new is invented here — the diff below only
+        // reports what the providers themselves started saying.
+        const before = modelIdsByKind(get().agentProbe);
+        await Promise.all([get().probeAgents(true), get().refreshModelCatalog(true)]);
+        const added: { kind: AgentKind; id: string; label: string }[] = [];
+        for (const p of get().agentProbe) {
+          const seen = before.get(p.kind);
+          // A kind that could not enumerate before (or cannot now) is skipped rather than counted:
+          // "we could not ask" would otherwise read as "everything here is new".
+          if (!seen || !p.models) continue;
+          for (const m of p.models) if (!seen.has(m.id)) added.push({ kind: p.kind, id: m.id, label: m.label });
+        }
+        set({ modelCheck: { at: Date.now(), added } });
       },
       async toggleModelFavorite(key) {
         const held = get().modelFavorites;

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -1938,7 +1938,7 @@ button.panel-title:hover { background: var(--rl-hover); }
   .diff-list, .diff-hunks, .diff-review-body, .commit-message,
   /* page panes */
   .cp-list, .activity-list, .task-detail-result, .notif-list, .notif-detail, .notif-split, .delegation-list,
-  .lecture-list, .install-cmd code, .code-preview,
+  .lecture-list, .install-cmd code, .code-preview, .cli-job-output,
   /* documents */
   .documents-tabs, .documents-picker, .documents-rich-surface, .documents-rich .tiptap, .documents-raw,
   /* the prompter — only the pinned strip's copy of the list is bounded enough to scroll */
@@ -2573,8 +2573,8 @@ button.panel-title:hover { background: var(--rl-hover); }
    Permissions tab's state chip only ever wears green on a probe basis (main/tcc.ts's rule). ——— */
 .engines-head { display: flex; align-items: center; gap: 12px; }
 .engines-head .page-lede { flex: 1; min-width: 0; }
-/* Narrow: Re-check drops below the lede rather than squeezing it into a six-word gutter. Placed
-   after the `flex: 1` above on purpose — a container query carries no extra specificity. */
+/* Narrow: the check buttons drop below the lede rather than squeezing it into a six-word gutter.
+   Placed after the `flex: 1` above on purpose — a container query carries no extra specificity. */
 @container (max-width: 640px) { .engines-head .page-lede { flex-basis: 100%; } }
 .engines-list { gap: 4px; }
 .engine-row { display: flex; gap: 10px; padding: 9px 10px; border-radius: var(--r-ctl); }
@@ -2585,6 +2585,18 @@ button.panel-title:hover { background: var(--rl-hover); }
 .engine-status { font-size: 12px; color: var(--rl-text-dim); }
 .engine-status[data-state="missing"] { color: var(--rl-warning); }
 .engine-status[data-state="unknown"] { color: var(--rl-text-faint); }
+/* The run button sits inside the command chip, so the command and the thing that runs it are one
+   object — reading it and clicking it are never two places on the page. */
+.engine-run { flex: none; }
+/* A running or finished install. Monospace, scrollable, capped: a package manager's output is read
+   at the tail, and an unbounded block would push every row below it off the page. */
+.cli-job { display: flex; flex-direction: column; gap: 6px; padding: 8px 10px; border-radius: var(--r-chip);
+  background: var(--rl-frame); border: 1px solid var(--rl-edge); }
+.cli-job-head { display: flex; align-items: center; gap: 8px; }
+.cli-job-state { flex: 1; min-width: 0; font-size: 12px; color: var(--rl-text-dim); }
+.cli-job[data-state="failed"] .cli-job-state { color: var(--rl-warning); }
+.cli-job-output { margin: 0; max-height: 180px; overflow: auto; font: 11px/1.5 var(--font-mono);
+  color: var(--rl-text-dim); white-space: pre-wrap; word-break: break-word; user-select: text; }
 .tcc-row { align-items: flex-start; }
 .tcc-row .btn-quiet { flex: none; margin-top: 1px; }
 .tcc-state { display: inline-flex; align-items: center; gap: 4px; padding: 1px 7px; border-radius: 999px;

--- a/apps/server/scripts/live-cli-check.ts
+++ b/apps/server/scripts/live-cli-check.ts
@@ -1,0 +1,92 @@
+/**
+ * Live check of the CLI manager against the REAL machine and the REAL registries.
+ *
+ *   pnpm --filter @realm/server exec tsx scripts/live-cli-check.ts
+ *
+ * **This script installs nothing and updates nothing.** It only runs `--version`, resolves symlinks,
+ * and issues public GETs — which is the point: the checking half of this feature is supposed to be
+ * safe to run unattended, so a live check of it must be safe to run too. The one thing it does not
+ * cover is `CliInstaller.start`, because covering that would mean running a package manager.
+ *
+ * What the unit fixtures cannot prove, and this does:
+ *
+ *   1. The registry shapes are still the shapes the parsers expect — a live `version` off npm and a
+ *      live `versions.stable` off formulae.brew.sh, both parsed to a version this actually compares.
+ *   2. Provenance on a real install tree: the classifier is fed real symlink chains from a real PATH,
+ *      not paths a test wrote. Any kind reported as `unknown` is printed with its resolved path, so a
+ *      layout Realm should recognise but does not shows up as a line to read rather than as silence.
+ *   3. Every command Realm would run is printed in full, so the "show the exact command" promise is
+ *      auditable by eye before any of it is ever wired to a button on a real machine.
+ *
+ * Exits non-zero if a check fails. Needs a network; agent CLIs are optional (an absent one is
+ * reported as absent, which is a valid answer).
+ */
+import { AGENT_INSTALL_ROUTES, AgentKindSchema, installCommand, isNewerVersion, parseBrewFormula, parseNpmLatest, parseVersion, updateChannel } from "@realm/contracts";
+import { CliService } from "../src/cli/service";
+import { agentBin } from "../src/cli/bins";
+import { resolveInstall } from "../src/cli/provenance";
+import { defaultAdapters } from "../src/app";
+import { finish, ok } from "./harness";
+
+async function main() {
+  console.log("== registry shapes, live ==");
+  // Two kinds with two different channels; both must parse to something `compareVersions` can order.
+  const npmChannel = updateChannel(AGENT_INSTALL_ROUTES.codex)!;
+  const brewChannel = updateChannel(AGENT_INSTALL_ROUTES["acp:goose"])!;
+  for (const [label, channel] of [["npm", npmChannel], ["brew", brewChannel]] as const) {
+    const res = await fetch(channel.url, { signal: AbortSignal.timeout(15_000), headers: { accept: "application/json" } });
+    const body: unknown = await res.json();
+    const version = channel.kind === "npm" ? parseNpmLatest(body) : parseBrewFormula(body);
+    ok(`${label} ${channel.url} answers 200`, res.ok, `status ${res.status}`);
+    ok(`${label} parses to a version`, !!version && !!parseVersion(version), String(version));
+  }
+
+  console.log("\n== this machine, as the classifier sees it ==");
+  let anyInstalled = false;
+  for (const kind of AgentKindSchema.options) {
+    const bin = agentBin(kind);
+    if (!bin) continue;
+    const found = await resolveInstall(bin);
+    if (!found) { console.log(`  --    ${kind.padEnd(14)} not on PATH`); continue; }
+    anyInstalled = true;
+    console.log(`  --    ${kind.padEnd(14)} ${found.provenance.padEnd(8)} ${found.realPath}`);
+  }
+  ok("at least one agent CLI is installed, so provenance was exercised at all", anyInstalled);
+
+  console.log("\n== cli.status, end to end ==");
+  const adapters = defaultAdapters();
+  const probe = async () => (await Promise.all(Object.values(adapters).map((a) => a!.probe()))).flat();
+  const rows = await new CliService({ probe }).status();
+  ok("answers a row for every kind", rows.length === AgentKindSchema.options.length, `${rows.length} rows`);
+
+  for (const r of rows) {
+    const bits = [
+      r.installed ? `installed ${r.version ?? "?"}` : "not installed",
+      `via ${r.provenance}`,
+      r.latest ? `latest ${r.latest}` : r.channel ? "latest unknown" : "no channel",
+      `action ${r.action}`,
+    ];
+    console.log(`  --    ${r.kind.padEnd(14)} ${bits.join(" · ")}`);
+    if (r.command) console.log(`        would run: ${r.command}`);
+    if (r.refusal) console.log(`        refused:   ${r.refusal}`);
+  }
+
+  console.log("\n== the invariants that keep this safe ==");
+  // Nothing on this machine may be offered an update through a method that did not install it.
+  const wrongMethod = rows.filter((r) => r.action === "update" && r.provenance !== AGENT_INSTALL_ROUTES[r.kind]?.method);
+  ok("no update is offered through the wrong package manager", wrongMethod.length === 0, wrongMethod.map((r) => `${r.kind}=${r.provenance}`).join(", "));
+  // An `install` offer only ever appears for a CLI that is genuinely absent.
+  const wrongInstall = rows.filter((r) => r.action === "install" && r.installed);
+  ok("no install is offered for a CLI that is already here", wrongInstall.length === 0, wrongInstall.map((r) => r.kind).join(", "));
+  // Every offered command is one the route table can regenerate — never an invented string.
+  const invented = rows.filter((r) => r.action === "install" && r.command !== installCommand(AGENT_INSTALL_ROUTES[r.kind]));
+  ok("every install command is the route table's own", invented.length === 0, invented.map((r) => r.kind).join(", "));
+  // `updateAvailable` must agree with the comparison, not be set on its own.
+  const bogus = rows.filter((r) => r.updateAvailable !== isNewerVersion(r.version, r.latest));
+  ok("updateAvailable agrees with the version comparison", bogus.length === 0, bogus.map((r) => r.kind).join(", "));
+  ok("fake is never offered anything", rows.find((r) => r.kind === "fake")?.action === "none");
+
+  finish();
+}
+
+void main();

--- a/apps/server/scripts/live-cli-check.ts
+++ b/apps/server/scripts/live-cli-check.ts
@@ -63,10 +63,11 @@ async function main() {
     const bits = [
       r.installed ? `installed ${r.version ?? "?"}` : "not installed",
       `via ${r.provenance}`,
-      r.latest ? `latest ${r.latest}` : r.channel ? "latest unknown" : "no channel",
+      r.latest ? `latest ${r.latest}` : "latest unknown",
       `action ${r.action}`,
     ];
     console.log(`  --    ${r.kind.padEnd(14)} ${bits.join(" · ")}`);
+    if (r.binPath) console.log(`        at:        ${r.binPath}`);
     if (r.command) console.log(`        would run: ${r.command}`);
     if (r.refusal) console.log(`        refused:   ${r.refusal}`);
   }

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -1,3 +1,4 @@
+import { agentBin } from "./cli/bins";
 import { openDatabase, type Db } from "./db/database";
 import { dbPath } from "./paths";
 import { ProfilesStore } from "./store/profiles";
@@ -82,7 +83,7 @@ export function defaultAdapters(): AdapterRegistry {
     codex: new CodexAdapter(),
     "acp:cursor": new AcpAdapter({
       kind: "acp:cursor",
-      bin: process.env.REALM_CURSOR_BIN ?? "cursor-agent",
+      bin: agentBin("acp:cursor"),
       args: ["acp"],
       label: "Cursor",
       loginHint: "Run `cursor-agent login`.",
@@ -91,7 +92,7 @@ export function defaultAdapters(): AdapterRegistry {
     }),
     "acp:gemini": new AcpAdapter({
       kind: "acp:gemini",
-      bin: process.env.REALM_GEMINI_BIN ?? "gemini",
+      bin: agentBin("acp:gemini"),
       args: ["--acp"],
       label: "Gemini",
       // Measured 2026-09-01 (gemini-cli 0.56.0): `initialize` advertises oauth-personal, gemini-api-key,
@@ -107,35 +108,35 @@ export function defaultAdapters(): AdapterRegistry {
     // spawn would cost a real round trip to learn nothing.
     "acp:opencode": new AcpAdapter({
       kind: "acp:opencode",
-      bin: process.env.REALM_OPENCODE_BIN ?? "opencode",
+      bin: agentBin("acp:opencode"),
       args: ["acp"],
       label: "OpenCode",
       loginHint: "Run `opencode auth login`.",
     }),
     "acp:copilot": new AcpAdapter({
       kind: "acp:copilot",
-      bin: process.env.REALM_COPILOT_BIN ?? "copilot",
+      bin: agentBin("acp:copilot"),
       args: ["--acp"],
       label: "GitHub Copilot",
       loginHint: "Run `copilot login`.",
     }),
     "acp:goose": new AcpAdapter({
       kind: "acp:goose",
-      bin: process.env.REALM_GOOSE_BIN ?? "goose",
+      bin: agentBin("acp:goose"),
       args: ["acp"],
       label: "goose",
       loginHint: "Run `goose configure` to pick a provider and set its API key.",
     }),
     "acp:qwen": new AcpAdapter({
       kind: "acp:qwen",
-      bin: process.env.REALM_QWEN_BIN ?? "qwen",
+      bin: agentBin("acp:qwen"),
       args: ["--acp"],
       label: "Qwen Code",
       loginHint: "Run `qwen` once to sign in with your Qwen account, or set OPENAI_API_KEY.",
     }),
     "acp:grok": new AcpAdapter({
       kind: "acp:grok",
-      bin: process.env.REALM_GROK_BIN ?? "grok",
+      bin: agentBin("acp:grok"),
       args: ["agent", "stdio"],
       label: "Grok",
       loginHint: "Run `grok login` (browser sign-in, needs SuperGrok or X Premium), or set XAI_API_KEY.",
@@ -155,14 +156,14 @@ export function defaultAdapters(): AdapterRegistry {
     // learn nothing. `AGENT_MODELS["acp:deepseek"]` carries the two models instead.
     "acp:deepseek": new AcpAdapter({
       kind: "acp:deepseek",
-      bin: process.env.REALM_DEEPSEEK_BIN ?? "dsh-acp-demo",
+      bin: agentBin("acp:deepseek"),
       args: [],
       label: "DeepSeek",
       loginHint: "Set DEEPSEEK_API_KEY — the DeepSeek Harness has no login command of its own.",
     }),
     "acp:fx": new AcpAdapter({
       kind: "acp:fx",
-      bin: process.env.REALM_FX_BIN ?? "fx",
+      bin: agentBin("acp:fx"),
       args: ["acp"],
       label: "fx",
       // fx gates `initialize` ITSELF on being signed in (measured: -32600 with this exact text), so a

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -1,4 +1,6 @@
 import { agentBin } from "./cli/bins";
+import { CliService } from "./cli/service";
+import { CliInstaller } from "./cli/install";
 import { openDatabase, type Db } from "./db/database";
 import { dbPath } from "./paths";
 import { ProfilesStore } from "./store/profiles";
@@ -215,6 +217,10 @@ export async function createApp(opts: { home: string; port: number; adapters?: A
   /** Plan 20's interjection: only timeouts, because an ask spawns nothing and so has no kind to fall
    *  back to. The behaviour suite needs sub-second budgets to exercise the timeout path. */
   ask?: { timeouts?: { budgetMs: number; pollMs: number } };
+  /** CLI manager knobs, injected for the same reason `titleGenerator` is omitted: a suite must never
+   *  reach a package registry, and it must read a PATH the test built rather than the developer's own
+   *  machine. Production callers pass neither and get the process environment and real fetch. */
+  cli?: { fetchImpl?: typeof fetch; env?: NodeJS.ProcessEnv };
   /** Upgrades a session's heuristic first-line title to a short model-written summary in the
    *  background (`SessionService.upgradeTitle`). A real, billed LLM call per session — omitted here
    *  on purpose so tests and live-check scripts never make one; the real server process (`main.ts`)
@@ -473,6 +479,16 @@ export async function createApp(opts: { home: string; port: number; adapters?: A
   // Model prices and context windows for the picker (public catalog, cached in `settings`). Nothing
   // depends on it: every method returns rows, and an unreachable catalog returns the stale ones.
   const modelCatalog = new ModelCatalogService({ settings });
+
+  // The CLI manager reads the same probe every other caller does, so an install card and this service
+  // never disagree about whether an agent is there. The installer's afterRun is what makes a finished
+  // install visible: it bypasses both caches before the `cli.done` event goes out.
+  const cli = new CliService({ probe: (o) => sessions.probe(o), ...opts.cli });
+  const cliInstaller = new CliInstaller({
+    onOutput: (e) => rpc.broadcast("cli.output", e),
+    onDone: (e) => rpc.broadcast("cli.done", e),
+    afterRun: () => cli.refresh(),
+  });
   // Spend and activity for Settings → Usage, and the budget watcher behind it. Reads only; the one
   // thing it writes is the budget row, and the one thing it emits is a threshold notification.
   usage = new UsageService({ db, settings, catalog: modelCatalog, notifications });
@@ -495,7 +511,7 @@ export async function createApp(opts: { home: string; port: number; adapters?: A
   const [machine, user] = await Promise.all([machineName(), userFirstName()]);
   registerMethods({
     rpc, home: opts.home, version: SERVER_VERSION, machineName: machine, userName: user,
-    profiles, spaces, projects, environments, envService, items, settings, skills, mcp, hub: mcpHub, gateway: mcpGateway, oauth, calls: mcpCalls, memory, terminals, browsers, browserBridge, documents, sessions, gitInfo: new GitInfoService(), gitDiff: new GitDiffService(), gitWrite, ships, ports, checkpoints, notifications, runs, reviews, search, forks, imports, lectures, plynn, modelCatalog, usage, graphify, delegation: delegationEngine,
+    profiles, spaces, projects, environments, envService, items, settings, skills, mcp, hub: mcpHub, gateway: mcpGateway, oauth, calls: mcpCalls, memory, terminals, browsers, browserBridge, documents, sessions, gitInfo: new GitInfoService(), gitDiff: new GitDiffService(), gitWrite, ships, ports, checkpoints, notifications, runs, reviews, search, forks, imports, lectures, plynn, modelCatalog, usage, graphify, delegation: delegationEngine, cli, cliInstaller,
     iconAssets, iconGeneration,
   });
   sessions.markStaleOnBoot();
@@ -518,6 +534,9 @@ export async function createApp(opts: { home: string; port: number; adapters?: A
       search.stop(); // before db.close: the backfill loop must not start a chunk on a closing handle
       runs?.close(); // likewise: an in-flight dispatch must not write to a closing handle
       terminals.closeAll();
+      // A package manager outliving the app would keep writing to a global prefix with nobody
+      // watching, and nothing left to re-probe afterwards.
+      cliInstaller.disposeAll();
       await sessions.closeAll();
       // Gateway before hub: stop accepting new proxied calls before the upstream clients they'd need go
       // away, so a request racing shutdown fails cleanly (connection refused) rather than mid-call.

--- a/apps/server/src/cli/bins.ts
+++ b/apps/server/src/cli/bins.ts
@@ -1,0 +1,40 @@
+import type { AgentKind } from "@realm/contracts";
+
+/**
+ * The binary each agent kind runs as, and the environment variable that repoints it.
+ *
+ * `defaultAdapters()` reads its ACP specs' `bin` from here rather than restating them, so pointing an
+ * adapter at a stub binary points the CLI manager's provenance lookup at the same one. Claude and
+ * Codex resolve their own defaults inside their probes (`probeClaude`, `probeCodex`) from the same two
+ * env vars; `bins.test.ts` pins those names by proving an override moves both.
+ *
+ * `fake` is null: the scripted dev adapter is compiled in and has no binary to find.
+ */
+const AGENT_BINS = {
+  claude: { env: "REALM_CLAUDE_BIN", bin: "claude" },
+  codex: { env: "REALM_CODEX_BIN", bin: "codex" },
+  "acp:cursor": { env: "REALM_CURSOR_BIN", bin: "cursor-agent" },
+  "acp:gemini": { env: "REALM_GEMINI_BIN", bin: "gemini" },
+  "acp:opencode": { env: "REALM_OPENCODE_BIN", bin: "opencode" },
+  "acp:copilot": { env: "REALM_COPILOT_BIN", bin: "copilot" },
+  "acp:goose": { env: "REALM_GOOSE_BIN", bin: "goose" },
+  "acp:qwen": { env: "REALM_QWEN_BIN", bin: "qwen" },
+  "acp:grok": { env: "REALM_GROK_BIN", bin: "grok" },
+  "acp:fx": { env: "REALM_FX_BIN", bin: "fx" },
+  "acp:deepseek": { env: "REALM_DEEPSEEK_BIN", bin: "dsh-acp-demo" },
+  fake: null,
+} as const satisfies Record<AgentKind, { env: string; bin: string } | null>;
+
+/** Every kind that runs a binary at all — which is every kind but the compiled-in `fake`. The
+ *  overload exists so an adapter spec, whose `bin` is a plain string, does not have to widen it. */
+type BinnedKind = Exclude<AgentKind, "fake">;
+
+/** What Realm would spawn for `kind` right now, override included. Null only for `fake`. */
+export function agentBin(kind: BinnedKind, env?: NodeJS.ProcessEnv): string;
+export function agentBin(kind: AgentKind, env?: NodeJS.ProcessEnv): string | null;
+export function agentBin(kind: AgentKind, env: NodeJS.ProcessEnv = process.env): string | null {
+  const entry = AGENT_BINS[kind];
+  if (!entry) return null;
+  const override = env[entry.env];
+  return override && override.trim() !== "" ? override : entry.bin;
+}

--- a/apps/server/src/cli/install.test.ts
+++ b/apps/server/src/cli/install.test.ts
@@ -1,0 +1,236 @@
+import { EventEmitter } from "node:events";
+import { Readable } from "node:stream";
+import type { ChildProcess, spawn as nodeSpawn } from "node:child_process";
+import { describe, expect, it, vi } from "vitest";
+import { AGENT_INSTALL_ROUTES, AgentKindSchema, type AgentKind, type CliJobEnd, type CliJobOutput } from "@realm/contracts";
+import { CliInstaller, commandSpec, specFor } from "./install";
+
+/**
+ * A child process that never was. Every install test runs against this — a real package manager must
+ * never be invoked by the suite, and the machine the suite runs on is not a fixture.
+ */
+function fakeSpawn() {
+  const calls: { file: string; args: string[]; opts: Record<string, unknown> }[] = [];
+  const children: (EventEmitter & { stdout: Readable; stderr: Readable; kill: ReturnType<typeof vi.fn> })[] = [];
+  const impl = ((file: string, args: string[], opts: Record<string, unknown>) => {
+    calls.push({ file, args, opts });
+    const child = Object.assign(new EventEmitter(), {
+      stdout: new Readable({ read() {} }),
+      stderr: new Readable({ read() {} }),
+      kill: vi.fn(),
+    });
+    children.push(child);
+    return child as unknown as ChildProcess;
+  }) as unknown as typeof nodeSpawn;
+  return { impl, calls, children, last: () => children[children.length - 1]! };
+}
+
+function harness() {
+  const output: CliJobOutput[] = [];
+  const done: CliJobEnd[] = [];
+  const probes: number[] = [];
+  const spawner = fakeSpawn();
+  const installer = new CliInstaller({
+    onOutput: (e) => output.push(e),
+    onDone: (e) => done.push(e),
+    afterRun: async () => { probes.push(done.length); },
+    spawnImpl: spawner.impl,
+    env: { PATH: "/stub" },
+  });
+  return { installer, output, done, probes, spawner };
+}
+
+/** Resolves once the installer's post-run probe and done callback have both flushed. */
+const settle = () => new Promise((r) => setTimeout(r, 0));
+
+describe("commandSpec", () => {
+  it("spawns npm as argv, never through a shell", () => {
+    const spec = commandSpec(AGENT_INSTALL_ROUTES.codex, "install", null);
+    expect(spec).toEqual({ display: "npm install -g @openai/codex", file: "npm", args: ["install", "-g", "@openai/codex"] });
+  });
+
+  it("pins an npm update to the version that was checked", () => {
+    expect(commandSpec(AGENT_INSTALL_ROUTES.codex, "update", "0.153.4")).toEqual({
+      display: "npm install -g @openai/codex@0.153.4", file: "npm", args: ["install", "-g", "@openai/codex@0.153.4"],
+    });
+  });
+
+  it("uses brew install to install and brew upgrade to update", () => {
+    expect(commandSpec(AGENT_INSTALL_ROUTES["acp:goose"], "install", null)?.args).toEqual(["install", "block-goose-cli"]);
+    expect(commandSpec(AGENT_INSTALL_ROUTES["acp:goose"], "update", "1.9.0")?.args).toEqual(["upgrade", "block-goose-cli"]);
+  });
+
+  it("runs a vendor pipeline through a plain non-login, non-interactive shell", () => {
+    // -l or -i would re-run the user's rc files and could block on a prompt; the server already
+    // carries the merged login PATH, so the shell exists only to interpret the pipe.
+    const spec = commandSpec(AGENT_INSTALL_ROUTES["acp:fx"], "install", null);
+    expect(spec?.file).toBe("/bin/bash");
+    expect(spec?.args[0]).toBe("-c");
+    expect(spec?.args).not.toContain("-l");
+    expect(spec?.args).not.toContain("-i");
+    expect(spec?.args[1]).toBe("curl -fsSL https://fx.sh/setup.sh | bash");
+  });
+
+  it("never offers to update a script route", () => {
+    expect(commandSpec(AGENT_INSTALL_ROUTES["acp:fx"], "update", "1.0.0")).toBe(null);
+    expect(commandSpec(AGENT_INSTALL_ROUTES["acp:cursor"], "update", "1.0.0")).toBe(null);
+  });
+
+  it("has nothing to run for the compiled-in fake adapter", () => {
+    expect(specFor("fake", "install", null)).toBe(null);
+    expect(specFor("fake", "update", "1.0.0")).toBe(null);
+  });
+
+  it("runs exactly the command it shows, for every argv-shaped route", () => {
+    // The promise this feature makes is that the string a user reads before clicking is the string
+    // that runs. For npm and brew that is checkable literally.
+    for (const kind of AgentKindSchema.options) {
+      for (const action of ["install", "update"] as const) {
+        const spec = commandSpec(AGENT_INSTALL_ROUTES[kind], action, "9.9.9");
+        if (!spec || spec.file === "/bin/bash") continue;
+        expect([spec.file, ...spec.args].join(" ")).toBe(spec.display);
+      }
+    }
+  });
+
+  it("refuses an update with no version to pin to", () => {
+    expect(commandSpec(AGENT_INSTALL_ROUTES.codex, "update", null)).toBe(null);
+  });
+});
+
+describe("CliInstaller", () => {
+  const npmSpec = commandSpec(AGENT_INSTALL_ROUTES.codex, "install", null)!;
+
+  it("spawns the spec's argv with no shell and with stdin closed", () => {
+    const h = harness();
+    h.installer.start("codex", "install", npmSpec);
+    const call = h.spawner.calls[0]!;
+    expect(call.file).toBe("npm");
+    expect(call.args).toEqual(["install", "-g", "@openai/codex"]);
+    expect(call.opts.shell).toBe(false);
+    // A package manager that decides to prompt must fail fast, not block on a TTY it has not got.
+    expect(call.opts.stdio).toEqual(["ignore", "pipe", "pipe"]);
+  });
+
+  it("turns colour off so the streamed output is readable text", () => {
+    const h = harness();
+    h.installer.start("codex", "install", npmSpec);
+    expect(h.spawner.calls[0]!.opts.env).toMatchObject({ NO_COLOR: "1", FORCE_COLOR: "0", PATH: "/stub" });
+  });
+
+  it("echoes back the exact command it started", () => {
+    const h = harness();
+    expect(h.installer.start("codex", "install", npmSpec)).toMatchObject({
+      kind: "codex", action: "install", command: "npm install -g @openai/codex",
+    });
+  });
+
+  it("streams stdout and stderr in the order they arrived, under one job id", async () => {
+    const h = harness();
+    const job = h.installer.start("codex", "install", npmSpec);
+    const child = h.spawner.last();
+    child.stdout.push("added 1 package\n");
+    child.stderr.push("npm warn deprecated\n");
+    await settle();
+    expect(h.output.map((o) => o.chunk)).toEqual(["added 1 package\n", "npm warn deprecated\n"]);
+    expect(h.output.every((o) => o.id === job.id && o.kind === "codex")).toBe(true);
+  });
+
+  it("re-probes before announcing it is done, so a client that refetches sees the new machine", async () => {
+    // Both callbacks write to one list, so the order recorded is the order they actually fired in —
+    // reading two separate lists afterwards cannot tell the two orderings apart.
+    const order: string[] = [];
+    const spawner = fakeSpawn();
+    const ends: CliJobEnd[] = [];
+    const installer = new CliInstaller({
+      onOutput: () => {},
+      onDone: (e) => { order.push("done"); ends.push(e); },
+      afterRun: async () => { order.push("probe"); },
+      spawnImpl: spawner.impl,
+    });
+    installer.start("codex", "install", npmSpec);
+    spawner.last().emit("close", 0);
+    await settle();
+    expect(order).toEqual(["probe", "done"]);
+    expect(ends[0]).toMatchObject({ kind: "codex", ok: true, code: 0, error: null });
+  });
+
+  it("re-probes after a failure too — a failed install can still have changed the machine", async () => {
+    const h = harness();
+    h.installer.start("codex", "install", npmSpec);
+    h.spawner.last().emit("close", 1);
+    await settle();
+    expect(h.probes.length).toBe(1);
+    expect(h.done[0]).toMatchObject({ ok: false, code: 1 });
+    expect(h.done[0]!.error).toContain("1");
+  });
+
+  it("reports a missing package manager as the error it is", async () => {
+    const h = harness();
+    h.installer.start("codex", "install", npmSpec);
+    h.spawner.last().emit("error", new Error("spawn npm ENOENT"));
+    await settle();
+    expect(h.done[0]).toMatchObject({ ok: false, code: null });
+    expect(h.done[0]!.error).toContain("ENOENT");
+  });
+
+  it("finishes exactly once when error and close both fire", async () => {
+    const h = harness();
+    h.installer.start("codex", "install", npmSpec);
+    const child = h.spawner.last();
+    child.emit("error", new Error("spawn npm ENOENT"));
+    child.emit("close", null);
+    await settle();
+    expect(h.done.length).toBe(1);
+    expect(h.done[0]!.error).toContain("ENOENT");
+  });
+
+  it("refuses a second run for the same kind, so two writers never race one global prefix", async () => {
+    const h = harness();
+    h.installer.start("codex", "install", npmSpec);
+    expect(h.installer.running("codex")).toBe(true);
+    expect(() => h.installer.start("codex", "install", npmSpec)).toThrow(/already installing/);
+    expect(h.spawner.calls.length).toBe(1);
+    h.spawner.last().emit("close", 0);
+    await settle();
+    expect(h.installer.running("codex")).toBe(false);
+    h.installer.start("codex", "install", npmSpec);
+    expect(h.spawner.calls.length).toBe(2);
+  });
+
+  it("allows two different kinds at once", () => {
+    const h = harness();
+    h.installer.start("codex", "install", npmSpec);
+    h.installer.start("acp:goose", "install", commandSpec(AGENT_INSTALL_ROUTES["acp:goose"], "install", null)!);
+    expect(h.spawner.calls.length).toBe(2);
+  });
+
+  it("kills a command that has run too long", async () => {
+    const h = harness();
+    const installer = new CliInstaller({
+      onOutput: () => {}, onDone: () => {}, afterRun: async () => {},
+      spawnImpl: h.spawner.impl, timeoutMs: 1,
+    });
+    installer.start("codex", "install", npmSpec);
+    await new Promise((r) => setTimeout(r, 10));
+    expect(h.spawner.last().kill).toHaveBeenCalledWith("SIGTERM");
+  });
+
+  it("stops narrating a runaway log instead of flooding the socket", async () => {
+    const h = harness();
+    h.installer.start("codex", "install", npmSpec);
+    const child = h.spawner.last();
+    for (let i = 0; i < 40; i++) child.stdout.push("x".repeat(10_000));
+    await settle();
+    expect(h.output.length).toBeLessThan(40);
+    expect(h.output[h.output.length - 1]!.chunk).toContain("truncated");
+  });
+
+  it("kills everything still running on shutdown", () => {
+    const h = harness();
+    h.installer.start("codex", "install", npmSpec);
+    h.installer.disposeAll();
+    expect(h.spawner.last().kill).toHaveBeenCalledWith("SIGTERM");
+    expect(h.installer.running("codex" as AgentKind)).toBe(false);
+  });
+});

--- a/apps/server/src/cli/install.ts
+++ b/apps/server/src/cli/install.ts
@@ -1,0 +1,150 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import {
+  AGENT_INSTALL_ROUTES, installCommand, newId, updateCommand,
+  type AgentKind, type CliJobEnd, type CliJobOutput, type CliJobStart, type InstallRoute,
+} from "@realm/contracts";
+
+export type InstallAction = "install" | "update";
+
+/** A command in both the forms this feature needs at once: the string the user reads before clicking,
+ *  and the argv Realm spawns. They are produced together so the second can never be something other
+ *  than the first — the whole promise of showing a command is that it is the one that runs. */
+export type CommandSpec = { display: string; file: string; args: string[] };
+
+/**
+ * The shell used for install routes that are a pipeline (`curl … | bash`), and nothing else.
+ *
+ * Deliberately `-c` alone: NOT `-l` and NOT `-i`. A login/interactive shell re-runs the user's rc
+ * files, can block on a prompt, and would give the child a PATH assembled by a second, different
+ * mechanism than the one the server was started with. The server already inherits the merged login
+ * PATH from the desktop main (see login-shell-path.ts), so a plain `-c` shell — which exists only to
+ * interpret the pipe — is the smallest thing that can run these commands.
+ */
+const PIPELINE_SHELL = "/bin/bash";
+
+/**
+ * Turn a route into something runnable, or null when Realm must not run anything.
+ *
+ * npm and brew are argv-shaped and get no shell at all: a package name never reaches a command line
+ * where quoting or globbing could reinterpret it. Only the vendor script routes need a shell, and
+ * only because the command the vendor publishes is a pipeline.
+ */
+export function commandSpec(route: InstallRoute | null, action: InstallAction, latest: string | null): CommandSpec | null {
+  const display = action === "install" ? installCommand(route) : updateCommand(route, latest ?? "");
+  if (!route || !display) return null;
+  if (route.method === "npm") {
+    const pkg = action === "install" ? route.pkg : `${route.pkg}@${latest}`;
+    return { display, file: "npm", args: ["install", "-g", pkg] };
+  }
+  if (route.method === "brew") {
+    return { display, file: "brew", args: [action === "install" ? "install" : "upgrade", route.formula] };
+  }
+  return { display, file: PIPELINE_SHELL, args: ["-c", route.command] };
+}
+
+/** The spec for `kind`, resolved through the route table. Null when that kind has no such action. */
+export function specFor(kind: AgentKind, action: InstallAction, latest: string | null): CommandSpec | null {
+  return commandSpec(AGENT_INSTALL_ROUTES[kind], action, latest);
+}
+
+/** A package manager on a cold cache is slow; a package manager waiting for something is forever.
+ *  Ten minutes is past the first and well short of the second. */
+const RUN_TIMEOUT_MS = 10 * 60 * 1000;
+
+/** Installer output is meant to be read, not archived. Past this many bytes the job keeps running
+ *  and stops narrating, so a runaway build log cannot flood the socket or the renderer's state. */
+const MAX_OUTPUT_BYTES = 256 * 1024;
+
+/**
+ * Runs one install or update command, streaming what it says.
+ *
+ * Every guard here answers "what if this is the wrong command, or the right one misbehaves":
+ *
+ *  - **stdin is closed.** A package manager that decides to ask something gets EOF and fails fast,
+ *    rather than blocking forever on a TTY that a background child process does not have.
+ *  - **One job per kind.** A second click while npm is mid-install would race two writers into the
+ *    same global prefix.
+ *  - **Colour off.** The renderer shows this text in a plain block; ANSI escapes would render as
+ *    punctuation. NO_COLOR and FORCE_COLOR=0 are the two spellings npm and brew respectively honour.
+ *  - **A re-probe afterwards, always** — including after a failure, because a failed install can
+ *    still have changed the machine, and the UI must show what is there rather than what was asked
+ *    for.
+ */
+export class CliInstaller {
+  private jobs = new Map<AgentKind, { id: string; child: ChildProcess }>();
+
+  constructor(private readonly d: {
+    onOutput: (e: CliJobOutput) => void;
+    onDone: (e: CliJobEnd) => void;
+    /** Re-runs the probe and version check with their caches bypassed. */
+    afterRun: () => Promise<unknown>;
+    spawnImpl?: typeof spawn;
+    env?: NodeJS.ProcessEnv;
+    timeoutMs?: number;
+  }) {}
+
+  /** True while a command is running for this kind. */
+  running(kind: AgentKind): boolean {
+    return this.jobs.has(kind);
+  }
+
+  /**
+   * Start `spec` for `kind`. The returned job carries the exact command that is now running, so a
+   * caller that showed the user one string and got a different one back would be able to tell.
+   *
+   * Throws rather than queuing when a job for this kind is already running: a second run is a
+   * double-click, and answering it with "already running" is the truth.
+   */
+  start(kind: AgentKind, action: InstallAction, spec: CommandSpec): CliJobStart {
+    if (this.jobs.has(kind)) throw new Error(`${kind} is already installing`);
+    const id = newId();
+    const spawnImpl = this.d.spawnImpl ?? spawn;
+    const child = spawnImpl(spec.file, spec.args, {
+      env: { ...(this.d.env ?? process.env), NO_COLOR: "1", FORCE_COLOR: "0" },
+      stdio: ["ignore", "pipe", "pipe"],
+      shell: false,
+    });
+    this.jobs.set(kind, { id, child });
+
+    let sent = 0;
+    let truncated = false;
+    const emit = (chunk: string): void => {
+      if (truncated) return;
+      if (sent + chunk.length > MAX_OUTPUT_BYTES) {
+        truncated = true;
+        this.d.onOutput({ id, kind, chunk: "\n… output truncated; the command is still running.\n" });
+        return;
+      }
+      sent += chunk.length;
+      this.d.onOutput({ id, kind, chunk });
+    };
+    // stderr is merged into the same stream because a package manager's progress, warnings and
+    // errors are one narrative and splitting them loses the order the user needs to read them in.
+    child.stdout?.on("data", (b: Buffer) => emit(b.toString()));
+    child.stderr?.on("data", (b: Buffer) => emit(b.toString()));
+
+    const timer = setTimeout(() => child.kill("SIGTERM"), this.d.timeoutMs ?? RUN_TIMEOUT_MS);
+    let settled = false;
+    const finish = (end: Omit<CliJobEnd, "id" | "kind">): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      this.jobs.delete(kind);
+      // The re-probe is awaited before the done event so a client that refetches on `done` reads the
+      // new truth, not the cache the install just invalidated.
+      void this.d.afterRun().catch(() => {}).then(() => this.d.onDone({ id, kind, ...end }));
+    };
+    // "error" fires instead of "close" when the binary itself is missing (no npm, no brew) — the one
+    // failure a user is most likely to hit, and the one with the most useful message.
+    child.on("error", (e: Error) => finish({ ok: false, code: null, error: e.message }));
+    child.on("close", (code) => finish({ ok: code === 0, code, error: code === 0 ? null : `exited with code ${code ?? "unknown"}` }));
+    return { id, kind, action, command: spec.display };
+  }
+
+  /** Stop everything on shutdown; a package manager outliving the app would keep writing to a global
+   *  prefix with nobody watching. */
+  disposeAll(): void {
+    for (const { child } of this.jobs.values()) child.kill("SIGTERM");
+    this.jobs.clear();
+  }
+}

--- a/apps/server/src/cli/provenance.test.ts
+++ b/apps/server/src/cli/provenance.test.ts
@@ -28,8 +28,20 @@ function install(root: string, opts: { real: string; link: string }): { binDir: 
 }
 
 describe("classifyPath", () => {
-  it("reads a Homebrew keg as brew", () => {
-    expect(classifyPath("/opt/homebrew/Cellar/block-goose-cli/1.9.0/bin/goose")).toBe("brew");
+  it("reads both of Homebrew's install roots as brew", () => {
+    // Formulae land in Cellar and casks in Caskroom; `codex` is a cask on the machine this was
+    // measured on, and calling that "not a package manager Realm recognises" would be a false
+    // sentence shown to a Homebrew user.
+    expect(classifyPath("/opt/homebrew/Cellar/block-goose-cli/1.49.0/bin/goose")).toBe("brew");
+    expect(classifyPath("/opt/homebrew/Caskroom/codex/0.146.0/bin/codex")).toBe("brew");
+  });
+
+  it("reads the vendor self-updater layouts as unknown, which is the common case", () => {
+    // Measured 2026-09-05: four of the five agent CLIs installed on a working machine look like this.
+    expect(classifyPath("/Users/x/.local/share/claude/versions/2.1.258")).toBe("unknown");
+    expect(classifyPath("/Users/x/.local/share/cursor-agent/versions/2026.07.25-e42b078/cursor-agent")).toBe("unknown");
+    expect(classifyPath("/Users/x/.opencode/bin/opencode")).toBe("unknown");
+    expect(classifyPath("/Users/x/.local/bin/fx")).toBe("unknown");
   });
 
   it("reads a global node_modules as npm", () => {

--- a/apps/server/src/cli/provenance.test.ts
+++ b/apps/server/src/cli/provenance.test.ts
@@ -1,0 +1,146 @@
+import { mkdtempSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { classifyPath, resolveInstall } from "./provenance";
+import { agentBin } from "./bins";
+import { probeClaude } from "@realm/adapters";
+
+const roots: string[] = [];
+afterEach(() => { for (const r of roots.splice(0)) rmSync(r, { recursive: true, force: true }); });
+
+function tree(): string {
+  const root = mkdtempSync(join(tmpdir(), "realm-cli-"));
+  roots.push(root);
+  return root;
+}
+
+/** A real executable file, and a PATH symlink pointing at it — the layout every package manager here
+ *  produces, and the only one `resolveInstall` is allowed to reason about. */
+function install(root: string, opts: { real: string; link: string }): { binDir: string } {
+  const realPath = join(root, opts.real);
+  mkdirSync(dirname(realPath), { recursive: true });
+  writeFileSync(realPath, "#!/bin/sh\n", { mode: 0o755 });
+  const linkPath = join(root, opts.link);
+  mkdirSync(dirname(linkPath), { recursive: true });
+  symlinkSync(realPath, linkPath);
+  return { binDir: dirname(linkPath) };
+}
+
+describe("classifyPath", () => {
+  it("reads a Homebrew keg as brew", () => {
+    expect(classifyPath("/opt/homebrew/Cellar/block-goose-cli/1.9.0/bin/goose")).toBe("brew");
+  });
+
+  it("reads a global node_modules as npm", () => {
+    expect(classifyPath("/opt/homebrew/lib/node_modules/@openai/codex/bin/codex.js")).toBe("npm");
+  });
+
+  it("reads a pnpm store as pnpm, not as the npm its node_modules would suggest", () => {
+    expect(classifyPath("/Users/x/Library/pnpm/global/5/.pnpm/@openai+codex@1.0.0/node_modules/@openai/codex/bin/codex.js")).toBe("pnpm");
+  });
+
+  it("prefers brew when a formula vendors a node_modules tree inside its keg", () => {
+    // `npm install -g` would not upgrade this copy, so calling it npm would be the dangerous answer.
+    expect(classifyPath("/opt/homebrew/Cellar/opencode/1.2.3/libexec/node_modules/opencode-ai/bin/opencode")).toBe("brew");
+  });
+
+  it("reads a plain downloaded binary as unknown", () => {
+    expect(classifyPath("/Users/x/.local/bin/cursor-agent")).toBe("unknown");
+  });
+
+  it("matches whole path segments, so a user directory that merely contains the word does not count", () => {
+    expect(classifyPath("/Users/x/Cellar-backups/goose")).toBe("unknown");
+    expect(classifyPath("/Users/x/node_modules-notes/codex")).toBe("unknown");
+  });
+});
+
+describe("resolveInstall", () => {
+  it("follows the PATH symlink to the real file and classifies that, not the PATH directory", async () => {
+    // The case the whole module exists for: brew and npm share /opt/homebrew/bin, so the directory a
+    // binary is found in proves nothing.
+    const root = tree();
+    const { binDir } = install(root, { real: "Cellar/block-goose-cli/1.9.0/bin/goose", link: "bin/goose" });
+    install(root, { real: "lib/node_modules/@openai/codex/bin/codex.js", link: "bin/codex" });
+    const env = { PATH: binDir };
+    expect((await resolveInstall("goose", env))?.provenance).toBe("brew");
+    expect((await resolveInstall("codex", env))?.provenance).toBe("npm");
+  });
+
+  it("reports the PATH entry it found and the real file separately", async () => {
+    const root = tree();
+    const { binDir } = install(root, { real: "lib/node_modules/opencode-ai/bin/opencode", link: "bin/opencode" });
+    const found = await resolveInstall("opencode", { PATH: binDir });
+    expect(found?.path).toBe(join(binDir, "opencode"));
+    expect(found?.realPath).toContain(join("node_modules", "opencode-ai"));
+  });
+
+  it("takes the first PATH entry that holds it, as a spawn would", async () => {
+    const root = tree();
+    const a = install(root, { real: "Cellar/x/1/bin/tool", link: "first/tool" });
+    const b = install(root, { real: "lib/node_modules/x/bin/tool", link: "second/tool" });
+    expect((await resolveInstall("tool", { PATH: `${a.binDir}:${b.binDir}` }))?.provenance).toBe("brew");
+    expect((await resolveInstall("tool", { PATH: `${b.binDir}:${a.binDir}` }))?.provenance).toBe("npm");
+  });
+
+  it("skips a non-executable file and keeps searching", async () => {
+    const root = tree();
+    const dead = join(root, "dead");
+    mkdirSync(dead, { recursive: true });
+    writeFileSync(join(dead, "tool"), "not executable", { mode: 0o644 });
+    const live = install(root, { real: "lib/node_modules/x/bin/tool", link: "live/tool" });
+    expect((await resolveInstall("tool", { PATH: `${dead}:${live.binDir}` }))?.provenance).toBe("npm");
+  });
+
+  it("skips a dangling symlink rather than claiming an install", async () => {
+    const root = tree();
+    const brokenDir = join(root, "broken");
+    mkdirSync(brokenDir, { recursive: true });
+    symlinkSync(join(root, "nowhere", "tool"), join(brokenDir, "tool"));
+    expect(await resolveInstall("tool", { PATH: brokenDir })).toBe(null);
+  });
+
+  it("answers null when nothing on PATH holds it, and when PATH is empty", async () => {
+    const root = tree();
+    expect(await resolveInstall("nothing-here", { PATH: root })).toBe(null);
+    expect(await resolveInstall("nothing-here", {})).toBe(null);
+  });
+
+  it("uses an explicit path as given instead of searching PATH", async () => {
+    const root = tree();
+    install(root, { real: "Cellar/x/1/bin/tool", link: "bin/tool" });
+    const found = await resolveInstall(join(root, "bin", "tool"), { PATH: "/nonexistent" });
+    expect(found?.provenance).toBe("brew");
+  });
+});
+
+describe("agentBin", () => {
+  it("names a binary for every kind but the compiled-in fake", () => {
+    expect(agentBin("fake", {})).toBe(null);
+    expect(agentBin("codex", {})).toBe("codex");
+    expect(agentBin("acp:cursor", {})).toBe("cursor-agent");
+    expect(agentBin("acp:deepseek", {})).toBe("dsh-acp-demo");
+  });
+
+  it("honours the same REALM_*_BIN override the adapters read", () => {
+    expect(agentBin("acp:opencode", { REALM_OPENCODE_BIN: "/tmp/stub" })).toBe("/tmp/stub");
+    expect(agentBin("acp:opencode", { REALM_OPENCODE_BIN: "  " })).toBe("opencode");
+  });
+
+  it("shares REALM_CLAUDE_BIN with probeClaude, so an override moves the probe and the lookup together", async () => {
+    // The env var name is the only thing binding this table to the adapter that owns the default;
+    // a probe run under the override must land on the very binary agentBin names.
+    const root = tree();
+    install(root, { real: "Cellar/claude/1/bin/claude", link: "bin/claude" });
+    const stub = join(root, "bin", "claude");
+    const prev = process.env.REALM_CLAUDE_BIN;
+    process.env.REALM_CLAUDE_BIN = stub;
+    try {
+      expect(agentBin("claude")).toBe(stub);
+      // The stub is `#!/bin/sh` with no output: it runs, so the probe reports available.
+      expect((await probeClaude()).available).toBe(true);
+    } finally {
+      if (prev === undefined) delete process.env.REALM_CLAUDE_BIN; else process.env.REALM_CLAUDE_BIN = prev;
+    }
+  });
+});

--- a/apps/server/src/cli/provenance.ts
+++ b/apps/server/src/cli/provenance.ts
@@ -1,0 +1,70 @@
+import { constants } from "node:fs";
+import { access, realpath } from "node:fs/promises";
+import { delimiter, isAbsolute, resolve, sep } from "node:path";
+import type { InstallProvenance } from "@realm/contracts";
+
+/**
+ * Where an agent CLI on this machine came from, so Realm never runs an update command that would not
+ * update the copy the user is actually running.
+ *
+ * The whole method rests on one observation: **every package manager here installs the real file
+ * somewhere characteristic and puts a symlink on PATH.** `/opt/homebrew/bin` holds both the brew
+ * symlinks and the npm-global shims when node itself came from brew, so the directory on PATH proves
+ * nothing — only the resolved target does.
+ *
+ *   brew   /opt/homebrew/bin/goose  → ../Cellar/block-goose-cli/1.9.0/bin/goose
+ *   npm    /opt/homebrew/bin/codex  → ../lib/node_modules/@openai/codex/bin/codex.js
+ *   pnpm   ~/Library/pnpm/codex     → ../pnpm/global/5/.pnpm/@openai+codex@0.1.0/node_modules/...
+ *   script ~/.local/bin/cursor-agent → a real file, no marker at all
+ */
+
+/** Every marker is matched as a whole path SEGMENT (`/Cellar/`, not the substring "Cellar"), so a
+ *  user directory called `~/Cellar-backups` or `~/node_modules-notes` cannot pass for a prefix. */
+const hasSegment = (path: string, name: string): boolean => path.split(sep).includes(name);
+
+/**
+ * Classify a *resolved* (symlink-free) binary path.
+ *
+ * Order matters. A Homebrew formula may vendor a `node_modules` tree inside its Cellar keg
+ * (`.../Cellar/opencode/1.2.3/libexec/node_modules/...`), and that install is brew's — `npm install -g`
+ * would not touch it. So Cellar wins over node_modules, and `.pnpm` wins over the plain node_modules
+ * that always encloses it.
+ */
+export function classifyPath(realPath: string): InstallProvenance {
+  if (hasSegment(realPath, "Cellar")) return "brew";
+  if (hasSegment(realPath, ".pnpm")) return "pnpm";
+  if (hasSegment(realPath, "node_modules")) return "npm";
+  return "unknown";
+}
+
+/**
+ * Find `bin` the way a spawn would, then follow it to the real file.
+ *
+ * PATH is read from the passed environment rather than resolved through a shell: the server child was
+ * started by the desktop main *after* `mergePath(loginShellPath())`, so `process.env.PATH` here is
+ * already the PATH a terminal would have. Asking a login shell again from inside the server would be
+ * a second, slower answer to a question already answered — and `login-shell-path.ts` exists precisely
+ * because getting it wrong is subtle.
+ *
+ * Returns null when the binary is not on PATH, is not executable, or its symlink chain is broken.
+ */
+export async function resolveInstall(
+  bin: string,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<{ path: string; realPath: string; provenance: InstallProvenance } | null> {
+  const candidates = bin.includes(sep)
+    // An explicit path (a REALM_*_BIN override pointing at a stub) is used as given, not searched for.
+    ? [isAbsolute(bin) ? bin : resolve(bin)]
+    : (env.PATH ?? "").split(delimiter).filter(Boolean).map((dir) => resolve(dir, bin));
+  for (const path of candidates) {
+    try {
+      await access(path, constants.X_OK);
+      const real = await realpath(path);
+      return { path, realPath: real, provenance: classifyPath(real) };
+    } catch {
+      // Not here, not executable, or a dangling link — the next PATH entry is the next candidate,
+      // exactly as a spawn would carry on.
+    }
+  }
+  return null;
+}

--- a/apps/server/src/cli/provenance.ts
+++ b/apps/server/src/cli/provenance.ts
@@ -12,10 +12,17 @@ import type { InstallProvenance } from "@realm/contracts";
  * symlinks and the npm-global shims when node itself came from brew, so the directory on PATH proves
  * nothing — only the resolved target does.
  *
- *   brew   /opt/homebrew/bin/goose  → ../Cellar/block-goose-cli/1.9.0/bin/goose
- *   npm    /opt/homebrew/bin/codex  → ../lib/node_modules/@openai/codex/bin/codex.js
- *   pnpm   ~/Library/pnpm/codex     → ../pnpm/global/5/.pnpm/@openai+codex@0.1.0/node_modules/...
- *   script ~/.local/bin/cursor-agent → a real file, no marker at all
+ * Measured on a real machine, 2026-09-05:
+ *
+ *   brew keg   /opt/homebrew/bin/goose  → ../Cellar/block-goose-cli/1.49.0/bin/goose
+ *   brew cask  /opt/homebrew/bin/codex  → ../Caskroom/codex/0.146.0/bin/codex
+ *   npm        /opt/homebrew/bin/codex  → ../lib/node_modules/@openai/codex/bin/codex.js
+ *   pnpm       ~/Library/pnpm/codex     → ../pnpm/global/5/.pnpm/@openai+codex@0.1.0/node_modules/...
+ *   vendor     ~/.local/share/claude/versions/2.1.258, ~/.opencode/bin/opencode, ~/.local/bin/fx
+ *
+ * That last row is the majority on a working machine — four of the five agent CLIs installed on the
+ * one measured came from a vendor script that self-updates. `unknown` is the common answer here, not
+ * an edge case, and it is why refusing to update is the default rather than the exception.
  */
 
 /** Every marker is matched as a whole path SEGMENT (`/Cellar/`, not the substring "Cellar"), so a
@@ -31,7 +38,11 @@ const hasSegment = (path: string, name: string): boolean => path.split(sep).incl
  * that always encloses it.
  */
 export function classifyPath(realPath: string): InstallProvenance {
-  if (hasSegment(realPath, "Cellar")) return "brew";
+  // Both of Homebrew's install roots: formulae land in Cellar, casks in Caskroom. Missing Caskroom
+  // would not make Realm run the wrong command — an npm route refuses `unknown` too — but it would
+  // tell a Homebrew user their CLI came from something Realm did not recognise, which is a worse
+  // sentence than the true one. (Measured: `codex` installs as a cask.)
+  if (hasSegment(realPath, "Cellar") || hasSegment(realPath, "Caskroom")) return "brew";
   if (hasSegment(realPath, ".pnpm")) return "pnpm";
   if (hasSegment(realPath, "node_modules")) return "npm";
   return "unknown";

--- a/apps/server/src/cli/routes.test.ts
+++ b/apps/server/src/cli/routes.test.ts
@@ -1,0 +1,98 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { WebSocket } from "ws";
+import { createApp, type App } from "../app";
+
+let app: App;
+const roots: string[] = [];
+afterEach(async () => {
+  await app?.close();
+  for (const r of roots.splice(0)) rmSync(r, { recursive: true, force: true });
+});
+
+async function client(port: number) {
+  const ws = await new Promise<WebSocket>((res, rej) => {
+    const w = new WebSocket(`ws://127.0.0.1:${port}`);
+    w.once("open", () => res(w));
+    w.once("error", rej);
+  });
+  const pending = new Map<string, (v: any) => void>();
+  const events: any[] = [];
+  ws.on("message", (d) => {
+    const m = JSON.parse(d.toString());
+    if ("id" in m) pending.get(m.id)?.(m); else events.push(m);
+  });
+  let n = 0;
+  const call = (method: string, params: unknown) => new Promise<any>((res, rej) => {
+    const id = String(++n);
+    const timer = setTimeout(() => { pending.delete(id); rej(new Error(`rpc ${method} timed out`)); }, 5000);
+    pending.set(id, (v) => { clearTimeout(timer); res(v); });
+    ws.send(JSON.stringify({ id, method, params }));
+  });
+  return { call, events, close: () => ws.close() };
+}
+
+/**
+ * An app with no agents registered, an empty PATH and a fetch that refuses to be called.
+ *
+ * All three matter: the suite must not spawn the developer's real agent CLIs, must not classify the
+ * developer's real installs, and must not reach npm. What is left is exactly the routes' own logic.
+ */
+async function boot() {
+  const home = mkdtempSync(join(tmpdir(), "realm-home-"));
+  roots.push(home);
+  const empty = mkdtempSync(join(tmpdir(), "realm-nopath-"));
+  roots.push(empty);
+  app = await createApp({
+    home, port: 0, adapters: {},
+    cli: {
+      env: { PATH: empty },
+      fetchImpl: (async () => { throw new Error("a route test must not reach a registry"); }) as unknown as typeof fetch,
+    },
+  });
+  return client(app.port);
+}
+
+describe("cli.status / cli.run routes", () => {
+  it("answers a row for every agent kind, with no agent registered and no network", async () => {
+    const c = await boot();
+    const { rows } = (await c.call("cli.status", {})).result;
+    expect(rows.length).toBeGreaterThan(5);
+    expect(rows.every((r: { installed: boolean }) => r.installed === false)).toBe(true);
+    // `fake` is compiled in and has no install route, so it must never carry a command.
+    expect(rows.find((r: { kind: string }) => r.kind === "fake")).toMatchObject({ action: "none", command: null });
+    // Everything else offers its install command and no version, because there is nothing to update.
+    expect(rows.find((r: { kind: string }) => r.kind === "codex")).toMatchObject({
+      action: "install", command: "npm install -g @openai/codex", latest: null,
+    });
+    c.close();
+  });
+
+  it("refuses an action the status does not offer, whatever the caller asks for", async () => {
+    // The named mutant: trusting the caller's `action` instead of re-deriving it. Nothing is
+    // installed here, so every kind's offer is "install" — an update must be refused at the route,
+    // not by a button that was never rendered.
+    const c = await boot();
+    const res = await c.call("cli.run", { kind: "codex", action: "update" });
+    expect(res.ok).toBe(false);
+    expect(res.error.code).toBe("CLI_ACTION_UNAVAILABLE");
+    c.close();
+  });
+
+  it("refuses to install a kind that has no install route at all", async () => {
+    const c = await boot();
+    const res = await c.call("cli.run", { kind: "fake", action: "install" });
+    expect(res.ok).toBe(false);
+    expect(res.error.code).toBe("CLI_ACTION_UNAVAILABLE");
+    c.close();
+  });
+
+  it("rejects a kind that is not an agent, and an action that is not one", async () => {
+    const c = await boot();
+    expect((await c.call("cli.run", { kind: "not-an-agent", action: "install" })).ok).toBe(false);
+    expect((await c.call("cli.run", { kind: "codex", action: "uninstall" })).ok).toBe(false);
+    c.close();
+  });
+});

--- a/apps/server/src/cli/service.test.ts
+++ b/apps/server/src/cli/service.test.ts
@@ -118,12 +118,11 @@ describe("CliService.status", () => {
     expect(fake.command).toBe(null);
   });
 
-  it("says a script-installed CLI has no version channel and offers no update", async () => {
+  it("asks nothing and offers nothing for a script-installed CLI, which has no version channel", async () => {
     const env = machine([{ bin: "cursor-agent", under: "npm" }]);
     const { impl, urls } = fakeFetch({});
-    const svc = new CliService({ probe: probes([{ kind: "acp:cursor", version: "2026.09.01" }]), fetchImpl: impl, env });
+    const svc = new CliService({ probe: probes([{ kind: "acp:cursor", version: "2026.07.25-e42b078" }]), fetchImpl: impl, env });
     const cursor = row(await svc.status(), "acp:cursor");
-    expect(cursor.channel).toBe(false);
     expect(cursor.latest).toBe(null);
     expect(cursor.action).toBe("none");
     expect(urls).toEqual([]);

--- a/apps/server/src/cli/service.test.ts
+++ b/apps/server/src/cli/service.test.ts
@@ -1,0 +1,208 @@
+import { mkdtempSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import type { ProbeResult } from "@realm/adapters";
+import type { AgentKind } from "@realm/contracts";
+import { CliService } from "./service";
+
+const roots: string[] = [];
+afterEach(() => { for (const r of roots.splice(0)) rmSync(r, { recursive: true, force: true }); });
+
+/** A PATH directory holding the named binaries, each a symlink into the layout its package manager
+ *  would have produced. No package manager is ever run — the layout IS the fact under test. */
+function machine(installs: { bin: string; under: "npm" | "brew" }[]): { PATH: string } {
+  const root = mkdtempSync(join(tmpdir(), "realm-clisvc-"));
+  roots.push(root);
+  const binDir = join(root, "bin");
+  mkdirSync(binDir, { recursive: true });
+  for (const { bin, under } of installs) {
+    const real = under === "brew"
+      ? join(root, "Cellar", bin, "1.0.0", "bin", bin)
+      : join(root, "lib", "node_modules", bin, "bin", `${bin}.js`);
+    mkdirSync(dirname(real), { recursive: true });
+    writeFileSync(real, "#!/bin/sh\n", { mode: 0o755 });
+    symlinkSync(real, join(binDir, bin));
+  }
+  return { PATH: binDir };
+}
+
+type Registry = Record<string, unknown>;
+
+/** A fetch that answers only from `registry`, and counts every request so caching can be proven. */
+function fakeFetch(registry: Registry) {
+  const urls: string[] = [];
+  const impl = (async (input: string | URL | Request) => {
+    const url = String(input);
+    urls.push(url);
+    const body = registry[url];
+    if (body === undefined) return { ok: false, status: 404, json: async () => ({}) } as Response;
+    return { ok: true, status: 200, json: async () => body } as Response;
+  }) as unknown as typeof fetch;
+  return { impl, urls };
+}
+
+const CODEX_LATEST = "https://registry.npmjs.org/@openai%2Fcodex/latest";
+const GOOSE_LATEST = "https://formulae.brew.sh/api/formula/block-goose-cli.json";
+
+function probes(rows: Partial<ProbeResult>[]): (o: { force?: boolean }) => Promise<ProbeResult[]> {
+  return async () => rows.map((r) => ({ kind: "fake" as AgentKind, available: true, version: null, loggedIn: null, reason: null, ...r }));
+}
+
+const row = (rows: Awaited<ReturnType<CliService["status"]>>, kind: AgentKind) => rows.find((r) => r.kind === kind)!;
+
+describe("CliService.status", () => {
+  it("offers an update when the registry is ahead of an npm install", async () => {
+    const env = machine([{ bin: "codex", under: "npm" }]);
+    const { impl } = fakeFetch({ [CODEX_LATEST]: { version: "0.153.4" } });
+    const svc = new CliService({ probe: probes([{ kind: "codex", version: "codex-cli 0.146.0" }]), fetchImpl: impl, env });
+    const codex = row(await svc.status(), "codex");
+    expect(codex.updateAvailable).toBe(true);
+    expect(codex.action).toBe("update");
+    expect(codex.command).toBe("npm install -g @openai/codex@0.153.4");
+    expect(codex.provenance).toBe("npm");
+    expect(codex.refusal).toBe(null);
+  });
+
+  it("offers nothing when the installed version is already the published one", async () => {
+    const env = machine([{ bin: "codex", under: "npm" }]);
+    const { impl } = fakeFetch({ [CODEX_LATEST]: { version: "0.146.0" } });
+    const svc = new CliService({ probe: probes([{ kind: "codex", version: "codex-cli 0.146.0" }]), fetchImpl: impl, env });
+    const codex = row(await svc.status(), "codex");
+    expect(codex.updateAvailable).toBe(false);
+    expect(codex.action).toBe("none");
+    expect(codex.command).toBe(null);
+    expect(codex.latest).toBe("0.146.0");
+  });
+
+  it("reports an update it will not apply, rather than hiding either half", async () => {
+    // codex installed by Homebrew: npm install -g would add a second copy, so the update is named
+    // and refused in the same row.
+    const env = machine([{ bin: "codex", under: "brew" }]);
+    const { impl } = fakeFetch({ [CODEX_LATEST]: { version: "0.153.4" } });
+    const svc = new CliService({ probe: probes([{ kind: "codex", version: "codex-cli 0.146.0" }]), fetchImpl: impl, env });
+    const codex = row(await svc.status(), "codex");
+    expect(codex.updateAvailable).toBe(true);
+    expect(codex.provenance).toBe("brew");
+    expect(codex.action).toBe("none");
+    expect(codex.command).toBe(null);
+    expect(codex.refusal).toContain("Homebrew");
+  });
+
+  it("upgrades a brew-installed CLI whose route is brew", async () => {
+    const env = machine([{ bin: "goose", under: "brew" }]);
+    const { impl } = fakeFetch({ [GOOSE_LATEST]: { versions: { stable: "1.9.0" } } });
+    const svc = new CliService({ probe: probes([{ kind: "acp:goose", version: "goose 1.8.0" }]), fetchImpl: impl, env });
+    const goose = row(await svc.status(), "acp:goose");
+    expect(goose.action).toBe("update");
+    expect(goose.command).toBe("brew upgrade block-goose-cli");
+  });
+
+  it("offers the install command, and no version, for a CLI that is not there", async () => {
+    const env = machine([]);
+    const { impl, urls } = fakeFetch({});
+    const svc = new CliService({ probe: probes([{ kind: "codex", available: false, reason: "not found" }]), fetchImpl: impl, env });
+    const codex = row(await svc.status(), "codex");
+    expect(codex.installed).toBe(false);
+    expect(codex.action).toBe("install");
+    expect(codex.command).toBe("npm install -g @openai/codex");
+    expect(codex.latest).toBe(null);
+    // Nothing to update means nothing to ask a registry about.
+    expect(urls).toEqual([]);
+  });
+
+  it("never offers to install the compiled-in fake adapter", async () => {
+    const svc = new CliService({ probe: probes([{ kind: "fake", available: false }]), fetchImpl: fakeFetch({}).impl, env: machine([]) });
+    const fake = row(await svc.status(), "fake");
+    expect(fake.action).toBe("none");
+    expect(fake.command).toBe(null);
+  });
+
+  it("says a script-installed CLI has no version channel and offers no update", async () => {
+    const env = machine([{ bin: "cursor-agent", under: "npm" }]);
+    const { impl, urls } = fakeFetch({});
+    const svc = new CliService({ probe: probes([{ kind: "acp:cursor", version: "2026.09.01" }]), fetchImpl: impl, env });
+    const cursor = row(await svc.status(), "acp:cursor");
+    expect(cursor.channel).toBe(false);
+    expect(cursor.latest).toBe(null);
+    expect(cursor.action).toBe("none");
+    expect(urls).toEqual([]);
+  });
+
+  it("answers with every row even when the registry is unreachable", async () => {
+    const env = machine([{ bin: "codex", under: "npm" }]);
+    const dead = (async () => { throw new Error("offline"); }) as unknown as typeof fetch;
+    const svc = new CliService({ probe: probes([{ kind: "codex", version: "codex-cli 0.146.0" }]), fetchImpl: dead, env });
+    const codex = row(await svc.status(), "codex");
+    expect(codex.installed).toBe(true);
+    expect(codex.latest).toBe(null);
+    expect(codex.updateAvailable).toBe(false);
+  });
+
+  it("does not claim an update when the registry answers an error status", async () => {
+    // A 404 (package renamed, registry hiccup) has a body; reading it without checking the status
+    // would turn an error page into a version number.
+    const env = machine([{ bin: "codex", under: "npm" }]);
+    const { impl } = fakeFetch({});
+    const svc = new CliService({ probe: probes([{ kind: "codex", version: "codex-cli 0.146.0" }]), fetchImpl: impl, env });
+    const codex = row(await svc.status(), "codex");
+    expect(codex.latest).toBe(null);
+    expect(codex.updateAvailable).toBe(false);
+    expect(codex.action).toBe("none");
+  });
+
+  it("does not claim an update when the registry answers a shape it does not understand", async () => {
+    const env = machine([{ bin: "codex", under: "npm" }]);
+    const { impl } = fakeFetch({ [CODEX_LATEST]: { latest: "0.153.4" } });
+    const svc = new CliService({ probe: probes([{ kind: "codex", version: "codex-cli 0.146.0" }]), fetchImpl: impl, env });
+    expect(row(await svc.status(), "codex").updateAvailable).toBe(false);
+  });
+});
+
+describe("CliService caching", () => {
+  it("asks the registry once per TTL, however many callers ask", async () => {
+    const env = machine([{ bin: "codex", under: "npm" }]);
+    const { impl, urls } = fakeFetch({ [CODEX_LATEST]: { version: "0.153.4" } });
+    const svc = new CliService({ probe: probes([{ kind: "codex", version: "codex-cli 0.146.0" }]), fetchImpl: impl, env });
+    await Promise.all([svc.status(), svc.status(), svc.status()]);
+    await svc.status();
+    expect(urls).toEqual([CODEX_LATEST]);
+  });
+
+  it("re-asks past the TTL", async () => {
+    const env = machine([{ bin: "codex", under: "npm" }]);
+    const { impl, urls } = fakeFetch({ [CODEX_LATEST]: { version: "0.153.4" } });
+    let clock = 0;
+    const svc = new CliService({ probe: probes([{ kind: "codex", version: "codex-cli 0.146.0" }]), fetchImpl: impl, env, ttlMs: 1000, now: () => clock });
+    await svc.status();
+    clock = 999;
+    await svc.status();
+    expect(urls.length).toBe(1);
+    clock = 1001;
+    await svc.status();
+    expect(urls.length).toBe(2);
+  });
+
+  it("force re-asks inside the TTL — the gesture after an install finished", async () => {
+    const env = machine([{ bin: "codex", under: "npm" }]);
+    const { impl, urls } = fakeFetch({ [CODEX_LATEST]: { version: "0.153.4" } });
+    const svc = new CliService({ probe: probes([{ kind: "codex", version: "codex-cli 0.146.0" }]), fetchImpl: impl, env });
+    await svc.status();
+    await svc.status({ force: true });
+    expect(urls.length).toBe(2);
+    await svc.refresh();
+    expect(urls.length).toBe(3);
+  });
+
+  it("passes force down to the probe, not only to its own cache", async () => {
+    const env = machine([]);
+    const forces: (boolean | undefined)[] = [];
+    const svc = new CliService({
+      probe: async (o) => { forces.push(o.force); return []; },
+      fetchImpl: fakeFetch({}).impl, env,
+    });
+    await svc.status();
+    await svc.status({ force: true });
+    expect(forces).toEqual([false, true]);
+  });
+});

--- a/apps/server/src/cli/service.ts
+++ b/apps/server/src/cli/service.ts
@@ -80,7 +80,6 @@ export class CliService {
     const latest = installed ? check?.latest ?? null : null;
     const base = {
       kind, installed, version, binPath: check?.binPath ?? null, provenance, latest,
-      channel: updateChannel(route) !== null,
     };
     if (!installed) {
       return { ...base, updateAvailable: false, action: installCommand(route) ? "install" : "none", command: installCommand(route), refusal: null };

--- a/apps/server/src/cli/service.ts
+++ b/apps/server/src/cli/service.ts
@@ -1,0 +1,128 @@
+import {
+  AGENT_INSTALL_ROUTES, AgentKindSchema, canRunUpdate, installCommand, isNewerVersion, parseBrewFormula,
+  parseNpmLatest, updateChannel, updateCommand, updateRefusal,
+  type AgentKind, type CliStatus, type InstallProvenance,
+} from "@realm/contracts";
+import type { ProbeResult } from "@realm/adapters";
+import { ProbeCache } from "../sessions/probe-cache";
+import { agentBin } from "./bins";
+import { resolveInstall } from "./provenance";
+
+/**
+ * How long a version check is reused. Six hours, not the probe's thirty seconds: a CLI's published
+ * version changes on a release cadence, and the cost of asking is a network round trip per installed
+ * agent. Every "check now" gesture forces past it, and so does finishing an install — after Realm
+ * changes the machine, a cached answer describes a machine that no longer exists.
+ */
+export const CLI_CHECK_TTL_MS = 6 * 60 * 60 * 1000;
+
+/** A published version lookup is a courtesy, never load-bearing: the same budget the model catalog
+ *  gives its fetch, and for the same reason — a slow registry may not become a slow Settings page. */
+const CHECK_TIMEOUT_MS = 8000;
+
+/** What one sweep learned about one kind. `latest` is null when the CLI is not installed (nothing to
+ *  update), when its route has no version channel, or when the lookup failed — three different
+ *  situations that all mean the same thing to a caller: do not claim an update exists. */
+type CliCheck = { binPath: string | null; provenance: InstallProvenance; latest: string | null };
+
+/**
+ * "Is there a newer version of each agent CLI, and may Realm install it?"
+ *
+ * The two halves are cached separately because they go stale at different rates and cost different
+ * things. Whether a CLI is *there* is the existing 30-second `agents.probe`, which spawns a child per
+ * agent; whether a newer one is *published* is this service's six-hour sweep, which is fs plus a
+ * public GET per installed agent. `status()` joins them, `force` forces both.
+ *
+ * The sweep only asks the registry about CLIs that are actually on the machine. A version the user
+ * cannot be shown a diff against is not worth a request — for a missing CLI the offer is "install
+ * it", which needs no version at all.
+ *
+ * Nothing here ever runs a package manager. Deciding whether an update exists and applying one are
+ * kept apart on purpose: this half is safe to run unattended on launch precisely because it cannot
+ * change the machine.
+ */
+export class CliService {
+  private checks: ProbeCache<Record<string, CliCheck>>;
+
+  constructor(private readonly d: {
+    /** `SessionService.probe` — the same cache every other probe caller rides. */
+    probe: (opts: { force?: boolean }) => Promise<ProbeResult[]>;
+    /** Injected so tests never reach a registry — and so a live check can. */
+    fetchImpl?: typeof fetch;
+    env?: NodeJS.ProcessEnv;
+    ttlMs?: number;
+    now?: () => number;
+  }) {
+    this.checks = new ProbeCache(() => this.sweep(), { ttlMs: d.ttlMs ?? CLI_CHECK_TTL_MS, now: d.now });
+  }
+
+  /** Every kind's install and update situation. Never throws: a caller asking "what is on this
+   *  machine" must get an answer even with the network gone. */
+  async status({ force = false }: { force?: boolean } = {}): Promise<CliStatus[]> {
+    const [probes, checks] = await Promise.all([
+      this.d.probe({ force }),
+      this.checks.get({ force }).catch((): Record<string, CliCheck> => ({})),
+    ]);
+    return AgentKindSchema.options.map((kind) => this.join(kind, probes.find((p) => p.kind === kind), checks[kind]));
+  }
+
+  /** Re-check with the caches bypassed — what an install or update calls when it finishes, because
+   *  the answer it just invalidated is the one the UI is about to render. */
+  refresh(): Promise<CliStatus[]> {
+    return this.status({ force: true });
+  }
+
+  private join(kind: AgentKind, probe: ProbeResult | undefined, check: CliCheck | undefined): CliStatus {
+    const route = AGENT_INSTALL_ROUTES[kind];
+    const provenance = check?.provenance ?? "unknown";
+    const installed = probe?.available ?? false;
+    const version = probe?.version ?? null;
+    const latest = installed ? check?.latest ?? null : null;
+    const base = {
+      kind, installed, version, binPath: check?.binPath ?? null, provenance, latest,
+      channel: updateChannel(route) !== null,
+    };
+    if (!installed) {
+      return { ...base, updateAvailable: false, action: installCommand(route) ? "install" : "none", command: installCommand(route), refusal: null };
+    }
+    if (!isNewerVersion(version, latest) || !latest) {
+      return { ...base, updateAvailable: false, action: "none", command: null, refusal: null };
+    }
+    // An update exists. Whether Realm may apply it is a separate question with its own answer, and a
+    // refusal is shown rather than swallowed — the user still learns a newer version is out there.
+    if (!canRunUpdate(route, provenance)) {
+      return { ...base, updateAvailable: true, action: "none", command: null, refusal: updateRefusal(route, provenance) };
+    }
+    return { ...base, updateAvailable: true, action: "update", command: updateCommand(route, latest), refusal: null };
+  }
+
+  /** One pass over every kind with a version channel: find its binary, then ask its registry. Both
+   *  legs are per-kind independent, so one dead registry costs one null rather than the whole sweep. */
+  private async sweep(): Promise<Record<string, CliCheck>> {
+    const env = this.d.env ?? process.env;
+    const entries = await Promise.all(AgentKindSchema.options.map(async (kind): Promise<[string, CliCheck]> => {
+      const bin = agentBin(kind, env);
+      const route = AGENT_INSTALL_ROUTES[kind];
+      const found = bin ? await resolveInstall(bin, env) : null;
+      const channel = updateChannel(route);
+      // No binary means nothing to update; no channel means no way to ask. Either way, no request.
+      const latest = found && channel ? await this.fetchLatest(channel) : null;
+      return [kind, { binPath: found?.path ?? null, provenance: found?.provenance ?? "unknown", latest }];
+    }));
+    return Object.fromEntries(entries);
+  }
+
+  private async fetchLatest(channel: { url: string; kind: "npm" | "brew" }): Promise<string | null> {
+    try {
+      const f = this.d.fetchImpl ?? fetch;
+      const res = await f(channel.url, { signal: AbortSignal.timeout(CHECK_TIMEOUT_MS), headers: { accept: "application/json" } });
+      if (!res.ok) return null;
+      const body: unknown = await res.json();
+      return channel.kind === "npm" ? parseNpmLatest(body) : parseBrewFormula(body);
+    } catch {
+      // A registry that is down, slow, or has changed shape is a reason to say nothing, never a
+      // reason to fail the caller — the rest of the Settings page must still render.
+      return null;
+    }
+  }
+}

--- a/apps/server/src/rpc/methods.ts
+++ b/apps/server/src/rpc/methods.ts
@@ -12,6 +12,8 @@ import type { CheckpointService } from "../checkpoints/service";
 import type { ItemsStore } from "../store/items";
 import type { SettingsStore } from "../store/settings";
 import type { ModelCatalogService } from "../models/catalog";
+import type { CliService } from "../cli/service";
+import { specFor, type CliInstaller } from "../cli/install";
 import type { SkillsService } from "../skills/service";
 import type { McpService } from "../mcp/service";
 import type { McpHub } from "../mcp/hub";
@@ -49,7 +51,7 @@ type Result<M extends MethodName> = MethodResult<M> | Promise<MethodResult<M>>;
 
 export type Deps = {
   rpc: RpcServer; home: string; version: string; machineName: string; userName: string;
-  profiles: ProfilesStore; spaces: SpacesStore; projects: ProjectsStore; environments: EnvironmentsStore; envService: EnvironmentService; items: ItemsStore; settings: SettingsStore; skills: SkillsService; mcp: McpService; hub: McpHub; gateway: McpGateway; oauth: McpOauth; calls: McpCallLogStore; memory: MemoryService; terminals: TerminalService; browsers: BrowserService; browserBridge: BrowserHostBridge; documents: DocumentService; sessions: SessionService; gitInfo: GitInfoService; gitDiff: GitDiffService; gitWrite: GitWriteService; ships: ShipsStore; ports: PortAllocator; checkpoints: CheckpointService; notifications: NotificationsService; usage: UsageService; graphify: GraphifyService; runs: RunService; reviews: ReviewService; search: SearchService; forks: ForkService; imports: ImportService; lectures: LectureService; plynn: PlynnService; modelCatalog: ModelCatalogService;
+  profiles: ProfilesStore; spaces: SpacesStore; projects: ProjectsStore; environments: EnvironmentsStore; envService: EnvironmentService; items: ItemsStore; settings: SettingsStore; skills: SkillsService; mcp: McpService; hub: McpHub; gateway: McpGateway; oauth: McpOauth; calls: McpCallLogStore; memory: MemoryService; terminals: TerminalService; browsers: BrowserService; browserBridge: BrowserHostBridge; documents: DocumentService; sessions: SessionService; gitInfo: GitInfoService; gitDiff: GitDiffService; gitWrite: GitWriteService; ships: ShipsStore; ports: PortAllocator; checkpoints: CheckpointService; notifications: NotificationsService; usage: UsageService; graphify: GraphifyService; runs: RunService; reviews: ReviewService; search: SearchService; forks: ForkService; imports: ImportService; lectures: LectureService; plynn: PlynnService; modelCatalog: ModelCatalogService; cli: CliService; cliInstaller: CliInstaller;
   iconAssets: IconAssetsStore; iconGeneration: IconGenerationService;
   delegation: DelegationEngine;
 };
@@ -503,6 +505,20 @@ export function registerMethods(d: Deps): void {
 
   reg("agents.probe", (p) => d.sessions.probe({ force: p.force }));
   reg("models.catalog", async (p) => ({ rows: await d.modelCatalog.list({ force: p.force }) }));
+
+  reg("cli.status", async (p) => ({ rows: await d.cli.status({ force: p.force }) }));
+  // Every decision about WHAT to run is re-made here from the server's own status, never taken from
+  // the caller: the client names a kind and an action, and gets a refusal unless that is exactly what
+  // the status currently offers. So the provenance rule (no `npm install -g` over a Homebrew install)
+  // and the no-route rule hold even against a hand-crafted call.
+  reg("cli.run", async (p) => {
+    const row = (await d.cli.status()).find((r) => r.kind === p.kind);
+    if (!row || row.action !== p.action) throw new RpcError("CLI_ACTION_UNAVAILABLE", `Realm is not offering to ${p.action} ${p.kind} right now`);
+    const spec = specFor(p.kind, p.action, row.latest);
+    if (!spec) throw new RpcError("CLI_ACTION_UNAVAILABLE", `no ${p.action} command for ${p.kind}`);
+    if (d.cliInstaller.running(p.kind)) throw new RpcError("CLI_ALREADY_RUNNING", `${p.kind} is already installing`);
+    return d.cliInstaller.start(p.kind, p.action, spec);
+  });
 
   // Settings → Usage. Space-checked like every other scoped read: a typo'd id should say so rather
   // than answering an empty page for a space that is not there (the `ships.list` posture).

--- a/packages/contracts/src/cli.test.ts
+++ b/packages/contracts/src/cli.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it } from "vitest";
+import {
+  AGENT_INSTALL_ROUTES, canRunUpdate, compareVersions, installCommand, isNewerVersion,
+  parseBrewFormula, parseNpmLatest, parseVersion, updateChannel, updateCommand, updateRefusal,
+} from "./cli";
+import { AGENT_CLI_COMMANDS } from "./presets";
+import { AgentKindSchema } from "./entities";
+
+describe("AGENT_INSTALL_ROUTES", () => {
+  it("covers every agent kind", () => {
+    for (const kind of AgentKindSchema.options) expect(kind in AGENT_INSTALL_ROUTES).toBe(true);
+  });
+
+  it("regenerates exactly the install command presets already offer for copying", () => {
+    for (const kind of AgentKindSchema.options) {
+      expect(installCommand(AGENT_INSTALL_ROUTES[kind])).toBe(AGENT_CLI_COMMANDS[kind].install);
+    }
+  });
+
+  it("gives fake no route, so nothing can offer to install the dev adapter", () => {
+    expect(AGENT_INSTALL_ROUTES.fake).toBe(null);
+    expect(installCommand(AGENT_INSTALL_ROUTES.fake)).toBe(null);
+  });
+});
+
+describe("updateCommand", () => {
+  it("pins npm to the version the check found, not @latest", () => {
+    expect(updateCommand({ method: "npm", pkg: "@openai/codex" }, "0.153.4")).toBe("npm install -g @openai/codex@0.153.4");
+  });
+
+  it("upgrades a brew formula by name", () => {
+    expect(updateCommand({ method: "brew", formula: "block-goose-cli" }, "1.9.0")).toBe("brew upgrade block-goose-cli");
+  });
+
+  it("refuses script installers, which cannot promise a version", () => {
+    expect(updateCommand(AGENT_INSTALL_ROUTES["acp:fx"], "1.0.0")).toBe(null);
+    expect(updateCommand(AGENT_INSTALL_ROUTES["acp:cursor"], "1.0.0")).toBe(null);
+  });
+
+  it("refuses with no route and with no version", () => {
+    expect(updateCommand(null, "1.0.0")).toBe(null);
+    expect(updateCommand({ method: "npm", pkg: "x" }, "")).toBe(null);
+  });
+});
+
+describe("updateChannel", () => {
+  it("escapes only the scope slash — an encoded @ 404s on the registry", () => {
+    expect(updateChannel({ method: "npm", pkg: "@openai/codex" })?.url).toBe("https://registry.npmjs.org/@openai%2Fcodex/latest");
+  });
+
+  it("leaves an unscoped package alone", () => {
+    expect(updateChannel({ method: "npm", pkg: "opencode-ai" })?.url).toBe("https://registry.npmjs.org/opencode-ai/latest");
+  });
+
+  it("points brew formulae at the public formula API", () => {
+    expect(updateChannel({ method: "brew", formula: "block-goose-cli" })).toEqual({
+      url: "https://formulae.brew.sh/api/formula/block-goose-cli.json", kind: "brew",
+    });
+  });
+
+  it("has no channel for a script installer or a kind with no route", () => {
+    expect(updateChannel(AGENT_INSTALL_ROUTES["acp:cursor"])).toBe(null);
+    expect(updateChannel(null)).toBe(null);
+  });
+});
+
+describe("registry parsers", () => {
+  it("reads the version off an npm latest document", () => {
+    expect(parseNpmLatest({ name: "@openai/codex", version: "0.153.4" })).toBe("0.153.4");
+  });
+
+  it("reads versions.stable off a brew formula, ignoring head", () => {
+    expect(parseBrewFormula({ versions: { stable: "1.9.0", head: "HEAD" } })).toBe("1.9.0");
+  });
+
+  it("answers null rather than throwing on anything else", () => {
+    for (const body of [null, undefined, {}, { version: 42 }, { version: "  " }, "nope", []]) {
+      expect(parseNpmLatest(body)).toBe(null);
+    }
+    for (const body of [null, {}, { versions: {} }, { versions: { stable: 3 } }]) {
+      expect(parseBrewFormula(body)).toBe(null);
+    }
+  });
+});
+
+describe("parseVersion", () => {
+  it("pulls the version out of what each CLI actually prints", () => {
+    expect(parseVersion("2.1.223 (Claude Code)")).toBe("2.1.223");
+    expect(parseVersion("codex-cli 0.146.0")).toBe("0.146.0");
+    expect(parseVersion("2026.09.01")).toBe("2026.09.01");
+    expect(parseVersion("0.1.2-rc.3")).toBe("0.1.2-rc.3");
+  });
+
+  it("does not mistake a digit in a product name for a version", () => {
+    expect(parseVersion("gpt-5-codex")).toBe(null);
+    expect(parseVersion("grok 4")).toBe(null);
+  });
+
+  it("answers null for nothing at all", () => {
+    expect(parseVersion(null)).toBe(null);
+    expect(parseVersion("")).toBe(null);
+    expect(parseVersion("unknown")).toBe(null);
+  });
+});
+
+describe("compareVersions", () => {
+  it("orders by numeric segment, not by string", () => {
+    expect(compareVersions("0.9.0", "0.10.0")).toBeLessThan(0);
+    expect(compareVersions("2.1.223", "2.1.99")).toBeGreaterThan(0);
+  });
+
+  it("treats a missing trailing segment as zero", () => {
+    expect(compareVersions("1.2", "1.2.0")).toBe(0);
+    expect(compareVersions("1.2", "1.2.1")).toBeLessThan(0);
+  });
+
+  it("orders a prerelease below the release that superseded it", () => {
+    expect(compareVersions("1.2.0-rc.1", "1.2.0")).toBeLessThan(0);
+    expect(compareVersions("1.2.0", "1.2.0-rc.1")).toBeGreaterThan(0);
+    expect(compareVersions("1.2.0-rc.1", "1.2.0-rc.2")).toBeLessThan(0);
+  });
+});
+
+describe("isNewerVersion", () => {
+  it("is true only when the registry is strictly ahead", () => {
+    expect(isNewerVersion("codex-cli 0.146.0", "0.153.4")).toBe(true);
+    expect(isNewerVersion("codex-cli 0.153.4", "0.153.4")).toBe(false);
+    expect(isNewerVersion("codex-cli 0.154.0", "0.153.4")).toBe(false);
+  });
+
+  it("is false when either side cannot be parsed — 'cannot tell' is not 'update available'", () => {
+    expect(isNewerVersion(null, "1.0.0")).toBe(false);
+    expect(isNewerVersion("1.0.0", null)).toBe(false);
+    expect(isNewerVersion("unknown", "1.0.0")).toBe(false);
+  });
+});
+
+describe("canRunUpdate", () => {
+  it("runs an npm route only against an npm install", () => {
+    const route = AGENT_INSTALL_ROUTES.codex;
+    expect(canRunUpdate(route, "npm")).toBe(true);
+    expect(canRunUpdate(route, "brew")).toBe(false);
+    expect(canRunUpdate(route, "pnpm")).toBe(false);
+    expect(canRunUpdate(route, "unknown")).toBe(false);
+  });
+
+  it("runs a brew route only against a brew install", () => {
+    const route = AGENT_INSTALL_ROUTES["acp:goose"];
+    expect(canRunUpdate(route, "brew")).toBe(true);
+    expect(canRunUpdate(route, "npm")).toBe(false);
+  });
+
+  it("never runs a script route, whatever the provenance", () => {
+    for (const p of ["npm", "pnpm", "brew", "unknown"] as const) {
+      expect(canRunUpdate(AGENT_INSTALL_ROUTES["acp:fx"], p)).toBe(false);
+    }
+  });
+});
+
+describe("updateRefusal", () => {
+  it("says nothing when the update can actually run", () => {
+    expect(updateRefusal(AGENT_INSTALL_ROUTES.codex, "npm")).toBe(null);
+  });
+
+  it("names both the method that installed it and the one Realm would have used", () => {
+    const why = updateRefusal(AGENT_INSTALL_ROUTES.codex, "brew");
+    expect(why).toContain("Homebrew");
+    expect(why).toContain("npm");
+    expect(why).toContain("second copy");
+  });
+
+  it("explains a script installer as a versioning problem, not a provenance one", () => {
+    expect(updateRefusal(AGENT_INSTALL_ROUTES["acp:fx"], "unknown")).toContain("script");
+  });
+});

--- a/packages/contracts/src/cli.test.ts
+++ b/packages/contracts/src/cli.test.ts
@@ -44,7 +44,7 @@ describe("updateCommand", () => {
 });
 
 describe("updateChannel", () => {
-  it("escapes only the scope slash — an encoded @ 404s on the registry", () => {
+  it("sends a scoped name in the form npm's registry documents", () => {
     expect(updateChannel({ method: "npm", pkg: "@openai/codex" })?.url).toBe("https://registry.npmjs.org/@openai%2Fcodex/latest");
   });
 
@@ -70,7 +70,10 @@ describe("registry parsers", () => {
   });
 
   it("reads versions.stable off a brew formula, ignoring head", () => {
-    expect(parseBrewFormula({ versions: { stable: "1.9.0", head: "HEAD" } })).toBe("1.9.0");
+    // The document formulae.brew.sh actually returned for block-goose-cli on 2026-09-05. `head` is
+    // the literal string "HEAD", so a parser reaching for the wrong key would return that as a
+    // version and every comparison against it would be nonsense.
+    expect(parseBrewFormula({ versions: { stable: "1.49.0", head: "HEAD", bottle: true } })).toBe("1.49.0");
   });
 
   it("answers null rather than throwing on anything else", () => {
@@ -85,9 +88,12 @@ describe("registry parsers", () => {
 
 describe("parseVersion", () => {
   it("pulls the version out of what each CLI actually prints", () => {
-    expect(parseVersion("2.1.223 (Claude Code)")).toBe("2.1.223");
+    // Every string here was read off a real `--version` on 2026-09-05, except the last.
+    expect(parseVersion("2.1.258 (Claude Code)")).toBe("2.1.258");
     expect(parseVersion("codex-cli 0.146.0")).toBe("0.146.0");
-    expect(parseVersion("2026.09.01")).toBe("2026.09.01");
+    expect(parseVersion("2026.07.25-e42b078")).toBe("2026.07.25-e42b078");
+    expect(parseVersion("1.18.13")).toBe("1.18.13");
+    expect(parseVersion("0.0.7")).toBe("0.0.7");
     expect(parseVersion("0.1.2-rc.3")).toBe("0.1.2-rc.3");
   });
 

--- a/packages/contracts/src/cli.ts
+++ b/packages/contracts/src/cli.ts
@@ -1,0 +1,188 @@
+import type { AgentKind } from "./entities";
+
+/**
+ * How each agent's CLI actually gets onto a machine, structured.
+ *
+ * `AGENT_CLI_COMMANDS` (presets.ts) already carries the install command as prose for copying. This
+ * table carries the same fact in the shape the update checker needs — a method plus the one
+ * identifier that method looks a version up by — and `installCommand()` below regenerates that prose
+ * from it. `cli.test.ts` asserts the two agree for every kind, so the copyable string and the string
+ * Realm would run can never drift apart.
+ *
+ * `null` means Realm has no install route for the kind and must offer no button: `fake` is compiled
+ * in, and any future kind whose install method cannot be established belongs here rather than
+ * getting a guessed package name.
+ */
+export type InstallRoute =
+  /** A global npm package. `pkg` is the registry name, which is also its `latest` lookup key. */
+  | { method: "npm"; pkg: string }
+  /** A Homebrew formula. `formula` is the name, which is also its formulae.brew.sh lookup key. */
+  | { method: "brew"; formula: string }
+  /**
+   * A vendor install script piped into a shell. `command` is verbatim from the vendor's own docs
+   * (flag order included — it is not normalized, because the string a user copies should be the
+   * string the vendor published). `host` is the domain the script is fetched from, so the UI can
+   * name who is about to run code on the machine.
+   */
+  | { method: "script"; host: string; command: string };
+
+/**
+ * Every kind's route. Each entry's identifier comes from the same source as its
+ * `AGENT_CLI_COMMANDS[kind].install` prose — the provider's own install docs — and nothing here is
+ * inferred from a binary name.
+ */
+export const AGENT_INSTALL_ROUTES = {
+  claude: { method: "npm", pkg: "@anthropic-ai/claude-code" },
+  codex: { method: "npm", pkg: "@openai/codex" },
+  "acp:gemini": { method: "npm", pkg: "@google/gemini-cli" },
+  "acp:cursor": { method: "script", host: "cursor.com", command: "curl https://cursor.com/install -fsS | bash" },
+  "acp:opencode": { method: "npm", pkg: "opencode-ai" },
+  "acp:copilot": { method: "npm", pkg: "@github/copilot" },
+  "acp:goose": { method: "brew", formula: "block-goose-cli" },
+  "acp:qwen": { method: "npm", pkg: "@qwen-code/qwen-code" },
+  "acp:grok": { method: "npm", pkg: "@xai-official/grok" },
+  "acp:fx": { method: "script", host: "fx.sh", command: "curl -fsSL https://fx.sh/setup.sh | bash" },
+  // The ACP server package, not the `dsh` launcher — see AGENT_CLI_COMMANDS for why this install
+  // fails today against the published registry.
+  "acp:deepseek": { method: "npm", pkg: "@deepseek-ai/dsh-acp-demo" },
+  fake: null,
+} as const satisfies Record<AgentKind, InstallRoute | null>;
+
+/** The command that puts the CLI on the machine, or null when there is no route. */
+export function installCommand(route: InstallRoute | null): string | null {
+  if (!route) return null;
+  if (route.method === "npm") return `npm install -g ${route.pkg}`;
+  if (route.method === "brew") return `brew install ${route.formula}`;
+  return route.command;
+}
+
+/**
+ * The command that moves an installed CLI to `version`, or null when Realm must not offer one.
+ *
+ * npm installs are pinned to the exact version the check found rather than `@latest`, so the command
+ * the user reads before clicking is the command whose outcome the UI just promised — with `@latest`
+ * a publish landing between the check and the click would install a version nobody agreed to.
+ *
+ * Script routes get null: re-running a vendor's install script does update the CLI, but there is no
+ * channel to learn what version it would land on (see `updateChannel`), so Realm would be offering
+ * an update it cannot claim is one.
+ */
+export function updateCommand(route: InstallRoute | null, version: string): string | null {
+  if (!route || !version) return null;
+  if (route.method === "npm") return `npm install -g ${route.pkg}@${version}`;
+  if (route.method === "brew") return `brew upgrade ${route.formula}`;
+  return null;
+}
+
+/**
+ * Where a route's "what is the newest version" answer comes from, or null when it has none.
+ *
+ * Both endpoints are public, unauthenticated, single-GET JSON, and neither carries anything about the
+ * user — same standing as MODEL_CATALOG_URL.
+ */
+export function updateChannel(route: InstallRoute | null): { url: string; kind: "npm" | "brew" } | null {
+  if (!route) return null;
+  // The registry wants a scoped name with only its slash escaped (`@openai%2Fcodex`);
+  // encodeURIComponent would also escape the leading `@`, which the registry 404s on.
+  if (route.method === "npm") return { url: `https://registry.npmjs.org/${route.pkg.replace("/", "%2F")}/latest`, kind: "npm" };
+  if (route.method === "brew") return { url: `https://formulae.brew.sh/api/formula/${route.formula}.json`, kind: "brew" };
+  return null;
+}
+
+/** `{ version }` off a registry `latest` document. Anything else reads as "no answer" rather than
+ *  throwing — an update check may never be able to fail its caller. */
+export function parseNpmLatest(body: unknown): string | null {
+  const v = (body as { version?: unknown } | null)?.version;
+  return typeof v === "string" && v.trim() !== "" ? v.trim() : null;
+}
+
+/** `versions.stable` off a formulae.brew.sh formula document. Shape verified against the public API
+ *  2026-09-05; `versions.head` is deliberately ignored, since `brew install` lands stable. */
+export function parseBrewFormula(body: unknown): string | null {
+  const v = (body as { versions?: { stable?: unknown } } | null)?.versions?.stable;
+  return typeof v === "string" && v.trim() !== "" ? v.trim() : null;
+}
+
+/**
+ * The version number inside whatever a `--version` flag printed.
+ *
+ * Every CLI decorates it differently — measured: claude prints `2.1.223 (Claude Code)`, codex prints
+ * `codex-cli 0.146.0`, cursor-agent prints a calendar version like `2026.09.01`. At least one dot is
+ * required so a lone digit in a product name (`gpt-5-codex`) is not mistaken for a version; the first
+ * match wins, because every observed format puts the version after any name and before any build
+ * decoration.
+ */
+export function parseVersion(raw: string | null | undefined): string | null {
+  if (!raw) return null;
+  return /\d+(?:\.\d+)+(?:-[0-9A-Za-z.]+)?/.exec(raw)?.[0] ?? null;
+}
+
+const segments = (v: string): number[] => v.split(".").map((s) => Number.parseInt(s, 10) || 0);
+
+/**
+ * Orders two release versions: negative when `a` is older, positive when newer, 0 when equal.
+ *
+ * Numeric segment compare with missing segments read as 0, so `1.2` and `1.2.0` are the same release.
+ * A prerelease suffix orders BELOW the same numbers without one (`1.2.0-rc.1` < `1.2.0`), which is
+ * semver's rule and the one that matters here: it stops an installed release candidate from reading
+ * as newer than the stable build that superseded it. Two prereleases of the same version compare
+ * lexically — good enough, because Realm only ever asks "is the registry strictly ahead of me".
+ */
+export function compareVersions(a: string, b: string): number {
+  const [aCore = "", aPre = ""] = a.split("-", 2);
+  const [bCore = "", bPre = ""] = b.split("-", 2);
+  const as = segments(aCore);
+  const bs = segments(bCore);
+  for (let i = 0; i < Math.max(as.length, bs.length); i++) {
+    const d = (as[i] ?? 0) - (bs[i] ?? 0);
+    if (d !== 0) return d < 0 ? -1 : 1;
+  }
+  if (aPre === bPre) return 0;
+  if (aPre === "") return 1;
+  if (bPre === "") return -1;
+  return aPre < bPre ? -1 : 1;
+}
+
+/** True only when `latest` is a real version strictly ahead of a real `installed`. An unparseable
+ *  version on either side answers false: "we cannot tell" must never render as "update available". */
+export function isNewerVersion(installed: string | null | undefined, latest: string | null | undefined): boolean {
+  const a = parseVersion(installed);
+  const b = parseVersion(latest);
+  if (!a || !b) return false;
+  return compareVersions(a, b) < 0;
+}
+
+/**
+ * How the installed binary got onto the machine, as far as its resolved path can prove.
+ *
+ * `unknown` is the honest majority answer — a downloaded binary, a vendor install script, or a
+ * package manager Realm does not classify all land there — and it is not a failure state. It only
+ * means Realm will not run an update command for that binary.
+ */
+export type InstallProvenance = "npm" | "pnpm" | "brew" | "unknown";
+
+/**
+ * Whether Realm may offer to run `route`'s update command against a binary of this provenance.
+ *
+ * The rule is "do not update what you did not install, by a method that did not install it". Running
+ * `npm install -g` against a Homebrew-installed CLI does not upgrade it — it drops a second copy into
+ * the npm prefix and whichever comes first on PATH wins, which is a confusing machine and a support
+ * problem Realm would have created. npm and pnpm are interchangeable here only in that both put the
+ * package under a global `node_modules`; an `npm install -g` over a pnpm global install is still a
+ * second copy, so pnpm is refused too.
+ */
+export function canRunUpdate(route: InstallRoute | null, provenance: InstallProvenance): boolean {
+  if (!route) return false;
+  if (route.method === "npm") return provenance === "npm";
+  if (route.method === "brew") return provenance === "brew";
+  return false;
+}
+
+/** Why an update Realm found cannot be applied for the user, in the user's terms. Null when it can. */
+export function updateRefusal(route: InstallRoute | null, provenance: InstallProvenance): string | null {
+  if (!route || canRunUpdate(route, provenance)) return null;
+  if (route.method === "script") return "Realm can't update this one — its installer is a script from the vendor, and re-running it gives no way to confirm which version you'd land on.";
+  const want = route.method === "npm" ? "npm" : "Homebrew";
+  const have = provenance === "brew" ? "Homebrew" : provenance === "unknown" ? "something other than a package manager Realm recognises" : provenance;
+  return `Installed with ${have}, so Realm won't update it with ${want} — that would leave a second copy on your PATH instead of upgrading this one.`;
+}

--- a/packages/contracts/src/cli.ts
+++ b/packages/contracts/src/cli.ts
@@ -215,3 +215,15 @@ export type CliStatus = {
   /** Why an available update is not offered as a button. Null whenever there is nothing to explain. */
   refusal: string | null;
 };
+
+/** A running install or update, answered the moment it starts. `command` is the exact string that is
+ *  now running, echoed back so a caller can prove the command it showed is the command it got. */
+export type CliJobStart = { id: string; kind: AgentKind; action: "install" | "update"; command: string };
+
+/** One chunk of a running job's output, stdout and stderr interleaved in the order they arrived. */
+export type CliJobOutput = { id: string; kind: AgentKind; chunk: string };
+
+/** A finished job. `ok` is the only field a UI should branch on; `code` and `error` are what it
+ *  shows. By the time this arrives the probe and version check have already been re-run, so a client
+ *  that refetches on it reads the machine as it is now. */
+export type CliJobEnd = { id: string; kind: AgentKind; ok: boolean; code: number | null; error: string | null };

--- a/packages/contracts/src/cli.ts
+++ b/packages/contracts/src/cli.ts
@@ -125,6 +125,10 @@ const segments = (v: string): number[] => v.split(".").map((s) => Number.parseIn
 /**
  * Orders two release versions: negative when `a` is older, positive when newer, 0 when equal.
  *
+ * Hand-rolled rather than reached for from `semver`, which is not a dependency of this repo and would
+ * be the wrong tool anyway: two of the five CLIs measured print versions semver rejects outright —
+ * cursor-agent's calendar-and-commit `2026.07.25-e42b078` and claude's `2.1.258 (Claude Code)`.
+ *
  * Numeric segment compare with missing segments read as 0, so `1.2` and `1.2.0` are the same release.
  * A prerelease suffix orders BELOW the same numbers without one (`1.2.0-rc.1` < `1.2.0`), which is
  * semver's rule and the one that matters here: it stops an installed release candidate from reading
@@ -209,8 +213,6 @@ export type CliStatus = {
   provenance: InstallProvenance;
   /** Newest published version, null when the CLI is absent, has no channel, or the lookup failed. */
   latest: string | null;
-  /** Whether this route has any way to learn a published version at all. */
-  channel: boolean;
   updateAvailable: boolean;
   action: "install" | "update" | "none";
   /** The exact command `action` would run, shown before it runs. Null when `action` is `"none"`. */

--- a/packages/contracts/src/cli.ts
+++ b/packages/contracts/src/cli.ts
@@ -186,3 +186,32 @@ export function updateRefusal(route: InstallRoute | null, provenance: InstallPro
   const have = provenance === "brew" ? "Homebrew" : provenance === "unknown" ? "something other than a package manager Realm recognises" : provenance;
   return `Installed with ${have}, so Realm won't update it with ${want} — that would leave a second copy on your PATH instead of upgrading this one.`;
 }
+
+/**
+ * One agent CLI's whole situation on this machine, as the Settings engines list and the install card
+ * read it.
+ *
+ * `action` is the only field a button should branch on, and it is deliberately narrower than the rest
+ * of the row: `updateAvailable` can be true while `action` is `"none"`, which is the case where Realm
+ * found a newer version but must not apply it (see `refusal`). Telling the user an update exists and
+ * refusing to run it is more useful than hiding either half.
+ */
+export type CliStatus = {
+  kind: AgentKind;
+  installed: boolean;
+  /** Raw, exactly as the CLI printed it — `parseVersion` is for comparing, not for showing. */
+  version: string | null;
+  /** The PATH entry the binary was found at, null when it is not installed or was not resolved. */
+  binPath: string | null;
+  provenance: InstallProvenance;
+  /** Newest published version, null when the CLI is absent, has no channel, or the lookup failed. */
+  latest: string | null;
+  /** Whether this route has any way to learn a published version at all. */
+  channel: boolean;
+  updateAvailable: boolean;
+  action: "install" | "update" | "none";
+  /** The exact command `action` would run, shown before it runs. Null when `action` is `"none"`. */
+  command: string | null;
+  /** Why an available update is not offered as a button. Null whenever there is nothing to explain. */
+  refusal: string | null;
+};

--- a/packages/contracts/src/cli.ts
+++ b/packages/contracts/src/cli.ts
@@ -82,8 +82,9 @@ export function updateCommand(route: InstallRoute | null, version: string): stri
  */
 export function updateChannel(route: InstallRoute | null): { url: string; kind: "npm" | "brew" } | null {
   if (!route) return null;
-  // The registry wants a scoped name with only its slash escaped (`@openai%2Fcodex`);
-  // encodeURIComponent would also escape the leading `@`, which the registry 404s on.
+  // `@openai%2Fcodex` — the form npm's own registry API documents for a scoped name. Measured
+  // 2026-09-05, the registry also answers 200 to the raw slash and to a fully percent-encoded name,
+  // so this is a matter of sending the documented URL rather than of the other forms being broken.
   if (route.method === "npm") return { url: `https://registry.npmjs.org/${route.pkg.replace("/", "%2F")}/latest`, kind: "npm" };
   if (route.method === "brew") return { url: `https://formulae.brew.sh/api/formula/${route.formula}.json`, kind: "brew" };
   return null;
@@ -96,8 +97,9 @@ export function parseNpmLatest(body: unknown): string | null {
   return typeof v === "string" && v.trim() !== "" ? v.trim() : null;
 }
 
-/** `versions.stable` off a formulae.brew.sh formula document. Shape verified against the public API
- *  2026-09-05; `versions.head` is deliberately ignored, since `brew install` lands stable. */
+/** `versions.stable` off a formulae.brew.sh formula document. Measured 2026-09-05 against the public
+ *  API: `versions` is `{ stable: "1.49.0", head: "HEAD", bottle: true }`. `head` is deliberately
+ *  ignored — it is the literal string "HEAD", not a version, and `brew install` lands stable. */
 export function parseBrewFormula(body: unknown): string | null {
   const v = (body as { versions?: { stable?: unknown } } | null)?.versions?.stable;
   return typeof v === "string" && v.trim() !== "" ? v.trim() : null;
@@ -106,8 +108,9 @@ export function parseBrewFormula(body: unknown): string | null {
 /**
  * The version number inside whatever a `--version` flag printed.
  *
- * Every CLI decorates it differently — measured: claude prints `2.1.223 (Claude Code)`, codex prints
- * `codex-cli 0.146.0`, cursor-agent prints a calendar version like `2026.09.01`. At least one dot is
+ * Every CLI decorates it differently. Measured 2026-09-05 across five installed CLIs: claude prints
+ * `2.1.258 (Claude Code)`, codex `codex-cli 0.146.0`, cursor-agent a calendar version with a commit
+ * suffix `2026.07.25-e42b078`, opencode a bare `1.18.13`, fx a bare `0.0.7`. At least one dot is
  * required so a lone digit in a product name (`gpt-5-codex`) is not mistaken for a version; the first
  * match wins, because every observed format puts the version after any name and before any build
  * decoration.

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -19,6 +19,7 @@ export * from "./review";
 export * from "./browser-agent";
 export * from "./fence";
 export * from "./chips";
+export * from "./cli";
 export * from "./computer-use";
 export * from "./delegation";
 export * from "./search";

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import type { CliJobStart, CliStatus } from "./cli";
 import { ProfileSchema, SpaceSchema, ProjectSchema, ItemSchema, ItemKindSchema, IdSchema, HexColorSchema, SessionSchema, AgentKindSchema, SessionStatusSchema, EnvironmentSchema, CheckpointSchema, BrowserSchema, IconAssetSchema, DocumentWorkspaceSchema, DocumentEntrySchema, DocumentKindSchema } from "./entities";
 
 import { ElementChipSchema, MAX_ELEMENT_CHIPS } from "./chips";
@@ -259,6 +260,29 @@ export const RestoreResultSchema = z.object({
 export type RestoreResult = z.infer<typeof RestoreResultSchema>;
 
 /** Method registry: params + result schemas. Server validates params; client types results. */
+/**
+ * The wire shapes for the CLI manager. They mirror `CliStatus` and `CliJobStart` in cli.ts, which
+ * carry the prose; the `satisfies` is the lock that stops the wire and the type callers program
+ * against drifting apart without a typecheck failure.
+ */
+export const CliActionSchema = z.enum(["install", "update"]);
+export const CliStatusSchema = z.object({
+  kind: AgentKindSchema,
+  installed: z.boolean(),
+  version: z.string().nullable(),
+  binPath: z.string().nullable(),
+  provenance: z.enum(["npm", "pnpm", "brew", "unknown"]),
+  latest: z.string().nullable(),
+  channel: z.boolean(),
+  updateAvailable: z.boolean(),
+  action: z.enum(["install", "update", "none"]),
+  command: z.string().nullable(),
+  refusal: z.string().nullable(),
+}) satisfies z.ZodType<CliStatus>;
+export const CliJobStartSchema = z.object({
+  id: z.string(), kind: AgentKindSchema, action: CliActionSchema, command: z.string(),
+}) satisfies z.ZodType<CliJobStart>;
+
 export const Methods = {
   "profiles.list":   { params: z.object({}), result: z.array(ProfileSchema) },
   "profiles.create": { params: z.object({ name: z.string().min(1), icon: z.string().default("user"), color: z.string().default("#6b7280") }), result: ProfileSchema },
@@ -897,6 +921,23 @@ export const Methods = {
     priceIn: z.number().nullable(), priceOut: z.number().nullable(), context: z.number().nullable(),
     efforts: z.array(z.string()), blurb: z.string().nullable(),
   })) }) },
+  /**
+   * Every agent CLI's install and update situation: what is on this machine, where it came from, what
+   * the provider has published, and the one command a click would run. `force` bypasses both caches
+   * behind it — the thirty-second probe and the six-hour version sweep — and is what "Check for
+   * updates" and the end of an install both use.
+   */
+  "cli.status": { params: z.object({ force: z.boolean().default(false) }), result: z.object({ rows: z.array(CliStatusSchema) }) },
+  /**
+   * Start the install or update `cli.status` offered for this kind, and answer with the exact command
+   * now running. Output arrives as `cli.output` events and the outcome as `cli.done`.
+   *
+   * The server re-derives the command from its OWN status rather than taking one from the caller, and
+   * refuses when that status does not currently offer this action. The gate lives here for the same
+   * reason the app updater's does: a hand-crafted call must not be able to talk Realm into running a
+   * package manager it decided not to offer.
+   */
+  "cli.run": { params: z.object({ kind: AgentKindSchema, action: CliActionSchema }), result: CliJobStartSchema },
   "agents.probe": { params: z.object({ force: z.boolean().default(false) }), result: z.array(z.object({ kind: AgentKindSchema, available: z.boolean(), version: z.string().nullable(), loggedIn: z.boolean().nullable(), reason: z.string().nullable(), models: z.array(z.object({ id: z.string(), label: z.string() })).nullable().optional() })) },
   "sessions.list":   { params: z.object({ spaceId: IdSchema }), result: z.array(SessionSchema) },
   /** Every session across every space — the client's sessionId→spaceId map for cross-space badges. */
@@ -973,6 +1014,12 @@ export type MethodParams<M extends MethodName> = z.input<(typeof Methods)[M]["pa
 export type MethodResult<M extends MethodName> = z.infer<(typeof Methods)[M]["result"]>;
 
 export const Events = {
+  /** One chunk of a running install's output. Broadcast rather than sent to the asking client: the
+   *  Settings page and a session's install card can both be watching the same install. */
+  "cli.output": z.object({ id: z.string(), kind: AgentKindSchema, chunk: z.string() }),
+  /** An install or update finished. The probe and the version sweep have already been re-run by the
+   *  time this lands, so a client that refetches `cli.status` on it reads the new machine. */
+  "cli.done": z.object({ id: z.string(), kind: AgentKindSchema, ok: z.boolean(), code: z.number().nullable(), error: z.string().nullable() }),
   "profiles.changed": z.object({}),
   "spaces.changed":   z.object({}),
   "items.changed":    z.object({ spaceId: IdSchema }),

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -273,7 +273,6 @@ export const CliStatusSchema = z.object({
   binPath: z.string().nullable(),
   provenance: z.enum(["npm", "pnpm", "brew", "unknown"]),
   latest: z.string().nullable(),
-  channel: z.boolean(),
   updateAvailable: z.boolean(),
   action: z.enum(["install", "update", "none"]),
   command: z.string().nullable(),


### PR DESCRIPTION
Stacked on #41.

**No command was invented.** `AGENT_CLI_COMMANDS` already held a vetted install string per kind, sourced from each provider's docs; `AGENT_INSTALL_ROUTES` now carries the same fact *structured* — method plus the identifier that method looks a version up by — and `installCommand()` regenerates the prose from it, with a test asserting the two agree for **every** kind so the copyable string and the runnable argv cannot drift. npm for eight kinds, brew for goose, a vendor script for cursor and fx (install offered, **update never** — no channel to promise a version), and nothing at all for `fake`.

**Provenance is read from the resolved binary, not the PATH entry.** `/opt/homebrew/bin` holds brew's symlinks and npm's global shims side by side, so the binary is resolved the way a spawn would and then `realpath`'d, and the *target* is classified — Cellar/Caskroom → brew, `.pnpm` → pnpm, `node_modules` → npm. Segment matching, so `~/Cellar-backups` doesn't qualify. `canRunUpdate` then refuses any method that didn't do the install, and the refusal names the resolved path, because "which copy?" is the next question for anyone with two on their PATH.

**What it found on a real machine** (read-only: `--version`, realpath, two public GETs, no installer):

```
claude    2.1.258 → 2.1.261 · vendor self-updater → update refused
codex     0.146.0 → 0.153.4 · Homebrew cask       → update refused
opencode  1.18.13 → 1.18.29 · own updater         → update refused
gemini    0.58.0  up to date · npm
```

Worth stating plainly: on that machine the Update button never appears. Four of five installed CLIs came from vendor self-updaters or a cask rather than the route's package manager, so what ships is an honest "you're three releases behind, and here's why Realm won't be the thing that fetches it". Correct, but it means the *update* half delivers less in practice than the *install* half. Closing it needs per-vendor self-update routes, which were not added because they could not be verified and guessing one is exactly what this design refuses to do.

**Launch does one thing and it only reads**: a single unforced `cli.status` fired after `booted`, never awaited, riding a six-hour cache — so it cannot delay first paint or make a session wait on a network call. **Every mutation is a click.** Auto-update-on-launch was deliberately not built: it would run `npm install -g` or `brew upgrade` unattended, changing the version the user's next session runs, mid-session, without asking — and a failed global install would leave them worse off with no output on screen. That is the same posture `updater.ts` already takes for Realm itself.

Model refresh reuses the seams that existed: `probeAgents(true)` and `refreshModelCatalog(true)` — the catalog's `force` had no caller until now — then diffs ids. A kind that couldn't enumerate is **skipped, not read as empty**, or the first successful enumeration would announce a provider's whole catalog as newly published.

96 new tests, none of which runs a package manager: a fake `spawn`, a fake `fetch`, and temp-dir symlink trees shaped like each manager's layout. 22 mutants verified red. Two claims written from memory turned out false and were corrected against the real registries — Homebrew has two install roots, and the npm registry does not 404 on a fully percent-encoded scoped name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)