### PR TITLE
Give a finished answer somewhere to hang its controls, and cite only the pages it was built from

### DIFF
--- a/apps/desktop/scripts/message-actions-live.mjs
+++ b/apps/desktop/scripts/message-actions-live.mjs
@@ -1,0 +1,280 @@
+/**
+ * Live check for the assistant message's action bar
+ * (run with: node apps/desktop/scripts/message-actions-live.mjs)
+ *
+ * Two of the bar's claims are claims about a real window, and jsdom can hold no opinion on either.
+ * That the buttons are CLICKABLE is a claim about hit-testing: they sit 2px apart, they carry a
+ * vertical-only overhang for exactly that reason, and only a real hit test at real coordinates can
+ * say whether one button's pad steals the click of the next. That the bar costs the prose nothing
+ * is a claim about layout, which jsdom reports as zero for every box on the page. The clipboard is
+ * the third: jsdom's is a stub that records what it was handed.
+ *
+ * What this deliberately does NOT check is the bar staying away mid-stream. The fake adapter queues
+ * a whole message's deltas in one burst — its delay is per script STEP, not per character — so
+ * there is no streaming window here to observe, and a check that cannot fail is worse than none.
+ * That gating is a logic claim, and message-actions.test.tsx owns it against a named mutant.
+ *
+ * Ports: env-overridable. Kills only the process it started, and writes only into a scratch dir with
+ * ONE exception worth stating: clicking Copy puts the message on the real system clipboard, because
+ * that is the thing being checked. It does not read the clipboard back — the value there before the
+ * click belongs to whoever is at the machine, and a test has no business logging it.
+ */
+import { spawn } from "node:child_process";
+import { connect } from "node:net";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
+const CDP_PORT = Number(process.env.LIVE_CDP_PORT ?? 9347), SERVER_PORT = Number(process.env.LIVE_SERVER_PORT ?? 8914);
+const scratch = fs.mkdtempSync(path.join(os.tmpdir(), "realm-actions-live-"));
+const results = {};
+let electron = null;
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+async function portFree(port) {
+  return new Promise((resolve) => {
+    const s = connect({ port, host: "127.0.0.1" });
+    s.once("connect", () => { s.destroy(); resolve(false); });
+    s.once("error", () => resolve(true));
+  });
+}
+
+async function until(fn, ms, tag) {
+  const t0 = Date.now();
+  for (;;) {
+    const v = await fn();
+    if (v) return v;
+    if (Date.now() - t0 > ms) throw new Error(`timeout:${tag}`);
+    await sleep(60);
+  }
+}
+
+function cdp(wsUrl) {
+  const ws = new WebSocket(wsUrl);
+  let id = 0;
+  const pending = new Map();
+  const events = [];
+  const ready = new Promise((res) => ws.addEventListener("open", res));
+  ws.addEventListener("message", (m) => {
+    const msg = JSON.parse(m.data);
+    if (msg.id !== undefined) pending.get(msg.id)?.(msg);
+    else if (msg.method === "Runtime.consoleAPICalled" && msg.params.type === "error") {
+      events.push(msg.params.args.map((a) => a.value ?? a.description ?? "").join(" "));
+    }
+  });
+  return {
+    ready, events,
+    send: (method, params) => new Promise((res, rej) => {
+      const i = ++id;
+      pending.set(i, (msg) => (msg.error ? rej(new Error(msg.error.message)) : res(msg.result)));
+      ws.send(JSON.stringify({ id: i, method, params }));
+    }),
+    close: () => ws.close(),
+  };
+}
+
+function rpc(port) {
+  const ws = new WebSocket(`ws://127.0.0.1:${port}`);
+  let id = 0;
+  const pending = new Map();
+  const ready = new Promise((res) => ws.addEventListener("open", res));
+  ws.addEventListener("message", (m) => {
+    const msg = JSON.parse(m.data);
+    if (msg.id !== undefined) pending.get(msg.id)?.(msg);
+  });
+  return {
+    ready,
+    call: (method, params) => new Promise((res, rej) => {
+      const i = String(++id);
+      pending.set(i, (msg) => (msg.ok ? res(msg.result) : rej(new Error(`${method}: ${msg.error?.message}`))));
+      ws.send(JSON.stringify({ id: i, method, params }));
+    }),
+    close: () => ws.close(),
+  };
+}
+
+const HELPERS = `
+window.__live = window.__live ?? {
+  setInput(el, value) {
+    const proto = el instanceof HTMLTextAreaElement ? HTMLTextAreaElement.prototype : HTMLInputElement.prototype;
+    const set = Object.getOwnPropertyDescriptor(proto, "value").set;
+    set.call(el, value); el.dispatchEvent(new Event("input", { bubbles: true }));
+  },
+  lastRow: () => [...document.querySelectorAll(".msg-assistant-row")].pop(),
+  /** The bar's state and the geometry that explains it, in one read. */
+  shot() {
+    const row = window.__live.lastRow();
+    if (!row) return null;
+    const prose = row.querySelector(".md");
+    const bar = row.querySelector(".msg-actions");
+    const r = (el) => { const b = el.getBoundingClientRect(); return { x: Math.round(b.x), y: Math.round(b.y), w: Math.round(b.width), h: Math.round(b.height), bottom: Math.round(b.bottom) }; };
+    return {
+      state: row.dataset.state,
+      busy: row.getAttribute("aria-busy"),
+      chars: (prose?.textContent ?? "").length,
+      bar: bar ? r(bar) : null,
+      prose: prose ? r(prose) : null,
+      buttons: [...row.querySelectorAll(".msg-action")].map((b) => ({ label: b.getAttribute("aria-label"), ...r(b) })),
+    };
+  },
+  /** Centre of a button, in viewport coordinates — what a real click needs. */
+  centreOf(label) {
+    const b = window.__live.lastRow()?.querySelector('.msg-action[aria-label="' + label + '"]');
+    if (!b) return null;
+    const r = b.getBoundingClientRect();
+    return { x: Math.round(r.x + r.width / 2), y: Math.round(r.y + r.height / 2) };
+  },
+  copiedOn: (label) => !!window.__live.lastRow()?.querySelector('.msg-action[aria-label="' + label + '"][data-copied]'),
+  pressed: (label) => window.__live.lastRow()?.querySelector('.msg-action[aria-label="' + label + '"]')?.getAttribute("aria-pressed"),
+};
+void 0`;
+
+async function evalIn(c, expr) {
+  const r = await c.send("Runtime.evaluate", { expression: HELPERS + ";\n" + expr, awaitPromise: true, returnByValue: true });
+  if (r.exceptionDetails) throw new Error(`page exception: ${r.exceptionDetails.exception?.description ?? r.exceptionDetails.text}`);
+  return r.result.value;
+}
+
+/** A real mouse press at real coordinates — the only thing that exercises hit-testing. */
+async function clickAt(c, { x, y }) {
+  for (const type of ["mousePressed", "mouseReleased"]) {
+    await c.send("Input.dispatchMouseEvent", { type, x, y, button: "left", clickCount: 1 });
+  }
+}
+
+const check = (name, cond, detail) => {
+  results[name] = { pass: !!cond, ...(detail !== undefined ? { detail } : {}) };
+  if (!cond) process.exitCode = 1;
+  console.log(`${cond ? "PASS" : "FAIL"} ${name}${detail !== undefined ? " " + JSON.stringify(detail) : ""}`);
+};
+
+async function main() {
+  for (const p of [CDP_PORT, SERVER_PORT]) {
+    if (!(await portFree(p))) throw new Error(`port ${p} is in use — refusing to run`);
+  }
+
+  const wrapper = path.join(scratch, "wrapper.mjs");
+  fs.writeFileSync(wrapper, [
+    'import { app } from "electron";',
+    'app.setPath("userData", process.env.LIVE_USER_DATA);',
+    "await import(process.env.LIVE_MAIN);",
+  ].join("\n"));
+  const electronBin = process.platform === "darwin"
+    ? path.join(repoRoot, "node_modules/.pnpm/electron@37.10.3/node_modules/electron/dist/Electron.app/Contents/MacOS/Electron")
+    : path.join(repoRoot, "apps/desktop/node_modules/.bin/electron");
+  electron = spawn(electronBin, [wrapper], {
+    env: {
+      ...process.env,
+      REALM_HOME: path.join(scratch, "home"),
+      REALM_PORT: String(SERVER_PORT),
+      REALM_DEVTOOLS_PORT: String(CDP_PORT),
+      REALM_SERVER_ENTRY: path.join(repoRoot, "apps/server/dist/main.js"),
+      REALM_ENABLE_FAKE_AGENT: "1",
+      LIVE_USER_DATA: path.join(scratch, "userData"),
+      LIVE_MAIN: path.join(repoRoot, "apps/desktop/out/main/index.js"),
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  electron.stderr.on("data", () => {}); electron.stdout.on("data", () => {});
+
+  const targets = () => fetch(`http://127.0.0.1:${CDP_PORT}/json/list`).then((r) => r.json()).catch(() => []);
+  const rendererTarget = await until(async () => (await targets()).find((t) => t.type === "page" && t.url.startsWith("file://")), 30000, "renderer target");
+  const c = cdp(rendererTarget.webSocketDebuggerUrl);
+  await c.ready;
+  await c.send("Runtime.enable");
+  await c.send("Page.enable");
+
+  await until(() => evalIn(c, `!!document.querySelector('.onboarding input:not([type=radio])')`), 20000, "onboarding");
+  await evalIn(c, `(() => {
+    const input = document.querySelector('.onboarding input:not([type=radio])');
+    __live.setInput(input, "Live");
+    input.closest("form").requestSubmit();
+    return true; })()`);
+  await until(() => evalIn(c, `!!document.querySelector('.composer')`), 20000, "composer");
+  await c.send("Emulation.setDeviceMetricsOverride", { width: 1180, height: 820, deviceScaleFactor: 2, mobile: false });
+  await sleep(400);
+
+  const api = rpc(SERVER_PORT);
+  await api.ready;
+  const sessions = await until(async () => {
+    const all = await api.call("sessions.listAll", {});
+    return all.length ? all : null;
+  }, 15000, "a session to drive");
+  const sessionId = sessions[0].id;
+  await api.call("sessions.setAgent", { id: sessionId, agentKind: "fake" });
+
+  // Long enough to wrap several lines, so "the bar sits below the prose" is a measurement of a real
+  // block rather than of a one-line message where every box would clear every other by accident.
+  const LONG = `Explain the following at length. ${"This sentence exists to give the message some height on the page. ".repeat(6)}`;
+  await api.call("sessions.send", { id: sessionId, text: LONG, attachments: [], mentions: [] });
+
+  // ── 1. Settled: the bar arrives, below the prose, without moving it ──
+  const done = await until(async () => {
+    const s = await evalIn(c, `__live.shot()`);
+    return s && s.state === "complete" && s.bar ? s : null;
+  }, 30000, "the finished message and its bar");
+  check("once complete the container drops aria-busy and the bar is there",
+    done.state === "complete" && done.busy === "false" && done.bar.h > 0, { state: done.state, busy: done.busy, bar: done.bar });
+  check("the bar sits below the prose, overlapping none of it", done.bar.y >= done.prose.bottom - 1,
+    { proseBottom: done.prose.bottom, barY: done.bar.y });
+  // The -6px optical inset must pull the glyph left WITHOUT widening the column the prose is in.
+  check("the bar is optically aligned with the prose, not indented past it",
+    Math.abs(done.buttons[0].x - done.prose.x) <= 8, { proseX: done.prose.x, firstButtonX: done.buttons[0].x });
+  check("all four controls are drawn, each with a real box",
+    done.buttons.length === 4 && done.buttons.every((b) => b.w >= 20 && b.h >= 20),
+    done.buttons.map((b) => `${b.label} ${b.w}x${b.h}`));
+
+  // ── 2. Hit-testing: adjacent buttons must not steal each other's clicks ──
+  // This is the check the vertical-only overhang exists for. A shared -6px inset would have each
+  // button's pad covering its neighbour, and the click below would land on the wrong control.
+  // The window may not hold OS focus under CDP, and the first click into an inactive window is spent
+  // activating it rather than reaching what is under the pointer. Spend it somewhere harmless.
+  // Spent on the message's own prose: a click there sets a caret and changes nothing, where one
+  // aimed at the chrome would navigate and take the message under test off screen.
+  await c.send("Page.bringToFront");
+  await clickAt(c, { x: done.prose.x + 20, y: done.prose.y + 8 });
+  await sleep(120);
+
+  const copyAt = await evalIn(c, `__live.centreOf("Copy message")`);
+  await clickAt(c, copyAt);
+  await sleep(120);
+  const copied = await evalIn(c, `({ copy: __live.copiedOn("Copy message"), up: __live.pressed("Good response"), down: __live.pressed("Bad response") })`);
+  check("clicking Copy at its real centre hits Copy and nothing beside it",
+    copied.copy === true && copied.up === "false" && copied.down === "false", copied);
+
+  // The neighbour, to prove the first result was not luck.
+  const downAt = await evalIn(c, `__live.centreOf("Bad response")`);
+  await clickAt(c, downAt);
+  await sleep(150);
+  const rated = await evalIn(c, `({ up: __live.pressed("Good response"), down: __live.pressed("Bad response") })`);
+  check("clicking the thumb next to it presses that one alone", rated.down === "true" && rated.up === "false",
+    { rated, copyCentre: copyAt, downCentre: downAt });
+
+  // ── 3. The verdict is on disk, in the session's own log ──
+  const rows = await until(async () => {
+    const evs = await api.call("sessions.events", { id: sessionId, afterSeq: 0, limit: 2000 });
+    const fb = evs.filter((e) => e.event.type === "feedback").map((e) => e.event.payload);
+    return fb.length ? fb : null;
+  }, 10000, "the feedback event on disk");
+  check("the verdict is written to session_events, where a relaunch will find it",
+    rows.at(-1).rating === "down", rows);
+
+  const shot = await c.send("Page.captureScreenshot", { format: "png" });
+  const out = path.join(os.tmpdir(), "realm-message-actions.png");
+  fs.writeFileSync(out, Buffer.from(shot.data, "base64"));
+  console.log(`SCREENSHOT ${out}`);
+
+  const errs = c.events.filter((e) => !e.includes("Autofill"));
+  check("no renderer console errors", errs.length === 0, errs.slice(0, 5));
+  api.close();
+  c.close();
+}
+
+main()
+  .catch((e) => { console.error("ERROR", e.message); process.exitCode = 1; })
+  .finally(() => {
+    electron?.kill("SIGTERM");
+    setTimeout(() => { electron?.kill("SIGKILL"); fs.rmSync(scratch, { recursive: true, force: true }); process.exit(process.exitCode ?? 0); }, 1200);
+  });

--- a/apps/desktop/src/renderer/src/panes/session/Markdown.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/Markdown.tsx
@@ -142,10 +142,11 @@ export function renderMarkdown(text: string, cite: readonly string[] = []): stri
 }
 
 /** Assistant prose: markdown → sanitized HTML. The text itself is whatever has actually arrived:
- *  deltas pace the stream, there is no reveal timer, so a re-render can never replay it. `enter`
- *  opts the block into the transcript's 180ms enter animation (§6 — set only for blocks that are
- *  genuinely new). */
-export function Markdown({ text, className = "", enter = false, cite = NO_CITATIONS }: { text: string; className?: string; enter?: boolean; cite?: readonly string[] }) {
+ *  deltas pace the stream, there is no reveal timer, so a re-render can never replay it.
+ *
+ *  §6's entrance is NOT this component's to carry: the rule reaches `.transcript-col`'s direct
+ *  children, and the prose has a wrapper above it that owns the mark instead. */
+export function Markdown({ text, className = "", cite = NO_CITATIONS }: { text: string; className?: string; cite?: readonly string[] }) {
   const html = useMemo(() => renderMarkdown(text, cite), [text, cite]);
   const body = useRef<HTMLDivElement>(null);
   const media = useMediaPortals(body, html);
@@ -163,7 +164,7 @@ export function Markdown({ text, className = "", enter = false, cite = NO_CITATI
     timers.current.set(btn, setTimeout(() => { btn.removeAttribute("data-copied"); timers.current.delete(btn); }, COPIED_MS));
   };
   return (
-    <div className={`md ${className}`.trim()} data-enter={enter || undefined}>
+    <div className={`md ${className}`.trim()}>
       {/* The markup is written imperatively rather than through `dangerouslySetInnerHTML`, and the
           reason is portals: React 19 does not commit a portal into a node it created by setting
           innerHTML, so media parked inside the prose would never appear. A node the effect below

--- a/apps/desktop/src/renderer/src/panes/session/Markdown.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/Markdown.tsx
@@ -35,6 +35,8 @@ DOMPurify.addHook("afterSanitizeAttributes", (node) => {
   if (node.tagName === "A") { node.setAttribute("target", "_blank"); node.setAttribute("rel", "noopener noreferrer"); }
 });
 
+const NO_CITATIONS: readonly string[] = [];
+
 /** How long the copy button holds its ✓ before cross-fading back (matches ToolCard's COPIED_MS). */
 const COPIED_MS = 1400;
 
@@ -56,9 +58,34 @@ const COPY_BUTTON_HTML =
  *  the marker was for — which of the five it is. Anything else in the brackets is left alone. */
 const CALLOUTS = new Set(["note", "tip", "important", "warning", "caution"]);
 
-function decorate(html: string): string {
-  if (!html.includes("<table") && !html.includes("<pre") && !html.includes("<blockquote")) return html;
+/**
+ * A numbered marker on a link the agent DID fetch.
+ *
+ * The numbers are the sources list's own, so `[2]` in the prose and `2` in the disclosure are one
+ * page. Only links whose href matches something actually retrieved get one: a marker on a url the
+ * model merely typed would present a claim as a citation, which is the one thing a citation must
+ * never do. A message with no matching links gets no markers and still gets its sources list —
+ * they answer different questions ("where did this sentence come from" against "what did you
+ * read"), and only the first needs the model to have linked anything.
+ */
+const citeKey = (url: string): string => url.replace(/\/+$/, "");
+
+function markCitations(doc: Document, cite: readonly string[]): void {
+  const index = new Map(cite.map((url, i) => [citeKey(url), i + 1]));
+  for (const a of Array.from(doc.body.querySelectorAll("a[href]"))) {
+    const n = index.get(citeKey(a.getAttribute("href") ?? ""));
+    if (n === undefined) continue;
+    const sup = doc.createElement("sup");
+    sup.className = "md-cite";
+    sup.textContent = String(n);
+    a.after(sup);
+  }
+}
+
+function decorate(html: string, cite: readonly string[]): string {
+  if (cite.length === 0 && !html.includes("<table") && !html.includes("<pre") && !html.includes("<blockquote")) return html;
   const doc = new DOMParser().parseFromString(html, "text/html");
+  markCitations(doc, cite);
   for (const quote of Array.from(doc.body.querySelectorAll("blockquote"))) {
     const first = quote.firstElementChild;
     const m = /^\[!(\w+)\]\s*/.exec(first?.textContent ?? "");
@@ -103,21 +130,23 @@ function decorate(html: string): string {
   return doc.body.innerHTML;
 }
 
-export function renderMarkdown(text: string): string {
+/** `cite` — urls the agent actually retrieved for this message, in the order the sources list shows
+ *  them. Empty everywhere but an assistant message that fetched something. */
+export function renderMarkdown(text: string, cite: readonly string[] = []): string {
   const html = marked.parse(text, { async: false });
   /* MathML and SVG join the HTML profile for KaTeX's sake: it emits `<math>` alongside its visual
    * markup (so the expression can be selected, copied and read aloud) and `<svg>` for the parts CSS
    * cannot draw — surd bars, stretchy braces. With the html profile alone the sanitizer strips both
    * and every formula loses its accessible half and its radicals. */
-  return decorate(DOMPurify.sanitize(html, { USE_PROFILES: { html: true, mathMl: true, svg: true }, ADD_ATTR: ["target"] }));
+  return decorate(DOMPurify.sanitize(html, { USE_PROFILES: { html: true, mathMl: true, svg: true }, ADD_ATTR: ["target"] }), cite);
 }
 
 /** Assistant prose: markdown → sanitized HTML. The text itself is whatever has actually arrived:
  *  deltas pace the stream, there is no reveal timer, so a re-render can never replay it. `enter`
  *  opts the block into the transcript's 180ms enter animation (§6 — set only for blocks that are
  *  genuinely new). */
-export function Markdown({ text, className = "", enter = false }: { text: string; className?: string; enter?: boolean }) {
-  const html = useMemo(() => renderMarkdown(text), [text]);
+export function Markdown({ text, className = "", enter = false, cite = NO_CITATIONS }: { text: string; className?: string; enter?: boolean; cite?: readonly string[] }) {
+  const html = useMemo(() => renderMarkdown(text, cite), [text, cite]);
   const body = useRef<HTMLDivElement>(null);
   const media = useMediaPortals(body, html);
   // Copy buttons live inside dangerouslySetInnerHTML, so they are wired by delegation; the ✓ hold

--- a/apps/desktop/src/renderer/src/panes/session/MessageActions.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/MessageActions.tsx
@@ -1,0 +1,39 @@
+import { Icon } from "@realm/ui";
+import { useEffect, useRef, useState } from "react";
+
+/** How long a copy control holds its ✓ before swapping back — ToolCard's and Markdown's beat, so
+ *  every copy in the transcript settles at the same pace. */
+const COPIED_MS = 1400;
+
+/**
+ * The controls under a finished assistant message.
+ *
+ * Mounted only once the message is complete, which is the whole design constraint: a bar under a
+ * paragraph that is still growing would be pushed down the pane by every delta, and a 20px button
+ * the reader has to chase is worth less than the stability it costs. Nothing here has an entrance
+ * animation for the same reason the transcript seeds its enter tracker as already-seen — on
+ * relaunch every message is complete at once, and forty bars fading in together reads as a fault
+ * rather than as forty arrivals.
+ */
+export function MessageActions({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false);
+  const timer = useRef<ReturnType<typeof setTimeout>>(undefined);
+  useEffect(() => () => clearTimeout(timer.current), []);
+  const copy = () => {
+    void navigator.clipboard.writeText(text);
+    setCopied(true);
+    clearTimeout(timer.current);
+    timer.current = setTimeout(() => setCopied(false), COPIED_MS);
+  };
+  return (
+    <div className="msg-actions" role="group" aria-label="Message actions">
+      {/* §6 icon swap: both glyphs stay mounted and cross-fade, and the accessible name never
+          changes — a tick is a change of state, not a change of control. */}
+      <button className="msg-action" aria-label="Copy message" title="Copy"
+        data-copied={copied || undefined} onClick={copy}>
+        <Icon name="copy" size={14} className="copy-icon" />
+        <Icon name="check" size={14} className="copied-icon" />
+      </button>
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/src/panes/session/MessageActions.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/MessageActions.tsx
@@ -15,7 +15,15 @@ const COPIED_MS = 1400;
  * relaunch every message is complete at once, and forty bars fading in together reads as a fault
  * rather than as forty arrivals.
  */
-export function MessageActions({ text }: { text: string }) {
+export function MessageActions({ text, onRetry, retryBusy = false }: {
+  text: string;
+  /** Present only on the message a retry would land after, and only when there is a user message to
+   *  ask again — the bar does not offer a button it cannot honour. */
+  onRetry?: () => void;
+  /** A turn is in flight. The control stays in place and greys rather than leaving, because a
+   *  button that disappears for the seconds a run takes reads as one that was never there. */
+  retryBusy?: boolean;
+}) {
   const [copied, setCopied] = useState(false);
   const timer = useRef<ReturnType<typeof setTimeout>>(undefined);
   useEffect(() => () => clearTimeout(timer.current), []);
@@ -34,6 +42,15 @@ export function MessageActions({ text }: { text: string }) {
         <Icon name="copy" size={14} className="copy-icon" />
         <Icon name="check" size={14} className="copied-icon" />
       </button>
+      {/* "Retry", not "Regenerate": this asks the question again as a new turn. The answer above it
+          stays where it is, because the agent's own context still holds it and a transcript that
+          disagreed with what the agent remembers would be the more expensive lie. */}
+      {onRetry && (
+        <button className="msg-action" aria-label="Retry" title="Ask the last message again"
+          disabled={retryBusy} onClick={onRetry}>
+          <Icon name="reload" size={14} />
+        </button>
+      )}
     </div>
   );
 }

--- a/apps/desktop/src/renderer/src/panes/session/MessageActions.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/MessageActions.tsx
@@ -1,5 +1,6 @@
 import { Icon } from "@realm/ui";
 import { useEffect, useRef, useState } from "react";
+import type { Rating } from "./transcript-model";
 
 /** How long a copy control holds its ✓ before swapping back — ToolCard's and Markdown's beat, so
  *  every copy in the transcript settles at the same pace. */
@@ -15,7 +16,7 @@ const COPIED_MS = 1400;
  * relaunch every message is complete at once, and forty bars fading in together reads as a fault
  * rather than as forty arrivals.
  */
-export function MessageActions({ text, onRetry, retryBusy = false }: {
+export function MessageActions({ text, onRetry, retryBusy = false, rating = null, onRate }: {
   text: string;
   /** Present only on the message a retry would land after, and only when there is a user message to
    *  ask again — the bar does not offer a button it cannot honour. */
@@ -23,6 +24,11 @@ export function MessageActions({ text, onRetry, retryBusy = false }: {
   /** A turn is in flight. The control stays in place and greys rather than leaving, because a
    *  button that disappears for the seconds a run takes reads as one that was never there. */
   retryBusy?: boolean;
+  /** The verdict already on this message, or null for one nobody has judged. Those are three
+   *  distinct states, not a boolean — "not rated" is not "rated down". */
+  rating?: Rating | null;
+  /** Absent in the read-only mounts, which draw the thumbs not at all rather than drawing dead ones. */
+  onRate?: (rating: Rating | null) => void;
 }) {
   const [copied, setCopied] = useState(false);
   const timer = useRef<ReturnType<typeof setTimeout>>(undefined);
@@ -51,6 +57,15 @@ export function MessageActions({ text, onRetry, retryBusy = false }: {
           <Icon name="reload" size={14} />
         </button>
       )}
+      {/* Pressing the verdict already showing takes it back, which is why these are `aria-pressed`
+          toggles and not a two-way choice: the reader who mis-clicked has somewhere to go, and
+          "unrated" stays reachable rather than being a state you can only leave. */}
+      {onRate && ([["up", "thumbsUp", "Good response"], ["down", "thumbsDown", "Bad response"]] as const).map(([v, icon, label]) => (
+        <button key={v} className="msg-action" aria-label={label} title={label}
+          aria-pressed={rating === v} onClick={() => onRate(rating === v ? null : v)}>
+          <Icon name={icon} size={14} />
+        </button>
+      ))}
     </div>
   );
 }

--- a/apps/desktop/src/renderer/src/panes/session/MessageActions.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/MessageActions.tsx
@@ -10,7 +10,7 @@ const COPIED_MS = 1400;
  * The controls under a finished assistant message.
  *
  * Mounted only once the message is complete, which is the whole design constraint: a bar under a
- * paragraph that is still growing would be pushed down the pane by every delta, and a 20px button
+ * paragraph that is still growing would be pushed down the pane by every delta, and a 26px button
  * the reader has to chase is worth less than the stability it costs. Nothing here has an entrance
  * animation for the same reason the transcript seeds its enter tracker as already-seen — on
  * relaunch every message is complete at once, and forty bars fading in together reads as a fault

--- a/apps/desktop/src/renderer/src/panes/session/MessageSources.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/MessageSources.tsx
@@ -1,0 +1,43 @@
+import { Icon } from "@realm/ui";
+import { useId, useState } from "react";
+import type { Source } from "./message-sources";
+
+/**
+ * The pages the answer above was built from, folded away until asked for.
+ *
+ * Collapsed by default because a source list is a citation, not content: the reader who wants to
+ * check where something came from goes looking, and the one who does not should not have four
+ * URLs between them and the next message.
+ *
+ * No favicons, unlike the reference. A favicon is fetched from the site it belongs to, so drawing
+ * one would have Realm making a request to every host an agent ever read, from the transcript,
+ * days later — a network call the reader did not ask for, to say nothing they cannot already see
+ * in the hostname.
+ */
+export function MessageSources({ sources }: { sources: readonly Source[] }) {
+  const [open, setOpen] = useState(false);
+  const id = useId();
+  return (
+    <div className="msg-sources" data-open={open || undefined}>
+      <button className="msg-sources-toggle" aria-expanded={open} aria-controls={id} onClick={() => setOpen((o) => !o)}>
+        <Icon name="chevronDown" size={12} className="msg-sources-chevron" />
+        <span>{sources.length} {sources.length === 1 ? "source" : "sources"}</span>
+      </button>
+      {/* `hidden` rather than unmounted: the button's `aria-controls` has to point at something that
+          exists, and a list that is built once keeps its numbering stable across every open. */}
+      <ol className="msg-sources-list" id={id} hidden={!open}>
+        {sources.map((s, i) => (
+          <li key={s.url}>
+            {/* target=_blank is what hands the url to the OS browser — main's window-open handler
+                takes http(s) and opens it there, the same route markdown links already take. */}
+            <a href={s.url} target="_blank" rel="noopener noreferrer" title={s.url}>
+              <span className="msg-source-n">{i + 1}</span>
+              <span className="msg-source-host">{s.host}</span>
+              {s.path && <span className="msg-source-path">{s.path}</span>}
+            </a>
+          </li>
+        ))}
+      </ol>
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/src/panes/session/SessionPane.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/SessionPane.tsx
@@ -177,6 +177,7 @@ export function SessionPane({ item, visible, focused = false }: PaneProps) {
   const sendMessage = useApp((s) => s.sendMessage);
   const interruptSession = useApp((s) => s.interruptSession);
   const retryLastTurn = useApp((s) => s.retryLastTurn);
+  const rateMessage = useApp((s) => s.rateMessage);
   const respondPermission = useApp((s) => s.respondPermission);
   const setSessionOptions = useApp((s) => s.setSessionOptions);
   const setSessionAgent = useApp((s) => s.setSessionAgent);
@@ -325,7 +326,8 @@ export function SessionPane({ item, visible, focused = false }: PaneProps) {
         sends={sends}
         mentionIds={liveMentionIds}
         onDecide={(requestId, d, answers) => run(() => respondPermission(id, requestId, d, answers))}
-        onRetry={() => { setSends((n) => n + 1); run(() => retryLastTurn(id)); }} />
+        onRetry={() => { setSends((n) => n + 1); run(() => retryLastTurn(id)); }}
+        onRate={(messageId, rating) => run(() => rateMessage(id, messageId, rating))} />
       {/* Between the log and the prompter, not inside the scroller: a delegated child running RIGHT
           NOW is not history, and it must not scroll away from the reader who went back to re-read
           something. It draws nothing at all when this session is waiting on no one. */}

--- a/apps/desktop/src/renderer/src/panes/session/SessionPane.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/SessionPane.tsx
@@ -176,6 +176,7 @@ export function SessionPane({ item, visible, focused = false }: PaneProps) {
   const openSession = useApp((s) => s.openSession);
   const sendMessage = useApp((s) => s.sendMessage);
   const interruptSession = useApp((s) => s.interruptSession);
+  const retryLastTurn = useApp((s) => s.retryLastTurn);
   const respondPermission = useApp((s) => s.respondPermission);
   const setSessionOptions = useApp((s) => s.setSessionOptions);
   const setSessionAgent = useApp((s) => s.setSessionAgent);
@@ -323,7 +324,8 @@ export function SessionPane({ item, visible, focused = false }: PaneProps) {
       <Transcript transcript={transcript} sessionStatus={status} visible={visible} focused={focused} cwd={session.cwd}
         sends={sends}
         mentionIds={liveMentionIds}
-        onDecide={(requestId, d, answers) => run(() => respondPermission(id, requestId, d, answers))} />
+        onDecide={(requestId, d, answers) => run(() => respondPermission(id, requestId, d, answers))}
+        onRetry={() => { setSends((n) => n + 1); run(() => retryLastTurn(id)); }} />
       {/* Between the log and the prompter, not inside the scroller: a delegated child running RIGHT
           NOW is not history, and it must not scroll away from the reader who went back to re-read
           something. It draws nothing at all when this session is waiting on no one. */}

--- a/apps/desktop/src/renderer/src/panes/session/Transcript.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/Transcript.tsx
@@ -4,6 +4,7 @@ import { chipRuns, mediaCandidatesIn, type SessionStatus } from "@realm/contract
 import { AttachmentTile } from "./AttachmentTile";
 import type { PermissionDecision } from "../../state/store";
 import { Markdown } from "./Markdown";
+import { MessageActions } from "./MessageActions";
 import { PermissionCard } from "./PermissionCard";
 import { PlanCard, PlanDecision, isPlanDecision } from "./PlanCard";
 import { QuestionCard, questionCardFor } from "./QuestionCard";
@@ -92,10 +93,14 @@ function AssistantMessage({ text, streaming, enter, cwd }: { text: string; strea
   const candidates = useMemo(() => (streaming ? [] : mediaCandidatesIn(text, cwd)), [streaming, text, cwd]);
   const files = useMediaFiles(candidates);
   return (
-    <>
-      <Markdown className="msg-assistant" text={text} enter={enter} />
+    // `data-enter` rides the ROW, not the prose: §6's entrance rule reaches `.transcript-col`'s
+    // direct children only, and the message stopped being one the moment it grew a wrapper.
+    <div className="msg-assistant-row" data-enter={enter || undefined}
+      data-state={streaming ? "streaming" : "complete"} aria-busy={streaming}>
+      <Markdown className="msg-assistant" text={text} />
       <MediaStrip files={files} />
-    </>
+      {!streaming && <MessageActions text={text} />}
+    </div>
   );
 }
 

--- a/apps/desktop/src/renderer/src/panes/session/Transcript.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/Transcript.tsx
@@ -10,7 +10,7 @@ import { PlanCard, PlanDecision, isPlanDecision } from "./PlanCard";
 import { QuestionCard, questionCardFor } from "./QuestionCard";
 import { ToolCard, ToolGroup } from "./ToolCard";
 import { formatDuration, groupTranscript, withEnter } from "./tool-group";
-import { blockKey, type Transcript as TranscriptModel } from "./transcript-model";
+import { blockKey, lastUserMessage, type Transcript as TranscriptModel } from "./transcript-model";
 import { runLabelFor } from "./run-label";
 import { useEnterTracker } from "./transcript-enter";
 import { MediaStrip } from "./media/MediaView";
@@ -89,7 +89,10 @@ function UserAttachments({ attachments }: { attachments: readonly { path: string
  * strip that appeared, changed and disappeared as the sentence completed would be worse than one
  * that waits for the full stop.
  */
-function AssistantMessage({ text, streaming, enter, cwd }: { text: string; streaming: boolean; enter: boolean; cwd: string | null }) {
+function AssistantMessage({ text, streaming, enter, cwd, onRetry, retryBusy }: {
+  text: string; streaming: boolean; enter: boolean; cwd: string | null;
+  onRetry?: () => void; retryBusy?: boolean;
+}) {
   const candidates = useMemo(() => (streaming ? [] : mediaCandidatesIn(text, cwd)), [streaming, text, cwd]);
   const files = useMediaFiles(candidates);
   return (
@@ -99,7 +102,7 @@ function AssistantMessage({ text, streaming, enter, cwd }: { text: string; strea
       data-state={streaming ? "streaming" : "complete"} aria-busy={streaming}>
       <Markdown className="msg-assistant" text={text} />
       <MediaStrip files={files} />
-      {!streaming && <MessageActions text={text} />}
+      {!streaming && <MessageActions text={text} onRetry={onRetry} retryBusy={retryBusy} />}
     </div>
   );
 }
@@ -107,8 +110,12 @@ function AssistantMessage({ text, streaming, enter, cwd }: { text: string; strea
 /** Scrolling message list. Follows the bottom while the reader is near it; otherwise offers a "new messages" pill.
  *  Content lives in a centered 680px `.transcript-col` so messages share rails with the prompter (§4);
  *  the scrollbar stays at the pane edge because `.transcript` itself is the scroller. */
-export function Transcript({ transcript, sessionStatus, onDecide, visible = true, focused = false, cwd = null, sends = 0, mentionIds = NO_MENTIONS }: {
+export function Transcript({ transcript, sessionStatus, onDecide, onRetry, visible = true, focused = false, cwd = null, sends = 0, mentionIds = NO_MENTIONS }: {
   transcript: TranscriptModel; sessionStatus: SessionStatus; onDecide: (requestId: string, d: PermissionDecision, answers?: Record<string, string>) => void; visible?: boolean;
+  /** Ask the last user message again. Offered on the newest assistant message only: "retry" names
+   *  the turn that just finished, and a button on message three of forty would silently act on
+   *  message forty instead. Absent in the read-only mounts the suite and the fork preview use. */
+  onRetry?: () => void;
   /** The pane sits in the focused leaf: the first pending permission card autofocuses (U-H4). */
   focused?: boolean;
   /** The session's working directory — the base a message's bare filenames are joined against when
@@ -133,6 +140,17 @@ export function Transcript({ transcript, sessionStatus, onDecide, visible = true
   const lastLen = lastText && "text" in lastText ? lastText.text?.length ?? 0 : 0;
   // Permission cards only make sense while the adapter is actually waiting; stale requests (crash, restart) are closed server-side.
   const permissions = sessionStatus === "waiting_permission" ? transcript.pendingPermissions : [];
+  // Retry belongs to the newest assistant message, and only when there is something to ask again —
+  // a session whose only messages came from a peer has nothing of the user's to re-send.
+  const retryKey = useMemo(() => {
+    if (!onRetry || !lastUserMessage(transcript)) return null;
+    for (let i = transcript.blocks.length - 1; i >= 0; i--) {
+      const b = transcript.blocks[i]!;
+      if (b.kind === "assistant") return blockKey(b, i);
+    }
+    return null;
+  }, [onRetry, transcript]);
+  const busy = sessionStatus === "running" || sessionStatus === "waiting_permission";
   // §6: 180ms enter, new items only. Everything on screen at mount is seeded as already-seen, so
   // re-rendering, scrolling, or coming back to this session never replays an entrance.
   const isEntering = useEnterTracker([
@@ -199,7 +217,8 @@ export function Transcript({ transcript, sessionStatus, onDecide, visible = true
                     send that lost its words rather than one that carried only files. */}
                 {b.text && <UserText text={b.text} mentionIds={mentionIds} />}
               </div>);
-            case "assistant": return <AssistantMessage key={key} text={b.text} streaming={b.streaming} enter={enter} cwd={cwd} />;
+            case "assistant": return <AssistantMessage key={key} text={b.text} streaming={b.streaming} enter={enter} cwd={cwd}
+              onRetry={key === retryKey ? onRetry : undefined} retryBusy={busy} />;
             case "thinking": return <Thinking key={key} text={b.text} enter={enter} />;
             case "tool": return <ToolCard key={key} block={b} sessionStatus={sessionStatus} enter={enter} nested={withEnter(it.nested, isEntering)} />;
             case "plan": return <PlanCard key={key} text={b.text} steps={b.steps} enter={enter} />;

--- a/apps/desktop/src/renderer/src/panes/session/Transcript.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/Transcript.tsx
@@ -5,6 +5,8 @@ import { AttachmentTile } from "./AttachmentTile";
 import type { PermissionDecision } from "../../state/store";
 import { Markdown } from "./Markdown";
 import { MessageActions } from "./MessageActions";
+import { MessageSources } from "./MessageSources";
+import { sourcesFor, type Source } from "./message-sources";
 import { PermissionCard } from "./PermissionCard";
 import { PlanCard, PlanDecision, isPlanDecision } from "./PlanCard";
 import { QuestionCard, questionCardFor } from "./QuestionCard";
@@ -31,6 +33,7 @@ function Thinking({ text, enter }: { text: string; enter?: boolean }) {
 }
 
 const NO_MENTIONS: readonly string[] = [];
+const NO_SOURCES: readonly Source[] = [];
 
 /**
  * A user message's text, with its chips drawn as chips.
@@ -89,20 +92,25 @@ function UserAttachments({ attachments }: { attachments: readonly { path: string
  * strip that appeared, changed and disappeared as the sentence completed would be worse than one
  * that waits for the full stop.
  */
-function AssistantMessage({ text, streaming, enter, cwd, onRetry, retryBusy, rating, onRate }: {
+function AssistantMessage({ text, streaming, enter, cwd, onRetry, retryBusy, rating, onRate, sources = NO_SOURCES }: {
   text: string; streaming: boolean; enter: boolean; cwd: string | null;
   onRetry?: () => void; retryBusy?: boolean; rating?: Rating | null; onRate?: (rating: Rating | null) => void;
+  /** The pages this turn actually fetched. Empty for the overwhelming majority of messages, which
+   *  is the honest answer: an agent that ran no fetch tool read nothing to cite. */
+  sources?: readonly Source[];
 }) {
   const candidates = useMemo(() => (streaming ? [] : mediaCandidatesIn(text, cwd)), [streaming, text, cwd]);
   const files = useMediaFiles(candidates);
+  const cite = useMemo(() => sources.map((s) => s.url), [sources]);
   return (
     // `data-enter` rides the ROW, not the prose: §6's entrance rule reaches `.transcript-col`'s
     // direct children only, and the message stopped being one the moment it grew a wrapper.
     <div className="msg-assistant-row" data-enter={enter || undefined}
       data-state={streaming ? "streaming" : "complete"} aria-busy={streaming}>
-      <Markdown className="msg-assistant" text={text} />
+      <Markdown className="msg-assistant" text={text} cite={cite} />
       <MediaStrip files={files} />
       {!streaming && <MessageActions text={text} onRetry={onRetry} retryBusy={retryBusy} rating={rating} onRate={onRate} />}
+      {!streaming && sources.length > 0 && <MessageSources sources={sources} />}
     </div>
   );
 }
@@ -154,6 +162,17 @@ export function Transcript({ transcript, sessionStatus, onDecide, onRetry, onRat
     return null;
   }, [onRetry, transcript]);
   const busy = sessionStatus === "running" || sessionStatus === "waiting_permission";
+  // Per message, not per transcript: a turn's fetches belong to the answer they were made for, and
+  // one list at the bottom would credit the newest message with everything ever read.
+  const sourcesByKey = useMemo(() => {
+    const out = new Map<string, Source[]>();
+    transcript.blocks.forEach((b, i) => {
+      if (b.kind !== "assistant" || b.streaming) return;
+      const found = sourcesFor(transcript.blocks, i);
+      if (found.length > 0) out.set(blockKey(b, i), found);
+    });
+    return out;
+  }, [transcript.blocks]);
   // §6: 180ms enter, new items only. Everything on screen at mount is seeded as already-seen, so
   // re-rendering, scrolling, or coming back to this session never replays an entrance.
   const isEntering = useEnterTracker([
@@ -223,7 +242,8 @@ export function Transcript({ transcript, sessionStatus, onDecide, onRetry, onRat
             case "assistant": return <AssistantMessage key={key} text={b.text} streaming={b.streaming} enter={enter} cwd={cwd}
               onRetry={key === retryKey ? onRetry : undefined} retryBusy={busy}
               rating={transcript.feedback[b.messageId] ?? null}
-              onRate={onRate && ((r) => onRate(b.messageId, r))} />;
+              onRate={onRate && ((r) => onRate(b.messageId, r))}
+              sources={sourcesByKey.get(key)} />;
             case "thinking": return <Thinking key={key} text={b.text} enter={enter} />;
             case "tool": return <ToolCard key={key} block={b} sessionStatus={sessionStatus} enter={enter} nested={withEnter(it.nested, isEntering)} />;
             case "plan": return <PlanCard key={key} text={b.text} steps={b.steps} enter={enter} />;

--- a/apps/desktop/src/renderer/src/panes/session/Transcript.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/Transcript.tsx
@@ -10,7 +10,7 @@ import { PlanCard, PlanDecision, isPlanDecision } from "./PlanCard";
 import { QuestionCard, questionCardFor } from "./QuestionCard";
 import { ToolCard, ToolGroup } from "./ToolCard";
 import { formatDuration, groupTranscript, withEnter } from "./tool-group";
-import { blockKey, lastUserMessage, type Transcript as TranscriptModel } from "./transcript-model";
+import { blockKey, lastUserMessage, type Rating, type Transcript as TranscriptModel } from "./transcript-model";
 import { runLabelFor } from "./run-label";
 import { useEnterTracker } from "./transcript-enter";
 import { MediaStrip } from "./media/MediaView";
@@ -89,9 +89,9 @@ function UserAttachments({ attachments }: { attachments: readonly { path: string
  * strip that appeared, changed and disappeared as the sentence completed would be worse than one
  * that waits for the full stop.
  */
-function AssistantMessage({ text, streaming, enter, cwd, onRetry, retryBusy }: {
+function AssistantMessage({ text, streaming, enter, cwd, onRetry, retryBusy, rating, onRate }: {
   text: string; streaming: boolean; enter: boolean; cwd: string | null;
-  onRetry?: () => void; retryBusy?: boolean;
+  onRetry?: () => void; retryBusy?: boolean; rating?: Rating | null; onRate?: (rating: Rating | null) => void;
 }) {
   const candidates = useMemo(() => (streaming ? [] : mediaCandidatesIn(text, cwd)), [streaming, text, cwd]);
   const files = useMediaFiles(candidates);
@@ -102,7 +102,7 @@ function AssistantMessage({ text, streaming, enter, cwd, onRetry, retryBusy }: {
       data-state={streaming ? "streaming" : "complete"} aria-busy={streaming}>
       <Markdown className="msg-assistant" text={text} />
       <MediaStrip files={files} />
-      {!streaming && <MessageActions text={text} onRetry={onRetry} retryBusy={retryBusy} />}
+      {!streaming && <MessageActions text={text} onRetry={onRetry} retryBusy={retryBusy} rating={rating} onRate={onRate} />}
     </div>
   );
 }
@@ -110,12 +110,15 @@ function AssistantMessage({ text, streaming, enter, cwd, onRetry, retryBusy }: {
 /** Scrolling message list. Follows the bottom while the reader is near it; otherwise offers a "new messages" pill.
  *  Content lives in a centered 680px `.transcript-col` so messages share rails with the prompter (§4);
  *  the scrollbar stays at the pane edge because `.transcript` itself is the scroller. */
-export function Transcript({ transcript, sessionStatus, onDecide, onRetry, visible = true, focused = false, cwd = null, sends = 0, mentionIds = NO_MENTIONS }: {
+export function Transcript({ transcript, sessionStatus, onDecide, onRetry, onRate, visible = true, focused = false, cwd = null, sends = 0, mentionIds = NO_MENTIONS }: {
   transcript: TranscriptModel; sessionStatus: SessionStatus; onDecide: (requestId: string, d: PermissionDecision, answers?: Record<string, string>) => void; visible?: boolean;
   /** Ask the last user message again. Offered on the newest assistant message only: "retry" names
    *  the turn that just finished, and a button on message three of forty would silently act on
    *  message forty instead. Absent in the read-only mounts the suite and the fork preview use. */
   onRetry?: () => void;
+  /** Record what the reader made of one answer, or with null take an earlier verdict back. Absent
+   *  means the thumbs are not drawn at all, rather than drawn dead. */
+  onRate?: (messageId: string, rating: Rating | null) => void;
   /** The pane sits in the focused leaf: the first pending permission card autofocuses (U-H4). */
   focused?: boolean;
   /** The session's working directory — the base a message's bare filenames are joined against when
@@ -218,7 +221,9 @@ export function Transcript({ transcript, sessionStatus, onDecide, onRetry, visib
                 {b.text && <UserText text={b.text} mentionIds={mentionIds} />}
               </div>);
             case "assistant": return <AssistantMessage key={key} text={b.text} streaming={b.streaming} enter={enter} cwd={cwd}
-              onRetry={key === retryKey ? onRetry : undefined} retryBusy={busy} />;
+              onRetry={key === retryKey ? onRetry : undefined} retryBusy={busy}
+              rating={transcript.feedback[b.messageId] ?? null}
+              onRate={onRate && ((r) => onRate(b.messageId, r))} />;
             case "thinking": return <Thinking key={key} text={b.text} enter={enter} />;
             case "tool": return <ToolCard key={key} block={b} sessionStatus={sessionStatus} enter={enter} nested={withEnter(it.nested, isEntering)} />;
             case "plan": return <PlanCard key={key} text={b.text} steps={b.steps} enter={enter} />;

--- a/apps/desktop/src/renderer/src/panes/session/message-actions.test.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/message-actions.test.tsx
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { Transcript } from "./Transcript";
+import { renderMarkdown } from "./Markdown";
 import type { Block, Transcript as TranscriptModel } from "./transcript-model";
 
 afterEach(() => cleanup());
@@ -12,6 +13,9 @@ const assistant = (text: string, streaming: boolean, messageId = "m1"): Block =>
   ({ kind: "assistant", messageId, text, streaming, ts: 1 });
 
 const user = (text: string): Block => ({ kind: "user", text, ts: 0 });
+
+const fetched = (url: string): Block =>
+  ({ kind: "tool", toolUseId: `t:${url}`, name: "WebFetch", input: { url }, result: { content: "page", isError: false }, ts: 0 });
 
 const row = () => document.querySelector(".msg-assistant-row")!;
 
@@ -134,5 +138,62 @@ describe("the assistant message's action bar", () => {
     render(<Transcript sessionStatus="idle" onDecide={() => {}}
       transcript={model([assistant("one", false)])} />);
     expect(screen.queryByRole("button", { name: "Good response" })).toBeNull();
+  });
+
+  it("folds the sources away until the reader asks, and names how many there are", () => {
+    render(<Transcript sessionStatus="idle" onDecide={() => {}}
+      transcript={model([user("q"), fetched("https://a.test/one"), fetched("https://b.test/two"), assistant("answer", false)])} />);
+    const toggle = screen.getByRole("button", { name: /2 sources/ });
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+    expect(document.querySelector(".msg-sources-list")).toHaveAttribute("hidden");
+    fireEvent.click(toggle);
+    expect(toggle).toHaveAttribute("aria-expanded", "true");
+    const links = [...document.querySelectorAll<HTMLAnchorElement>(".msg-sources-list a")];
+    expect(links.map((a) => a.getAttribute("href"))).toEqual(["https://a.test/one", "https://b.test/two"]);
+    // target=_blank is the whole mechanism for reaching the OS browser; without it a click would
+    // navigate the renderer itself out of the app.
+    expect(links[0]!.getAttribute("target")).toBe("_blank");
+  });
+
+  it("says nothing at all about sources when the turn fetched nothing", () => {
+    render(<Transcript sessionStatus="idle" onDecide={() => {}}
+      transcript={model([user("q"), assistant("an answer with https://typed.test/x in it", false)])} />);
+    expect(document.querySelector(".msg-sources")).toBeNull();
+  });
+
+  it("credits the answer whose turn did the fetching, not the one after it", () => {
+    render(<Transcript sessionStatus="idle" onDecide={() => {}}
+      transcript={model([
+        user("first"), fetched("https://a.test/one"), assistant("one", false),
+        user("second"), assistant("two", false, "m2"),
+      ])} />);
+    const bars = [...document.querySelectorAll(".msg-assistant-row")];
+    expect(bars[0]!.querySelector(".msg-sources")).not.toBeNull();
+    expect(bars[1]!.querySelector(".msg-sources")).toBeNull();
+  });
+});
+
+describe("inline citation markers", () => {
+  it("numbers a link the agent actually fetched, matching the sources list", () => {
+    const html = renderMarkdown("See [the docs](https://a.test/one) and [more](https://b.test/two).",
+      ["https://a.test/one", "https://b.test/two"]);
+    expect(html).toContain('<sup class="md-cite">1</sup>');
+    expect(html).toContain('<sup class="md-cite">2</sup>');
+  });
+
+  it("leaves a link the agent never fetched unmarked — a typed url is not a citation", () => {
+    // The mutant this kills: marking every link, which would present the model's own recollection
+    // as evidence it went and checked.
+    const html = renderMarkdown("Fetched [one](https://a.test/one), guessed [two](https://guess.test/x).",
+      ["https://a.test/one"]);
+    expect(html.match(/md-cite/g)).toHaveLength(1);
+    expect(html).toContain('<sup class="md-cite">1</sup>');
+    expect(html).not.toContain('<sup class="md-cite">2</sup>');
+  });
+
+  it("marks nothing when nothing was fetched, and leaves the prose byte-identical", () => {
+    const text = "Read more at [the docs](https://a.test/one).";
+    expect(renderMarkdown(text)).toBe(renderMarkdown(text, []));
+    expect(renderMarkdown(text)).not.toContain("md-cite");
   });
 });

--- a/apps/desktop/src/renderer/src/panes/session/message-actions.test.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/message-actions.test.tsx
@@ -11,6 +11,8 @@ const model = (blocks: Block[]): TranscriptModel =>
 const assistant = (text: string, streaming: boolean, messageId = "m1"): Block =>
   ({ kind: "assistant", messageId, text, streaming, ts: 1 });
 
+const user = (text: string): Block => ({ kind: "user", text, ts: 0 });
+
 const row = () => document.querySelector(".msg-assistant-row")!;
 
 describe("the assistant message's action bar", () => {
@@ -66,5 +68,37 @@ describe("the assistant message's action bar", () => {
       transcript={model([assistant("first", false), assistant("second", false, "m2")])} />);
     expect(document.querySelector(".transcript-col > .msg-assistant-row[data-enter]")).not.toBeNull();
     expect(document.querySelector(".md[data-enter]")).toBeNull();
+  });
+
+  it("offers Retry on the newest answer only — the button acts on the last turn wherever it sits", () => {
+    render(<Transcript sessionStatus="idle" onDecide={() => {}} onRetry={() => {}}
+      transcript={model([user("one"), assistant("first", false), user("two"), assistant("second", false, "m2")])} />);
+    const bars = [...document.querySelectorAll(".msg-actions")];
+    expect(bars).toHaveLength(2);
+    expect(bars[0]!.querySelector('[aria-label="Retry"]')).toBeNull();
+    expect(bars[1]!.querySelector('[aria-label="Retry"]')).not.toBeNull();
+  });
+
+  it("does not offer Retry when there is nothing of the user's to ask again", () => {
+    render(<Transcript sessionStatus="idle" onDecide={() => {}} onRetry={() => {}}
+      transcript={model([assistant("unprompted", false)])} />);
+    expect(screen.queryByRole("button", { name: "Retry" })).toBeNull();
+  });
+
+  it("greys Retry while a turn is live rather than taking it away", () => {
+    const view = render(<Transcript sessionStatus="running" onDecide={() => {}} onRetry={() => {}}
+      transcript={model([user("one"), assistant("done", false)])} />);
+    expect(screen.getByRole("button", { name: "Retry" })).toBeDisabled();
+    view.rerender(<Transcript sessionStatus="idle" onDecide={() => {}} onRetry={() => {}}
+      transcript={model([user("one"), assistant("done", false)])} />);
+    expect(screen.getByRole("button", { name: "Retry" })).toBeEnabled();
+  });
+
+  it("hands the click straight to the pane", () => {
+    const retried = vi.fn();
+    render(<Transcript sessionStatus="idle" onDecide={() => {}} onRetry={retried}
+      transcript={model([user("one"), assistant("done", false)])} />);
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    expect(retried).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/desktop/src/renderer/src/panes/session/message-actions.test.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/message-actions.test.tsx
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { Transcript } from "./Transcript";
+import type { Block, Transcript as TranscriptModel } from "./transcript-model";
+
+afterEach(() => cleanup());
+
+const model = (blocks: Block[]): TranscriptModel =>
+  ({ blocks, run: null, pendingPermissions: [], usage: { costUsd: 0, inputTokens: 0, outputTokens: 0, numTurns: 0 }, init: null });
+
+const assistant = (text: string, streaming: boolean, messageId = "m1"): Block =>
+  ({ kind: "assistant", messageId, text, streaming, ts: 1 });
+
+const row = () => document.querySelector(".msg-assistant-row")!;
+
+describe("the assistant message's action bar", () => {
+  it("stays away until the message is finished", () => {
+    const view = render(<Transcript sessionStatus="running" onDecide={() => {}}
+      transcript={model([assistant("half a sen", true)])} />);
+    expect(screen.queryByRole("group", { name: "Message actions" })).toBeNull();
+
+    view.rerender(<Transcript sessionStatus="idle" onDecide={() => {}}
+      transcript={model([assistant("half a sentence, then the rest.", false)])} />);
+    expect(screen.getByRole("group", { name: "Message actions" })).toBeInTheDocument();
+  });
+
+  it("says which of the two states it is in, on the container the reference puts it on", () => {
+    const view = render(<Transcript sessionStatus="running" onDecide={() => {}}
+      transcript={model([assistant("mid", true)])} />);
+    expect(row()).toHaveAttribute("data-state", "streaming");
+    expect(row()).toHaveAttribute("aria-busy", "true");
+
+    view.rerender(<Transcript sessionStatus="idle" onDecide={() => {}}
+      transcript={model([assistant("mid stream, now done", false)])} />);
+    expect(row()).toHaveAttribute("data-state", "complete");
+    expect(row()).toHaveAttribute("aria-busy", "false");
+  });
+
+  it("copies the message's own source text, not the rendered prose", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", { value: { writeText }, configurable: true });
+    vi.useFakeTimers();
+    try {
+      render(<Transcript sessionStatus="idle" onDecide={() => {}}
+        transcript={model([assistant("# Heading\n\nwith `code`", false)])} />);
+      const copy = screen.getByRole("button", { name: "Copy message" });
+      // Both glyphs stay mounted — the tick is a state change on one control, so the swap rule has
+      // something to cross-fade and the accessible name never moves.
+      expect(copy.querySelector(".copy-icon")).not.toBeNull();
+      expect(copy.querySelector(".copied-icon")).not.toBeNull();
+      fireEvent.click(copy);
+      expect(writeText).toHaveBeenCalledWith("# Heading\n\nwith `code`");
+      expect(copy).toHaveAttribute("data-copied");
+      act(() => { vi.advanceTimersByTime(2_000); });
+      expect(copy).not.toHaveAttribute("data-copied");
+    } finally { vi.useRealTimers(); }
+  });
+
+  it("keeps the entrance mark on the element §6's rule can actually reach", () => {
+    // The wrapper made the prose a grandchild of `.transcript-col`, and `> [data-enter]` does not
+    // reach one — an entrance left on the inner div animates nothing at all. Only a block that is
+    // genuinely arriving carries the mark, so this has to grow one to have anything to look at.
+    const view = render(<Transcript sessionStatus="idle" onDecide={() => {}}
+      transcript={model([assistant("first", false)])} />);
+    view.rerender(<Transcript sessionStatus="idle" onDecide={() => {}}
+      transcript={model([assistant("first", false), assistant("second", false, "m2")])} />);
+    expect(document.querySelector(".transcript-col > .msg-assistant-row[data-enter]")).not.toBeNull();
+    expect(document.querySelector(".md[data-enter]")).toBeNull();
+  });
+});

--- a/apps/desktop/src/renderer/src/panes/session/message-actions.test.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/message-actions.test.tsx
@@ -64,14 +64,14 @@ describe("the assistant message's action bar", () => {
 
   it("keeps the entrance mark on the element §6's rule can actually reach", () => {
     // The wrapper made the prose a grandchild of `.transcript-col`, and `> [data-enter]` does not
-    // reach one — an entrance left on the inner div animates nothing at all. Only a block that is
-    // genuinely arriving carries the mark, so this has to grow one to have anything to look at.
+    // reach one. Only a block that is genuinely arriving carries the mark, so this has to grow one
+    // to have anything to look at. (Markdown no longer takes an `enter` at all, so putting the mark
+    // back on the prose is a compile error rather than a thing this has to catch.)
     const view = render(<Transcript sessionStatus="idle" onDecide={() => {}}
       transcript={model([assistant("first", false)])} />);
     view.rerender(<Transcript sessionStatus="idle" onDecide={() => {}}
       transcript={model([assistant("first", false), assistant("second", false, "m2")])} />);
     expect(document.querySelector(".transcript-col > .msg-assistant-row[data-enter]")).not.toBeNull();
-    expect(document.querySelector(".md[data-enter]")).toBeNull();
   });
 
   it("offers Retry on the newest answer only — the button acts on the last turn wherever it sits", () => {

--- a/apps/desktop/src/renderer/src/panes/session/message-actions.test.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/message-actions.test.tsx
@@ -6,7 +6,7 @@ import type { Block, Transcript as TranscriptModel } from "./transcript-model";
 afterEach(() => cleanup());
 
 const model = (blocks: Block[]): TranscriptModel =>
-  ({ blocks, run: null, pendingPermissions: [], usage: { costUsd: 0, inputTokens: 0, outputTokens: 0, numTurns: 0 }, init: null });
+  ({ blocks, run: null, pendingPermissions: [], usage: { costUsd: 0, inputTokens: 0, outputTokens: 0, numTurns: 0 }, init: null, feedback: {} });
 
 const assistant = (text: string, streaming: boolean, messageId = "m1"): Block =>
   ({ kind: "assistant", messageId, text, streaming, ts: 1 });
@@ -100,5 +100,39 @@ describe("the assistant message's action bar", () => {
       transcript={model([user("one"), assistant("done", false)])} />);
     fireEvent.click(screen.getByRole("button", { name: "Retry" }));
     expect(retried).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows the verdict already on the message, and only on that message", () => {
+    render(<Transcript sessionStatus="idle" onDecide={() => {}} onRate={() => {}}
+      transcript={{ ...model([assistant("one", false), assistant("two", false, "m2")]), feedback: { m2: "down" } }} />);
+    const bars = [...document.querySelectorAll(".msg-actions")];
+    expect(bars[0]!.querySelector('[aria-label="Bad response"]')).toHaveAttribute("aria-pressed", "false");
+    expect(bars[1]!.querySelector('[aria-label="Bad response"]')).toHaveAttribute("aria-pressed", "true");
+    expect(bars[1]!.querySelector('[aria-label="Good response"]')).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("rates the message by its own id, not by where it sits", () => {
+    // The mutant: keying feedback on the block index. Blocks are appended constantly, and a verdict
+    // that moved to a different message on the next turn would be worse than none.
+    const onRate = vi.fn();
+    render(<Transcript sessionStatus="idle" onDecide={() => {}} onRate={onRate}
+      transcript={model([assistant("one", false), assistant("two", false, "m2")])} />);
+    const bars = [...document.querySelectorAll(".msg-actions")];
+    fireEvent.click(bars[1]!.querySelector('[aria-label="Good response"]')!);
+    expect(onRate).toHaveBeenCalledWith("m2", "up");
+  });
+
+  it("pressing the verdict that is already showing takes it back", () => {
+    const onRate = vi.fn();
+    render(<Transcript sessionStatus="idle" onDecide={() => {}} onRate={onRate}
+      transcript={{ ...model([assistant("one", false)]), feedback: { m1: "up" } }} />);
+    fireEvent.click(screen.getByRole("button", { name: "Good response" }));
+    expect(onRate).toHaveBeenCalledWith("m1", null);
+  });
+
+  it("draws no thumbs at all where nothing can record them", () => {
+    render(<Transcript sessionStatus="idle" onDecide={() => {}}
+      transcript={model([assistant("one", false)])} />);
+    expect(screen.queryByRole("button", { name: "Good response" })).toBeNull();
   });
 });

--- a/apps/desktop/src/renderer/src/panes/session/message-sources.test.ts
+++ b/apps/desktop/src/renderer/src/panes/session/message-sources.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import { sourcesFor, turnBlocks } from "./message-sources";
+import type { Block } from "./transcript-model";
+
+const user = (text: string): Block => ({ kind: "user", text, ts: 0 });
+const say = (text: string, messageId = "m1"): Block => ({ kind: "assistant", messageId, text, streaming: false, ts: 0 });
+const tool = (name: string, input: Record<string, unknown>, result: { content: string; isError: boolean } | null = { content: "ok", isError: false }): Block =>
+  ({ kind: "tool", toolUseId: `t${name}${JSON.stringify(input)}`, name, input, result, ts: 0 });
+
+const urls = (blocks: Block[]) => sourcesFor(blocks, blocks.length - 1).map((s) => s.url);
+
+describe("what counts as a source", () => {
+  it("takes the url a WebFetch was actually pointed at", () => {
+    expect(urls([user("q"), tool("WebFetch", { url: "https://example.com/a", prompt: "read it" }), say("answer")]))
+      .toEqual(["https://example.com/a"]);
+  });
+
+  it("takes the browser tools too, prefixed as MCP delivers them", () => {
+    // Claude's SDK prefixes every MCP tool `mcp__<server>__<tool>`, and nothing in the renderer
+    // normalises that — matched on the bare name or these never match at all.
+    expect(urls([
+      user("q"),
+      tool("mcp__realm__realm-browser__browser_open", { url: "https://a.test/x" }),
+      tool("mcp__realm__realm-browser__browser_navigate", { browserId: "b1", url: "https://b.test/y" }),
+      say("answer"),
+    ])).toEqual(["https://a.test/x", "https://b.test/y"]);
+  });
+
+  it("refuses a WebSearch: a query is not a page, and its results are links it was shown, not read", () => {
+    // Refused by NAME, not by luck. The `url` is in the input here deliberately — the search shapes
+    // differ across adapters and one carrying a url must still not count, because searching a page
+    // is not reading it. Without the name check this passes only until an adapter changes.
+    expect(urls([
+      user("q"),
+      tool("WebSearch", { query: "best kettle", url: "https://shop.test/kettle" },
+        { content: "1. https://shop.test/kettle\n2. https://other.test/k", isError: false }),
+      say("answer"),
+    ])).toEqual([]);
+  });
+
+  it("refuses a url the model merely typed — nothing in here reads the message at all", () => {
+    expect(urls([user("q"), say("You can read more at https://invented.test/page and [here](https://also.test/x).")]))
+      .toEqual([]);
+  });
+
+  it("refuses a fetch that failed, and one that has not come back", () => {
+    expect(urls([user("q"), tool("WebFetch", { url: "https://dead.test/a" }, { content: "404", isError: true }), say("a")])).toEqual([]);
+    expect(urls([user("q"), tool("WebFetch", { url: "https://slow.test/a" }, null), say("a")])).toEqual([]);
+  });
+
+  it("refuses a url that is not a page anyone can be sent to", () => {
+    expect(urls([user("q"), tool("WebFetch", { url: "file:///etc/passwd" }), say("a")])).toEqual([]);
+    expect(urls([user("q"), tool("WebFetch", { url: "not a url" }), say("a")])).toEqual([]);
+    expect(urls([user("q"), tool("WebFetch", { url: 42 }), say("a")])).toEqual([]);
+  });
+
+  it("credits each answer with its own turn's fetches, never the previous turn's", () => {
+    const blocks: Block[] = [
+      user("first"), tool("WebFetch", { url: "https://one.test/a" }), say("one", "m1"),
+      user("second"), tool("WebFetch", { url: "https://two.test/b" }), say("two", "m2"),
+    ];
+    expect(sourcesFor(blocks, 2).map((s) => s.url)).toEqual(["https://one.test/a"]);
+    expect(sourcesFor(blocks, 5).map((s) => s.url)).toEqual(["https://two.test/b"]);
+  });
+
+  it("lists one page once, however many times it was fetched", () => {
+    expect(urls([
+      user("q"),
+      tool("WebFetch", { url: "https://example.com/a" }),
+      tool("mcp__realm__realm-browser__browser_open", { url: "https://example.com/a" }),
+      say("answer"),
+    ])).toEqual(["https://example.com/a"]);
+  });
+
+  it("splits a url into the part that says WHO and the part that says which page", () => {
+    const [s] = sourcesFor([user("q"), tool("WebFetch", { url: "https://www.example.com/docs/a?v=2" }), say("a")], 2);
+    expect(s).toEqual({ url: "https://www.example.com/docs/a?v=2", host: "example.com", path: "/docs/a?v=2" });
+  });
+
+  it("scopes a turn to the user message that opened it", () => {
+    const blocks: Block[] = [user("a"), say("one"), user("b"), tool("WebFetch", { url: "https://x.test/" }), say("two", "m2")];
+    expect(turnBlocks(blocks, 4).map((b) => b.kind)).toEqual(["tool"]);
+    expect(turnBlocks(blocks, 1).map((b) => b.kind)).toEqual([]);
+  });
+});

--- a/apps/desktop/src/renderer/src/panes/session/message-sources.ts
+++ b/apps/desktop/src/renderer/src/panes/session/message-sources.ts
@@ -1,0 +1,74 @@
+import type { Block } from "./transcript-model";
+
+export type Source = { url: string; host: string; path: string };
+
+/**
+ * The pages an answer was actually built from.
+ *
+ * A source here is a page the agent RETRIEVED, and that is a much narrower thing than a URL that
+ * appears somewhere in the turn. Three kinds of near-source are deliberately refused:
+ *
+ *  - **Links in the assistant's prose.** A URL the model typed is a URL the model typed. It may be
+ *    remembered, guessed, or wrong, and dressing it as a citation would launder a claim into
+ *    evidence. Nothing in here reads the message text at all.
+ *  - **`WebSearch`.** Its input is a query, not a page, and its result is a list of things the model
+ *    was shown rather than things it read. The result is also a flattened string whose shape no
+ *    contract in this repo pins, so parsing it would be guessing at a format that can change under
+ *    us without a single test going red.
+ *  - **Calls that failed or have not come back.** A fetch that errored retrieved nothing, and one
+ *    still in flight has not retrieved it yet.
+ *
+ * What is left is the honest set: tools whose INPUT carries the url as structured data — `WebFetch`,
+ * and the browser tools that point a pane at a page — that came back without an error. When no such
+ * call ran in the turn, the answer has no sources, and the message says nothing rather than
+ * inventing some.
+ */
+const FETCH_TOOLS = new Set(["WebFetch", "browser_open", "browser_navigate"]);
+
+/** MCP tools reach the transcript fully prefixed (`mcp__<server>__realm-browser__browser_open`), and
+ *  nothing in the renderer normalises them, so the bare name has to be recovered here. */
+const bareToolName = (name: string): string => {
+  const at = name.lastIndexOf("__");
+  return at < 0 ? name : name.slice(at + 2);
+};
+
+const toSource = (url: string): Source | null => {
+  try {
+    const u = new URL(url);
+    // http(s) only. A `file:` or `data:` url is not a page anyone can be cited to.
+    if (u.protocol !== "http:" && u.protocol !== "https:") return null;
+    return { url, host: u.host.replace(/^www\./, ""), path: `${u.pathname}${u.search}`.replace(/\/$/, "") };
+  } catch { return null; }
+};
+
+/**
+ * The blocks belonging to the turn that produced the message at `index` — back to the user message
+ * that started it, or to the beginning of the transcript.
+ *
+ * Scoped to the turn on purpose. A page fetched an hour ago, three questions back, is not what this
+ * answer was built from, and listing it under this one would be the same overreach as scraping the
+ * prose. Under-reporting is the safe direction here: a fetch whose turn boundary is ambiguous is
+ * left out rather than attributed to an answer that may not have used it.
+ */
+export function turnBlocks(blocks: readonly Block[], index: number): readonly Block[] {
+  let start = 0;
+  for (let i = index - 1; i >= 0; i--) if (blocks[i]!.kind === "user") { start = i + 1; break; }
+  return blocks.slice(start, index);
+}
+
+/** The sources for the assistant block at `index`, in the order the agent fetched them, deduped. */
+export function sourcesFor(blocks: readonly Block[], index: number): Source[] {
+  const out: Source[] = [];
+  const seen = new Set<string>();
+  for (const b of turnBlocks(blocks, index)) {
+    if (b.kind !== "tool" || !FETCH_TOOLS.has(bareToolName(b.name))) continue;
+    if (!b.result || b.result.isError) continue;
+    const url = b.input["url"];
+    if (typeof url !== "string") continue;
+    const source = toSource(url);
+    if (!source || seen.has(source.url)) continue;
+    seen.add(source.url);
+    out.push(source);
+  }
+  return out;
+}

--- a/apps/desktop/src/renderer/src/panes/session/plan-card.test.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/plan-card.test.tsx
@@ -6,7 +6,7 @@ import type { Block, PendingPermission, Transcript as TranscriptModel } from "./
 afterEach(() => cleanup());
 
 const model = (blocks: Block[], pendingPermissions: PendingPermission[] = []): TranscriptModel =>
-  ({ blocks, run: null, pendingPermissions, usage: { costUsd: 0, inputTokens: 0, outputTokens: 0, numTurns: 0 }, init: null });
+  ({ blocks, run: null, pendingPermissions, usage: { costUsd: 0, inputTokens: 0, outputTokens: 0, numTurns: 0 }, init: null, feedback: {} });
 
 const perm = (over: Partial<PendingPermission> = {}): PendingPermission =>
   ({ requestId: "r1", toolName: "ExitPlanMode", title: "Exit plan mode?", input: { plan: "# Ship it" }, ...over });

--- a/apps/desktop/src/renderer/src/panes/session/run-label.test.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/run-label.test.tsx
@@ -46,7 +46,7 @@ describe("the word a run wears", () => {
 });
 
 const model = (blocks: Block[], run: TranscriptModel["run"] = null): TranscriptModel =>
-  ({ blocks, run, pendingPermissions: [], usage: { costUsd: 0, inputTokens: 0, outputTokens: 0, numTurns: 0 }, init: null });
+  ({ blocks, run, pendingPermissions: [], usage: { costUsd: 0, inputTokens: 0, outputTokens: 0, numTurns: 0 }, init: null, feedback: {} });
 
 describe("what the transcript says about the run", () => {
   it("shimmers this run's verb while it works, not a generic `Working…`", () => {

--- a/apps/desktop/src/renderer/src/panes/session/tool-card.test.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/tool-card.test.tsx
@@ -27,7 +27,7 @@ describe("⌥-click opens the whole ledger", () => {
       { kind: "tool", toolUseId: id, name: "Bash", input: { command: id }, result: { content: id, isError: false }, ts: i * 2 },
       { kind: "assistant", messageId: `m${i}`, text: "and then", streaming: false, ts: i * 2 + 1 },
     ]) as Block[]),
-    pendingPermissions: [], usage: { costUsd: 0, inputTokens: 0, outputTokens: 0, numTurns: 0 }, init: null, run: null,
+    pendingPermissions: [], usage: { costUsd: 0, inputTokens: 0, outputTokens: 0, numTurns: 0 }, init: null, run: null, feedback: {},
   });
   const rows = () => screen.getAllByRole("button", { name: /tool call/ });
   const openStates = () => rows().map((r) => r.getAttribute("aria-expanded"));
@@ -446,7 +446,7 @@ describe("copy ✓ (§6 icon swap)", () => {
 
 describe("tool groups inside the transcript", () => {
   const model = (blocks: Block[]): TranscriptModel =>
-    ({ blocks, pendingPermissions: [], usage: { costUsd: 0, inputTokens: 0, outputTokens: 0, numTurns: 0 }, init: null, run: null });
+    ({ blocks, pendingPermissions: [], usage: { costUsd: 0, inputTokens: 0, outputTokens: 0, numTurns: 0 }, init: null, run: null, feedback: {} });
   const run = (n: number) => model(Array.from({ length: n }, (_, k) => tool(`t${k + 1}`, "Read", { file_path: `/f${k}.ts` })));
   const view = (n: number) => <Transcript transcript={run(n)} sessionStatus="idle" onDecide={() => {}} />;
 
@@ -477,7 +477,7 @@ describe("settled tool cards do not re-render behind a streaming answer", () => 
     const settled: Block[] = cards.flatMap((c, i) => [{ kind: "user", text: `q${i}`, ts: i } as Block, c]);
     const withStream = (text: string): TranscriptModel => ({
       blocks: [...settled, { kind: "assistant", messageId: "live", text, streaming: true, ts: 99 }],
-      pendingPermissions: [], usage: { costUsd: 0, inputTokens: 0, outputTokens: 0, numTurns: 0 }, init: null, run: null,
+      pendingPermissions: [], usage: { costUsd: 0, inputTokens: 0, outputTokens: 0, numTurns: 0 }, init: null, run: null, feedback: {},
     });
 
     const spy = vi.spyOn(summaryModule, "toolSummary");

--- a/apps/desktop/src/renderer/src/panes/session/transcript-enter.test.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/transcript-enter.test.tsx
@@ -73,10 +73,10 @@ describe("Transcript enter animation (§6: 180ms, new items only)", () => {
   it("keeps the mark through the re-renders that happen during the 180ms — streaming deltas must not abort it", () => {
     const { rerender } = render(view(model([user("hi")])));
     rerender(view(model([user("hi"), assistant("he", true)]), "running"));
-    expect(entering()).toEqual(["md msg-assistant"]);
+    expect(entering()).toEqual(["msg-assistant-row"]);
     rerender(view(model([user("hi"), assistant("hello", true)]), "running"));
     rerender(view(model([user("hi"), assistant("hello there")]), "idle"));
-    expect(entering()).toEqual(["md msg-assistant"]); // still marked, and still the only one
+    expect(entering()).toEqual(["msg-assistant-row"]); // still marked, and still the only one
   });
 
   it("re-rendering with unchanged blocks never promotes an existing block to entering", () => {

--- a/apps/desktop/src/renderer/src/panes/session/transcript-enter.test.tsx
+++ b/apps/desktop/src/renderer/src/panes/session/transcript-enter.test.tsx
@@ -42,7 +42,7 @@ describe("enter tracker (§6: new items only)", () => {
 });
 
 const model = (blocks: Block[], pendingPermissions: PendingPermission[] = []): TranscriptModel =>
-  ({ blocks, pendingPermissions, usage: { costUsd: 0, inputTokens: 0, outputTokens: 0, numTurns: 0 }, init: null, run: null });
+  ({ blocks, pendingPermissions, usage: { costUsd: 0, inputTokens: 0, outputTokens: 0, numTurns: 0 }, init: null, run: null, feedback: {} });
 
 const user = (text: string): Block => ({ kind: "user", text, ts: 0 });
 const assistant = (text: string, streaming = false): Block => ({ kind: "assistant", messageId: "m1", text, streaming, ts: 0 });

--- a/apps/desktop/src/renderer/src/panes/session/transcript-model.test.ts
+++ b/apps/desktop/src/renderer/src/panes/session/transcript-model.test.ts
@@ -195,3 +195,43 @@ describe("how long the run worked", () => {
     expect(runBlocks(t)).toMatchObject([{ ms: 1_000 }, { ms: 4_000 }]);
   });
 });
+
+describe("feedback", () => {
+  const rate = (messageId: string, rating: "up" | "down" | null) => sessionEvent("feedback", { messageId, rating });
+
+  it("keeps a rating against the message it judges, and nothing against the ones it does not", () => {
+    const t = reduceAll([
+      sessionEvent("assistant_text", { messageId: "m1", text: "one" }),
+      sessionEvent("assistant_text", { messageId: "m2", text: "two" }),
+      rate("m1", "up"),
+    ]);
+    expect(t.feedback).toEqual({ m1: "up" });
+  });
+
+  it("lets the reader change their mind, and take the verdict back entirely", () => {
+    // Three states, not two: absent is "not judged", which a boolean could not tell from "down".
+    const up = reduceAll([rate("m1", "up")]);
+    expect(up.feedback).toEqual({ m1: "up" });
+    const down = reduceAll([rate("m1", "up"), rate("m1", "down")]);
+    expect(down.feedback).toEqual({ m1: "down" });
+    const withdrawn = reduceAll([rate("m1", "up"), rate("m1", null)]);
+    expect(withdrawn.feedback).toEqual({});
+  });
+
+  it("survives the relaunch, because it is in the log the transcript is rebuilt from", () => {
+    // The whole reason this is an event and not a settings row.
+    const events = [
+      sessionEvent("user_message", { text: "hi", attachments: [] }),
+      sessionEvent("assistant_text", { messageId: "m1", text: "hello" }),
+      rate("m1", "down"),
+    ];
+    expect(reduceAll(events).feedback).toEqual({ m1: "down" });
+    expect(reduceAll(events.slice())).toEqual(reduceAll(events));
+  });
+
+  it("never touches the blocks — a verdict is about a message, not a thing in the scrollback", () => {
+    const before = reduceAll([sessionEvent("assistant_text", { messageId: "m1", text: "hello" })]);
+    const after = reduceTranscript(before, rate("m1", "up"));
+    expect(after.blocks).toBe(before.blocks);
+  });
+});

--- a/apps/desktop/src/renderer/src/panes/session/transcript-model.ts
+++ b/apps/desktop/src/renderer/src/panes/session/transcript-model.ts
@@ -52,6 +52,26 @@ export const blockKey = (b: Block, i: number): string =>
 
 export const emptyTranscript = (): Transcript => ({ blocks: [], pendingPermissions: [], usage: { costUsd: 0, inputTokens: 0, outputTokens: 0, numTurns: 0 }, init: null, run: null });
 
+export type UserBlock = Extract<Block, { kind: "user" }>;
+
+/**
+ * The message a retry would ask again: the last one the USER wrote.
+ *
+ * A `from`-bearing block is skipped rather than returned. Those are another session's words
+ * delivered into this one, and re-sending one would put the user's hand on a question they never
+ * asked — the same reason the bubble is attributed instead of drawn plain.
+ *
+ * Null means there is nothing to ask again, which is the honest state of a session before its first
+ * send and of one whose only messages arrived from a peer.
+ */
+export const lastUserMessage = (t: Transcript): UserBlock | null => {
+  for (let i = t.blocks.length - 1; i >= 0; i--) {
+    const b = t.blocks[i]!;
+    if (b.kind === "user" && !b.from) return b;
+  }
+  return null;
+};
+
 const findLast = (blocks: Block[], pred: (b: Block) => boolean): number => { for (let i = blocks.length - 1; i >= 0; i--) if (pred(blocks[i]!)) return i; return -1; };
 
 /** Pure reducer: normalized session events → what the transcript renders. Deltas accumulate into the open

--- a/apps/desktop/src/renderer/src/panes/session/transcript-model.ts
+++ b/apps/desktop/src/renderer/src/panes/session/transcript-model.ts
@@ -29,6 +29,7 @@ export type Block =
    *  just watching (see run-label.ts). */
   | { kind: "run"; ms: number; startedAt: number; ts: number };
 
+export type Rating = "up" | "down";
 export type PendingPermission = { requestId: string; toolName: string; input: Record<string, unknown>; title: string };
 export type Usage = { costUsd: number; inputTokens: number; outputTokens: number; numTurns: number };
 export type Transcript = {
@@ -42,6 +43,9 @@ export type Transcript = {
   /** The run in flight: when it started, and the permission-prompt time to take off its clock.
    *  `waitingSince` is the open half of that accounting. Null between runs. */
   run: { startedAt: number; waitedMs: number; waitingSince: number | null } | null;
+  /** What the reader made of each answer, keyed by `messageId`. Only rated messages appear: absent
+   *  is "not judged", which is a different state from either verdict and must stay tellable. */
+  feedback: Record<string, Rating>;
 };
 
 /** Stable render identity for a block. Tool calls key on their own id so a card keeps its expanded
@@ -50,7 +54,7 @@ export type Transcript = {
 export const blockKey = (b: Block, i: number): string =>
   b.kind === "tool" ? `tool:${b.toolUseId}` : b.kind === "plan" ? `plan:${b.planId}` : `${b.kind}:${i}`;
 
-export const emptyTranscript = (): Transcript => ({ blocks: [], pendingPermissions: [], usage: { costUsd: 0, inputTokens: 0, outputTokens: 0, numTurns: 0 }, init: null, run: null });
+export const emptyTranscript = (): Transcript => ({ blocks: [], pendingPermissions: [], usage: { costUsd: 0, inputTokens: 0, outputTokens: 0, numTurns: 0 }, init: null, run: null, feedback: {} });
 
 export type UserBlock = Extract<Block, { kind: "user" }>;
 
@@ -118,6 +122,13 @@ export function reduceTranscript(t: Transcript, e: SessionEvent): Transcript {
       };
       if (i >= 0) blocks[i] = block; else blocks.push(block);
       return { ...t, blocks };
+    }
+    // Append-only, so the last verdict for a message wins and a retraction is a `null` rating
+    // rather than a row going away — the log records the reader changing their mind, not just
+    // where they landed.
+    case "feedback": {
+      const { [e.payload.messageId]: _prev, ...rest } = t.feedback;
+      return { ...t, feedback: e.payload.rating ? { ...rest, [e.payload.messageId]: e.payload.rating } : rest };
     }
     case "usage": return { ...t, usage: e.payload };
     case "init": return { ...t, init: { model: e.payload.model, tools: e.payload.tools, providerSessionId: e.payload.providerSessionId, ...(e.payload.availableModes ? { availableModes: e.payload.availableModes } : {}) } };

--- a/apps/desktop/src/renderer/src/state/live-api.ts
+++ b/apps/desktop/src/renderer/src/state/live-api.ts
@@ -79,6 +79,7 @@ export const liveApi = (): Api => ({
     await rpc().call("sessions.send", { id, text, attachments, mentions, ...(elements?.length ? { elements } : {}) });
   },
   interruptSession: async (id) => { await rpc().call("sessions.interrupt", { id }); },
+  recordFeedback: async (id, messageId, rating) => { await rpc().call("sessions.recordFeedback", { id, messageId, rating }); },
   respondPermission: async (id, requestId, decision, answers) => { await rpc().call("sessions.respondPermission", { id, requestId, decision, ...(answers ? { answers } : {}) }); },
   setSessionOptions: (id, o) => rpc().call("sessions.setOptions", { id, ...o }),
   setSessionAgent: (id, agentKind) => rpc().call("sessions.setAgent", { id, agentKind }),

--- a/apps/desktop/src/renderer/src/state/store.test-fakes.ts
+++ b/apps/desktop/src/renderer/src/state/store.test-fakes.ts
@@ -742,6 +742,7 @@ export function fakeApi(overrides: FakeData = {}): FakeApi {
       return m;
     },
     interruptSession: async (id) => { calls.push(`interrupt:${id}`); },
+    recordFeedback: async (id, messageId, rating) => { calls.push(`recordFeedback:${id}:${messageId}=${rating ?? "none"}`); },
     respondPermission: async (id, requestId, decision) => { calls.push(`respondPermission:${id}:${requestId}:${decision}`); },
     setSessionOptions: async (id, o) => {
       calls.push(`setSessionOptions:${id}`);

--- a/apps/desktop/src/renderer/src/state/store.test.ts
+++ b/apps/desktop/src/renderer/src/state/store.test.ts
@@ -1233,6 +1233,35 @@ describe("app store", () => {
       });
     });
 
+    describe("rateMessage", () => {
+      const rated = async () => {
+        api = fakeApi({
+          items: { s1: [item("i2", "s1", { kind: "session", refId: "se1", title: "Fake agent session" })] },
+          sessions: [session("se1", "s1", { status: "idle" })],
+          sessionEvents: { se1: [stored("se1", 1, sessionEvent("assistant_text", { messageId: "m1", text: "hello" }))] },
+        });
+        const store = createAppStore(api); await store.getState().boot();
+        await store.getState().openSession("se1");
+        return store;
+      };
+
+      it("shows the verdict before the round trip finishes, then records it", async () => {
+        const store = await rated();
+        const pending = store.getState().rateMessage("se1", "m1", "up");
+        expect(store.getState().transcripts.se1!.t.feedback).toEqual({ m1: "up" });
+        await pending;
+        expect(api.calls).toContain("recordFeedback:se1:m1=up");
+      });
+
+      it("takes a verdict back rather than storing a third one", async () => {
+        const store = await rated();
+        await store.getState().rateMessage("se1", "m1", "down");
+        await store.getState().rateMessage("se1", "m1", null);
+        expect(store.getState().transcripts.se1!.t.feedback).toEqual({});
+        expect(api.calls).toContain("recordFeedback:se1:m1=none");
+      });
+    });
+
     it("sendMessage / interrupt / respondPermission / setSessionOptions call the api; options merge into the session", async () => {
       api = seed(); const store = createAppStore(api); await store.getState().boot();
       await store.getState().sendMessage("se1", "go");

--- a/apps/desktop/src/renderer/src/state/store.test.ts
+++ b/apps/desktop/src/renderer/src/state/store.test.ts
@@ -1168,6 +1168,71 @@ describe("app store", () => {
       expect(api.data.settings["ui.lastAgentKind"]).toBe("codex");
     });
 
+    describe("retryLastTurn", () => {
+      /** A session whose transcript is loaded and whose turn has ended — the state Retry is offered in. */
+      const idle = async (rows: StoredSessionEvent[]) => {
+        api = fakeApi({
+          items: { s1: [item("i2", "s1", { kind: "session", refId: "se1", title: "Fake agent session" })] },
+          sessions: [session("se1", "s1", { status: "idle" })],
+          sessionEvents: { se1: rows },
+        });
+        const store = createAppStore(api); await store.getState().boot();
+        await store.getState().openSession("se1");
+        return store;
+      };
+
+      it("sends the user's last words again, attachments included", async () => {
+        const store = await idle([
+          stored("se1", 1, sessionEvent("user_message", { text: "first", attachments: [] })),
+          stored("se1", 2, sessionEvent("assistant_text", { messageId: "m1", text: "one" })),
+          stored("se1", 3, sessionEvent("user_message", { text: "second", attachments: [{ path: "/tmp/a.png", mime: "image/png" }] })),
+          stored("se1", 4, sessionEvent("assistant_text", { messageId: "m2", text: "two" })),
+        ]);
+        await store.getState().retryLastTurn("se1");
+        expect(api.sent).toEqual([{ id: "se1", text: "second", attachments: [{ path: "/tmp/a.png", mime: "image/png" }] }]);
+      });
+
+      it("leaves the answer it is retrying exactly where it was", async () => {
+        // The mutant: dropping the superseded assistant block to make room for the new one. No
+        // adapter can rewind, so the agent still has that answer in context — a transcript that
+        // hid it would disagree with what the agent remembers.
+        const store = await idle([
+          stored("se1", 1, sessionEvent("user_message", { text: "ask", attachments: [] })),
+          stored("se1", 2, sessionEvent("assistant_text", { messageId: "m1", text: "a poor answer" })),
+        ]);
+        await store.getState().retryLastTurn("se1");
+        const blocks = store.getState().transcripts.se1!.t.blocks;
+        expect(blocks.map((b) => b.kind)).toEqual(["user", "assistant"]);
+        expect(blocks[1]).toMatchObject({ text: "a poor answer" });
+      });
+
+      it("refuses while a turn is live, on both of the statuses that mean it", async () => {
+        for (const status of ["running", "waiting_permission"] as const) {
+          const store = await idle([stored("se1", 1, sessionEvent("user_message", { text: "ask", attachments: [] }))]);
+          store.setState({ sessionStatus: { se1: status } });
+          await store.getState().retryLastTurn("se1");
+          expect(api.sent, status).toEqual([]);
+        }
+      });
+
+      it("will not re-ask a question a peer session asked", async () => {
+        // Plan 20's interjection: another agent's words in this transcript. Re-sending one would
+        // put the user's hand on a question they never wrote.
+        const store = await idle([
+          stored("se1", 1, sessionEvent("user_message", { text: "mine", attachments: [] })),
+          stored("se1", 2, sessionEvent("user_message", { text: "theirs", attachments: [], from: { sessionId: "se2", title: "Peer" } })),
+        ]);
+        await store.getState().retryLastTurn("se1");
+        expect(api.sent).toEqual([{ id: "se1", text: "mine", attachments: [] }]);
+      });
+
+      it("does nothing at all when the user has not sent anything yet", async () => {
+        const store = await idle([stored("se1", 1, sessionEvent("init", { providerSessionId: "p", model: "m", tools: [], cwd: "/tmp" }))]);
+        await store.getState().retryLastTurn("se1");
+        expect(api.sent).toEqual([]);
+      });
+    });
+
     it("sendMessage / interrupt / respondPermission / setSessionOptions call the api; options merge into the session", async () => {
       api = seed(); const store = createAppStore(api); await store.getState().boot();
       await store.getState().sendMessage("se1", "go");

--- a/apps/desktop/src/renderer/src/state/store.ts
+++ b/apps/desktop/src/renderer/src/state/store.ts
@@ -17,7 +17,7 @@ import { CONTRAST_RANGE, DEFAULT_FONTS, DEFAULT_GROUND_ALPHA, DEFAULT_SELECTION,
   isThemeName, overrideKey, parseThemeOverrides, themeModes,
   type Mode, type ThemeName, type ThemeOverride, type ThemeOverrides, type ThemeSelection } from "@realm/ui";
 import type { ThemePref } from "../theme/useTheme";
-import { emptyTranscript, lastUserMessage, reduceTranscript, type Transcript } from "../panes/session/transcript-model";
+import { emptyTranscript, lastUserMessage, reduceTranscript, type Rating, type Transcript } from "../panes/session/transcript-model";
 import { allowlistKey, getBrowserBridges, parseAllowlist } from "../panes/browser/browser-client";
 
 export type CreateSpaceInput = { name: string; icon: string; profileId: string; color?: string };
@@ -216,6 +216,7 @@ export type Api = {
    *  and resolves them so a raw `@name` never reaches an agent (contracts/mentions.ts). */
   sendMessage(id: string, text: string, attachments: Attachment[], mentions: string[], elements?: ElementChip[]): Promise<void>;
   interruptSession(id: string): Promise<void>;
+  recordFeedback(id: string, messageId: string, rating: Rating | null): Promise<void>;
   respondPermission(id: string, requestId: string, decision: PermissionDecision, answers?: Record<string, string>): Promise<void>;
   setSessionOptions(id: string, o: SessionOptions): Promise<Session>;
   /** `sessions.setAgent` — rejected by the server once the session has any event. */
@@ -1052,6 +1053,10 @@ export type AppState = {
    *  A no-op while a turn is live, and a no-op when the user has not sent anything yet. */
   retryLastTurn(id: string): Promise<void>;
   interruptSession(id: string): Promise<void>;
+  /** Rate one assistant message, or with null take an earlier rating back. Optimistic: the verdict
+   *  is on screen before the round trip, because a thumb that waits on the disk reads as a dead
+   *  button. The broadcast that follows lands on the same reducer and settles to the same state. */
+  rateMessage(sessionId: string, messageId: string, rating: Rating | null): Promise<void>;
   respondPermission(id: string, requestId: string, decision: PermissionDecision, answers?: Record<string, string>): Promise<void>;
   setSessionOptions(id: string, o: SessionOptions): Promise<void>;
   /** Move a session between Build and Plan (the prompter's mode chip), parking and restoring the
@@ -2732,6 +2737,14 @@ export function createAppStore(api: Api): StoreApi<AppState> {
         await api.sendMessage(id, msg.text, msg.attachments ?? [], mentions);
       },
       async interruptSession(id) { await api.interruptSession(id); },
+      async rateMessage(sessionId, messageId, rating) {
+        const entry = get().transcripts[sessionId];
+        if (entry) {
+          const { [messageId]: _prev, ...rest } = entry.t.feedback;
+          setTranscript(sessionId, { ...entry, t: { ...entry.t, feedback: rating ? { ...rest, [messageId]: rating } : rest } });
+        }
+        await api.recordFeedback(sessionId, messageId, rating);
+      },
       /**
        * Answering a permission — plus the one case where the answer also settles the MODE axis.
        *

--- a/apps/desktop/src/renderer/src/state/store.ts
+++ b/apps/desktop/src/renderer/src/state/store.ts
@@ -17,7 +17,7 @@ import { CONTRAST_RANGE, DEFAULT_FONTS, DEFAULT_GROUND_ALPHA, DEFAULT_SELECTION,
   isThemeName, overrideKey, parseThemeOverrides, themeModes,
   type Mode, type ThemeName, type ThemeOverride, type ThemeOverrides, type ThemeSelection } from "@realm/ui";
 import type { ThemePref } from "../theme/useTheme";
-import { emptyTranscript, reduceTranscript, type Transcript } from "../panes/session/transcript-model";
+import { emptyTranscript, lastUserMessage, reduceTranscript, type Transcript } from "../panes/session/transcript-model";
 import { allowlistKey, getBrowserBridges, parseAllowlist } from "../panes/browser/browser-client";
 
 export type CreateSpaceInput = { name: string; icon: string; profileId: string; color?: string };
@@ -1047,6 +1047,10 @@ export type AppState = {
    *  to it, record the `user-dispatch` origin, and bring its pane in BESIDE without focusing it.
    *  The draft clears exactly as a normal send; an empty draft is a no-op. */
   dispatchDraft(sessionId: string): Promise<void>;
+  /** Ask the last user message again, as a NEW turn. Not a regenerate — no adapter can rewind a
+   *  conversation, so the superseded answer stays in the transcript and in the agent's context.
+   *  A no-op while a turn is live, and a no-op when the user has not sent anything yet. */
+  retryLastTurn(id: string): Promise<void>;
   interruptSession(id: string): Promise<void>;
   respondPermission(id: string, requestId: string, decision: PermissionDecision, answers?: Record<string, string>): Promise<void>;
   setSessionOptions(id: string, o: SessionOptions): Promise<void>;
@@ -2693,6 +2697,39 @@ export function createAppStore(api: Api): StoreApi<AppState> {
         const items = await api.listItems(source.spaceId);
         if (isSpace(source.spaceId) && seq === itemsFetchSeq) set({ items });
         await get().openItemBesideQuiet(itemId);
+      },
+      /**
+       * Ask the last question again.
+       *
+       * This is NOT a regenerate, and the difference is the whole design. No agent Realm supports
+       * can rewind a conversation — the checkpoints sheet already tells the user so, and
+       * `sessions.fork` records `AGENT_CONVERSATION_REWIND` as false for every adapter — so the
+       * answer the reader was unhappy with is still in the agent's context and cannot be taken out
+       * of it. What this does is send the same words as a NEW turn, which is what the user could
+       * have done by retyping them. Nothing is removed from the transcript or the event log, and
+       * the superseded answer keeps its place: the record is what happened, and the agent
+       * remembers it either way.
+       *
+       * Refused while a turn is live, and refused here rather than only in the bar. The three
+       * adapters disagree about what a send mid-turn even means — Claude queues it behind the one
+       * running, Codex steers the turn in flight, ACP opens a second concurrent prompt — and none
+       * of those is "ask that again". There is deliberately no interrupt-then-send dance either:
+       * interrupting denies whatever permission prompt is open, and that is a decision the user
+       * did not make by pressing Retry.
+       *
+       * Mentions are re-scanned rather than replayed, because the persisted `user_message` never
+       * carried them — and re-scanning is what an ordinary send does too, so a retry resolves `@name`
+       * against the same live library a fresh send would. Element chips are not replayed at all:
+       * they point into a browser pane that has since navigated, and handing the agent a stale
+       * reference is worse than handing it none.
+       */
+      async retryLastTurn(id) {
+        const status = get().sessionStatus[id] ?? get().sessions[id]?.status ?? "idle";
+        if (status === "running" || status === "waiting_permission") return;
+        const t = get().transcripts[id]?.t; if (!t) return;
+        const msg = lastUserMessage(t); if (!msg) return;
+        const mentions = mentionIds(msg.text, new Set(mentionableIds(id)));
+        await api.sendMessage(id, msg.text, msg.attachments ?? [], mentions);
       },
       async interruptSession(id) { await api.interruptSession(id); },
       /**

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -272,8 +272,8 @@ kbd { font: 11px var(--font-mono); }
 /* Hit-target extension (V-F8): the visual button stays small; the click target grows 6px each way.
    .tool-copy joins the list — its 20px box sits alone at its row's right edge, so the overhang
    never crosses another interactive element. */
-.icon-btn, .item-close, .item-shelf, .tool-copy, .msg-action { position: relative; }
-.icon-btn::after, .item-close::after, .item-shelf::after, .tool-copy::after, .msg-action::after { content: ""; position: absolute; inset: -6px; }
+.icon-btn, .item-close, .item-shelf, .tool-copy { position: relative; }
+.icon-btn::after, .item-close::after, .item-shelf::after, .tool-copy::after { content: ""; position: absolute; inset: -6px; }
 
 /* Plan 9 W3 — SidebarNav's section label: sentence case, 12.5/500, ink-3. */
 .group-label { font-size: 12.5px; font-weight: var(--fw-medium); color: var(--rl-text-faint); padding: 12px 8px 4px; }
@@ -1043,6 +1043,14 @@ button.panel-title:hover { background: var(--rl-hover); }
 .msg-actions { display: flex; align-items: center; gap: 2px; margin-left: -6px; }
 .msg-action { display: grid; place-items: center; width: 26px; height: 26px; border-radius: var(--r-ctl); color: var(--rl-text-faint); }
 .msg-action:hover:not(:disabled) { background: var(--rl-hover); color: var(--rl-text-bright); }
+/* A thumb's glyph does not change when it is pressed, so the fill has to say so — one rung past
+   hover, exactly as .icon-btn's toggles do, and on the transition the button already carries. */
+.msg-action[aria-pressed="true"] { background: var(--hover-2); color: var(--rl-text-bright); }
+/* Hit-target extension, VERTICAL only. The shared -6px overhang assumes a control with no
+   interactive neighbour — which is why .tool-copy can take it, sitting alone at its row's edge —
+   and these sit 2px apart, where it would have every button stealing clicks from the next. */
+.msg-action { position: relative; }
+.msg-action::after { content: ""; position: absolute; inset: -6px 0; }
 .md { line-height: 1.55; overflow-wrap: anywhere; }
 .msg-assistant.md { line-height: 1.6; }
 .md > div > :first-child { margin-top: 0; } .md > div > :last-child { margin-bottom: 0; }

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -272,8 +272,8 @@ kbd { font: 11px var(--font-mono); }
 /* Hit-target extension (V-F8): the visual button stays small; the click target grows 6px each way.
    .tool-copy joins the list — its 20px box sits alone at its row's right edge, so the overhang
    never crosses another interactive element. */
-.icon-btn, .item-close, .item-shelf, .tool-copy { position: relative; }
-.icon-btn::after, .item-close::after, .item-shelf::after, .tool-copy::after { content: ""; position: absolute; inset: -6px; }
+.icon-btn, .item-close, .item-shelf, .tool-copy, .msg-action { position: relative; }
+.icon-btn::after, .item-close::after, .item-shelf::after, .tool-copy::after, .msg-action::after { content: ""; position: absolute; inset: -6px; }
 
 /* Plan 9 W3 — SidebarNav's section label: sentence case, 12.5/500, ink-3. */
 .group-label { font-size: 12.5px; font-weight: var(--fw-medium); color: var(--rl-text-faint); padding: 12px 8px 4px; }
@@ -1033,7 +1033,16 @@ button.panel-title:hover { background: var(--rl-hover); }
 .msg-user-files .attach-tile { width: 56px; height: 56px; }
 .msg-user-files .attach-art { border-radius: var(--r-row); }
 /* Ara refresh §4: assistant prose is plain — 15px/1.6, no card. */
+/* The message and everything the message owns — its media strip, its action bar — in one column, at
+   the gap `.transcript-col` used to give them as siblings, so growing the wrapper moved nothing. */
+.msg-assistant-row { display: flex; flex-direction: column; gap: 8px; }
 .msg-assistant { max-width: 72ch; font-size: 15px; line-height: 1.6; }
+/* The bar under a finished message. The negative inset is optical, not spacing: the first glyph is
+   14px inside a 26px box, so without it the row of buttons would hang 6px right of the prose it
+   belongs to and read as indented. */
+.msg-actions { display: flex; align-items: center; gap: 2px; margin-left: -6px; }
+.msg-action { display: grid; place-items: center; width: 26px; height: 26px; border-radius: var(--r-ctl); color: var(--rl-text-faint); }
+.msg-action:hover:not(:disabled) { background: var(--rl-hover); color: var(--rl-text-bright); }
 .md { line-height: 1.55; overflow-wrap: anywhere; }
 .msg-assistant.md { line-height: 1.6; }
 .md > div > :first-child { margin-top: 0; } .md > div > :last-child { margin-bottom: 0; }
@@ -2004,16 +2013,17 @@ button.panel-title:hover { background: var(--rl-hover); }
    it read as one glyph turning over rather than two crossing past each other, and the control keeps
    ONE glyph box and ONE accessible name throughout: a swap is a change of state, not of control. */
 .icon-swap { display: grid; place-items: center; }
-.icon-swap > *, .tool-copy .copy-icon, .tool-copy .copied-icon, .composer-send svg { grid-area: 1 / 1;
+.icon-swap > *, .tool-copy .copy-icon, .tool-copy .copied-icon, .msg-action .copy-icon, .msg-action .copied-icon, .composer-send svg { grid-area: 1 / 1;
   transition: opacity var(--dur-swap) var(--ease-out-strong), transform var(--dur-swap) var(--ease-out-strong), filter var(--dur-swap) var(--ease-out-strong); }
 .icon-swap:not([data-on]) .swap-on, .icon-swap[data-on] .swap-off,
 .tool-copy:not([data-copied]) .copied-icon, .tool-copy[data-copied] .copy-icon,
+.msg-action:not([data-copied]) .copied-icon, .msg-action[data-copied] .copy-icon,
 .composer-send[data-state="send"] .stop-icon, .composer-send[data-state="stop"] .send-icon {
   opacity: 0; transform: scale(.25); filter: blur(4px); }
 
 /* Hover fills (§6): 100ms `ease`, background (and the text colour riding along with it) only —
    never `all`, never geometry. */
-.item-row, .item-close, .item-shelf, .icon-btn, .btn, .ghost-chip, .tool-row, .tool-group-row, .tool-copy,
+.item-row, .item-close, .item-shelf, .icon-btn, .btn, .ghost-chip, .tool-row, .tool-group-row, .tool-copy, .msg-action,
 .delegation-row, .delegation-item,
 .strip-space, .strip-profile, .space-card, .suggestion-chip, .palette-opt, .permission-option, .menu [role^="menuitem"],
 .question-option, .question-skip {
@@ -2021,12 +2031,12 @@ button.panel-title:hover { background: var(--rl-hover); }
 }
 /* Press (§6): 120ms to scale .97 on every pressable — buttons, chips, send, permission options.
    Full-width rows (.tool-row, .item-row) are left out: a wide surface shrinking reads as a glitch. */
-.btn, .icon-btn, .ghost-chip, .suggestion-chip, .composer-send, .permission-option, .tool-copy {
+.btn, .icon-btn, .ghost-chip, .suggestion-chip, .composer-send, .permission-option, .tool-copy, .msg-action {
   transition: background-color var(--dur-hover) ease, color var(--dur-hover) ease, transform var(--dur-press) var(--ease-out-strong);
 }
 .btn:active:not(:disabled), .icon-btn:active:not(:disabled), .ghost-chip:active:not(:disabled),
 .suggestion-chip:active:not(:disabled), .composer-send:active:not(:disabled),
-.permission-option:active:not(:disabled), .tool-copy:active:not(:disabled) { transform: scale(.97); }
+.permission-option:active:not(:disabled), .tool-copy:active:not(:disabled), .msg-action:active:not(:disabled) { transform: scale(.97); }
 .drop-zone { transition: opacity var(--dur-drag) linear; }
 
 /* §6 "do NOT animate: theme/mode switching". useTheme sets this for a beat around a palette rewrite;

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -1051,6 +1051,30 @@ button.panel-title:hover { background: var(--rl-hover); }
    and these sit 2px apart, where it would have every button stealing clicks from the next. */
 .msg-action { position: relative; }
 .msg-action::after { content: ""; position: absolute; inset: -6px 0; }
+
+/* The sources disclosure. Folded away by default: a citation is there to be checked, not read, and
+   four urls between two messages cost every reader to serve the one who went looking. */
+.msg-sources { display: flex; flex-direction: column; gap: 6px; }
+.msg-sources-toggle { display: inline-flex; align-items: center; gap: 5px; align-self: flex-start;
+  padding: 3px 7px 3px 5px; border-radius: var(--r-chip); font-size: 12px; color: var(--rl-text-dim); }
+.msg-sources-toggle:hover { background: var(--rl-hover); color: var(--rl-text-bright); }
+/* The chevron points at the list when it is open — the one rotation §6 allows on a disclosure,
+   on the swap rung because it is a glyph changing state rather than a box changing size. */
+.msg-sources-chevron { transform: rotate(-90deg); transition: transform var(--dur-swap) var(--ease-out-strong); }
+.msg-sources[data-open] .msg-sources-chevron { transform: rotate(0deg); }
+.msg-sources-list { display: flex; flex-direction: column; gap: 2px; margin: 0; padding: 0; list-style: none; }
+.msg-sources-list a { display: flex; align-items: baseline; gap: 8px; padding: 4px 8px; border-radius: var(--r-ctl);
+  font-size: 12px; color: var(--rl-text-dim); text-decoration: none; }
+.msg-sources-list a:hover { background: var(--rl-hover); color: var(--rl-text-bright); }
+/* Tabular so a two-digit marker does not shift the hostnames under it out of line. */
+.msg-source-n { flex: none; min-width: 14px; font-variant-numeric: tabular-nums; color: var(--rl-text-faint); }
+.msg-source-host { font-weight: var(--fw-medium); color: var(--rl-text-bright); }
+/* The path is the least of the three and the longest: it gives up its width first and truncates. */
+.msg-source-path { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: var(--rl-text-faint); }
+/* An inline marker on a link the agent actually fetched. It sits on the same numbering as the list
+   above, so [2] in a sentence and 2 in the disclosure are one page. */
+.md-cite { margin-left: 1px; padding: 0 3px; border-radius: var(--r-chip); vertical-align: super;
+  font-size: 9px; font-variant-numeric: tabular-nums; color: var(--rl-text-dim); background: var(--rl-raised); }
 .md { line-height: 1.55; overflow-wrap: anywhere; }
 .msg-assistant.md { line-height: 1.6; }
 .md > div > :first-child { margin-top: 0; } .md > div > :last-child { margin-bottom: 0; }

--- a/apps/desktop/src/renderer/src/styles.test.ts
+++ b/apps/desktop/src/renderer/src/styles.test.ts
@@ -226,6 +226,16 @@ describe("§6 motion table", () => {
     expect(bodiesFor(".tool-copy:not([data-copied]) .copied-icon").join(" ")).toContain("blur(4px)");
   });
 
+  it("the message action bar reaches for the rungs the copy button already pays for, not a set of its own", () => {
+    const swap = bodiesFor(".msg-action .copy-icon").join(" ");
+    for (const prop of ["opacity", "transform", "filter"]) expect(swap, prop).toContain(`${prop} ${dur("--dur-swap")}`);
+    expect(bodiesFor(".msg-action:not([data-copied]) .copied-icon").join(" ")).toContain("blur(4px)");
+    const btn = bodiesFor(".msg-action").join(" ");
+    expect(btn).toContain(`background-color ${dur("--dur-hover")} ease`);
+    expect(btn).toContain(`transform ${dur("--dur-press")} var(--ease-out-strong)`);
+    expect(bodiesFor(".msg-action:active:not(:disabled)").join(" ")).toContain("transform: scale(.97)");
+  });
+
   it("W2's prompter hero→docked move keeps its 320ms ease-in-out-strong (§6 assigns that easing to on-screen movement)", () => {
     expect(bodiesFor(".composer-dock").join(" ")).toContain(`transition: transform ${dur("--dur-move")} var(--ease-in-out-strong)`);
   });

--- a/apps/desktop/src/renderer/src/styles.test.ts
+++ b/apps/desktop/src/renderer/src/styles.test.ts
@@ -234,6 +234,13 @@ describe("§6 motion table", () => {
     expect(btn).toContain(`background-color ${dur("--dur-hover")} ease`);
     expect(btn).toContain(`transform ${dur("--dur-press")} var(--ease-out-strong)`);
     expect(bodiesFor(".msg-action:active:not(:disabled)").join(" ")).toContain("transform: scale(.97)");
+    // A thumb's glyph is the same pressed or not, so the fill is the only thing saying which — one
+    // rung past hover, the same reading .icon-btn's toggles get.
+    expect(bodiesFor('.msg-action[aria-pressed="true"]').join(" ")).toContain("background: var(--hover-2)");
+    // The shared -6px overhang is deliberately NOT taken: these sit 2px apart, and it would have
+    // each button stealing clicks from the next.
+    // Exactly one rule reaches it: joining the shared list would give it a second, all-sides one.
+    expect(bodiesFor(".msg-action::after")).toEqual(['content: ""; position: absolute; inset: -6px 0;']);
   });
 
   it("W2's prompter hero→docked move keeps its 320ms ease-in-out-strong (§6 assigns that easing to on-screen movement)", () => {

--- a/apps/desktop/src/renderer/src/styles.test.ts
+++ b/apps/desktop/src/renderer/src/styles.test.ts
@@ -243,6 +243,11 @@ describe("§6 motion table", () => {
     expect(bodiesFor(".msg-action::after")).toEqual(['content: ""; position: absolute; inset: -6px 0;']);
   });
 
+  it("the sources chevron turns on the swap rung — a glyph changing state, not a box changing size", () => {
+    expect(bodiesFor(".msg-sources-chevron").join(" ")).toContain(`transform ${dur("--dur-swap")} var(--ease-out-strong)`);
+    expect(bodiesFor(".msg-sources[data-open] .msg-sources-chevron").join(" ")).toContain("rotate(0deg)");
+  });
+
   it("W2's prompter hero→docked move keeps its 320ms ease-in-out-strong (§6 assigns that easing to on-screen movement)", () => {
     expect(bodiesFor(".composer-dock").join(" ")).toContain(`transition: transform ${dur("--dur-move")} var(--ease-in-out-strong)`);
   });

--- a/apps/server/src/rpc/methods.ts
+++ b/apps/server/src/rpc/methods.ts
@@ -540,6 +540,7 @@ export function registerMethods(d: Deps): void {
   reg("sessions.create", (p) => d.sessions.create({ ...p, dispatchedBy: p.userDispatched ? { kind: "user-dispatch", sessionId: null } : null }));
   reg("sessions.send", async (p) => { await d.sessions.send(p.id, { text: p.text, attachments: p.attachments, mentions: p.mentions, elements: p.elements }); return { ok: true as const }; });
   reg("sessions.interrupt", async (p) => { await d.sessions.interrupt(p.id); return { ok: true as const }; });
+  reg("sessions.recordFeedback", (p) => { d.sessions.recordFeedback(p.id, p.messageId, p.rating); return { ok: true as const }; });
   reg("sessions.respondPermission", (p) => { d.sessions.respondPermission(p.id, p.requestId, p.decision, p.answers); return { ok: true as const }; });
   reg("sessions.setOptions", (p) => d.sessions.setOptions(p.id, { model: p.model, effort: p.effort, permissionMode: p.permissionMode }));
   reg("sessions.setAgent", (p) => d.sessions.setAgent(p.id, p.agentKind));

--- a/apps/server/src/sessions/service.test.ts
+++ b/apps/server/src/sessions/service.test.ts
@@ -227,6 +227,27 @@ describe("SessionService over rpc", () => {
     c.close();
   });
 
+  it("a verdict on an answer is written to the session's own log and replayed from it", async () => {
+    // The whole case for making feedback an event: it comes back with the transcript, from the same
+    // rows, with no second lookup to drift. And it goes nowhere else — the assertion below is the
+    // full list of places it lands.
+    const { c, sp } = await boot();
+    const s1 = (await c.call("sessions.create", { spaceId: sp.id, agentKind: "fake" })).result.session;
+    expect((await c.call("sessions.recordFeedback", { id: s1.id, messageId: "m1", rating: "up" })).result).toEqual({ ok: true });
+    await c.call("sessions.recordFeedback", { id: s1.id, messageId: "m1", rating: "down" });
+
+    const rows = (await c.call("sessions.events", { id: s1.id })).result
+      .filter((r: Any) => r.event.type === "feedback").map((r: Any) => r.event.payload);
+    expect(rows).toEqual([{ messageId: "m1", rating: "up" }, { messageId: "m1", rating: "down" }]);
+    c.close();
+  });
+
+  it("refuses a verdict on a session that does not exist, rather than orphaning a row", async () => {
+    const { c } = await boot();
+    expect((await c.call("sessions.recordFeedback", { id: "01ARZ3NDEKTSV4RRFFQ69G5FAV", messageId: "m1", rating: "up" })).error.code).toBe("NOT_FOUND");
+    c.close();
+  });
+
   it("rejects unknown agents, unknown sessions and unknown projects", async () => {
     const { c, sp } = await boot();
     expect((await c.call("sessions.create", { spaceId: sp.id, agentKind: "codex" })).error.code).toBe("AGENT_UNAVAILABLE");

--- a/apps/server/src/sessions/service.ts
+++ b/apps/server/src/sessions/service.ts
@@ -279,6 +279,18 @@ export class SessionService {
   emitExternal(id: string, ev: SessionEvent): void {
     this.onEvent(id, ev);
   }
+  /**
+   * Record what the reader thought of one answer. Goes down the same `onEvent` path as everything
+   * else on the transcript, so it persists and broadcasts by the rules already in force and lands
+   * in the panes showing this session without a second channel.
+   *
+   * `get` first, so a verdict on a session that no longer exists is a NOT_FOUND rather than an
+   * orphan row the foreign key would have refused anyway.
+   */
+  recordFeedback(id: string, messageId: string, rating: "up" | "down" | null): void {
+    this.get(id);
+    this.onEvent(id, sessionEvent("feedback", { messageId, rating }));
+  }
   async setOptions(id: string, o: { model?: string; effort?: string; permissionMode?: string }): Promise<Session> {
     const s = this.d.sessions.update({ id, ...o });
     await this.live.get(id)?.handle.setOptions({ model: o.model, permissionMode: o.permissionMode });

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -964,6 +964,10 @@ export const Methods = {
   "sessions.send":   { params: z.object({ id: IdSchema, text: z.string(), attachments: z.array(z.object({ path: z.string(), mime: z.string() })).default([]), mentions: z.array(SkillIdSchema).max(32).default([]), elements: z.array(ElementChipSchema).max(MAX_ELEMENT_CHIPS).optional() })
     .refine((p) => p.text.length > 0 || p.attachments.length > 0, { message: "a message needs text or at least one attachment" }), result: z.object({ ok: z.literal(true) }) },
   "sessions.interrupt": { params: z.object({ id: IdSchema }), result: z.object({ ok: z.literal(true) }) },
+  /** The reader's verdict on one assistant message, appended to that session's own event log and
+   *  going nowhere else — there is no endpoint behind this and no aggregate anywhere. `rating: null`
+   *  retracts an earlier one. */
+  "sessions.recordFeedback": { params: z.object({ id: IdSchema, messageId: z.string().min(1), rating: z.enum(["up", "down"]).nullable() }), result: z.object({ ok: z.literal(true) }) },
   /** `answers` rides along only for question-shaped tools (AskUserQuestion): question text -> chosen
    *  label, multi-select comma-joined. Deliberately a record of strings rather than a free-form input
    *  override — the UI answers a question, it never gets to rewrite the tool's arguments. */

--- a/packages/contracts/src/session-events.ts
+++ b/packages/contracts/src/session-events.ts
@@ -48,6 +48,21 @@ const P = {
     text: z.string().optional(),
     steps: z.array(z.object({ text: z.string(), status: z.enum(["pending", "in_progress", "completed"]) })).optional(),
   }),
+  /** The reader's verdict on one assistant message, and the only event here the USER authors about
+   *  the agent rather than to it.
+   *
+   *  It is an event, not a settings row, for three reasons. A transcript is rebuilt from this log at
+   *  every relaunch, so a verdict kept anywhere else has to be re-joined to a message by a second
+   *  lookup that can silently drift. `permission_response` is the precedent — a user's decision
+   *  recorded beside the thing it decides. And `session_events` is `ON DELETE CASCADE` from
+   *  `sessions`, while the settings table has no delete at all: KV feedback would outlive by years
+   *  the session it was about.
+   *
+   *  `rating: null` is a retraction — the reader taking it back. Append-only, so the LAST rating for
+   *  a `messageId` wins and the earlier ones stay as the record of a mind being changed.
+   *
+   *  This never leaves the machine. Nothing reads it but the transcript that drew it. */
+  feedback: z.object({ messageId: z.string(), rating: z.enum(["up", "down"]).nullable() }),
   init: z.object({
     providerSessionId: z.string(), model: z.string(), tools: z.array(z.string()), cwd: z.string(),
     /** The instruction files the agent says it loaded — Codex `thread/start` `instructionSources`, W3's
@@ -80,6 +95,7 @@ export const SessionEventSchema = z.discriminatedUnion("type", [
   variant("usage"),
   variant("init"),
   variant("plan"),
+  variant("feedback"),
 ]);
 
 export type SessionEvent = z.infer<typeof SessionEventSchema>;
@@ -91,7 +107,7 @@ export function sessionEvent<T extends SessionEventType>(type: T, payload: Sessi
 }
 
 /** Event types the server persists; the rest (assistant_delta) are ephemeral. */
-export const PERSISTED_EVENT_TYPES: SessionEventType[] = ["user_message", "assistant_text", "thinking", "tool_call", "tool_result", "permission_request", "permission_response", "status", "error", "usage", "init", "plan"];
+export const PERSISTED_EVENT_TYPES: SessionEventType[] = ["user_message", "assistant_text", "thinking", "tool_call", "tool_result", "permission_request", "permission_response", "status", "error", "usage", "init", "plan", "feedback"];
 
 export const StoredSessionEventSchema = z.object({ seq: z.number().int(), sessionId: z.string(), event: SessionEventSchema });
 export type StoredSessionEvent = { seq: number; sessionId: string; event: SessionEvent };

--- a/packages/ui/src/Icon.tsx
+++ b/packages/ui/src/Icon.tsx
@@ -19,6 +19,8 @@ import {
   Maximize01Icon, Minimize01Icon, LayoutTable01Icon, SidebarLeft01Icon, Archive02Icon, ArchiveArrowUpIcon,
   // Inline media playback (MediaView.tsx).
   PlayIcon, PauseIcon, VolumeHighIcon, VolumeOffIcon,
+  // The reader's verdict on an assistant message (MessageActions.tsx).
+  ThumbsUpIcon, ThumbsDownIcon,
 } from "@hugeicons-pro/core-stroke-standard";
 import { brandMarks, isBrandName, type BrandName } from "./brand-icons";
 
@@ -32,6 +34,7 @@ export const icons = {
   send: SentIcon, stop: StopIcon, sparkles: SparklesIcon, chevronDown: ArrowDown01Icon, arrowDown: ArrowDown02Icon, arrowUp: ArrowUp02Icon,
   checkCircle: CheckmarkCircle02Icon, errorCircle: CancelCircleIcon, alert: Alert02Icon, bot: BotIcon, tool: Wrench01Icon, code: CodeIcon, idea: IdeaIcon,
   copy: Copy01Icon, plan: Task01Icon, attach: Attachment01Icon, image: Image01Icon, reload: RefreshIcon,
+  thumbsUp: ThumbsUpIcon, thumbsDown: ThumbsDownIcon,
   branch: GitBranchIcon, diff: GitCompareIcon, commit: GitCommitIcon, pullRequest: GitPullRequestIcon,
   splitRight: Layout2ColumnIcon, splitDown: Layout2RowIcon,
   // Pane focus (zoom one pane to the whole host) and its inverse; `group` is a pane group's tab.


### PR DESCRIPTION
Stacked on #44. Copy, retry, feedback and sources on a completed assistant message.

**Retry is a re-ask, not a regenerate, and the codebase already said why.** `CheckpointsSheet.tsx` tells the user "No agent Realm supports can rewind a conversation," and `sessions.fork` records `AGENT_CONVERSATION_REWIND` as false for every adapter — `AgentHandle` has no truncate verb. The disliked answer is in the agent's context permanently, so hiding it would make the transcript disagree with what the agent remembers. `retryLastTurn` re-sends the last *user-authored* message as a new turn and leaves the superseded answer in place.

Interrupt-then-retry was also rejected: `interrupt` denies any open permission prompt, and the reader did not decide that by pressing Retry. Retry is refused while a turn is live — guarded in the store rather than only on the button, because the adapters disagree about what a mid-turn send even means (Claude queues, Codex steers, ACP opens a second prompt; none of them is "ask again").

**Feedback is a persisted `feedback` session event.** The decisive fact against settings-KV: that table has `get` and `set` and **no delete**, so a verdict there would outlive by years the session it judged, while `session_events` is `ON DELETE CASCADE` from `sessions`. Transcripts are rebuilt from that log at relaunch, so anything else needs a second lookup that can drift — and `permission_response` is the precedent for recording a user's verdict beside the thing it judges. Nullable rating, because "not judged" is a third state that must stay reachable. It never leaves the machine.

**Sources are only tools whose *input* carries the url as structured data** — `WebFetch`, `browser_open`, `browser_navigate` — that returned without error, scoped to the turn that produced the message. Refused, each with a test: **URLs in the assistant's prose** (nothing reads the message text at all — a link the model typed is not a source it read), **`WebSearch`** (its input is a query and its result is links it was *shown*), failed or in-flight fetches, and non-http(s) schemes. Favicons were refused too, unlike the reference: drawing one means Realm calling out to every host an agent ever read, days later, from the transcript.

The tests caught a real bug on the way: `bareToolName` used `lastIndexOf("__")` with no guard, so an unprefixed `WebFetch` was sliced to `ebFetch` and never matched.

16 mutants planted, 16 dead — but **two survived first** and both exposed weak tests, which is the point of running them: an assertion that only held when `enter` was false, and a `WebSearch` refusal that passed by luck because the fixture had no `url` field rather than because the name was refused.

Two live checks were **removed rather than faked**: a mid-stream assertion that could never fail (the fake adapter queues a whole message's deltas in one burst, so there is no window to catch), and a clipboard read-back that returned the *user's real system clipboard* and leaked unrelated content into the log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)