### PR TITLE
Prevent accidental sidebar swipes and single-space drift

### DIFF
--- a/.github/workflows/product-validation.yml
+++ b/.github/workflows/product-validation.yml
@@ -1,0 +1,27 @@
+name: Product validation
+on:
+  pull_request:
+  workflow_dispatch:
+permissions:
+  contents: read
+jobs:
+  sidebar:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - name: Gesture behavior
+        run: node scripts/validate-sidebar.mjs gesture
+      - name: Rendered evidence gate
+        if: always()
+        run: node scripts/validate-sidebar.mjs visual
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: sidebar-validation-${{ github.event.pull_request.head.sha || github.sha }}
+          path: .validation/
+          if-no-files-found: error

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ apps/desktop/release/
 # Playwright CLI scratch — console logs, page snapshots and screenshots from live checks.
 .playwright-cli/
 .vercel
+.validation/

--- a/apps/desktop/src/renderer/src/state/gesture.test.ts
+++ b/apps/desktop/src/renderer/src/state/gesture.test.ts
@@ -4,6 +4,44 @@ import { createDragSwipe } from "./gesture";
 const BOUNDS = { canPrev: true, canNext: true };
 const mk = () => createDragSwipe({ width: 240, idleMs: 90 });
 
+describe.each([false, true])("sidebar intent (native phases: %s)", (native) => {
+  const start = () => { const t = mk(); if (native) t.phase("began", 0); return t; };
+
+  it("never displaces a single space in either direction", () => {
+    const t = start();
+    for (const dx of [2, 80, -160]) {
+      expect(t.wheel(dx, 0, 10, { canPrev: false, canNext: false })).toEqual({ type: "ignore" });
+      expect(t.offset()).toBe(0);
+    }
+  });
+
+  it("ignores horizontal jitter until a deliberate drag accumulates", () => {
+    const t = start();
+    expect(t.wheel(2, 0, 10, BOUNDS)).toEqual({ type: "ignore" });
+    expect(t.wheel(2, 0, 20, BOUNDS)).toEqual({ type: "ignore" });
+    expect(t.wheel(3, 0, 30, BOUNDS)).toEqual({ type: "move", offset: 7 });
+  });
+
+  it("does not turn diagonal scrolling into a horizontal drag", () => {
+    const t = start();
+    for (let i = 1; i <= 10; i++) expect(t.wheel(5, 5, i * 10, BOUNDS)).toEqual({ type: "ignore" });
+    expect(t.offset()).toBe(0);
+  });
+
+  it("still allows a deliberate swipe after vertical scrolling", () => {
+    const t = start();
+    expect(t.wheel(2, 100, 10, BOUNDS)).toEqual({ type: "ignore" });
+    expect(t.wheel(-20, 0, 20, BOUNDS)).toEqual({ type: "move", offset: -20 });
+  });
+
+  it("settles a displaced page when the last other space disappears", () => {
+    const t = start();
+    expect(t.wheel(20, 0, 10, BOUNDS)).toEqual({ type: "move", offset: 20 });
+    expect(t.wheel(20, 0, 20, { canPrev: false, canNext: false })).toEqual({ type: "settle" });
+    expect(t.offset()).toBe(0);
+  });
+});
+
 describe("drag swipe (timer fallback — no phase source)", () => {
   it("small drag moves the content, then settles back on idle", () => {
     const t = mk();

--- a/apps/desktop/src/renderer/src/state/gesture.ts
+++ b/apps/desktop/src/renderer/src/state/gesture.ts
@@ -43,6 +43,7 @@ export function createDragSwipe(opts: { width: number; commitFraction?: number; 
   let shown = 0;             // rubber-adjusted offset actually shown
   let locked = false;        // after a commit / during momentum: swallow deltas
   let dragging = false;
+  let pendingX = 0;
   let lastCommitDir: "next" | "prev" | null = null;
   let fingersDown = false;   // only meaningful with native phases
   let hasPhases = false;     // once we've seen any phase, timers stop deciding
@@ -50,7 +51,7 @@ export function createDragSwipe(opts: { width: number; commitFraction?: number; 
   let lastBounds: SwipeBounds = { canPrev: true, canNext: true };
   let samples: Array<{ dx: number; ts: number }> = [];
 
-  const reset = () => { acc = 0; shown = 0; locked = false; dragging = false; samples = []; };
+  const reset = () => { acc = 0; shown = 0; locked = false; dragging = false; pendingX = 0; samples = []; };
 
   /** Mean px/ms over the last 100ms. The first sample in the window contributes its *timestamp*, not
    *  its delta: that delta was travelled before the window opened, and counting it against zero
@@ -87,6 +88,11 @@ export function createDragSwipe(opts: { width: number; commitFraction?: number; 
   return {
     wheel(dx: number, dy: number, ts: number, bounds: SwipeBounds): SwipeUpdate {
       lastBounds = bounds;
+      if (!bounds.canPrev && !bounds.canNext) {
+        const displaced = shown !== 0;
+        reset();
+        return displaced ? { type: "settle" } : { type: "ignore" };
+      }
       if (!hasPhases && ts - lastTs > idleMs) reset(); // fallback: long gap = new gesture
       lastTs = ts;
       if (locked) {
@@ -96,9 +102,14 @@ export function createDragSwipe(opts: { width: number; commitFraction?: number; 
         else return { type: "ignore" };
       }
       if (hasPhases && !fingersDown) return { type: "ignore" }; // stray delta after lift (e.g. momentum) — never displaces
-      if (!dragging && Math.abs(dy) > Math.abs(dx)) return { type: "ignore" }; // vertical scroll
-      dragging = true;
-      acc += dx;
+      if (!dragging) {
+        // Require horizontal intent before moving content, not merely before committing a page.
+        if (Math.abs(dx) <= Math.abs(dy) * 1.5) { pendingX = 0; return { type: "ignore" }; }
+        pendingX += dx;
+        if (Math.abs(pendingX) < 6) return { type: "ignore" };
+        dragging = true;
+        acc = pendingX;
+      } else acc += dx;
       samples.push({ dx, ts });
 
       const wall = (acc > 0 && !bounds.canNext) || (acc < 0 && !bounds.canPrev);
@@ -121,7 +132,7 @@ export function createDragSwipe(opts: { width: number; commitFraction?: number; 
       lastTs = ts;
       switch (p) {
         case "began":
-          fingersDown = true; locked = false; acc = 0; shown = 0; dragging = false; samples = [];
+          fingersDown = true; reset();
           return { type: "ignore" };
         case "changed":
           return { type: "ignore" };

--- a/docs/dev/sidebar-validation.md
+++ b/docs/dev/sidebar-validation.md
@@ -1,0 +1,25 @@
+# Sidebar gesture validation
+
+A single-space sidebar must remain stationary under wheel or trackpad input. With multiple spaces,
+minor diagonal jitter must not move the sidebar; deliberate horizontal swipes must still work.
+Preserve vertical scrolling, edge behavior, cancellation, and momentum handling.
+
+Run `node scripts/validate-sidebar.mjs gesture` for the focused regression suite. It uses the public
+Vitest package without installing the desktop application's private icon dependencies. Every run
+writes its result and candidate SHA under `.validation/`.
+
+The state-machine suite is not complete UI proof. Build the candidate on macOS and check single and
+multiple spaces using a real trackpad, including vertical scrolling, diagonal jitter, deliberate
+swipes, cancellation, and momentum. Review dark and light modes. Do not test the previously installed
+app and attribute that result to this candidate.
+
+Record manual rendered evidence as JSON with `head` (the tested commit), `observer`, `checks`, and
+`captures`. Checks are booleans named `singleSpaceStable`, `verticalScrollPreserved`,
+`deliberateSwipeWorks`, `cancelAndMomentumSettle`, and `darkAndLightReviewed`. Each capture contains
+`theme` (`dark` or `light`), `path`, and its hexadecimal SHA-256 in `sha256`; keep captures with the receipt.
+Set `REALM_SIDEBAR_VISUAL_EVIDENCE` to that receipt and run
+`node scripts/validate-sidebar.mjs visual`. Missing, stale, or incomplete evidence is blocked.
+
+CI checks out the actual PR head and retains evidence even when checks fail. Its rendered gate stays
+blocked without candidate-specific macOS evidence; a passing gesture suite does not make the PR
+merge-ready. No CI step builds or replaces the user's installed Realm application.

--- a/scripts/gesture.vitest.config.mjs
+++ b/scripts/gesture.vitest.config.mjs
@@ -1,0 +1,7 @@
+// The gesture state machine has no DOM or private icon-package dependencies.
+export default {
+  test: {
+    environment: "node",
+    include: ["apps/desktop/src/renderer/src/state/gesture.test.ts", "scripts/validate-sidebar.test.ts"],
+  },
+};

--- a/scripts/validate-sidebar.mjs
+++ b/scripts/validate-sidebar.mjs
@@ -1,0 +1,41 @@
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+
+mkdirSync(".validation", { recursive: true });
+const mode = process.argv[2] ?? "gesture";
+if (!["gesture", "visual"].includes(mode)) throw new Error("Expected gesture or visual");
+const head = spawnSync("git", ["rev-parse", "HEAD"], { encoding: "utf8" }).stdout.trim();
+let status = "blocked";
+let summary = "Rendered macOS evidence for this candidate is required; see docs/dev/sidebar-validation.md.";
+try {
+  if (mode === "gesture") {
+    const result = spawnSync("npm", ["exec", "--yes", "--package=vitest@3.2.4", "--", "vitest", "run", "--config", "scripts/gesture.vitest.config.mjs"], { encoding: "utf8", timeout: 120_000 });
+    writeFileSync(".validation/gesture.log", `${result.stdout ?? ""}\n${result.stderr ?? ""}`);
+    status = result.error || result.signal ? "blocked" : result.status === 0 ? "passed" : "failed";
+    summary = `Gesture regression suite: ${status}. See gesture.log.`;
+  } else if (process.env.REALM_SIDEBAR_VISUAL_EVIDENCE) {
+    const input = JSON.parse(readFileSync(process.env.REALM_SIDEBAR_VISUAL_EVIDENCE, "utf8"));
+    const checks = ["singleSpaceStable", "verticalScrollPreserved", "deliberateSwipeWorks", "cancelAndMomentumSettle", "darkAndLightReviewed"];
+    if (input.head !== head || !input.observer || !checks.every(key => typeof input.checks?.[key] === "boolean")) throw new Error("Incomplete or stale rendered evidence");
+    if (!Array.isArray(input.captures) || !["dark", "light"].every(theme => input.captures.some(capture => capture.theme === theme))) throw new Error("Dark and light captures required");
+    for (const capture of input.captures) {
+      const bytes = readFileSync(capture.path);
+      if (!bytes.length || createHash("sha256").update(bytes).digest("hex") !== capture.sha256) throw new Error("Missing or changed capture");
+    }
+    status = checks.every(key => input.checks[key]) ? "passed" : "failed";
+    summary = `Rendered checks recorded by ${input.observer}: ${status}.`;
+    writeFileSync(".validation/rendered-receipt.json", JSON.stringify(input, null, 2));
+  }
+} catch (error) { summary = `Validation blocked: ${error.message}`; }
+const evidence = {
+  schemaVersion: "tabellio-validator-evidence/v0.1",
+  validatorId: `sidebar-${mode}`,
+  status, summary, metrics: [],
+  cost: { telemetry: "not_applicable", usd: null, modelCalls: null, toolCalls: null },
+  artifacts: [],
+};
+writeFileSync(`.validation/${mode}.json`, JSON.stringify(evidence, null, 2));
+writeFileSync(`.validation/${mode}-head.json`, JSON.stringify({ head, status }, null, 2));
+console.log(JSON.stringify({ head, mode, status, summary }));
+process.exitCode = status === "passed" ? 0 : status === "failed" ? 1 : 2;

--- a/scripts/validate-sidebar.test.ts
+++ b/scripts/validate-sidebar.test.ts
@@ -1,0 +1,20 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+import { describe, expect, it } from "vitest";
+
+describe("rendered evidence gate", () => {
+  it.each([undefined, { head: "stale", observer: "fixture" }])("blocks missing or stale evidence: %s", input => {
+    const dir = mkdtempSync(join(tmpdir(), "RealmEvidence"));
+    try {
+      const path = join(dir, "receipt.json");
+      if (input) writeFileSync(path, JSON.stringify(input));
+      const result = spawnSync(process.execPath, ["scripts/validate-sidebar.mjs", "visual"], {
+        encoding: "utf8", env: { ...process.env, REALM_SIDEBAR_VISUAL_EVIDENCE: path },
+      });
+      expect(result.status).toBe(2);
+      expect(JSON.parse(result.stdout).status).toBe("blocked");
+    } finally { rmSync(dir, { recursive: true }); }
+  });
+});

--- a/tabellio.validation.json
+++ b/tabellio.validation.json
@@ -1,0 +1,68 @@
+{
+  "schemaVersion": "tabellio-validation/v0.2",
+  "id": "realm-sidebar-validation",
+  "failFast": false,
+  "requireEntireCheckpoint": false,
+  "acceptance": {
+    "id": "sidebar-swipe-intent",
+    "source": "docs/dev/sidebar-validation.md",
+    "risk": "low",
+    "outcomes": [
+      "A single space remains stationary",
+      "Multiple spaces require deliberate horizontal input"
+    ],
+    "invariants": [
+      "Vertical scrolling and intentional space switching remain usable"
+    ],
+    "forbiddenOutcomes": [
+      "Accidental horizontal drift",
+      "Unverified rendered behavior reported as passed"
+    ],
+    "requiredValidatorTypes": [
+      "workflow",
+      "visual"
+    ]
+  },
+  "validators": [
+    {
+      "id": "sidebar-gesture",
+      "type": "workflow",
+      "argv": [
+        "node",
+        "scripts/validate-sidebar.mjs",
+        "gesture"
+      ],
+      "cwd": ".",
+      "timeoutMs": 150000,
+      "required": true,
+      "evidence": {
+        "path": ".validation/gesture.json"
+      },
+      "policy": {
+        "metricThresholds": [],
+        "maxCostUsd": null,
+        "requireCostTelemetry": false
+      }
+    },
+    {
+      "id": "sidebar-visual",
+      "type": "visual",
+      "argv": [
+        "node",
+        "scripts/validate-sidebar.mjs",
+        "visual"
+      ],
+      "cwd": ".",
+      "timeoutMs": 10000,
+      "required": true,
+      "evidence": {
+        "path": ".validation/visual.json"
+      },
+      "policy": {
+        "metricThresholds": [],
+        "maxCostUsd": null,
+        "requireCostTelemetry": false
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Problem and change

The sidebar moves horizontally even when the active profile has only one space, and small diagonal wheel input can start dragging before a user intends to switch spaces.

Keep a single space stationary, settle an in-progress drag when its last neighboring space disappears, and require at least 6 px of accumulated horizontal movement with a 1.5:1 horizontal preference before dragging begins. Preserve deliberate swipes, vertical scrolling, edge resistance, cancellation, and momentum handling.

## Validation

- Reproduced the original behavior with failing regression tests before the fix.
- 30 focused tests pass, covering native phase events and timer fallback, plus fail-closed evidence handling.
- Added the workspace-required validation manifest and PR-head CI evidence workflow. The focused suite uses public Vitest without requiring the private icon packages.
- Exact candidate: `7b93c54bdcc3ab2e8a3ede6d837626862527ac00`.
- Exact-candidate product validation: **blocked**. Gesture checks passed; a rendered macOS build and real-trackpad checks in dark/light modes are still required. The new CI rendered gate also remains blocked without that evidence.

This PR is intentionally a draft, not merge-ready. The installed Realm application has not been rebuilt or replaced. Codex baseline import/refresh is separate follow-up work.
