### PR TITLE
Sound the two notifications that ask you to come back

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -33,6 +33,7 @@
     "@vitejs/plugin-react": "^4.3.0",
     "@xterm/addon-fit": "^0.10.0",
     "@xterm/xterm": "^5.5.0",
+    "cuelume": "^0.2.2",
     "dompurify": "^3.4.13",
     "electron": "^37.0.0",
     "electron-builder": "^26.15.3",

--- a/apps/desktop/src/renderer/src/panes/settings/SettingsPage.tsx
+++ b/apps/desktop/src/renderer/src/panes/settings/SettingsPage.tsx
@@ -638,6 +638,10 @@ function AppTab() {
           </li>
         </ul>
         <div className="slider-row">
+          {/* Labelled where the other sliders on this tab are not: theirs are the whole subject of
+              their field, this one hangs off a switch two rows up, so a bare bar and a percentage
+              would leave the reader to guess what the percentage measures. */}
+          <span className="slider-value">Volume</span>
           <input type="range" aria-label="Sound volume" disabled={!desktopNotifications || !soundCues}
             min={0} max={100} step={5}
             value={Math.round(soundVolume * 100)}

--- a/apps/desktop/src/renderer/src/panes/settings/SettingsPage.tsx
+++ b/apps/desktop/src/renderer/src/panes/settings/SettingsPage.tsx
@@ -471,6 +471,10 @@ function AppTab() {
   // so it is never null and the row never renders a loading state the others need.
   const desktopNotifications = useApp((s) => s.desktopNotifications);
   const setDesktopNotifications = useApp((s) => s.setDesktopNotifications);
+  const soundCues = useApp((s) => s.soundCues);
+  const soundVolume = useApp((s) => s.soundVolume);
+  const setSoundCues = useApp((s) => s.setSoundCues);
+  const setSoundVolume = useApp((s) => s.setSoundVolume);
   const setDefaultPermissionMode = useApp((s) => s.setDefaultPermissionMode);
   const run = useApp((s) => s.run);
   useEffect(() => { void run(() => refreshSettingsPrefs()); }, [run, refreshSettingsPrefs]);
@@ -620,8 +624,27 @@ function AppTab() {
               checked={desktopNotifications}
               onChange={(e) => run(() => setDesktopNotifications(e.target.checked))} />
           </li>
+          {/* Nested under the switch above, and inert while it is off, because the sound is part of a
+              notification rather than a second way of being told: it plays only alongside one that
+              was actually posted. */}
+          <li className="settings-row">
+            <div className="settings-row-main">
+              <span className="settings-row-name">Play a sound with it</span>
+              <span className="settings-row-desc">One cue when a turn finishes, another when an agent is waiting on you.</span>
+            </div>
+            <input type="checkbox" role="switch" className="switch" aria-label="Play a sound with it"
+              disabled={!desktopNotifications} checked={soundCues}
+              onChange={(e) => run(() => setSoundCues(e.target.checked))} />
+          </li>
         </ul>
-        <p className="settings-hint">Only when Realm is not the app you are in — a notification for something already on your screen is noise. Clicking one opens the session it came from. The categories below decide what counts; this decides whether it leaves the app.</p>
+        <div className="slider-row">
+          <input type="range" aria-label="Sound volume" disabled={!desktopNotifications || !soundCues}
+            min={0} max={100} step={5}
+            value={Math.round(soundVolume * 100)}
+            onChange={(e) => run(() => setSoundVolume(Number(e.target.value) / 100))} />
+          <span className="slider-value">{Math.round(soundVolume * 100)}%</span>
+        </div>
+        <p className="settings-hint">Only when Realm is not the app you are in — a notification for something already on your screen is noise. Clicking one opens the session it came from. The categories below decide what counts; this decides whether it leaves the app. The sound follows your Mac's volume, so muting the machine mutes it.</p>
       </div>
 
       <div className="field"><span>Notifications</span>

--- a/apps/desktop/src/renderer/src/panes/settings/SettingsPage.tsx
+++ b/apps/desktop/src/renderer/src/panes/settings/SettingsPage.tsx
@@ -638,17 +638,18 @@ function AppTab() {
           </li>
         </ul>
         <div className="slider-row">
-          {/* Labelled where the other sliders on this tab are not: theirs are the whole subject of
-              their field, this one hangs off a switch two rows up, so a bare bar and a percentage
-              would leave the reader to guess what the percentage measures. */}
-          <span className="slider-value">Volume</span>
+          {/* The readout names its quantity, where the other two sliders on this tab are named by the
+              heading of the field they are the whole subject of. This one hangs off a switch two rows
+              up, so a bare percentage would leave the reader to work out what it measures — and a
+              label to the LEFT would be the one slider on the tab whose bar does not start on the
+              same edge as the rest. */}
           <input type="range" aria-label="Sound volume" disabled={!desktopNotifications || !soundCues}
             min={0} max={100} step={5}
             value={Math.round(soundVolume * 100)}
             onChange={(e) => run(() => setSoundVolume(Number(e.target.value) / 100))} />
-          <span className="slider-value">{Math.round(soundVolume * 100)}%</span>
+          <span className="slider-value">Volume {Math.round(soundVolume * 100)}%</span>
         </div>
-        <p className="settings-hint">Only when Realm is not the app you are in — a notification for something already on your screen is noise. Clicking one opens the session it came from. The categories below decide what counts; this decides whether it leaves the app. The sound follows your Mac's volume, so muting the machine mutes it.</p>
+        <p className="settings-hint">Only when Realm is not the app you are in — a notification for something already on your screen is noise. Clicking one opens the session it came from. The categories below decide what counts; this decides whether it leaves the app. The sound follows the system volume, so muting the machine mutes it.</p>
       </div>
 
       <div className="field"><span>Notifications</span>

--- a/apps/desktop/src/renderer/src/panes/settings/settings-page.test.tsx
+++ b/apps/desktop/src/renderer/src/panes/settings/settings-page.test.tsx
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { GROUND_ALPHA_RANGE } from "@realm/ui";
 import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
-import { AGENT_CLI_COMMANDS, DEFAULT_PERMISSION_MODE_KEY, NOTIFICATIONS_DESKTOP_KEY, NOTIFICATIONS_DISABLED_KEY, PAGE_REF_IDS } from "@realm/contracts";
+import { AGENT_CLI_COMMANDS, DEFAULT_PERMISSION_MODE_KEY, NOTIFICATIONS_DESKTOP_KEY, NOTIFICATIONS_DISABLED_KEY, NOTIFICATIONS_SOUND_KEY, NOTIFICATIONS_SOUND_VOLUME_KEY, PAGE_REF_IDS } from "@realm/contracts";
 import { engineVersionLabel, SettingsPage } from "./SettingsPage";
 import { StoreContext, createAppStore } from "../../state/store";
 import { fakeApi, item, macRow, notification, type FakeData } from "../../state/store.test-fakes";
@@ -470,6 +470,41 @@ describe("App tab", () => {
     await waitFor(() => expect(api.data.badgeCount).toBe(0)); // …and OFF clears the dock
     // The category set is a different question and stays exactly as it was.
     expect(api.data.settings[NOTIFICATIONS_DISABLED_KEY]).toEqual(["mcp_health"]);
+  });
+
+  it("the sound switch defaults on, at half volume, and writes its own key", async () => {
+    const { api, store } = await openApp();
+    const sw = screen.getByRole("switch", { name: "Play a sound with it" });
+    expect(sw).toBeChecked();
+    expect(screen.getByRole("slider", { name: "Sound volume" })).toHaveValue("50");
+    fireEvent.click(sw);
+    await waitFor(() => expect(api.data.settings[NOTIFICATIONS_SOUND_KEY]).toBe(false));
+    expect(store.getState().soundCues).toBe(false);
+    // The wider gate is a different question and is not written by this switch.
+    expect(api.data.settings[NOTIFICATIONS_DESKTOP_KEY]).toBeUndefined();
+  });
+
+  it("the volume writes 0…1 however the slider counts, and a stored level renders", async () => {
+    const { api, store } = await openApp({ settings: { [NOTIFICATIONS_SOUND_VOLUME_KEY]: 0.2 } });
+    const slider = screen.getByRole("slider", { name: "Sound volume" });
+    expect(slider).toHaveValue("20");
+    fireEvent.change(slider, { target: { value: "75" } });
+    await waitFor(() => expect(api.data.settings[NOTIFICATIONS_SOUND_VOLUME_KEY]).toBe(0.75));
+    expect(store.getState().soundVolume).toBe(0.75);
+  });
+
+  it("THE orphaned-control mutant: with notifications off, neither sound control can be reached", async () => {
+    // The cue only ever accompanies a toast that was posted, so a sound switch that stayed live with
+    // toasts off would offer a setting that cannot do anything.
+    await openApp({ settings: { [NOTIFICATIONS_DESKTOP_KEY]: false } });
+    expect(screen.getByRole("switch", { name: "Play a sound with it" })).toBeDisabled();
+    expect(screen.getByRole("slider", { name: "Sound volume" })).toBeDisabled();
+  });
+
+  it("the volume is inert while the sound is off, and the switch above it is not", async () => {
+    await openApp({ settings: { [NOTIFICATIONS_SOUND_KEY]: false } });
+    expect(screen.getByRole("switch", { name: "Play a sound with it" })).not.toBeDisabled();
+    expect(screen.getByRole("slider", { name: "Sound volume" })).toBeDisabled();
   });
 
   it("a toggle writes EXACTLY its own category (the named mutant: the wrong category), leaving the rest of the set alone", async () => {

--- a/apps/desktop/src/renderer/src/panes/settings/settings-page.test.tsx
+++ b/apps/desktop/src/renderer/src/panes/settings/settings-page.test.tsx
@@ -477,6 +477,8 @@ describe("App tab", () => {
     const sw = screen.getByRole("switch", { name: "Play a sound with it" });
     expect(sw).toBeChecked();
     expect(screen.getByRole("slider", { name: "Sound volume" })).toHaveValue("50");
+    // The readout says what it measures: the slider sits two rows under the switch it belongs to.
+    expect(screen.getByText("Volume 50%")).toBeInTheDocument();
     fireEvent.click(sw);
     await waitFor(() => expect(api.data.settings[NOTIFICATIONS_SOUND_KEY]).toBe(false));
     expect(store.getState().soundCues).toBe(false);

--- a/apps/desktop/src/renderer/src/state/cues.test.ts
+++ b/apps/desktop/src/renderer/src/state/cues.test.ts
@@ -1,0 +1,63 @@
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { DEFAULT_NOTIFICATION_SOUND_VOLUME } from "@realm/contracts";
+import { CUE_BY_CATEGORY, cueVolume } from "./cues";
+
+/* Vite rewrites `import.meta.url` to a non-file scheme under jsdom, so walk up from the cwd instead
+   (vitest may be invoked from the repo root or from apps/desktop). */
+function repoDir(rel: string): string {
+  let dir = process.cwd();
+  for (let i = 0; i < 6; i++) { const p = join(dir, rel); if (existsSync(p)) return p; dir = dirname(dir); }
+  throw new Error(`cannot locate ${rel} from ${process.cwd()}`);
+}
+
+function sourceFiles(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((e) => {
+    const p = join(dir, e.name);
+    if (e.isDirectory()) return sourceFiles(p);
+    return /\.tsx?$/.test(e.name) && !/\.test\.tsx?$/.test(e.name) ? [p] : [];
+  });
+}
+
+/* Prose ABOUT `bind()` and the attributes it wires — this file's own, and cues.ts's — must not read
+   as a use of them. Line comments are cut only where the slashes do not follow a colon, so a URL in
+   a comment cannot swallow the rest of its line. */
+const code = (path: string): string =>
+  readFileSync(path, "utf8").replace(/\/\*[\s\S]*?\*\//g, "").replace(/(^|[^:])\/\/.*$/gm, "$1");
+
+describe("cues", () => {
+  it("an unreadable or out-of-range volume falls back to the default, never to silence", () => {
+    for (const bad of [null, undefined, "loud", NaN, Infinity, -0.5, 4]) {
+      expect(cueVolume(bad)).toBe(DEFAULT_NOTIFICATION_SOUND_VOLUME);
+    }
+    expect(cueVolume(0)).toBe(0); // an explicit zero IS a preference, and is kept
+    expect(cueVolume(0.2)).toBe(0.2);
+    expect(cueVolume(1)).toBe(1);
+  });
+
+  it("two sounds, no more: the table maps categories onto a vocabulary of exactly `ready` and `chime`", () => {
+    expect(new Set(Object.values(CUE_BY_CATEGORY))).toEqual(new Set(["ready", "chime"]));
+  });
+
+  /**
+   * cuelume's `bind()` wires every `data-cuelume-*` attribute for hovers, presses, releases and
+   * toggles — a sound on ordinary UI interaction, which is the one thing these cues must never
+   * become. Nothing else in the suite can see it: `bind()` attaches document listeners at call time,
+   * so a stray call in a module no test mounts would ship silently. This reads the renderer sources
+   * instead, which is the only place the absence is visible.
+   */
+  it("THE bind() mutant: the renderer reaches for `play` and nothing else in cuelume", () => {
+    const root = repoDir("apps/desktop/src/renderer/src");
+    const importers = sourceFiles(root)
+      .map((p) => [p, code(p)] as const)
+      .filter(([, src]) => /from\s+["']cuelume["']/.test(src));
+    // One importer, so there is one place to look when asking what Realm makes noise for.
+    expect(importers.map(([p]) => p.slice(root.length + 1))).toEqual(["state/live-api.ts"]);
+    for (const [, src] of importers) {
+      const imported = /import\s*\{([^}]*)\}\s*from\s*["']cuelume["']/.exec(src)?.[1] ?? "";
+      expect(imported.split(",").map((s) => s.trim()).filter(Boolean)).toEqual(["play"]);
+    }
+    expect(sourceFiles(root).some((p) => /data-cuelume-/.test(code(p)))).toBe(false);
+  });
+});

--- a/apps/desktop/src/renderer/src/state/cues.ts
+++ b/apps/desktop/src/renderer/src/state/cues.ts
@@ -1,14 +1,12 @@
 /**
  * The sound cues, and the one table that says which feed rows earn one.
  *
- * Cues are synthesised by cuelume (github.com/Danilaa1/cuelume, MIT © Daniel Belyi) — no audio files,
- * one lazily-created `AudioContext`, every tone built from oscillators the moment it plays. Two
- * shipped WAVs would have cost more bytes than the whole library and would still have needed a
- * decoder, a loader and a cache; a synthesiser needs a function call.
+ * Synthesised by cuelume (github.com/Danilaa1/cuelume, MIT © Daniel Belyi) — no audio files, one
+ * lazily-created `AudioContext`, every tone built from oscillators the moment it plays.
  *
- * **cuelume's `bind()` is never called.** It wires every `data-cuelume-*` attribute for presses,
- * releases, toggles and hovers, which would put a sound on ordinary UI interaction. Only `play` is
- * used, and only from the sites below.
+ * cuelume's `bind()` is never called. It wires every `data-cuelume-*` attribute for presses,
+ * releases, toggles and hovers, which would put a sound on ordinary UI interaction; `play` is the
+ * only export Realm touches, and cues.test.ts holds that line.
  */
 import { DEFAULT_NOTIFICATION_SOUND_VOLUME, type NotificationCategory } from "@realm/contracts";
 
@@ -22,13 +20,12 @@ export type CueName = "ready" | "chime";
  * - `chime` — a thing you set going has STOPPED, and cannot go on until you decide something.
  *
  * `session_done` fires for error settles as well as clean ones, and the row carries no status to
- * tell them apart — only prose in `body`. `ready` is chosen because it stays true either way: the
- * turn is over and the session is yours again, however it ended. Splitting it would mean matching on
- * that prose.
+ * tell them apart — only prose in `body`. `ready` stays true either way, so splitting it into a
+ * failure cue would mean matching on that prose.
  *
  * Absent deliberately: `mcp_health`, `agent_probe`, `budget`, `worktree_hazard`. Each is a fact about
  * the machine that its toast already carries, and none is a person being called back to do
- * something — a sound on every category is how an app becomes one you mute.
+ * something.
  */
 export const CUE_BY_CATEGORY: Partial<Record<NotificationCategory, CueName>> = {
   session_done: "ready",

--- a/apps/desktop/src/renderer/src/state/cues.ts
+++ b/apps/desktop/src/renderer/src/state/cues.ts
@@ -1,0 +1,44 @@
+/**
+ * The sound cues, and the one table that says which feed rows earn one.
+ *
+ * Cues are synthesised by cuelume (github.com/Danilaa1/cuelume, MIT © Daniel Belyi) — no audio files,
+ * one lazily-created `AudioContext`, every tone built from oscillators the moment it plays. Two
+ * shipped WAVs would have cost more bytes than the whole library and would still have needed a
+ * decoder, a loader and a cache; a synthesiser needs a function call.
+ *
+ * **cuelume's `bind()` is never called.** It wires every `data-cuelume-*` attribute for presses,
+ * releases, toggles and hovers, which would put a sound on ordinary UI interaction. Only `play` is
+ * used, and only from the sites below.
+ */
+import { DEFAULT_NOTIFICATION_SOUND_VOLUME, type NotificationCategory } from "@realm/contracts";
+
+/** cuelume's own names for the two recipes Realm uses. */
+export type CueName = "ready" | "chime";
+
+/**
+ * Which surfaced rows earn a sound, grouped by what they MEAN rather than by category:
+ *
+ * - `ready` — a thing you set going has finished and is waiting for you.
+ * - `chime` — a thing you set going has STOPPED, and cannot go on until you decide something.
+ *
+ * `session_done` fires for error settles as well as clean ones, and the row carries no status to
+ * tell them apart — only prose in `body`. `ready` is chosen because it stays true either way: the
+ * turn is over and the session is yours again, however it ended. Splitting it would mean matching on
+ * that prose.
+ *
+ * Absent deliberately: `mcp_health`, `agent_probe`, `budget`, `worktree_hazard`. Each is a fact about
+ * the machine that its toast already carries, and none is a person being called back to do
+ * something — a sound on every category is how an app becomes one you mute.
+ */
+export const CUE_BY_CATEGORY: Partial<Record<NotificationCategory, CueName>> = {
+  session_done: "ready",
+  run_done: "ready",
+  review_done: "ready",
+  permission: "chime",
+  run_blocked: "chime",
+};
+
+/** Read a stored volume. Out-of-range and unreadable values fall back to the default rather than
+ *  clamping to silence — a preference nobody could read is not a preference for no sound. */
+export const cueVolume = (raw: unknown): number =>
+  typeof raw === "number" && Number.isFinite(raw) && raw >= 0 && raw <= 1 ? raw : DEFAULT_NOTIFICATION_SOUND_VOLUME;

--- a/apps/desktop/src/renderer/src/state/live-api.ts
+++ b/apps/desktop/src/renderer/src/state/live-api.ts
@@ -1,3 +1,4 @@
+import { play } from "cuelume";
 import { rpc } from "../rpc/client";
 import { getTerminalHub } from "../panes/terminal-hub";
 import type { Api } from "./store";
@@ -113,6 +114,13 @@ export const liveApi = (): Api => ({
   checkUpdates: () => window.realm.updates.check(),
   installUpdate: () => window.realm.updates.install(),
   showDesktopNotification: (input) => window.realm.notify.show(input),
+  // cuelume builds nothing until the first `play`, so importing it costs no AudioContext. What it
+  // will not do is sound before the document has had a user gesture — it checks
+  // `navigator.userActivation.hasBeenActive` itself and returns. Electron leaves a context `running`
+  // without one, so that flag is the only gate here, and any click or keypress in the window flips
+  // it for the document's lifetime. A cue that arrives before the user has ever touched this window
+  // is therefore dropped, silently and on purpose; the toast it would have accompanied still shows.
+  playCue: (cue, volume) => { play(cue, { volume }); },
   setBadgeCount: (count) => window.realm.notify.badge(count),
   gitInfo: (cwd) => rpc().call("workspace.gitInfo", { cwd }),
   diff: (cwd) => rpc().call("workspace.diff", { cwd }),

--- a/apps/desktop/src/renderer/src/state/live-api.ts
+++ b/apps/desktop/src/renderer/src/state/live-api.ts
@@ -114,12 +114,11 @@ export const liveApi = (): Api => ({
   checkUpdates: () => window.realm.updates.check(),
   installUpdate: () => window.realm.updates.install(),
   showDesktopNotification: (input) => window.realm.notify.show(input),
-  // cuelume builds nothing until the first `play`, so importing it costs no AudioContext. What it
-  // will not do is sound before the document has had a user gesture — it checks
-  // `navigator.userActivation.hasBeenActive` itself and returns. Electron leaves a context `running`
-  // without one, so that flag is the only gate here, and any click or keypress in the window flips
-  // it for the document's lifetime. A cue that arrives before the user has ever touched this window
-  // is therefore dropped, silently and on purpose; the toast it would have accompanied still shows.
+  // cuelume builds nothing until the first `play`, so importing it costs no AudioContext. It then
+  // refuses to sound until the document has had a user gesture, checking
+  // `navigator.userActivation.hasBeenActive` itself — Electron leaves a context `running` without
+  // one, so that flag is the only gate, and any click or keypress flips it for the document's life.
+  // A cue arriving before the user has ever touched this window is dropped; its toast still shows.
   playCue: (cue, volume) => { play(cue, { volume }); },
   setBadgeCount: (count) => window.realm.notify.badge(count),
   gitInfo: (cwd) => rpc().call("workspace.gitInfo", { cwd }),

--- a/apps/desktop/src/renderer/src/state/store-notifications.test.ts
+++ b/apps/desktop/src/renderer/src/state/store-notifications.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { createAppStore } from "./store";
 import { fakeApi, item, notification, session } from "./store.test-fakes";
-import { allItems, navEntry, NOTIFICATIONS_DESKTOP_KEY } from "@realm/contracts";
+import { allItems, navEntry, NOTIFICATIONS_DESKTOP_KEY, NOTIFICATIONS_SOUND_KEY, NOTIFICATIONS_SOUND_VOLUME_KEY } from "@realm/contracts";
 
 const boot = async (overrides: Parameters<typeof fakeApi>[0] = {}) => {
   const api = fakeApi(overrides);
@@ -282,5 +282,65 @@ describe("store — the desktop (OS) hop", () => {
     await store.getState().activateDesktopNotification("h2");
     expect(store.getState().items.filter((i) => i.kind === "notifications-page")).toHaveLength(1);
     expect(store.getState().notificationsSelectedId).toBe("h2");
+  });
+});
+
+describe("store — the sound cues", () => {
+  it("a settle cues `ready` and a permission cues `chime` — the two moments that call you back", async () => {
+    const { api, store } = await boot();
+    store.getState().applyNotificationsChanged({ notification: notification("n1", { category: "session_done" }), unread: 1 });
+    await tick();
+    expect(api.calls).toContain("playCue:ready@0.5");
+    store.getState().applyNotificationsChanged({ notification: notification("n2", { category: "permission", actedAt: null }), unread: 2 });
+    await tick();
+    expect(api.calls).toContain("playCue:chime@0.5");
+  });
+
+  it("THE widened-table mutant: infrastructure rows toast in silence", async () => {
+    // Every category surfaces a row and every row toasts. Sound is the narrower set on purpose — a
+    // failing MCP server, a CLI that stopped probing, a budget ceiling and a refused worktree removal
+    // are facts their toast already carries, not a person being called back to do something.
+    const { api, store } = await boot();
+    for (const category of ["mcp_health", "agent_probe", "budget", "worktree_hazard"] as const) {
+      store.getState().applyNotificationsChanged({ notification: notification(`n-${category}`, { category }), unread: 1 });
+    }
+    await tick();
+    expect(api.data.shownNotifications).toHaveLength(4); // all four still reached the OS
+    expect(api.calls.some((c) => c.startsWith("playCue"))).toBe(false);
+  });
+
+  it("THE focused-window mutant: main suppressed the toast, so there is nothing for a cue to accompany", async () => {
+    const { api, store } = await boot({ windowFocused: true });
+    store.getState().applyNotificationsChanged({ notification: notification("n1"), unread: 1 });
+    await tick();
+    expect(api.calls).toContain("showDesktopNotification:n1"); // asked, as always
+    expect(api.calls.some((c) => c.startsWith("playCue"))).toBe(false);
+  });
+
+  it("THE ignored-setting mutant: sound off is silent, and the toast is untouched", async () => {
+    const { api, store } = await boot({ settings: { [NOTIFICATIONS_SOUND_KEY]: false } });
+    expect(store.getState().soundCues).toBe(false);
+    store.getState().applyNotificationsChanged({ notification: notification("n1"), unread: 1 });
+    await tick();
+    expect(api.data.shownNotifications.map((n) => n.id)).toEqual(["n1"]);
+    expect(api.calls.some((c) => c.startsWith("playCue"))).toBe(false);
+  });
+
+  it("the desktop switch is the wider gate: with toasts off nothing sounds either", async () => {
+    const { api, store } = await boot({ settings: { [NOTIFICATIONS_DESKTOP_KEY]: false } });
+    expect(store.getState().soundCues).toBe(true); // the sound preference itself is untouched
+    store.getState().applyNotificationsChanged({ notification: notification("n1"), unread: 1 });
+    await tick();
+    expect(api.calls.some((c) => c.startsWith("playCue"))).toBe(false);
+  });
+
+  it("the stored volume rides every cue, and an unreadable one falls back rather than to silence", async () => {
+    const { api, store } = await boot({ settings: { [NOTIFICATIONS_SOUND_VOLUME_KEY]: 0.2 } });
+    expect(store.getState().soundVolume).toBe(0.2);
+    store.getState().applyNotificationsChanged({ notification: notification("n1"), unread: 1 });
+    await tick();
+    expect(api.calls).toContain("playCue:ready@0.2");
+    const bad = await boot({ settings: { [NOTIFICATIONS_SOUND_VOLUME_KEY]: 4 } });
+    expect(bad.store.getState().soundVolume).toBe(0.5);
   });
 });

--- a/apps/desktop/src/renderer/src/state/store.test-fakes.ts
+++ b/apps/desktop/src/renderer/src/state/store.test-fakes.ts
@@ -854,8 +854,7 @@ export function fakeApi(overrides: FakeData = {}): FakeApi {
       data.shownNotifications.push(input);
       return true;
     },
-    // No synthesiser anywhere in the suite: the request IS the observable, so a test can assert which
-    // cue was asked for, at what volume, without Web Audio existing.
+    // The request IS the observable, so the suite can assert cue and volume with no Web Audio in it.
     playCue: (cue, volume) => { calls.push(`playCue:${cue}@${volume}`); },
     setBadgeCount: async (count) => { calls.push(`setBadgeCount:${count}`); data.badgeCount = count; },
     probeAgents: async (force) => {

--- a/apps/desktop/src/renderer/src/state/store.test-fakes.ts
+++ b/apps/desktop/src/renderer/src/state/store.test-fakes.ts
@@ -854,6 +854,9 @@ export function fakeApi(overrides: FakeData = {}): FakeApi {
       data.shownNotifications.push(input);
       return true;
     },
+    // No synthesiser anywhere in the suite: the request IS the observable, so a test can assert which
+    // cue was asked for, at what volume, without Web Audio existing.
+    playCue: (cue, volume) => { calls.push(`playCue:${cue}@${volume}`); },
     setBadgeCount: async (count) => { calls.push(`setBadgeCount:${count}`); data.badgeCount = count; },
     probeAgents: async (force) => {
       calls.push(`probeAgents:${force}`);

--- a/apps/desktop/src/renderer/src/state/store.ts
+++ b/apps/desktop/src/renderer/src/state/store.ts
@@ -1339,6 +1339,10 @@ export type AppState = {
   /** The Settings→App desktop switch. Writes `NOTIFICATIONS_DESKTOP_KEY` and immediately pushes the
    *  badge the new answer implies, so switching off clears the dock rather than freezing a number. */
   setDesktopNotifications(enabled: boolean): Promise<void>;
+  /** The Settings→App sound switch and its level (0…1). Each writes its key and holds the answer, so
+   *  the next broadcast sounds under the new one without waiting for a settings refresh. */
+  setSoundCues(enabled: boolean): Promise<void>;
+  setSoundVolume(volume: number): Promise<void>;
   /** Select a feed row into the page's detail column (null = back to the bare list). Records the move
    *  on the trail of the pane showing `pageItemId`, so the arrows retrace it, and marks the row read —
    *  opening a notification is the definition of having seen it. */
@@ -3304,13 +3308,15 @@ export function createAppStore(api: Api): StoreApi<AppState> {
       },
       setProfilePageTab(profileId, tab) { set({ profilePageTab: { ...get().profilePageTab, [profileId]: tab } }); },
       async refreshSettingsPrefs() {
-        const [rawDisabled, rawMode, rawDesktop] = await Promise.all([
+        const [rawDisabled, rawMode, rawDesktop, rawSound, rawVolume] = await Promise.all([
           api.getSetting(NOTIFICATIONS_DISABLED_KEY), api.getSetting(DEFAULT_PERMISSION_MODE_KEY), api.getSetting(NOTIFICATIONS_DESKTOP_KEY),
+          api.getSetting(NOTIFICATIONS_SOUND_KEY), api.getSetting(NOTIFICATIONS_SOUND_VOLUME_KEY),
         ]);
         const disabledCategories = (Array.isArray(rawDisabled) ? rawDisabled : [])
           .filter((c): c is NotificationCategory => (NOTIFICATION_CATEGORIES as readonly string[]).includes(c as string));
         const defaultPermissionMode = PERMISSION_MODES.some((m) => m.id === rawMode) ? (rawMode as string) : "default";
-        set({ settingsPrefs: { disabledCategories, defaultPermissionMode }, desktopNotifications: rawDesktop !== false });
+        set({ settingsPrefs: { disabledCategories, defaultPermissionMode }, desktopNotifications: rawDesktop !== false,
+          soundCues: rawSound !== false, soundVolume: cueVolume(rawVolume) });
       },
       async refreshModelFavorites() {
         const raw = await api.getSetting(MODEL_FAVORITES_KEY);
@@ -3549,6 +3555,17 @@ export function createAppStore(api: Api): StoreApi<AppState> {
         // Republish the count under the new answer: switching off has to CLEAR the dock, not leave
         // the last number sitting there until something else happens to change it.
         applyUnread(get().notificationsUnread);
+      },
+      async setSoundCues(enabled) {
+        await api.setSetting(NOTIFICATIONS_SOUND_KEY, enabled);
+        set({ soundCues: enabled });
+      },
+      async setSoundVolume(volume) {
+        // Stored through the same reader boot uses, so a value the UI could not produce cannot be
+        // written by anything else either.
+        const v = cueVolume(volume);
+        await api.setSetting(NOTIFICATIONS_SOUND_VOLUME_KEY, v);
+        set({ soundVolume: v });
       },
       async selectNotification(pageItemId, id) {
         set({ notificationsSelectedId: id });

--- a/apps/desktop/src/renderer/src/state/store.ts
+++ b/apps/desktop/src/renderer/src/state/store.ts
@@ -5,7 +5,7 @@ import {
   activeGroup, activeLayout, addGroup as groupsAdd, reconcileGroups, allGroupItems, detachItemFrom, groupAtOffset, groupOfItem, groupsFromLayout, moveItemToGroup as groupsMoveItem, removeGroup as groupsRemove, renameGroup as groupsRename, setActiveGroup as groupsSetActive, setActiveLayout, SpaceGroupsSchema, toggleZoom as groupsToggleZoom, unzoom as groupsUnzoom, zoomLeaf as groupsZoom,
   canNav, forgetNavItems, navEntry, pushNav, reconcileNav, stepNav,
   AGENT_SKILL_SUPPORT, AGENT_SUPPORTS_PERMISSION_MODES, basenameOf, elementChipLabel, elementChipToken, formatAttachmentSize, keepLiveChips, MAX_ELEMENT_CHIPS, MAX_ATTACHMENT_BYTES, mentionIds, mimeForPath, PAGE_REF_IDS,
-  DEFAULT_PERMISSION_MODE_KEY, NOTIFICATIONS_DESKTOP_KEY, NOTIFICATIONS_DISABLED_KEY, NOTIFICATIONS_SOUND_KEY, NOTIFICATIONS_SOUND_VOLUME_KEY, NOTIFICATION_CATEGORIES, PERMISSION_MODES, MODEL_FAVORITES_KEY, parseSpaceIcon, type ModelInfo,
+  DEFAULT_NOTIFICATION_SOUND_VOLUME, DEFAULT_PERMISSION_MODE_KEY, NOTIFICATIONS_DESKTOP_KEY, NOTIFICATIONS_DISABLED_KEY, NOTIFICATIONS_SOUND_KEY, NOTIFICATIONS_SOUND_VOLUME_KEY, NOTIFICATION_CATEGORIES, PERMISSION_MODES, MODEL_FAVORITES_KEY, parseSpaceIcon, type ModelInfo,
   type DestinationPageKind, type NotificationCategory, type NavEntry, type PaneHistory, type DocumentEntry, type DocumentKind, type DocumentWorkspace,
   type AgentKind, type Attachment, type CliJobEnd, type CliJobOutput, type CliJobStart, type CliStatus, type BrowserCredential, type BrowserPickedElement, type DelegatedRun, type ElementChip, type BrowserCredentialInput, type Checkpoint, type DiffSummary, type Environment, type FileDiff, type GitInfo, type IconAsset, type ImportApplyParams, type ImportResult, type ImportScan, type Item, type GuideProgress, type Lecture, type PlynnImportResult, type PlynnMeeting, type StartLectureResult, type Layout, type McpCall, type McpOauthStatus, type McpServer, type McpServerStatus, type McpTransport, type MemorySources, type MemoryState, type MethodResult, type Notification, type PaneGroup, type PresetName, type Profile, type Project, type RestorePreview, type RestoreResult, type ReviewResult, type SearchResults, type Session, type SessionMode, type SessionStatus, type Ship, type ShipResult, type Skill, type Space, type SpaceGroups, type StoredSessionEvent, type WorktreeAck, type WorktreeStatus, type SkillSource, type Run, type RunAttempt, type RunState, type UsageBudget, type UsageBucketKind, type UsageSummary,
 } from "@realm/contracts";
@@ -297,10 +297,10 @@ export type Api = {
   /** Ask main to post an OS toast for a surfaced feed row. Answers whether one was actually shown —
    *  main suppresses it while the Realm window is focused, and that call is main's to make. */
   showDesktopNotification(input: { id: string; title: string; body: string | null }): Promise<boolean>;
-  /** Play one cue at `volume` (0…1). Synchronous and never throws: the synthesiser is a no-op wherever
+  /** Play one cue at `volume` (0…1). Synchronous and never throws — the synthesiser is a no-op wherever
    *  Web Audio is missing or still locked, and a silent renderer must not take the feed handler with
-   *  it. Lives on the renderer side of the Api because the sound is made in the window, unlike the
-   *  toast — but it answers to main's decision, not its own (see applyNotificationsChanged). */
+   *  it. Unlike the toast the sound is made in the window, but it still answers to main's decision
+   *  rather than its own (see applyNotificationsChanged). */
   playCue(cue: CueName, volume: number): void;
   /** Push the dock badge. Every unread change goes through here; 0 clears it. */
   setBadgeCount(count: number): Promise<void>;
@@ -657,9 +657,8 @@ export type AppState = {
    *  the first broadcast can arrive, and `settingsPrefs` stays null until the Settings page mounts —
    *  a toast that only worked after a visit to Settings would be a toast that does not work. */
   desktopNotifications: boolean;
-  /** Whether a toast main actually posted also plays a cue, and how loud (0…1). Held out here beside
-   *  `desktopNotifications` for the same reason it is: the first broadcast can arrive long before the
-   *  Settings page mounts, and a cue that only worked after a visit to Settings would not work. */
+  /** Whether a toast main actually posted also plays a cue, and how loud (0…1). Held out beside
+   *  `desktopNotifications`, and for the reason given there. */
   soundCues: boolean;
   soundVolume: number;
   agentProbe: AgentProbe[];
@@ -1916,7 +1915,7 @@ export function createAppStore(api: Api): StoreApi<AppState> {
       mcpServers: [], mcpProviders: [], mcpToolsError: {},
       profileMemory: {},
       mcpCalls: [], mcpCallsFilter: {}, mcpCallsHasMore: false,
-      notifications: [], notificationsUnread: 0, notificationsCursor: null, desktopNotifications: true, soundCues: true, soundVolume: cueVolume(null), notificationsSelectedId: null, paneHistory: {},
+      notifications: [], notificationsUnread: 0, notificationsCursor: null, desktopNotifications: true, soundCues: true, soundVolume: DEFAULT_NOTIFICATION_SOUND_VOLUME, notificationsSelectedId: null, paneHistory: {},
 
       activeSpace() { const id = get().activeSpaceId; return id ? get().spaces.find((s) => s.id === id) : undefined; },
       activeProfileId() { return get().activeSpace()?.profileId ?? null; },
@@ -3487,11 +3486,9 @@ export function createAppStore(api: Api): StoreApi<AppState> {
           // another app is exactly the toast worth showing. Whether one appears is main's call
           // (window focus), and a failed toast must never take the feed handler down with it.
           //
-          // The cue rides that same answer rather than re-deriving it. `show` reports whether a toast
-          // was POSTED, so a sound can only follow one that was — the focus rule stays a single
-          // implementation in notify.ts, and the audible signal can never disagree with the visible
-          // one. Two consequences, both intended: nothing sounds while Realm is the focused app, and
-          // nothing sounds for a row whose category the table below leaves out.
+          // The cue rides that same answer rather than re-deriving it: `show` reports whether a toast
+          // was POSTED, so a sound can only follow one that was. The focus rule keeps a single
+          // implementation in notify.ts, and nothing sounds while Realm is the app you are in.
           if (get().desktopNotifications) {
             const cue = CUE_BY_CATEGORY[n.category];
             void api.showDesktopNotification({ id: n.id, title: n.title, body: n.body })

--- a/apps/desktop/src/renderer/src/state/store.ts
+++ b/apps/desktop/src/renderer/src/state/store.ts
@@ -5,12 +5,13 @@ import {
   activeGroup, activeLayout, addGroup as groupsAdd, reconcileGroups, allGroupItems, detachItemFrom, groupAtOffset, groupOfItem, groupsFromLayout, moveItemToGroup as groupsMoveItem, removeGroup as groupsRemove, renameGroup as groupsRename, setActiveGroup as groupsSetActive, setActiveLayout, SpaceGroupsSchema, toggleZoom as groupsToggleZoom, unzoom as groupsUnzoom, zoomLeaf as groupsZoom,
   canNav, forgetNavItems, navEntry, pushNav, reconcileNav, stepNav,
   AGENT_SKILL_SUPPORT, AGENT_SUPPORTS_PERMISSION_MODES, basenameOf, elementChipLabel, elementChipToken, formatAttachmentSize, keepLiveChips, MAX_ELEMENT_CHIPS, MAX_ATTACHMENT_BYTES, mentionIds, mimeForPath, PAGE_REF_IDS,
-  DEFAULT_PERMISSION_MODE_KEY, NOTIFICATIONS_DESKTOP_KEY, NOTIFICATIONS_DISABLED_KEY, NOTIFICATION_CATEGORIES, PERMISSION_MODES, MODEL_FAVORITES_KEY, parseSpaceIcon, type ModelInfo,
+  DEFAULT_PERMISSION_MODE_KEY, NOTIFICATIONS_DESKTOP_KEY, NOTIFICATIONS_DISABLED_KEY, NOTIFICATIONS_SOUND_KEY, NOTIFICATIONS_SOUND_VOLUME_KEY, NOTIFICATION_CATEGORIES, PERMISSION_MODES, MODEL_FAVORITES_KEY, parseSpaceIcon, type ModelInfo,
   type DestinationPageKind, type NotificationCategory, type NavEntry, type PaneHistory, type DocumentEntry, type DocumentKind, type DocumentWorkspace,
   type AgentKind, type Attachment, type CliJobEnd, type CliJobOutput, type CliJobStart, type CliStatus, type BrowserCredential, type BrowserPickedElement, type DelegatedRun, type ElementChip, type BrowserCredentialInput, type Checkpoint, type DiffSummary, type Environment, type FileDiff, type GitInfo, type IconAsset, type ImportApplyParams, type ImportResult, type ImportScan, type Item, type GuideProgress, type Lecture, type PlynnImportResult, type PlynnMeeting, type StartLectureResult, type Layout, type McpCall, type McpOauthStatus, type McpServer, type McpServerStatus, type McpTransport, type MemorySources, type MemoryState, type MethodResult, type Notification, type PaneGroup, type PresetName, type Profile, type Project, type RestorePreview, type RestoreResult, type ReviewResult, type SearchResults, type Session, type SessionMode, type SessionStatus, type Ship, type ShipResult, type Skill, type Space, type SpaceGroups, type StoredSessionEvent, type WorktreeAck, type WorktreeStatus, type SkillSource, type Run, type RunAttempt, type RunState, type UsageBudget, type UsageBucketKind, type UsageSummary,
 } from "@realm/contracts";
 import { createContext, useCallback, useContext, useMemo, useSyncExternalStore } from "react";
 import { SHEET_MIN_WIDTH, complementOf, snapBrowserLeaves } from "./no-overlay";
+import { CUE_BY_CATEGORY, cueVolume, type CueName } from "./cues";
 import { CONTRAST_RANGE, DEFAULT_FONTS, DEFAULT_GROUND_ALPHA, DEFAULT_SELECTION, clampContrast, clampGroundAlpha,
   isOverridden, parseFontPref, type FontPref,
   isThemeName, overrideKey, parseThemeOverrides, themeModes,
@@ -296,6 +297,11 @@ export type Api = {
   /** Ask main to post an OS toast for a surfaced feed row. Answers whether one was actually shown —
    *  main suppresses it while the Realm window is focused, and that call is main's to make. */
   showDesktopNotification(input: { id: string; title: string; body: string | null }): Promise<boolean>;
+  /** Play one cue at `volume` (0…1). Synchronous and never throws: the synthesiser is a no-op wherever
+   *  Web Audio is missing or still locked, and a silent renderer must not take the feed handler with
+   *  it. Lives on the renderer side of the Api because the sound is made in the window, unlike the
+   *  toast — but it answers to main's decision, not its own (see applyNotificationsChanged). */
+  playCue(cue: CueName, volume: number): void;
   /** Push the dock badge. Every unread change goes through here; 0 clears it. */
   setBadgeCount(count: number): Promise<void>;
   /** `workspace.gitInfo`: null when cwd is not a git repo (server caches ~3s). */
@@ -651,6 +657,11 @@ export type AppState = {
    *  the first broadcast can arrive, and `settingsPrefs` stays null until the Settings page mounts —
    *  a toast that only worked after a visit to Settings would be a toast that does not work. */
   desktopNotifications: boolean;
+  /** Whether a toast main actually posted also plays a cue, and how loud (0…1). Held out here beside
+   *  `desktopNotifications` for the same reason it is: the first broadcast can arrive long before the
+   *  Settings page mounts, and a cue that only worked after a visit to Settings would not work. */
+  soundCues: boolean;
+  soundVolume: number;
   agentProbe: AgentProbe[];
   /** Per-agent install/update situation. Empty until something asks; the engines list and the
    *  install card both read it, and neither may block on it. */
@@ -1901,7 +1912,7 @@ export function createAppStore(api: Api): StoreApi<AppState> {
       mcpServers: [], mcpProviders: [], mcpToolsError: {},
       profileMemory: {},
       mcpCalls: [], mcpCallsFilter: {}, mcpCallsHasMore: false,
-      notifications: [], notificationsUnread: 0, notificationsCursor: null, desktopNotifications: true, notificationsSelectedId: null, paneHistory: {},
+      notifications: [], notificationsUnread: 0, notificationsCursor: null, desktopNotifications: true, soundCues: true, soundVolume: cueVolume(null), notificationsSelectedId: null, paneHistory: {},
 
       activeSpace() { const id = get().activeSpaceId; return id ? get().spaces.find((s) => s.id === id) : undefined; },
       activeProfileId() { return get().activeSpace()?.profileId ?? null; },
@@ -1935,8 +1946,12 @@ export function createAppStore(api: Api): StoreApi<AppState> {
         // at boot at all because the first broadcast can arrive long before anyone opens Settings.
         // A failed read keeps the default-on answer: a preference nobody could read is not a
         // preference to switch the feature off.
-        const desktop = await api.getSetting(NOTIFICATIONS_DESKTOP_KEY).catch(() => null);
-        set({ desktopNotifications: desktop !== false });
+        const [desktop, sound, volume] = await Promise.all([
+          api.getSetting(NOTIFICATIONS_DESKTOP_KEY).catch(() => null),
+          api.getSetting(NOTIFICATIONS_SOUND_KEY).catch(() => null),
+          api.getSetting(NOTIFICATIONS_SOUND_VOLUME_KEY).catch(() => null),
+        ]);
+        set({ desktopNotifications: desktop !== false, soundCues: sound !== false, soundVolume: cueVolume(volume) });
         // The sidebar's unread pill needs the count before the page is ever opened. One row, not a
         // page — the count rides every list result. A badge, not a dependency: a failure here must
         // not take boot down with it.
@@ -3465,7 +3480,18 @@ export function createAppStore(api: Api): StoreApi<AppState> {
           // about which PANE is focused; a turn settling on the focused pane while Realm sits behind
           // another app is exactly the toast worth showing. Whether one appears is main's call
           // (window focus), and a failed toast must never take the feed handler down with it.
-          if (get().desktopNotifications) void api.showDesktopNotification({ id: n.id, title: n.title, body: n.body }).catch(() => {});
+          //
+          // The cue rides that same answer rather than re-deriving it. `show` reports whether a toast
+          // was POSTED, so a sound can only follow one that was — the focus rule stays a single
+          // implementation in notify.ts, and the audible signal can never disagree with the visible
+          // one. Two consequences, both intended: nothing sounds while Realm is the focused app, and
+          // nothing sounds for a row whose category the table below leaves out.
+          if (get().desktopNotifications) {
+            const cue = CUE_BY_CATEGORY[n.category];
+            void api.showDesktopNotification({ id: n.id, title: n.title, body: n.body })
+              .then((posted) => { if (posted && cue && get().soundCues) api.playCue(cue, get().soundVolume); })
+              .catch(() => {});
+          }
         } else if (get().notifications.length > 0) {
           // A resolution or a markRead from elsewhere: re-read the held slice so a permission row can
           // never keep rendering "pending" after it was answered in some other pane or window.

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -2315,6 +2315,9 @@ button.panel-title:hover { background: var(--rl-hover); }
 .switch:checked { background: var(--rl-accent); }
 .switch:checked::after { translate: 13px 0; }
 .switch:focus-visible { outline: 1.5px solid var(--rl-accent); outline-offset: 2px; }
+/* A checked switch keeps the accent at full strength when disabled, so without this a dependent
+   toggle reads as live and on. .45 is the disabled opacity every other control here uses. */
+.switch:disabled { opacity: .45; cursor: default; }
 
 .memory-doc { min-height: 140px; padding: 8px 9px; border-radius: var(--r-ctl); border: 1px solid var(--rl-line); background: var(--field); color: var(--rl-text-bright); outline: none; font: 12px/1.5 var(--font-mono); resize: vertical; }
 .memory-doc:focus { border-color: var(--rl-accent); }

--- a/apps/desktop/src/renderer/src/styles.test.ts
+++ b/apps/desktop/src/renderer/src/styles.test.ts
@@ -1201,6 +1201,14 @@ describe("§6 do-NOT-animate list", () => {
     }
   });
 
+  it("a disabled switch is visibly disabled, wherever it is nested", () => {
+    // `.switch:checked` paints the accent at full strength, and `disabled` changes nothing else about
+    // it — a dependent toggle would otherwise read as live and on. The only other disabled treatment
+    // a switch can pick up is `.slider-row input:disabled`, which reaches the one switch that happens
+    // to sit inside a slider row and no other.
+    expect(bodiesFor(".switch:disabled").join(" ")).toContain("opacity: .45");
+  });
+
   it("the focused-pane marks are instant — §6 does not animate pane focus switching", () => {
     // The underline, the inked header icon and the empty-leaf top rule all move when focus moves.
     const focusRules = RULES.filter((x) => x.selectors.some((s) => /^\.panel(\[data-focused\]|-title|-icon)/.test(s)));

--- a/packages/contracts/src/notifications.ts
+++ b/packages/contracts/src/notifications.ts
@@ -76,3 +76,18 @@ export const NOTIFICATIONS_DISABLED_KEY = "notifications.disabledCategories";
  * suppressed never reach here at all, so this is a narrowing of that set, never a widening.
  */
 export const NOTIFICATIONS_DESKTOP_KEY = "notifications.desktop";
+
+/**
+ * Settings keys for the audible half of a desktop notification: whether a posted toast also plays a
+ * cue, and how loud (0…1). Both NARROW the desktop switch rather than standing beside it — a cue is
+ * only ever played to accompany a toast main actually posted, so with `NOTIFICATIONS_DESKTOP_KEY`
+ * off there is no interruption for a sound to be part of.
+ *
+ * Default ON, at half volume: the cue inherits an opt-in the user already made, it can only sound
+ * while Realm is in the background, and a cue nobody ever hears is a cue nobody ever finds in
+ * Settings to keep. Half volume because the synthesiser's own output stage is generous and a cue
+ * heard hundreds of times should sit under the room, not on top of it.
+ */
+export const NOTIFICATIONS_SOUND_KEY = "notifications.sound";
+export const NOTIFICATIONS_SOUND_VOLUME_KEY = "notifications.soundVolume";
+export const DEFAULT_NOTIFICATION_SOUND_VOLUME = 0.5;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,6 +77,9 @@ importers:
       '@xterm/xterm':
         specifier: ^5.5.0
         version: 5.5.0
+      cuelume:
+        specifier: ^0.2.2
+        version: 0.2.2
       dompurify:
         specifier: ^3.4.13
         version: 3.4.13
@@ -2104,6 +2107,9 @@ packages:
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  cuelume@0.2.2:
+    resolution: {integrity: sha512-TiNzJRjhddjC4jy4M7sv63V/86VaFhdIs6iHUCrc4CKhqypaxRBv1aedCBGebrz/cO7nroPkEfqHe/P7fOE2GQ==}
 
   data-urls@5.0.0:
     resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
@@ -5524,6 +5530,8 @@ snapshots:
       rrweb-cssom: 0.8.0
 
   csstype@3.2.3: {}
+
+  cuelume@0.2.2: {}
 
   data-urls@5.0.0:
     dependencies:


### PR DESCRIPTION
Stacked on #43.

Two cues, mapped by meaning rather than by event: **`ready`** for a thing you started finishing (`session_done`, `run_done`, `review_done`), **`chime`** for a thing that stopped and needs you (`permission`, `run_blocked`). Rejected: `mcp_health`, `agent_probe`, `budget`, `worktree_hazard` — facts about the machine that their toast already carries, with nobody being called back.

The error cue was rejected for a concrete reason: `session_done` fires for error settles too, and the row carries no status to tell them apart — only prose in `body` — so a failure cue would mean matching on prose. `ready` stays true however a turn ended.

**Focused-window suppression is consumed, not copied.** `showDesktopNotification` already returns whether a toast was actually *posted*, and `notify.ts` posts nothing while the window is focused. The store plays a cue only on a `true`. So the focus rule keeps one implementation and the audible signal cannot disagree with the visible one — and it structurally satisfies "sound is never the only signal", since a cue can only ride a toast that exists. The stated cost: with desktop notifications off there is no sound, and Settings nests the sound switch under that one and greys it out so the dependency is visible rather than surprising.

**Default on, at 50%** — it rides an opt-in already made, can only sound while Realm is in the background, and is strictly rarer than the toast it accompanies, while off-by-default makes it undiscoverable.

**The audio gate was measured, not assumed.** In Electron 37 `new AudioContext()` starts *running* with no gesture, because Electron overrides Chromium's autoplay policy — but `navigator.userActivation.hasBeenActive` stays false until a real click, and cuelume's own `play()` refuses on that flag. That, not Electron, is the real gate. A second probe counted Web Audio node construction: 0 oscillators before a gesture, 2 plus a noise buffer for `ready` after one, a distinct graph for `chime`, and nothing at all at volume 0.

`bind()` is never called — it wires every `data-cuelume-*` attribute for press, release, toggle and hover, which is precisely what was ruled out. A source-reading test enforces that, because `bind()` attaches document listeners at call time and no mounted-component test could see it.

Screenshotting the real app caught a bug the tests could not: this is the first switch in the app that can be disabled outside a slider row, so it rendered at full accent strength while inert — reading as live and on.

Two honest gaps: macOS Focus/DND is not exposed to Electron, so a cue will sound during Focus even though the OS silences the banner; and the very first cue after launch is dropped if the user has never clicked in the window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)