### PR TITLE
A grain wash on the calm surfaces, bounded by each theme's own accent

### DIFF
--- a/apps/desktop/scripts/wash-live.mjs
+++ b/apps/desktop/scripts/wash-live.mjs
@@ -1,0 +1,371 @@
+/**
+ * Live check for the decorative wash (run with: node apps/desktop/scripts/wash-live.mjs)
+ *
+ * Boots the REAL built app on a scratch REALM_HOME and measures the decoration as pixels. Nothing
+ * here is checkable in jsdom, and two of the claims are not checkable off the CSSOM either:
+ *
+ *   - `oklch(from var(--accent) …)` is RELATIVE COLOUR SYNTAX. If Chromium cannot parse it the whole
+ *     `background-image` declaration is invalid and the computed value falls back to `none` — a
+ *     silent, total loss of the feature that every string assertion in styles.test.ts still passes.
+ *   - Grain is a texture. Its presence is a variance in the pixels and nothing else; a screenshot is
+ *     the only place that number exists.
+ *   - "Still under reduced motion" is a claim about two frames, not about a stylesheet. The check is
+ *     that two shots a second apart are IDENTICAL under the preference and DIFFERENT without it —
+ *     an animation slowed rather than stopped fails the first half.
+ *
+ * Screenshots of every decorated surface, in both modes, on a dark palette and a light one, land in
+ * /tmp and are meant to be LOOKED at. A wash that clears every assertion and looks like a smudge is
+ * still wrong.
+ *
+ * REBUILD FIRST (`pnpm build`): this boots apps/desktop/out, not the sources.
+ * Ports: env-overridable. Touches only a scratch dir; kills only the process it started.
+ */
+import { spawn } from "node:child_process";
+import { connect } from "node:net";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
+const CDP_PORT = Number(process.env.LIVE_CDP_PORT ?? 9347), SERVER_PORT = Number(process.env.LIVE_SERVER_PORT ?? 8914);
+const scratch = fs.mkdtempSync(path.join(os.tmpdir(), "realm-wash-live-"));
+let electron = null;
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+/** The three ink floors from packages/ui/src/themes.ts. Restated because this runs under plain node
+ *  against the BUILT app, and a copy that disagrees with the source is the drift worth catching. */
+const FLOOR = { ink: 4.5, ink2: 3, ink3: 2.4 };
+
+async function portFree(port) {
+  return new Promise((resolve) => {
+    const s = connect({ port, host: "127.0.0.1" });
+    s.once("connect", () => { s.destroy(); resolve(false); });
+    s.once("error", () => resolve(true));
+  });
+}
+
+async function until(fn, ms, tag) {
+  const t0 = Date.now();
+  for (;;) {
+    const v = await fn();
+    if (v) return v;
+    if (Date.now() - t0 > ms) throw new Error(`timeout:${tag}`);
+    await sleep(150);
+  }
+}
+
+function cdp(wsUrl) {
+  const ws = new WebSocket(wsUrl);
+  let id = 0;
+  const pending = new Map();
+  const events = [];
+  const ready = new Promise((res) => ws.addEventListener("open", res));
+  ws.addEventListener("message", (m) => {
+    const msg = JSON.parse(m.data);
+    if (msg.id !== undefined) pending.get(msg.id)?.(msg);
+    else if (msg.method === "Runtime.consoleAPICalled" && msg.params.type === "error") {
+      events.push(msg.params.args.map((a) => a.value ?? a.description ?? "").join(" "));
+    }
+  });
+  return {
+    ready, events,
+    send: (method, params) => new Promise((res, rej) => {
+      const i = ++id;
+      pending.set(i, (msg) => (msg.error ? rej(new Error(msg.error.message)) : res(msg.result)));
+      ws.send(JSON.stringify({ id: i, method, params }));
+    }),
+    close: () => ws.close(),
+  };
+}
+
+const HELPERS = `
+window.__live = window.__live ?? {
+  setInput(el, value) {
+    const proto = el instanceof HTMLTextAreaElement ? HTMLTextAreaElement.prototype : HTMLInputElement.prototype;
+    Object.getOwnPropertyDescriptor(proto, "value").set.call(el, value);
+    el.dispatchEvent(new Event("input", { bubbles: true }));
+  },
+  async menu(label) {
+    document.querySelector('[aria-label="Space menu"]').click();
+    for (let i = 0; i < 40 && !document.querySelector('[role="menu"]'); i++) await new Promise((r) => setTimeout(r, 25));
+    const hit = [...document.querySelectorAll('[role="menu"] button')].find((b) => b.textContent.trim() === label);
+    if (!hit) { document.querySelector('[role="menu"]')?.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true })); throw new Error("no menu item: " + label); }
+    hit.click();
+    return true;
+  },
+  /** Open a page pane by its command-palette entry. */
+  async openPage(re) {
+    document.querySelector('[aria-label="Space menu"]')?.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "k", metaKey: true, bubbles: true }));
+    for (let i = 0; i < 40 && !document.querySelector(".palette-list"); i++) await new Promise((r) => setTimeout(r, 25));
+    const open = [...document.querySelectorAll(".palette-list [role=option], .palette-list button")]
+      .find((b) => new RegExp(re, "i").test(b.textContent));
+    if (!open) throw new Error("no palette entry: " + re);
+    open.click();
+    return true;
+  },
+  /** The first-run card is shown once and never again, so after onboarding the only way to look at
+   *  the grain on another palette is to plant the same markup and let the real cascade resolve it —
+   *  the fragment carries no styling of its own beyond where it sits. */
+  plantCard(vars) {
+    let host = document.getElementById("live-card");
+    if (!host) {
+      host = document.createElement("section");
+      host.id = "live-card";
+      host.className = "sheet onboarding wash";
+      host.setAttribute("data-grain", "");
+      host.style.cssText = "position:fixed;right:32px;top:96px;z-index:9999;width:380px;height:260px";
+      host.innerHTML = '<div class="sheet-head"><h3>Welcome to Realm</h3></div>' +
+        '<div class="sheet-body"><p class="muted onboarding-lead">Realm drives the agent CLIs already installed on this machine.</p></div>';
+      document.body.appendChild(host);
+    }
+    for (const [k, v] of Object.entries(vars)) host.style.setProperty(k, v);
+    return true;
+  },
+  rect(sel) { const el = document.querySelector(sel); return el ? el.getBoundingClientRect().toJSON() : null; },
+  /** Whether the decoration survived parsing at all. A computed background-image of "none" on a
+   *  .wash element means the relative-colour declaration was thrown away. */
+  washState(sel) {
+    const el = document.querySelector(sel);
+    if (!el) return null;
+    const s = getComputedStyle(el);
+    return { image: s.backgroundImage, ground: s.backgroundColor, hue: s.getPropertyValue("--grain-hue").trim() };
+  },
+  srgb(color) {
+    const g = (this._cv ??= document.createElement("canvas").getContext("2d", { willReadFrequently: true }));
+    g.clearRect(0, 0, 1, 1); g.fillStyle = color; g.fillRect(0, 0, 1, 1);
+    return [...g.getImageData(0, 0, 1, 1).data].slice(0, 3);
+  },
+  /** The ink a real element on the page is actually painted in. */
+  inkOf(sel) { const el = document.querySelector(sel); return el ? this.srgb(getComputedStyle(el).color) : null; },
+  async _pixels(b64) {
+    const img = new Image();
+    await new Promise((res, rej) => { img.onload = res; img.onerror = rej; img.src = "data:image/png;base64," + b64; });
+    const c = document.createElement("canvas"); c.width = img.width; c.height = img.height;
+    c.getContext("2d").drawImage(img, 0, 0);
+    return { c, dpr: img.width / window.innerWidth };
+  },
+  /** Mean colour of a CSS-pixel rect, and the standard deviation of its luminance. The mean says
+   *  which ground was painted; the deviation is the only number that says whether it has grain. */
+  async patch(b64, r) {
+    const { c, dpr } = await this._pixels(b64);
+    const x = Math.floor(r.x * dpr), y = Math.floor(r.y * dpr);
+    const w = Math.max(1, Math.floor(r.w * dpr)), h = Math.max(1, Math.floor(r.h * dpr));
+    const d = c.getContext("2d").getImageData(x, y, w, h).data;
+    let sr = 0, sg = 0, sb = 0, n = 0; const lum = [];
+    for (let i = 0; i < d.length; i += 4) { sr += d[i]; sg += d[i+1]; sb += d[i+2]; n++;
+      lum.push(0.299 * d[i] + 0.587 * d[i+1] + 0.114 * d[i+2]); }
+    const mean = lum.reduce((a, b) => a + b, 0) / n;
+    return { rgb: [sr/n, sg/n, sb/n], sd: Math.sqrt(lum.reduce((a, v) => a + (v - mean) ** 2, 0) / n) };
+  },
+  /** Largest per-channel difference between two shots over a rect — zero means nothing moved. */
+  async diff(a, b, r) {
+    const A = await this._pixels(a), B = await this._pixels(b);
+    const x = Math.floor(r.x * A.dpr), y = Math.floor(r.y * A.dpr);
+    const w = Math.max(1, Math.floor(r.w * A.dpr)), h = Math.max(1, Math.floor(r.h * A.dpr));
+    const da = A.c.getContext("2d").getImageData(x, y, w, h).data;
+    const db = B.c.getContext("2d").getImageData(x, y, w, h).data;
+    let worst = 0;
+    for (let i = 0; i < da.length; i++) if (i % 4 !== 3) worst = Math.max(worst, Math.abs(da[i] - db[i]));
+    return worst;
+  },
+};
+`;
+
+async function evalIn(c, expr) {
+  const r = await c.send("Runtime.evaluate", { expression: HELPERS + ";\n" + expr, awaitPromise: true, returnByValue: true });
+  if (r.exceptionDetails) throw new Error(`page exception: ${r.exceptionDetails.exception?.description ?? r.exceptionDetails.text}`);
+  return r.result.value;
+}
+
+let failures = 0;
+function check(name, cond, detail = "") {
+  if (!cond) failures++;
+  console.log(`${cond ? "ok  " : "FAIL"} ${name}${detail ? `  — ${detail}` : ""}`);
+}
+
+const relLum = (c) => { const [r, g, b] = c.map((v) => { const x = v / 255; return x <= 0.04045 ? x / 12.92 : ((x + 0.055) / 1.055) ** 2.4; });
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b; };
+const contrast = (a, b) => { const [x, y] = [relLum(a), relLum(b)]; return (Math.max(x, y) + 0.05) / (Math.min(x, y) + 0.05); };
+
+const shot = async (c) => (await c.send("Page.captureScreenshot", { format: "png" })).data;
+const save = (tag, b64) => {
+  const out = path.join(os.tmpdir(), `realm-wash-${tag}.png`);
+  fs.writeFileSync(out, Buffer.from(b64, "base64"));
+  console.log(`SCREENSHOT ${tag} ${out}`);
+  return out;
+};
+const media = (c, features) => c.send("Emulation.setEmulatedMedia", { features });
+
+async function main() {
+  for (const p of [CDP_PORT, SERVER_PORT]) if (!(await portFree(p))) throw new Error(`port ${p} is in use — refusing to run`);
+  const mainEntry = path.join(repoRoot, "apps/desktop/out/main/index.js");
+  if (!fs.existsSync(mainEntry)) throw new Error("apps/desktop/out is missing — run `pnpm build` first");
+
+  const wrapper = path.join(scratch, "wrapper.mjs");
+  fs.writeFileSync(wrapper, [
+    'import { app } from "electron";',
+    'app.setPath("userData", process.env.LIVE_USER_DATA);',
+    "await import(process.env.LIVE_MAIN);",
+  ].join("\n"));
+  const electronBin = process.platform === "darwin"
+    ? path.join(repoRoot, "node_modules/.pnpm/electron@37.10.3/node_modules/electron/dist/Electron.app/Contents/MacOS/Electron")
+    : path.join(repoRoot, "apps/desktop/node_modules/.bin/electron");
+  electron = spawn(electronBin, [wrapper], {
+    env: { ...process.env,
+      REALM_HOME: path.join(scratch, "home"),
+      REALM_PORT: String(SERVER_PORT),
+      REALM_DEVTOOLS_PORT: String(CDP_PORT),
+      REALM_SERVER_ENTRY: path.join(repoRoot, "apps/server/dist/main.js"),
+      LIVE_USER_DATA: path.join(scratch, "userData"),
+      LIVE_MAIN: mainEntry,
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  electron.stderr.on("data", () => {}); electron.stdout.on("data", () => {});
+
+  const targets = () => fetch(`http://127.0.0.1:${CDP_PORT}/json/list`).then((r) => r.json()).catch(() => []);
+  const target = await until(async () => (await targets()).find((t) => t.type === "page" && t.url.startsWith("file://")), 30000, "renderer target");
+  const c = cdp(target.webSocketDebuggerUrl);
+  await c.ready;
+  await c.send("Runtime.enable");
+  await c.send("Page.enable");
+  await until(() => evalIn(c, `!!document.querySelector('.onboarding input:not([type=radio])')`), 20000, "onboarding");
+  await c.send("Emulation.setDeviceMetricsOverride", { width: 1200, height: 820, deviceScaleFactor: 1, mobile: false });
+  await sleep(500);
+
+  // ── 1. The first-run card, which is the one surface that wears the grain ───────────────────────
+  const card = await evalIn(c, `__live.washState('.sheet.onboarding')`);
+  check("1 the wash survives parsing (relative colour syntax resolved)",
+    !!card && card.image !== "none" && card.image.includes("gradient"),
+    `background-image: ${String(card?.image).slice(0, 72)}…`);
+  // `url(` appears twice in the texture layer alone — the outer data URI and the SVG's own
+  // filter='url(#g)' — so the texture is counted by its data URI, not by the function name.
+  check("2 the texture and the lift are both in the stack",
+    !!card && (card.image.match(/url\("data:/g) ?? []).length === 1 && (card.image.match(/gradient/g) ?? []).length === 2,
+    `${(card?.image.match(/gradient/g) ?? []).length} gradients, ${(card?.image.match(/url\("data:/g) ?? []).length} textures`);
+  check("3 the launch draw reached the element", !!card && card.hue !== "" && Math.abs(Number(card.hue)) <= 40, `--grain-hue: ${card?.hue}`);
+  save("onboarding-realm-dark", await shot(c));
+
+  /* The pixel measurements need a patch of ground with no text on it, and the real first-run card is
+     a form from its heading down. So they run against the same markup, planted and resolved by the
+     real cascade — the fragment carries only its position. */
+  await evalIn(c, `__live.plantCard({ "--grain-hue": "24", "--grain-x": "72%", "--grain-y": "6%", "--grain-spread": "96%" })`);
+  await sleep(400);
+  const pr = await evalIn(c, `__live.rect('#live-card')`);
+  const flat = { x: pr.x + 16, y: pr.y + 150, w: pr.width - 32, h: 80 };
+  const near = { x: pr.x + pr.width - 90, y: pr.y + 10, w: 70, h: 26 };
+  const far = { x: pr.x + 14, y: pr.y + pr.height - 40, w: 70, h: 26 };
+
+  const on = await shot(c);
+  const grained = await evalIn(c, `__live.patch(${JSON.stringify(on)}, ${JSON.stringify(flat)})`);
+  const hot = await evalIn(c, `__live.patch(${JSON.stringify(on)}, ${JSON.stringify(near)})`);
+  const cold = await evalIn(c, `__live.patch(${JSON.stringify(on)}, ${JSON.stringify(far)})`);
+
+  // The mutant, on the same pixels: take the decoration away and the ground goes flat and even.
+  await evalIn(c, `(() => { document.getElementById('live-card').classList.remove('wash'); return true; })()`);
+  await sleep(300);
+  const offShot = await shot(c);
+  const bareGround = await evalIn(c, `__live.patch(${JSON.stringify(offShot)}, ${JSON.stringify(flat)})`);
+  const bareHot = await evalIn(c, `__live.patch(${JSON.stringify(offShot)}, ${JSON.stringify(near)})`);
+  check("4 the grain is really in the pixels, not just in the stylesheet",
+    grained.sd > bareGround.sd + 0.35, `sd ${grained.sd.toFixed(2)} decorated vs ${bareGround.sd.toFixed(2)} plain`);
+  check("5 the field paints, and falls off across the card the way a field should",
+    Math.max(...hot.rgb.map((v, i) => Math.abs(v - cold.rgb[i]))) >= 2,
+    `origin ${hot.rgb.map(Math.round)} vs far corner ${cold.rgb.map(Math.round)}`);
+  // Measured at the field's ORIGIN. The flat strip above is deliberately at the far corner, where
+  // the field has fallen off to nothing — a ground that had moved there would be a field that does
+  // not fall off, which is a wash over the whole card rather than a light on one corner of it.
+  check("6 at its origin the field really has moved the ground off the bare --surface",
+    Math.max(...hot.rgb.map((v, i) => Math.abs(v - bareHot.rgb[i]))) >= 2,
+    `${hot.rgb.map((v) => v.toFixed(1))} vs ${bareHot.rgb.map((v) => v.toFixed(1))}`);
+  await evalIn(c, `(() => { document.getElementById('live-card').classList.add('wash'); return true; })()`);
+  await sleep(300);
+
+  // ── The drift, and whether the preference actually stops it ────────────────────────────────────
+  const a1 = await shot(c); await sleep(1400); const a2 = await shot(c);
+  const moved = await evalIn(c, `__live.diff(${JSON.stringify(a1)}, ${JSON.stringify(a2)}, ${JSON.stringify(flat)})`);
+  check("7 the grain drifts on its own", moved > 0, `largest channel change over 1.4s: ${moved}`);
+
+  await media(c, [{ name: "prefers-reduced-motion", value: "reduce" }]);
+  await sleep(500);
+  const b1 = await shot(c); await sleep(1400); const b2 = await shot(c);
+  const still = await evalIn(c, `__live.diff(${JSON.stringify(b1)}, ${JSON.stringify(b2)}, ${JSON.stringify(flat)})`);
+  check("8 reduced motion stops it dead rather than slowing it", still === 0, `largest channel change over 1.4s: ${still}`);
+  save("onboarding-reduced-motion", b2);
+
+  // ── Reduced transparency takes the decoration away entirely ────────────────────────────────────
+  await media(c, [{ name: "prefers-reduced-transparency", value: "reduce" }]);
+  await sleep(500);
+  const rt = await shot(c);
+  const bare = await evalIn(c, `__live.patch(${JSON.stringify(rt)}, ${JSON.stringify(flat)})`);
+  check("9 reduced transparency leaves the plain surface, grain and field both gone",
+    Math.abs(bare.sd - bareGround.sd) < 0.3 && Math.max(...bare.rgb.map((v, i) => Math.abs(v - bareGround.rgb[i]))) < 2,
+    `sd ${bare.sd.toFixed(2)} vs plain ${bareGround.sd.toFixed(2)}; ${bare.rgb.map(Math.round)} vs ${bareGround.rgb.map(Math.round)}`);
+  save("onboarding-reduced-transparency", rt);
+  await media(c, []);
+  await sleep(300);
+  await evalIn(c, `(() => { document.getElementById('live-card')?.remove(); return true; })()`);
+
+  // ── Past onboarding, to the two decorated pages ────────────────────────────────────────────────
+  await evalIn(c, `(() => {
+    const input = document.querySelector('.onboarding input:not([type=radio])');
+    __live.setInput(input, "Live");
+    input.closest("form").requestSubmit();
+    return true; })()`);
+  await until(() => evalIn(c, `!!document.querySelector('.composer')`), 20000, "composer");
+
+  for (const [palette, mode, tag] of [["Realm", "Dark", "realm-dark"], ["GitHub", "Light", "github-light"]]) {
+    await evalIn(c, `__live.menu(${JSON.stringify(`Theme: ${mode}`)})`);
+    await sleep(300);
+    await evalIn(c, `__live.menu(${JSON.stringify(`Palette: ${palette}`)})`);
+    await sleep(500);
+
+    for (const [name, sel, re] of [["settings", ".settings-page-pane", "settings"], ["notifications", ".notifications-page-pane", "notification"]]) {
+      await evalIn(c, `__live.openPage(${JSON.stringify(re)})`);
+      await until(() => evalIn(c, `!!document.querySelector('${sel}')`), 15000, `${name} pane`);
+      await sleep(450);
+      const state = await evalIn(c, `__live.washState('${sel}')`);
+      check(`10 ${name}/${tag}: the field paints and carries no texture`,
+        !!state && state.image !== "none" && state.image.includes("gradient") && !state.image.includes("url("),
+        `${(state?.image.match(/gradient/g) ?? []).length} gradients, ${(state?.image.match(/url\(/g) ?? []).length} textures`);
+
+      const r = await evalIn(c, `__live.rect('${sel} .page-head')`);
+      const png = await shot(c);
+      save(`${name}-${tag}`, png);
+      // The subtitle under the page title is --ink-2 sitting straight on the decorated ground.
+      const ink = await evalIn(c, `__live.inkOf('${sel} .page-sub')`);
+      const ground = await evalIn(c, `__live.patch(${JSON.stringify(png)}, ${JSON.stringify({ x: r.x + r.width - 90, y: r.y + 8, w: 60, h: 20 })})`);
+      const ratio = contrast(ink, ground.rgb.map(Math.round));
+      check(`11 ${name}/${tag}: the subtitle still clears its floor on the decorated ground`,
+        ratio >= FLOOR.ink2, `${ratio.toFixed(2)}:1 against ${FLOOR.ink2} (ink ${ink}, ground ${ground.rgb.map(Math.round)})`);
+      check(`12 ${name}/${tag}: the page ground is genuinely flat — no texture reached --canvas`,
+        ground.sd < 2.2, `sd ${ground.sd.toFixed(2)}`);
+    }
+
+    // The first-run card cannot be reopened, so its markup is planted and resolved by the real
+    // cascade — the point is to look at the grain on a light palette as well as a dark one.
+    await evalIn(c, `__live.plantCard({ "--grain-hue": "24", "--grain-x": "70%", "--grain-y": "4%", "--grain-spread": "96%" })`);
+    await sleep(500);
+    const planted = await shot(c);
+    save(`card-${tag}`, planted);
+    const pr = await evalIn(c, `__live.rect('#live-card')`);
+    const grainy = await evalIn(c, `__live.patch(${JSON.stringify(planted)}, ${JSON.stringify({ x: pr.x + 20, y: pr.y + 150, w: pr.width - 40, h: 60 })})`);
+    check(`13 card/${tag}: the grain is visible on this palette too`, grainy.sd > 0.7, `sd ${grainy.sd.toFixed(2)}`);
+    await evalIn(c, `(() => { document.getElementById('live-card')?.remove(); return true; })()`);
+  }
+
+  const errs = c.events.filter((e) => !/Autofill/.test(e));
+  check("14 no renderer console errors", errs.length === 0, errs.join(" | "));
+  c.close();
+  console.log(failures === 0 ? "\nALL CLEAR" : `\n${failures} FAILED`);
+  if (failures) process.exitCode = 1;
+}
+
+main()
+  .catch((e) => { console.error("ERROR", e.message); process.exitCode = 1; })
+  .finally(() => {
+    electron?.kill("SIGTERM");
+    setTimeout(() => { electron?.kill("SIGKILL"); fs.rmSync(scratch, { recursive: true, force: true }); process.exit(process.exitCode ?? 0); }, 1200);
+  });

--- a/apps/desktop/src/renderer/src/components/Onboarding.tsx
+++ b/apps/desktop/src/renderer/src/components/Onboarding.tsx
@@ -3,6 +3,7 @@ import { Icon } from "@realm/ui";
 import { useEffect, useRef, useState } from "react";
 import { FALLBACK_AGENT, useApp } from "../state/store";
 import { agentAvailability, type AgentAvailability } from "../state/agent-availability";
+import { grainVars } from "../theme/grain";
 
 /**
  * Status pill text + tone per §3 (fill = 14% color-mix, text at full strength).
@@ -72,7 +73,7 @@ export function Onboarding() {
 
   return (
     <div className="onboarding-stage">
-      <section className="sheet onboarding" aria-labelledby="onboarding-title">
+      <section className="sheet onboarding wash" data-grain style={grainVars("onboarding")} aria-labelledby="onboarding-title">
         <div className="sheet-head"><h3 id="onboarding-title">Welcome to Realm</h3></div>
         <div className="sheet-body">
           <p className="muted onboarding-lead">

--- a/apps/desktop/src/renderer/src/panes/notifications/NotificationsPage.tsx
+++ b/apps/desktop/src/renderer/src/panes/notifications/NotificationsPage.tsx
@@ -3,6 +3,7 @@ import { Icon } from "@realm/ui";
 import type { Notification, NotificationCategory } from "@realm/contracts";
 import { useApp } from "../../state/store";
 import { PermissionCard } from "../session/PermissionCard";
+import { grainVars } from "../../theme/grain";
 import type { PaneProps } from "../registry";
 
 const CATEGORY_ICON: Record<NotificationCategory, string> = {
@@ -71,7 +72,7 @@ export function NotificationsPage({ item }: PaneProps) {
   const selected = notifications.find((n) => n.id === selectedId) ?? null;
 
   return (
-    <div className="page notifications-page-pane">
+    <div className="page notifications-page-pane wash" style={grainVars("notifications-page")}>
       <header className="page-head">
         <span className="page-glyph"><Icon name="notifications-page" size={20} /></span>
         <div className="page-title">

--- a/apps/desktop/src/renderer/src/panes/settings/SettingsPage.tsx
+++ b/apps/desktop/src/renderer/src/panes/settings/SettingsPage.tsx
@@ -12,6 +12,7 @@ import { agentAvailability, isBlocked } from "../../state/agent-availability";
 import { useApp, type CliJob, type SubmitKey } from "../../state/store";
 import type { PaneProps } from "../registry";
 import { hasWindowMaterial, useResolvedMode, type ThemePref } from "../../theme/useTheme";
+import { grainVars } from "../../theme/grain";
 import { ImportPanel } from "../../components/settings/ImportPanel";
 import { UsagePanel } from "./usage/UsagePanel";
 
@@ -42,7 +43,7 @@ export function engineVersionLabel(version: string): string {
 export function SettingsPage(_props: PaneProps) {
   const [tab, setTab] = useState<SettingsTab>("engines");
   return (
-    <div className="page settings-page-pane">
+    <div className="page settings-page-pane wash" style={grainVars("settings-page")}>
       <header className="page-head">
         <span className="page-glyph"><Icon name="settings-page" size={20} /></span>
         <div className="page-title">

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -3337,10 +3337,10 @@ body[data-media-lightbox] .transcript .media-el { visibility: hidden; }
    question.
 
    Two layers, and which of them a surface gets is decided by its GROUND, not by taste. The colour
-   field is luminance-neutral (theme/tokens.css) and can go anywhere. The grain is a luminance
-   excursion and can only go where a lift can pay for it, which on the measured faces means a
-   `--surface` ground and not a `--canvas` one — so `.page` takes the field alone and says nothing
-   about texture.
+   field holds the ground's own lightness (theme/tokens.css) and so can go anywhere. The grain is a
+   luminance excursion and can only go where a lift can bank the budget for it first, which on the
+   measured faces means a `--surface` ground and not a `--canvas` one — so `.page` takes the field
+   alone.
 
    Painted as background layers on the surface itself rather than as an absolutely-positioned child.
    That is what keeps it out of the no-overlay problem (state/no-overlay.ts): a background cannot
@@ -3352,18 +3352,16 @@ body[data-media-lightbox] .transcript .media-el { visibility: hidden; }
    The fallbacks are what the surface looks like if they never do: centred, unrotated, still the
    theme's accent. */
 .wash {
-  background-image: radial-gradient(var(--grain-spread, 90%) 76% at var(--grain-x, 50%) var(--grain-y, 0%),
+  --grain-field: radial-gradient(var(--grain-spread, 90%) 76% at var(--grain-x, 50%) var(--grain-y, 0%),
     oklch(from var(--accent) var(--grain-wash-l) var(--grain-wash-c) calc(h + var(--grain-hue, 0)) / var(--grain-wash-a)),
     transparent 72%);
+  background-image: var(--grain-field);
   background-repeat: no-repeat;
 }
-/* Grain over lift over field. The lift is flat, so it is a gradient of one colour — the only way to
-   put a solid into the background-image stack, where it has to sit to be under the speckles. */
+/* Grain over lift over field. The lift is flat, so it is a gradient of one colour — a solid has no
+   other way into the background-image stack, and under the speckles is where it has to sit. */
 .wash[data-grain] {
-  background-image: var(--grain-tex), linear-gradient(var(--grain-lift), var(--grain-lift)),
-    radial-gradient(var(--grain-spread, 90%) 76% at var(--grain-x, 50%) var(--grain-y, 0%),
-      oklch(from var(--accent) var(--grain-wash-l) var(--grain-wash-c) calc(h + var(--grain-hue, 0)) / var(--grain-wash-a)),
-      transparent 72%);
+  background-image: var(--grain-tex), linear-gradient(var(--grain-lift), var(--grain-lift)), var(--grain-field);
   background-repeat: repeat, no-repeat, no-repeat;
   background-size: 160px 160px, auto, auto;
   background-position: 0 0, 0 0, 0 0;

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -3329,3 +3329,53 @@ body[data-media-lightbox] .transcript .media-el { visibility: hidden; }
 .plan-approve { background: var(--rl-accent); color: var(--rl-accent-contrast); font-weight: var(--fw-label); }
 .plan-reject { background: var(--hover); color: var(--ink-2); }
 .plan-reject:hover { background: var(--hover-2); color: var(--ink); }
+
+/* ── The decorative wash ──────────────────────────────────────────────────────
+   Worn by the surfaces a person sits on rather than passes through: Settings, Notifications, and
+   the first-run card. Everything else — every confirm, rename and delete sheet, the palette — stays
+   plain, because a decorated ground on a surface that exists to ask one question decorates the
+   question.
+
+   Two layers, and which of them a surface gets is decided by its GROUND, not by taste. The colour
+   field is luminance-neutral (theme/tokens.css) and can go anywhere. The grain is a luminance
+   excursion and can only go where a lift can pay for it, which on the measured faces means a
+   `--surface` ground and not a `--canvas` one — so `.page` takes the field alone and says nothing
+   about texture.
+
+   Painted as background layers on the surface itself rather than as an absolutely-positioned child.
+   That is what keeps it out of the no-overlay problem (state/no-overlay.ts): a background cannot
+   extend past its own element, so it can never end up over the WebContentsView the way a floating
+   layer can. It is also why the sheet's field does not scroll away from under its own content —
+   a background is fixed to the border box, an inset:0 child is not.
+
+   `--grain-hue`, `--grain-x`, `--grain-y` and `--grain-spread` arrive inline from theme/grain.ts.
+   The fallbacks are what the surface looks like if they never do: centred, unrotated, still the
+   theme's accent. */
+.wash {
+  background-image: radial-gradient(var(--grain-spread, 90%) 76% at var(--grain-x, 50%) var(--grain-y, 0%),
+    oklch(from var(--accent) var(--grain-wash-l) var(--grain-wash-c) calc(h + var(--grain-hue, 0)) / var(--grain-wash-a)),
+    transparent 72%);
+  background-repeat: no-repeat;
+}
+/* Grain over lift over field. The lift is flat, so it is a gradient of one colour — the only way to
+   put a solid into the background-image stack, where it has to sit to be under the speckles. */
+.wash[data-grain] {
+  background-image: var(--grain-tex), linear-gradient(var(--grain-lift), var(--grain-lift)),
+    radial-gradient(var(--grain-spread, 90%) 76% at var(--grain-x, 50%) var(--grain-y, 0%),
+      oklch(from var(--accent) var(--grain-wash-l) var(--grain-wash-c) calc(h + var(--grain-hue, 0)) / var(--grain-wash-a)),
+      transparent 72%);
+  background-repeat: repeat, no-repeat, no-repeat;
+  background-size: 160px 160px, auto, auto;
+  background-position: 0 0, 0 0, 0 0;
+  /* One tile per cycle, so the loop closes on the seam `stitchTiles` made invisible. Slow enough to
+     be weather rather than motion; the first-run card is the only surface that wears it, because it
+     is the only decorated one a person passes through rather than sits on, and an ambient animation
+     on a pane somebody leaves open all day is a battery cost with no reader. */
+  animation: rl-grain-drift 24s linear infinite;
+}
+@keyframes rl-grain-drift { to { background-position: 160px 160px, 0 0, 0 0; } }
+/* Asked for less translucency: the decoration is the one thing here that is purely decorative, so it
+   goes rather than changing medium. The surface underneath is a finished design without it. */
+@media (prefers-reduced-transparency: reduce) {
+  .wash, .wash[data-grain] { background-image: none; }
+}

--- a/apps/desktop/src/renderer/src/styles.test.ts
+++ b/apps/desktop/src/renderer/src/styles.test.ts
@@ -80,8 +80,10 @@ describe("§6 motion ladder", () => {
     const bare = new Set([...css.replace(/\/\*[\s\S]*?\*\//g, "")
       .matchAll(/(?:transition|animation)[^;{}]*?(?<![\d.])([\d.]+m?s)\b/g)].map((m) => m[1]!));
     // Loop PERIODS are a tempo, not the duration of a change, and the stagger step is a delay
-    // between siblings rather than a duration at all. Neither belongs on the ladder.
-    for (const period of ["0.9s", "1.4s", "3.6s", "5s", "40ms"]) bare.delete(period);
+    // between siblings rather than a duration at all. Neither belongs on the ladder. 24s is the
+    // grain's drift: an ambient tempo an order of magnitude off the slowest rung, and putting it on
+    // the ladder would invite a UI transition to reach for it.
+    for (const period of ["0.9s", "1.4s", "3.6s", "5s", "24s", "40ms"]) bare.delete(period);
     expect([...bare].sort()).toEqual([]);
   });
 });
@@ -524,6 +526,10 @@ describe("Plan 9 W1 — the BUI bridge", () => {
       // The video scrubber's fill (MediaView.tsx): the played fraction, set inline per frame so the
       // track and the knob are one box and cannot drift out of register.
       "--media-progress",
+      // The decorative wash's geometry (theme/grain.ts): drawn once per launch per surface and set
+      // inline, because a value that is randomised cannot be written in a stylesheet. Every one is
+      // used with a fallback, so a surface that never receives them is still a finished surface.
+      "--grain-hue", "--grain-x", "--grain-y", "--grain-spread",
     ]);
     const used = new Set([...css.matchAll(/var\((--[a-z0-9-]+)/g)].map((m) => m[1]!));
     expect([...used].filter((n) => !defined.has(n) && !n.startsWith("--dsg-")).sort()).toEqual([]);
@@ -1661,5 +1667,68 @@ describe("custom themes", () => {
         expect(want.syntax[role], `${mode} syntax.${role}`).toBe(hexIn(token, block));
       }
     }
+  });
+});
+
+describe("the decorative wash", () => {
+  const tokensCss = readFileSync(repoFile("apps/desktop/src/renderer/src/theme/tokens.css"), "utf8");
+  const wash = bodiesFor(".wash").join(" ");
+  const grain = bodiesFor(".wash[data-grain]").join(" ");
+  /* Every selector that paints any part of the decoration. If a rule is ever added that puts it on a
+     pseudo-element or a child, these lists are what notice. */
+  const painters = RULES.filter((r) => /--grain-tex|--grain-lift|--grain-wash-l/.test(r.body)).flatMap((r) => r.selectors);
+
+  it("is painted as the surface's own background, never as a layer over it", () => {
+    // state/no-overlay.ts exists because a WebContentsView composites ABOVE everything React draws,
+    // so any floating surface has to be kept off its rect. A background cannot leave its own element
+    // and so can never join that problem; an absolutely-positioned child could.
+    expect(wash).toContain("background-image:");
+    for (const body of [wash, grain]) {
+      expect(body).not.toMatch(/position:\s*(absolute|fixed)/);
+      expect(body).not.toContain("inset:");
+      expect(body).not.toContain("z-index:");
+    }
+    expect(painters.filter((s) => /::(before|after)/.test(s))).toEqual([]);
+  });
+
+  it("keeps texture off a --canvas ground, where the contrast budget is zero", () => {
+    // theme/grain.test.ts measures it: the derivation puts --ink-3 at exactly its 2.4 floor on
+    // --canvas for six light faces, so a luminance excursion there has nothing to spend. `.page` is
+    // --canvas, and takes the luminance-neutral colour field alone.
+    const textured = RULES.filter((r) => r.body.includes("var(--grain-tex)")).flatMap((r) => r.selectors);
+    expect(textured).toEqual([".wash[data-grain]"]);
+    expect(wash).not.toContain("var(--grain-tex)");
+    expect(wash).not.toContain("var(--grain-lift)");
+  });
+
+  it("drifts by exactly one tile, so the loop closes on a seam that is not there", () => {
+    // feTurbulence stitchTiles makes the 160px tile repeat without a join; translating by any other
+    // distance would park the texture mid-tile and show one.
+    expect(grain).toContain("background-size: 160px 160px");
+    expect(blockAfter("@keyframes rl-grain-drift")).toContain("background-position: 160px 160px");
+  });
+
+  it("is genuinely still under reduced motion, and gone under reduced transparency", () => {
+    // The animation is on the ELEMENT, so the global `* { animation: none }` reaches it — which is
+    // only true while nothing here moves to a pseudo-element, hence the check above.
+    expect(grain).toContain("animation: rl-grain-drift");
+    const transparency = blocksAfter("@media (prefers-reduced-transparency: reduce)").join("\n").replace(/\s+/g, " ");
+    expect(transparency).toContain(".wash, .wash[data-grain] { background-image: none; }");
+  });
+
+  it("randomises hue and place, never the lightness the contrast proof rests on", () => {
+    // --grain-wash-l/-c are pinned per mode in tokens.css because they are what keeps the field off
+    // the luminance axis. If either became an inline value, grain.test.ts would still pass and the
+    // guarantee would be gone.
+    for (const name of ["--grain-wash-l", "--grain-wash-c", "--grain-wash-a", "--grain-lift", "--grain-tex"]) {
+      expect(tokensCss, name).toContain(`${name}:`);
+      expect(css, name).not.toMatch(new RegExp(`${name}\\s*:`));
+    }
+    // The light face flips the pin: .97 sits inside the light grounds' own band the way .10 sits
+    // below every dark one.
+    expect(tokensCss).toContain("--grain-wash-l: 0.10");
+    expect(tokensCss).toContain("--grain-wash-l: 0.97");
+    expect(wash).toContain("var(--grain-hue, 0)");
+    expect(wash).toContain("var(--grain-x, 50%)");
   });
 });

--- a/apps/desktop/src/renderer/src/styles.test.ts
+++ b/apps/desktop/src/renderer/src/styles.test.ts
@@ -1726,8 +1726,8 @@ describe("the decorative wash", () => {
     }
     // The light face flips the pin: .97 sits inside the light grounds' own band the way .10 sits
     // below every dark one.
-    expect(tokensCss).toContain("--grain-wash-l: 0.10");
-    expect(tokensCss).toContain("--grain-wash-l: 0.97");
+    expect(tokensCss).toContain("--grain-wash-l: 0.17");
+    expect(tokensCss).toContain("--grain-wash-l: 0.98");
     expect(wash).toContain("var(--grain-hue, 0)");
     expect(wash).toContain("var(--grain-x, 50%)");
   });

--- a/apps/desktop/src/renderer/src/theme/grain-contrast.test.ts
+++ b/apps/desktop/src/renderer/src/theme/grain-contrast.test.ts
@@ -2,7 +2,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { CONTRAST_FLOOR, REALM_SEED, THEMES, deriveVars, themeVars } from "@realm/ui/src/themes";
-import { hexToOklch, oklchToHex, parseOklch, srgb, srgbLuminance } from "@realm/ui/src/oklch";
+import { hexToOklch, parseOklch, srgb, srgbLuminance } from "@realm/ui/src/oklch";
 import { grainVars } from "./grain";
 
 /* The wash is decoration; the contrast floor is not. This walks every face the app can wear, paints
@@ -134,8 +134,8 @@ describe("the decorative wash never costs text its contrast floor", () => {
     // reader: a wash heavy enough to move the ground's lightness stops being decoration ON the
     // user's palette and becomes a different palette. Contrast alone would allow far more than this
     // on a dark face, where darkening the ground only ever helps.
-    const okl = (rgb: Rgb) => hexToOklch(oklchToHex({ l: 0, c: 0, h: 0 }) === "" ? "#000" : "#" +
-      rgb.map((v) => Math.round(Math.max(0, Math.min(1, v)) * 255).toString(16).padStart(2, "0")).join("")).l;
+    const okl = (rgb: Rgb) => hexToOklch("#" + rgb
+      .map((v) => Math.round(Math.max(0, Math.min(1, v)) * 255).toString(16).padStart(2, "0")).join("")).l;
     for (const surface of SURFACES) {
       for (const face of FACES) {
         const plain = okl(srgb(parseOklch(face.vars[surface.ground]!)));
@@ -146,6 +146,23 @@ describe("the decorative wash never costs text its contrast floor", () => {
           expect(moved, `${face.label} ${surface.ground} at ${hue}deg`).toBeLessThan(0.025);
         }
       }
+    }
+  });
+
+  it("the lift pushes the ground away from the ink and the speckles push it back", () => {
+    /* The two layers have to point OPPOSITE ways or the lift is not paying for anything: it exists
+       to bank a margin in advance so the grain can spend it. Contrast alone will not catch this,
+       because on a dark face a grain that darkens along WITH the lift only ever raises the ratio —
+       it just carries the ground further from the palette and leaves the lift doing nothing. */
+    for (const face of FACES) {
+      const ground = srgbLuminance(srgb(parseOklch(face.vars["--surface"]!)));
+      const ink = srgbLuminance(srgb(parseOklch(face.vars["--ink-3"]!)));
+      const away = Math.sign(ground - ink);
+      // The lift may be a no-op where the ground is already at the end of the gamut — One Light's
+      // surface is pure white and nothing is whiter — but it may never point at the ink.
+      expect(Math.sign(srgbLuminance(layer(decl(face.mode, "--grain-lift")).rgb) - ground) * away,
+        `lift, ${face.label}`).toBeGreaterThanOrEqual(0);
+      expect(Math.sign(srgbLuminance(texture(face.mode).rgb) - ground) * away, `speckles, ${face.label}`).toBe(-1);
     }
   });
 

--- a/apps/desktop/src/renderer/src/theme/grain-contrast.test.ts
+++ b/apps/desktop/src/renderer/src/theme/grain-contrast.test.ts
@@ -2,7 +2,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { CONTRAST_FLOOR, REALM_SEED, THEMES, deriveVars, themeVars } from "@realm/ui/src/themes";
-import { parseOklch, srgb, srgbLuminance } from "@realm/ui/src/oklch";
+import { hexToOklch, oklchToHex, parseOklch, srgb, srgbLuminance } from "@realm/ui/src/oklch";
 import { grainVars } from "./grain";
 
 /* The wash is decoration; the contrast floor is not. This walks every face the app can wear, paints
@@ -127,6 +127,26 @@ describe("the decorative wash never costs text its contrast floor", () => {
       }
     }
     expect(worst).toBeGreaterThan(-0.01);
+  });
+
+  it("adds hue to the ground without restating its lightness", () => {
+    // The other ceiling on these numbers, and the one that is about the design rather than the
+    // reader: a wash heavy enough to move the ground's lightness stops being decoration ON the
+    // user's palette and becomes a different palette. Contrast alone would allow far more than this
+    // on a dark face, where darkening the ground only ever helps.
+    const okl = (rgb: Rgb) => hexToOklch(oklchToHex({ l: 0, c: 0, h: 0 }) === "" ? "#000" : "#" +
+      rgb.map((v) => Math.round(Math.max(0, Math.min(1, v)) * 255).toString(16).padStart(2, "0")).join("")).l;
+    for (const surface of SURFACES) {
+      for (const face of FACES) {
+        const plain = okl(srgb(parseOklch(face.vars[surface.ground]!)));
+        for (const hue of HUE_OFFSETS) {
+          // Measured on the STEADY ground, without the speckles: the grain's excursion is the
+          // texture itself, bounded by the lift and by the floor, not by this.
+          const moved = Math.abs(okl(decorate(face.vars, face.mode, surface.ground, hue, false)) - plain);
+          expect(moved, `${face.label} ${surface.ground} at ${hue}deg`).toBeLessThan(0.025);
+        }
+      }
+    }
   });
 
   it("the texture is paid for by the lift, not by the reader", () => {

--- a/apps/desktop/src/renderer/src/theme/grain-contrast.test.ts
+++ b/apps/desktop/src/renderer/src/theme/grain-contrast.test.ts
@@ -1,0 +1,146 @@
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { CONTRAST_FLOOR, REALM_SEED, THEMES, deriveVars, themeVars } from "@realm/ui/src/themes";
+import { parseOklch, srgb, srgbLuminance } from "@realm/ui/src/oklch";
+import { grainVars } from "./grain";
+
+/* The wash is decoration; the contrast floor is not. This walks every face the app can wear, paints
+   the decoration over the ground the surface actually has, and reads the ratio back — because the
+   thing that makes a decorative background dangerous here is that it looks fine on the face you
+   built it on and puts text under the floor on one of the sixteen you did not.
+ 
+   Every number comes out of tokens.css and out of grain.ts. Nothing is restated, so the proof cannot
+   go on describing a stylesheet that has changed. */
+
+function repoFile(rel: string): string {
+  let dir = process.cwd();
+  for (let i = 0; i < 6; i++) { const p = join(dir, rel); if (existsSync(p)) return p; dir = dirname(dir); }
+  throw new Error(`cannot locate ${rel} from ${process.cwd()}`);
+}
+const tokensCss = readFileSync(repoFile("apps/desktop/src/renderer/src/theme/tokens.css"), "utf8");
+
+/** The grain section's two halves. The base :root is the dark face; light overrides it. */
+const section = tokensCss.slice(tokensCss.indexOf("══ DECORATIVE GRAIN"));
+const half = { dark: section.slice(0, section.indexOf(':root[data-mode="light"]')), light: section.slice(section.indexOf(':root[data-mode="light"]')) };
+const decl = (mode: Mode, name: string): string => {
+  for (const body of [half[mode], half.dark]) {
+    const m = new RegExp(`${name}:\\s*([^;]+);`).exec(body);
+    if (m) return m[1]!.trim();
+  }
+  throw new Error(`${name} is not declared in the grain section of tokens.css`);
+};
+type Mode = "dark" | "light";
+type Rgb = [number, number, number];
+
+/** `oklch(0 0 0 / 0.05)` → the colour and how much of it lands. */
+function layer(value: string): { rgb: Rgb; alpha: number } {
+  const m = /^oklch\(([\d.]+) ([\d.]+) ([\d.]+)(?: \/ ([\d.]+))?\)$/.exec(value);
+  if (!m) throw new Error(`not a plain oklch layer: ${value}`);
+  return { rgb: srgb({ l: Number(m[1]), c: Number(m[2]), h: Number(m[3]) }), alpha: Number(m[4] ?? 1) };
+}
+
+/** The shipped texture, read out of its own feColorMatrix: the RGB it forces and the alpha ceiling
+ *  its luminance row can reach. Conservative — it costs the darkest speckle the filter can emit. */
+function texture(mode: Mode): { rgb: Rgb; alpha: number } {
+  const v = /values='([^']+)'/.exec(decl(mode, "--grain-tex"));
+  if (!v) throw new Error("no feColorMatrix in --grain-tex");
+  const n = v[1]!.trim().split(/\s+/).map(Number);
+  expect(n, "an feColorMatrix is 4 rows of 5").toHaveLength(20);
+  return { rgb: [n[4]!, n[9]!, n[14]!], alpha: n.slice(15, 20).reduce((a, b) => a + Math.max(0, b), 0) };
+}
+
+const over = (ground: Rgb, top: Rgb, alpha: number): Rgb =>
+  ground.map((v, i) => v * (1 - alpha) + top[i]! * alpha) as Rgb;
+const ratio = (a: Rgb, b: Rgb) => {
+  const [x, y] = [srgbLuminance(a), srgbLuminance(b)];
+  return (Math.max(x, y) + 0.05) / (Math.min(x, y) + 0.05);
+};
+
+/** Every face the app ships. `realm` has no seed table — tokens.css IS its palette — so it comes
+ *  through the derivation styles.test.ts already pins against that file. */
+const FACES: { label: string; mode: Mode; vars: Record<string, string> }[] = [];
+for (const theme of THEMES) {
+  for (const mode of ["dark", "light"] as const) {
+    if (theme.name === "realm") { FACES.push({ label: `realm ${mode}`, mode, vars: deriveVars(REALM_SEED[mode], mode) }); continue; }
+    const vars = themeVars(theme.name, mode) as Record<string, string>;
+    if (vars["--surface"]) FACES.push({ label: `${theme.label} ${mode}`, mode, vars });
+  }
+}
+
+const INK = [["--ink", CONTRAST_FLOOR.ink], ["--ink-2", CONTRAST_FLOOR.ink2], ["--ink-3", CONTRAST_FLOOR.ink3]] as const;
+/** The offsets the shipped randomiser can actually produce, not an arc restated here. */
+const HUE_OFFSETS = [...new Set(Array.from({ length: 600 }, (_, i) =>
+  Number((grainVars("sheet", i) as unknown as Record<string, string>)["--grain-hue"])))];
+
+/** The ground under each decorated surface, and whether it is textured. `.page` is --rl-panel, which
+ *  the bridge in styles.css resolves to --canvas; `.sheet` is --surface. */
+const SURFACES = [
+  { name: "Settings / Notifications (.page)", ground: "--canvas", grain: false },
+  { name: "first run (.sheet)", ground: "--surface", grain: true },
+] as const;
+
+/** The decorated ground, worst pixel: the wash at its peak, the lift, and the speckle that spends
+ *  the most of the budget the lift banked. */
+function decorate(vars: Record<string, string>, mode: Mode, ground: string, hue: number, grain: boolean): Rgb {
+  const wash = {
+    rgb: srgb({ l: Number(decl(mode, "--grain-wash-l")), c: Number(decl(mode, "--grain-wash-c")), h: (parseOklch(vars["--accent"]!).h + hue + 360) % 360 }),
+    alpha: Number(decl(mode, "--grain-wash-a")),
+  };
+  let g = over(srgb(parseOklch(vars[ground]!)), wash.rgb, wash.alpha);
+  if (!grain) return g;
+  const lift = layer(decl(mode, "--grain-lift"));
+  const tex = texture(mode);
+  g = over(g, lift.rgb, lift.alpha);
+  return over(g, tex.rgb, tex.alpha);
+}
+
+describe("the decorative wash never costs text its contrast floor", () => {
+  for (const surface of SURFACES) {
+    it(`${surface.name}: every ink tier clears its floor on all ${FACES.length} faces, at every hue the draw can land on`, () => {
+      const misses: string[] = [];
+      for (const face of FACES) {
+        for (const hue of HUE_OFFSETS) {
+          const ground = decorate(face.vars, face.mode, surface.ground, hue, surface.grain);
+          for (const [token, floor] of INK) {
+            const r = ratio(srgb(parseOklch(face.vars[token]!)), ground);
+            if (r < floor) misses.push(`${face.label} ${token} at ${hue}deg: ${r.toFixed(3)} < ${floor}`);
+          }
+        }
+      }
+      expect(misses.slice(0, 8)).toEqual([]);
+    });
+  }
+
+  it("the colour field costs nothing at all, because its lightness never leaves the ground's own band", () => {
+    // This is the property that lets the field be painted on --canvas, where the derivation has left
+    // no room: --ink-3 sits at exactly 2.400 against a 2.4 floor on six light faces. A field that
+    // moved luminance by any amount would take one of them under; a field that only moves hue cannot.
+    let worst = 0;
+    for (const face of FACES) {
+      for (const hue of HUE_OFFSETS) {
+        const ground = decorate(face.vars, face.mode, "--canvas", hue, false);
+        for (const [token] of INK) {
+          const ink = srgb(parseOklch(face.vars[token]!));
+          worst = Math.min(worst, ratio(ink, ground) - ratio(ink, srgb(parseOklch(face.vars["--canvas"]!))));
+        }
+      }
+    }
+    expect(worst).toBeGreaterThan(-0.01);
+  });
+
+  it("the texture is paid for by the lift, not by the reader", () => {
+    // The speckles push the ground back TOWARD the ink; the lift has already pushed it the same way
+    // away. Remove the lift and the grain spends the text's margin instead — which is the whole
+    // reason a --canvas ground gets no texture, since there is no margin there to spend.
+    for (const face of FACES) {
+      const lifted = decorate(face.vars, face.mode, "--surface", 0, true);
+      const tex = texture(face.mode);
+      const unlifted = over(over(srgb(parseOklch(face.vars["--surface"]!)),
+        srgb({ l: Number(decl(face.mode, "--grain-wash-l")), c: Number(decl(face.mode, "--grain-wash-c")), h: parseOklch(face.vars["--accent"]!).h }),
+        Number(decl(face.mode, "--grain-wash-a"))), tex.rgb, tex.alpha);
+      const ink = srgb(parseOklch(face.vars["--ink-3"]!));
+      expect(ratio(ink, lifted), face.label).toBeGreaterThan(ratio(ink, unlifted));
+    }
+  });
+});

--- a/apps/desktop/src/renderer/src/theme/grain.test.ts
+++ b/apps/desktop/src/renderer/src/theme/grain.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { grainVars } from "./grain";
+
+const num = (v: unknown) => Number(String(v).replace(/(deg|%)$/, ""));
+const SURFACES = ["sheet", "settings-page", "notifications-page"];
+const vars = (surface: string, seed: number) => grainVars(surface, seed) as unknown as Record<string, string>;
+
+/* The bounds are written out here rather than imported from the module: a test that reads its
+   expectation out of the constant it is checking widens with it, and every widening is exactly the
+   change that would put a decorative field somewhere it does not belong. */
+describe("the decorative wash's randomisation", () => {
+  it("stays inside the arc and the top band, whatever the seed", () => {
+    for (let seed = 0; seed < 3000; seed++) {
+      for (const surface of SURFACES) {
+        const v = vars(surface, seed);
+        expect(Math.abs(num(v["--grain-hue"]))).toBeLessThanOrEqual(40);
+        expect(num(v["--grain-x"])).toBeGreaterThanOrEqual(12);
+        expect(num(v["--grain-x"])).toBeLessThanOrEqual(88);
+        // Never below the midline: the app lights everything from above, and a glow climbing out of
+        // a bottom corner reads as a rendering fault rather than as a decision.
+        expect(num(v["--grain-y"])).toBeLessThan(50);
+        expect(num(v["--grain-spread"])).toBeGreaterThanOrEqual(72);
+        expect(num(v["--grain-spread"])).toBeLessThanOrEqual(108);
+      }
+    }
+  });
+
+  it("is the same picture every time it is asked, so a re-render cannot reshuffle it", () => {
+    expect(grainVars("sheet", 12345)).toEqual(grainVars("sheet", 12345));
+  });
+
+  it("gives two surfaces on screen together two different pictures", () => {
+    expect(new Set(SURFACES.map((s) => JSON.stringify(grainVars(s, 7)))).size).toBe(SURFACES.length);
+  });
+
+  it("re-rolls with the launch seed rather than being a constant", () => {
+    expect(new Set(Array.from({ length: 64 }, (_, i) => JSON.stringify(grainVars("sheet", i)))).size).toBeGreaterThan(48);
+  });
+
+  it("spends the whole arc and the whole spread, so the bounds bind nothing that is never reached", () => {
+    const draws = Array.from({ length: 4000 }, (_, i) => vars("sheet", i));
+    const hues = draws.map((v) => num(v["--grain-hue"]));
+    const spread = draws.map((v) => num(v["--grain-spread"]));
+    expect(Math.min(...hues)).toBeLessThan(-37);
+    expect(Math.max(...hues)).toBeGreaterThan(37);
+    expect(Math.min(...spread)).toBeLessThan(75);
+    expect(Math.max(...spread)).toBeGreaterThan(105);
+  });
+});

--- a/apps/desktop/src/renderer/src/theme/grain.ts
+++ b/apps/desktop/src/renderer/src/theme/grain.ts
@@ -41,7 +41,9 @@ const between = (t: number, [lo, hi]: readonly [number, number]): number => lo +
 export function grainVars(surface: string, seed: number = LAUNCH_SEED): CSSProperties {
   const key = `${seed}:${surface}`;
   return {
-    "--grain-hue": `${Math.round(between(draw(key, 0), [-ARC, ARC]))}deg`,
+    // A bare number, not an angle: inside oklch(from ...) the origin's `h` component IS a number,
+    // and calc() will not add a <angle> to it.
+    "--grain-hue": `${Math.round(between(draw(key, 0), [-ARC, ARC]))}`,
     "--grain-x": `${Math.round(between(draw(key, 1), ORIGIN.x))}%`,
     "--grain-y": `${Math.round(between(draw(key, 2), ORIGIN.y))}%`,
     "--grain-spread": `${Math.round(between(draw(key, 3), SPREAD))}%`,

--- a/apps/desktop/src/renderer/src/theme/grain.ts
+++ b/apps/desktop/src/renderer/src/theme/grain.ts
@@ -2,13 +2,12 @@ import type { CSSProperties } from "react";
 
 /** Decorative wash geometry, drawn once per launch.
  *
- *  The user asked for randomised colour. Free randomisation is not available here: every hue the app
- *  paints is a token with a meaning (--red is failure, --green is done), and a decorative field that
- *  landed on one by chance would say something. So the only degree of freedom is an offset from the
- *  theme's OWN accent, held inside an arc narrow enough that the result still reads as the palette
- *  the user chose. Lightness and chroma are NOT randomised — they are pinned in tokens.css to the
- *  band that leaves every ink tier above its contrast floor, and are the reason this is safe to ship
- *  on all seventeen faces.
+ *  The colour is randomised, but not freely: every hue the app paints is a token with a meaning
+ *  (--red is failure, --green is done), and a field that landed on one by chance would say
+ *  something. The only degree of freedom is an offset from the theme's OWN accent, inside an arc
+ *  narrow enough that the result still reads as the palette on screen. Lightness and chroma are not
+ *  drawn at all — they are pinned in tokens.css to the band that leaves every ink tier above its
+ *  contrast floor, and are why this is safe on all seventeen faces.
  *
  *  Seeded once per launch, keyed by surface: two surfaces on screen together should not be the same
  *  picture, and one surface must not repaint itself on every React render. A launch is also the
@@ -36,8 +35,9 @@ function hash(key: string): number {
 const draw = (key: string, n: number): number => hash(`${key}#${n}`) / 0x100000000;
 const between = (t: number, [lo, hi]: readonly [number, number]): number => lo + t * (hi - lo);
 
-/** The custom properties styles.css reads. Exported as a pure function of (surface, seed) so a test
- *  can pin the bounds without stubbing Math.random. */
+/** The custom properties styles.css reads. Pure in (surface, seed): the launch seed is a default
+ *  rather than a closure, so the bounds can be walked over thousands of draws without stubbing
+ *  Math.random. */
 export function grainVars(surface: string, seed: number = LAUNCH_SEED): CSSProperties {
   const key = `${seed}:${surface}`;
   return {

--- a/apps/desktop/src/renderer/src/theme/grain.ts
+++ b/apps/desktop/src/renderer/src/theme/grain.ts
@@ -1,0 +1,49 @@
+import type { CSSProperties } from "react";
+
+/** Decorative wash geometry, drawn once per launch.
+ *
+ *  The user asked for randomised colour. Free randomisation is not available here: every hue the app
+ *  paints is a token with a meaning (--red is failure, --green is done), and a decorative field that
+ *  landed on one by chance would say something. So the only degree of freedom is an offset from the
+ *  theme's OWN accent, held inside an arc narrow enough that the result still reads as the palette
+ *  the user chose. Lightness and chroma are NOT randomised — they are pinned in tokens.css to the
+ *  band that leaves every ink tier above its contrast floor, and are the reason this is safe to ship
+ *  on all seventeen faces.
+ *
+ *  Seeded once per launch, keyed by surface: two surfaces on screen together should not be the same
+ *  picture, and one surface must not repaint itself on every React render. A launch is also the
+ *  longest window over which "stable while it is on screen" is trivially true — a sheet that is
+ *  closed and reopened comes back the same, which a per-open seed would not give. */
+
+/** The arc, in degrees either side of the accent. Wide enough to read as a choice, narrow enough
+ *  that no offset reaches the semantic hues on any palette. */
+const ARC = 40;
+
+/** The wash is anchored in the top band, never below the midline: the app's shadow language puts the
+ *  light source above, and a glow rising from a bottom corner reads as a rendering fault. */
+const ORIGIN = { x: [12, 88], y: [-12, 22] } as const;
+const SPREAD = [72, 108] as const;
+
+const LAUNCH_SEED = (Math.random() * 0xffffffff) >>> 0;
+
+function hash(key: string): number {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < key.length; i++) { h ^= key.charCodeAt(i); h = Math.imul(h, 0x01000193); }
+  return h >>> 0;
+}
+
+/** Successive independent draws from one key, each in 0..1. */
+const draw = (key: string, n: number): number => hash(`${key}#${n}`) / 0x100000000;
+const between = (t: number, [lo, hi]: readonly [number, number]): number => lo + t * (hi - lo);
+
+/** The custom properties styles.css reads. Exported as a pure function of (surface, seed) so a test
+ *  can pin the bounds without stubbing Math.random. */
+export function grainVars(surface: string, seed: number = LAUNCH_SEED): CSSProperties {
+  const key = `${seed}:${surface}`;
+  return {
+    "--grain-hue": `${Math.round(between(draw(key, 0), [-ARC, ARC]))}deg`,
+    "--grain-x": `${Math.round(between(draw(key, 1), ORIGIN.x))}%`,
+    "--grain-y": `${Math.round(between(draw(key, 2), ORIGIN.y))}%`,
+    "--grain-spread": `${Math.round(between(draw(key, 3), SPREAD))}%`,
+  } as CSSProperties;
+}

--- a/apps/desktop/src/renderer/src/theme/tokens.css
+++ b/apps/desktop/src/renderer/src/theme/tokens.css
@@ -561,10 +561,16 @@ a {
  * The derivation leaves NO headroom: it places --ink-3 at exactly 2.400 against a 2.4 floor on six
  * light faces. So the two layers are built to spend none.
  *
- * `--grain-wash-l` is the whole reason the colour is free. Pinned BELOW every dark ground (the
- * darkest is L .176) and INSIDE the light grounds' own band (.932–1.000), the wash moves hue
- * without moving luminance, and hue is not what contrast is computed from. The alpha could go
- * several times higher before any tier moved.
+ * `--grain-wash-l` is the whole reason the colour is free. Pinned just BELOW every dark ground (the
+ * darkest is L .176) and INSIDE the light grounds' own band (.932–1.000), the wash moves hue without
+ * moving luminance, and hue is not what contrast is computed from. Chroma is where the colour comes
+ * from and it costs nothing, so it is spent freely; the alphas differ by six times between the modes
+ * for the same reason, since on a light face the wash is already almost exactly the ground's
+ * lightness and more of it changes almost nothing.
+ *
+ * The ceiling on all three is not the floor but the PALETTE: past about .02 of OKLCH lightness the
+ * decorated ground stops reading as the user's canvas with something on it and starts reading as a
+ * different canvas. grain.test.ts holds that line as well as the contrast one.
  *
  * The grain cannot be free, because grain IS a luminance excursion. `--grain-lift` pays for it in
  * advance: a solid layer pushing the ground AWAY from the ink (down in dark, up in light), so the
@@ -572,10 +578,10 @@ a {
  * `--surface` ground; on `--canvas` the budget is zero in both directions and nothing textured may
  * be painted there. */
 :root {
-  --grain-wash-l: 0.10;
-  --grain-wash-c: 0.09;
-  --grain-wash-a: 0.12;
-  --grain-lift: oklch(0 0 0 / 0.05);
+  --grain-wash-l: 0.17;
+  --grain-wash-c: 0.28;
+  --grain-wash-a: 0.08;
+  --grain-lift: oklch(0 0 0 / 0.07);
   /* Alpha-only fractal noise, monochrome, tiled. The 0.035 in the matrix's alpha row is the
    * speckles' ceiling and is the number grain.test.ts checks; changing it here changes the proof.
    * `stitchTiles` is what lets the tile repeat without a seam, and is why the drift can translate by
@@ -586,8 +592,9 @@ a {
 /* Light faces invert both directions: the lift climbs toward white and the speckles are black,
  * because on a light ground it is darkening that costs contrast. */
 :root[data-mode="light"] {
-  --grain-wash-l: 0.97;
-  --grain-wash-c: 0.05;
-  --grain-lift: oklch(1 0 0 / 0.05);
+  --grain-wash-l: 0.98;
+  --grain-wash-c: 0.06;
+  --grain-wash-a: 0.32;
+  --grain-lift: oklch(1 0 0 / 0.07);
   --grain-tex: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='160'%3E%3Cfilter id='g' color-interpolation-filters='sRGB'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='.9' numOctaves='3' stitchTiles='stitch'/%3E%3CfeColorMatrix values='0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 .035 0 0 0 0'/%3E%3C/filter%3E%3Crect width='160' height='160' filter='url(%23g)'/%3E%3C/svg%3E");
 }

--- a/apps/desktop/src/renderer/src/theme/tokens.css
+++ b/apps/desktop/src/renderer/src/theme/tokens.css
@@ -550,3 +550,44 @@ a {
 @media (prefers-reduced-transparency: reduce) {
   :root { --sidebar-ground: var(--page); }
 }
+
+/* ══ DECORATIVE GRAIN ══════════════════════════════════════════════════════════
+ * A calm surface may carry a soft field of the theme's own accent and, where there is room for it,
+ * a film of grain. Both are decoration, and the app holds text to a contrast floor per role
+ * (CONTRAST_FLOOR, packages/ui/src/themes.ts), so the numbers below are not taste — they are the
+ * band inside which every ink tier on all seventeen faces still clears its floor. grain.test.ts
+ * walks the faces and proves it.
+ *
+ * The derivation leaves NO headroom: it places --ink-3 at exactly 2.400 against a 2.4 floor on six
+ * light faces. So the two layers are built to spend none.
+ *
+ * `--grain-wash-l` is the whole reason the colour is free. Pinned BELOW every dark ground (the
+ * darkest is L .176) and INSIDE the light grounds' own band (.932–1.000), the wash moves hue
+ * without moving luminance, and hue is not what contrast is computed from. The alpha could go
+ * several times higher before any tier moved.
+ *
+ * The grain cannot be free, because grain IS a luminance excursion. `--grain-lift` pays for it in
+ * advance: a solid layer pushing the ground AWAY from the ink (down in dark, up in light), so the
+ * speckles spend a budget that was already banked instead of the text's. That only balances on a
+ * `--surface` ground; on `--canvas` the budget is zero in both directions and nothing textured may
+ * be painted there. */
+:root {
+  --grain-wash-l: 0.10;
+  --grain-wash-c: 0.09;
+  --grain-wash-a: 0.12;
+  --grain-lift: oklch(0 0 0 / 0.05);
+  /* Alpha-only fractal noise, monochrome, tiled. The 0.035 in the matrix's alpha row is the
+   * speckles' ceiling and is the number grain.test.ts checks; changing it here changes the proof.
+   * `stitchTiles` is what lets the tile repeat without a seam, and is why the drift can translate by
+   * exactly one tile and land back on itself. */
+  --grain-tex: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='160'%3E%3Cfilter id='g' color-interpolation-filters='sRGB'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='.9' numOctaves='3' stitchTiles='stitch'/%3E%3CfeColorMatrix values='0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 .035 0 0 0 0'/%3E%3C/filter%3E%3Crect width='160' height='160' filter='url(%23g)'/%3E%3C/svg%3E");
+}
+
+/* Light faces invert both directions: the lift climbs toward white and the speckles are black,
+ * because on a light ground it is darkening that costs contrast. */
+:root[data-mode="light"] {
+  --grain-wash-l: 0.97;
+  --grain-wash-c: 0.05;
+  --grain-lift: oklch(1 0 0 / 0.05);
+  --grain-tex: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='160'%3E%3Cfilter id='g' color-interpolation-filters='sRGB'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='.9' numOctaves='3' stitchTiles='stitch'/%3E%3CfeColorMatrix values='0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 .035 0 0 0 0'/%3E%3C/filter%3E%3Crect width='160' height='160' filter='url(%23g)'/%3E%3C/svg%3E");
+}

--- a/apps/desktop/src/renderer/src/theme/wash-surfaces.test.tsx
+++ b/apps/desktop/src/renderer/src/theme/wash-surfaces.test.tsx
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { PAGE_REF_IDS } from "@realm/contracts";
+import { Sheet } from "../components/Sheet";
+import { Onboarding } from "../components/Onboarding";
+import { SettingsPage } from "../panes/settings/SettingsPage";
+import { NotificationsPage } from "../panes/notifications/NotificationsPage";
+import { StoreContext, createAppStore } from "../state/store";
+import { fakeApi, item } from "../state/store.test-fakes";
+
+async function mount(ui: React.ReactElement) {
+  const store = createAppStore(fakeApi({ spaces: [], items: {} }));
+  await store.getState().boot();
+  return render(<StoreContext.Provider value={store}>{ui}</StoreContext.Provider>);
+}
+const page = (kind: "settings-page" | "notifications-page") =>
+  item(`w-${kind}`, "s1", { kind, title: kind, refId: PAGE_REF_IDS[kind] });
+
+const GEOMETRY = ["--grain-hue", "--grain-x", "--grain-y", "--grain-spread"];
+const washed = (el: HTMLElement) => {
+  expect(el.classList.contains("wash"), el.className).toBe(true);
+  for (const name of GEOMETRY) expect(el.style.getPropertyValue(name), name).not.toBe("");
+  return el;
+};
+
+describe("which surfaces wear the decorative wash", () => {
+  it("Settings and Notifications take the colour field, and no texture", async () => {
+    for (const kind of ["settings-page", "notifications-page"] as const) {
+      const { container } = await mount(kind === "settings-page"
+        ? <SettingsPage item={page(kind)} visible />
+        : <NotificationsPage item={page(kind)} visible />);
+      const root = washed(container.querySelector<HTMLElement>(`.${kind}-pane`)!);
+      // `.page` is a --canvas ground, where the contrast budget for a luminance excursion is zero.
+      expect(root.hasAttribute("data-grain")).toBe(false);
+      cleanup();
+    }
+  });
+
+  it("the first-run card takes the grain too, because a --surface ground can pay for it", async () => {
+    await mount(<Onboarding />);
+    const card = washed(screen.getByLabelText("Welcome to Realm"));
+    expect(card.hasAttribute("data-grain")).toBe(true);
+  });
+
+  it("leaves every other sheet plain — a surface that exists to ask one question is not decorated", async () => {
+    await mount(<Sheet title="Delete this space?" onClose={() => {}}>body</Sheet>);
+    const dialog = screen.getByRole("dialog");
+    expect(dialog.classList.contains("wash")).toBe(false);
+    expect(dialog.style.getPropertyValue("--grain-hue")).toBe("");
+  });
+
+  it("gives two surfaces open together two different fields", async () => {
+    const { container } = await mount(<><SettingsPage item={page("settings-page")} visible />
+      <NotificationsPage item={page("notifications-page")} visible /></>);
+    const [a, b] = ["settings-page-pane", "notifications-page-pane"]
+      .map((c) => GEOMETRY.map((n) => container.querySelector<HTMLElement>(`.${c}`)!.style.getPropertyValue(n)).join());
+    expect(a).not.toBe(b);
+  });
+
+  it("holds the field still across a re-render, so nothing reshuffles under the reader", async () => {
+    const store = createAppStore(fakeApi({ spaces: [], items: {} }));
+    await store.getState().boot();
+    const ui = <StoreContext.Provider value={store}><SettingsPage item={page("settings-page")} visible /></StoreContext.Provider>;
+    const { container, rerender } = render(ui);
+    const read = () => GEOMETRY.map((n) => container.querySelector<HTMLElement>(".settings-page-pane")!.style.getPropertyValue(n)).join();
+    const before = read();
+    rerender(ui);
+    expect(read()).toBe(before);
+  });
+});

--- a/packages/ui/src/oklch.ts
+++ b/packages/ui/src/oklch.ts
@@ -86,6 +86,23 @@ export function parseOklch(value: string): Oklch {
  *  asserted never to have. Any walk whose stopping condition is a floor measures this instead. */
 export const emitted = (o: Oklch): Oklch => parseOklch(css(o));
 
+/** Gamut-clipped sRGB, gamma-ENCODED, 0..1 per channel: the numbers the compositor holds.
+ *
+ *  `luminance` below reads the LINEAR channels, which is right for a colour that is simply named.
+ *  Anything that has to blend colours needs these instead, because alpha compositing happens in the
+ *  encoded space — mixing two colours on the linear channels and taking the luminance of the result
+ *  describes a pixel the screen will never show. */
+export function srgb(o: Oklch): [number, number, number] {
+  const [r, g, b] = toLinearRgb(o);
+  return [fromLinear(r), fromLinear(g), fromLinear(b)];
+}
+
+/** WCAG 2.x relative luminance of an sRGB triple — for a colour that was composited rather than
+ *  named, and so has no OKLCH form to ask. */
+export function srgbLuminance([r, g, b]: readonly number[]): number {
+  return 0.2126 * toLinear(r!) + 0.7152 * toLinear(g!) + 0.0722 * toLinear(b!);
+}
+
 /** WCAG 2.x relative luminance. */
 export function luminance(o: Oklch): number {
   const [r, g, b] = toLinearRgb(o);


### PR DESCRIPTION
Stacked on #42.

**The WebGL dependency was rejected, and the deciding argument was contrast, not bundle size.** Realm holds text to `CONTRAST_FLOOR` per role across 17 theme faces. Measuring the headroom the derivation actually leaves gave the answer: **none** — `--ink-3` lands at *exactly* 2.400 against a 2.4 floor on six light faces. A mesh gradient paints arbitrary colour behind text and cannot be bounded against that. A layer whose colour is derived from the theme's own tokens can be, and can be *proved*, on every face, in a unit test. The secondary arguments all point the same way: a GPU context per surface in an app people leave open all day, a blank canvas when WebGL is unavailable or the context is lost, and a 26-variant animation library in a codebase with no animation dependency at all.

**Which layers a surface gets is decided by its ground, not by taste.** Settings and Notifications sit on `--canvas`, where the measured budget for any luminance excursion is **zero in both directions**, so they get the colour field only — and stay static. Rejecting WebGL on battery grounds and then shipping a permanent 60fps composite on the two longest-dwell panes would have been incoherent. The first-run card sits on `--surface` and gets field, lift, grain and a 24s drift.

**Left deliberately plain:** every other `Sheet`, the backdrop, and the command palette. `Sheet.tsx` is untouched, and there is a test asserting a delete sheet is still plain — the one that fails if this ever spreads by default. A decorated ground on a surface that exists to ask one question decorates the question.

**Randomisation is bounded to ±40° from the theme's own accent.** Free hue would eventually land on `--red` or `--green` and *say* something. Lightness and chroma aren't drawn at all — they're pinned in `tokens.css` and carry the contrast guarantee. Seeded per launch, keyed by surface, stable across re-render and reopen.

The proof composites the real layers over each face's real ground at every hue the shipped randomiser can produce — 17 faces × 81 offsets — reading every constant *out of* `tokens.css`, down to parsing the speckle ceiling from the texture's own `feColorMatrix`. Worst margin **+0.0193**. On real pixels, subtitle contrast measures 7.09–7.11:1 on Realm Dark and 5.15–5.17:1 on GitHub Light against a floor of 3.

An early version was provably safe and visually a no-op — invisible on GitHub Light. Since contrast is computed from luminance alone, chroma is free; re-pinning lightness to the ground's band and pushing chroma to the gamut bought 4× the colour at zero cost, which made the *palette* the binding constraint rather than the floor.

Two mutants **survived** and forced real fixes: widening the hue arc 40→400 passed because the test read its expectation from the same constant, and inverting the dark grain from white to black passed every contrast assertion — darkening a dark ground only raises the ratio — while making the lift pointless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)